### PR TITLE
Rerun analyses and clear currentPause when needed

### DIFF
--- a/src/devtools/client/debugger/src/client/commands.js
+++ b/src/devtools/client/debugger/src/client/commands.js
@@ -162,18 +162,22 @@ async function evaluateExpressions(sources, options) {
 }
 
 async function evaluate(source, { asyncIndex, frameId } = {}) {
-  const { returned, exception, failed } = await ThreadFront.evaluate({
-    asyncIndex,
-    frameId,
-    text: source,
-  });
-  if (failed) {
+  try {
+    const { returned, exception, failed } = await ThreadFront.evaluate({
+      asyncIndex,
+      frameId,
+      text: source,
+    });
+    if (failed) {
+      return { exception: createPrimitiveValueFront("Evaluation failed") };
+    }
+    if (returned) {
+      return { result: returned };
+    }
+    return { exception };
+  } catch (e) {
     return { exception: createPrimitiveValueFront("Evaluation failed") };
   }
-  if (returned) {
-    return { result: returned };
-  }
-  return { exception };
 }
 
 async function autocomplete(input, cursor, frameId) {

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -32,6 +32,7 @@ import { getPausePointParams, getTest, updateUrlWithParams } from "ui/utils/envi
 import KeyShortcuts, { isEditableElement } from "ui/utils/key-shortcuts";
 import { features } from "ui/utils/prefs";
 import { trackEvent } from "ui/utils/telemetry";
+import { refetchDataForTimeRange } from "./app";
 
 import type { UIStore, UIThunkAction } from "./index";
 
@@ -591,6 +592,8 @@ export function syncFocusedRegion(): UIThunkAction {
       },
       window.sessionId
     );
+
+    dispatch(refetchDataForTimeRange(focusRegion));
   };
 }
 


### PR DESCRIPTION
I started down [a long road](https://github.com/RecordReplay/devtools/compare/jm-analyses-reducer?expand=1), understanding all of the ways that we should change breakpoints/analyses to make them more stable and compatible with #6590. But a little ways down that road I saw some cheap and quick wins, so while I have uhhh... [kind of a lot written about where to go next](https://kinopio.club/a-user-walks-into-a-print-statement-Ubk9AJUa-o3vxPcxySACY), this at least gets us at a dumb place where:

- We will not error when we were at a Pause that now falls in an unloaded region
- We will refetch analyses when we select a new focus region (see the docs linked above about future improvements on this, it is super naive)

Is a slightly dirty (but viable) fix for #6576