### PR TITLE
Add e2e test for video playback (#5850)

### DIFF
--- a/public/test/scripts/video_playback.js
+++ b/public/test/scripts/video_playback.js
@@ -1,0 +1,17 @@
+// Test that video playback updates the screenshot
+Test.describe(`video playback.`, async () => {
+  await Test.seekToTime(0);
+  await Test.startPlayback();
+
+  const start = Date.now();
+  let hash = window.currentScreenshotHash;
+  let i = 0;
+  while (i < 5 && Date.now() - start < 5000) {
+    await new Promise(resolve => setTimeout(resolve, 50));
+    if (window.currentScreenshotHash !== hash) {
+      hash = window.currentScreenshotHash;
+      i++;
+    }
+  }
+  Test.assert(i === 5, "the displayed screenshot should change");
+});

--- a/src/test/harness.js
+++ b/src/test/harness.js
@@ -608,12 +608,19 @@ async function toggleMappedSources() {
   return clickElement(".mapped-source button");
 }
 
-async function playbackRecording() {
+async function seekToTime(time) {
+  const timeline = await waitUntil(() => gToolbox.timeline, {
+    waitingFor: "timeline to be visible",
+  });
+  timeline.seekToTime(time);
+  await waitForPausedNoSource();
+}
+
+async function startPlayback() {
   const timeline = await waitUntil(() => gToolbox.timeline, {
     waitingFor: "timeline to be visible",
   });
   timeline.startPlayback();
-  await waitUntil(() => !timeline.state.playback, { waitingFor: "playback to start" });
 }
 
 async function findMarkupNode(text) {
@@ -899,7 +906,8 @@ const testCommands = {
   addEventListenerLogpoints,
   toggleExceptionLogging,
   toggleMappedSources,
-  playbackRecording,
+  startPlayback,
+  seekToTime,
   findMarkupNode,
   toggleMarkupNode,
   searchMarkup,

--- a/src/ui/components/Timeline/index.tsx
+++ b/src/ui/components/Timeline/index.tsx
@@ -59,7 +59,8 @@ class Timeline extends Component<PropsFromRedux, { isDragging: boolean }> {
 
   async componentDidMount() {
     // Used in the test harness for starting playback recording.
-    gToolbox.timeline = this;
+    const { startPlayback, seekToTime } = this.props;
+    gToolbox.timeline = { startPlayback, seekToTime };
     this.props.updateTimelineDimensions();
   }
 

--- a/test/manifest.js
+++ b/test/manifest.js
@@ -331,6 +331,11 @@ module.exports = [
     targets: ["gecko", "chromium"],
   },
   {
+    example: "doc_rr_basic.html",
+    script: "video_playback.js",
+    targets: ["gecko", "chromium"],
+  },
+  {
     example: "node/spawn.js",
     script: "node_spawn-01.js",
     targets: ["node"],


### PR DESCRIPTION
This test is currently unreliable due to performance issues: it tries to look at the hash of the currently displayed screenshot every 50ms, but the 50ms delay can actually take several seconds as can be seen in this recording: http://localhost:8080/recording/replay-of-localhost8080--b2d8651f-962d-44ed-917c-0845043b0b88