### PR TITLE
Show original classname in ObjectInspector (#6316)

### DIFF
--- a/packages/protocol/scope-map-cache.ts
+++ b/packages/protocol/scope-map-cache.ts
@@ -1,0 +1,22 @@
+import { Location } from "@replayio/protocol";
+
+import { ThreadFront } from "./thread/thread";
+import { defer } from "./utils";
+
+export default class ScopeMapCache {
+  private cache = new Map<string, Promise<Record<string, string>>>();
+
+  getScopeMap(location: Location): Promise<Record<string, string>> {
+    const cacheKey = `${location.sourceId}:${location.line}:${location.column}`;
+    let promise = this.cache.get(cacheKey);
+    if (!promise) {
+      promise = (async () => {
+        const { client } = await import("./socket");
+        const { map } = await client.Debugger.getScopeMap({ location }, ThreadFront.sessionId!);
+        return map ? Object.fromEntries(map) : {};
+      })();
+      this.cache.set(cacheKey, promise);
+    }
+    return promise;
+  }
+}

--- a/packages/protocol/thread/thread.ts
+++ b/packages/protocol/thread/thread.ts
@@ -42,6 +42,7 @@ import groupBy from "lodash/groupBy";
 import uniqueId from "lodash/uniqueId";
 
 import { MappedLocationCache } from "../mapped-location-cache";
+import ScopeMapCache from "../scope-map-cache";
 import { client, log } from "../socket";
 import { defer, assert, EventEmitter, ArrayMap } from "../utils";
 
@@ -180,6 +181,8 @@ class _ThreadFront {
   onSource: ((source: newSource) => void) | undefined;
 
   mappedLocations = new MappedLocationCache();
+
+  scopeMaps = new ScopeMapCache();
 
   // Points which will be reached when stepping in various directions from a point.
   resumeTargets = new Map<string, PauseDescription>();
@@ -682,6 +685,10 @@ class _ThreadFront {
     return await pause.getScopes(frameId);
   }
 
+  getScopeMap(location: Location): Promise<Record<string, string>> {
+    return this.scopeMaps.getScopeMap(location);
+  }
+
   async evaluate({
     asyncIndex,
     text,
@@ -1019,6 +1026,18 @@ class _ThreadFront {
       return locations.find(l => l.sourceId == alternateId);
     }
     return null;
+  }
+
+  getGeneratedLocation(locations: MappedLocation) {
+    const sourceIds = new Set<SourceId>(locations.map(location => location.sourceId));
+    return locations.find(location => {
+      const generated = this.getGeneratedSourceIds(location.sourceId);
+      if (!generated) {
+        return true;
+      }
+      // Don't return a location if it is an original version of another one of the given locations.
+      return !generated.some(generatedId => sourceIds.has(generatedId));
+    });
   }
 
   // Get the source which should be used in the devtools from an array of

--- a/src/devtools/client/webconsole/actions/messages.ts
+++ b/src/devtools/client/webconsole/actions/messages.ts
@@ -9,6 +9,7 @@ import {
   prepareMessage,
   isBrowserInternalMessage,
 } from "devtools/client/webconsole/utils/messages";
+import { loadValue } from "devtools/packages/devtools-reps/object-inspector/items/utils";
 import { TestMessageHandlers } from "ui/actions/find-tests";
 import { LogpointHandlers } from "ui/actions/logpoint";
 import { client } from "protocol/socket";
@@ -115,7 +116,7 @@ export function onConsoleMessage(msg: WiredMessage): UIThunkAction {
     }
 
     if (msg.argumentValues) {
-      await Promise.all(msg.argumentValues.map(value => value.loadIfNecessary()));
+      await Promise.all(msg.argumentValues.map(loadValue));
     }
 
     const packet = {
@@ -178,7 +179,7 @@ function onLogpointResult(
 ): UIThunkAction {
   return async (dispatch, getState, { ThreadFront }) => {
     if (values) {
-      await Promise.all(values.map(value => value.loadIfNecessary()));
+      await Promise.all(values.map(loadValue));
     }
     const packet = {
       errorMessage: "",

--- a/src/devtools/packages/devtools-reps/object-inspector/items/index.tsx
+++ b/src/devtools/packages/devtools-reps/object-inspector/items/index.tsx
@@ -9,7 +9,13 @@ import { ObjectInspectorItemProps } from "../components/ObjectInspectorItem";
 
 export * from "./utils";
 
-import { GETTERS_FROM_PROTOTYPES, isValueLoaded, getChildValues, renderRep } from "./utils";
+import {
+  GETTERS_FROM_PROTOTYPES,
+  isValueLoaded,
+  getChildValues,
+  renderRep,
+  loadValue,
+} from "./utils";
 
 export interface LabelAndValue {
   label?: React.ReactNode;
@@ -63,9 +69,7 @@ export class ContainerItem implements IItem {
   }
 
   async loadChildren() {
-    await Promise.all(
-      this.contents.map(item => item.type === "value" && item.contents.loadIfNecessary())
-    );
+    await Promise.all(this.contents.map(item => item.type === "value" && loadValue(item.contents)));
   }
 
   shouldUpdate(prevItem: Item) {
@@ -246,7 +250,7 @@ export class KeyValueItem implements IItem {
   }
 
   async loadChildren() {
-    await Promise.all([this.key.loadIfNecessary(), this.value.loadIfNecessary()]);
+    await Promise.all([loadValue(this.key), loadValue(this.value)]);
   }
 
   shouldUpdate(prevItem: Item) {
@@ -472,7 +476,7 @@ export class ValueItem implements IItem {
       await current.loadIfNecessary();
     }, GETTERS_FROM_PROTOTYPES);
 
-    await Promise.all(getChildValues(this.contents).map(value => value.loadIfNecessary()));
+    await Promise.all(getChildValues(this.contents).map(loadValue));
   }
 
   recreate() {

--- a/src/devtools/packages/devtools-reps/object-inspector/items/utils.ts
+++ b/src/devtools/packages/devtools-reps/object-inspector/items/utils.ts
@@ -1,4 +1,5 @@
 import { Pause, ValueFront } from "protocol/thread";
+import { features } from "ui/utils/prefs";
 
 import { MODE } from "../../reps/constants";
 
@@ -18,6 +19,16 @@ export const GETTERS_FROM_PROTOTYPES = 1;
 
 export function isValueLoaded(value: ValueFront): boolean {
   return value.isPrimitive() || !value.hasPreviewOverflow();
+}
+
+/**
+ * Ensure the ValueFront is ready to be displayed in the ObjectInspector
+ */
+export async function loadValue(value: ValueFront) {
+  await value.loadIfNecessary();
+  if (features.originalClassNames) {
+    await value.mapClassName();
+  }
 }
 
 export function shouldRenderRootsInReps(roots: Item[]): boolean {

--- a/src/devtools/packages/devtools-reps/reps/grip.js
+++ b/src/devtools/packages/devtools-reps/reps/grip.js
@@ -105,7 +105,7 @@ function getTitleElement(props, object) {
 }
 
 function getTitle(props, object) {
-  return props.title || object.className() || DEFAULT_TITLE;
+  return props.title || object.originalClassName || object.className() || DEFAULT_TITLE;
 }
 
 function safePropIterator(props, object, max) {

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -35,6 +35,7 @@ pref("devtools.features.enableLargeText", false);
 pref("devtools.features.softFocus", false);
 pref("devtools.features.repaintEvaluations", false);
 pref("devtools.features.testSupport", false);
+pref("devtools.features.originalClassNames", false);
 
 export const prefs = new PrefsHelper("devtools", {
   eventListenersBreakpoints: ["Bool", "event-listeners-breakpoints"],
@@ -68,6 +69,7 @@ export const features = new PrefsHelper("devtools.features", {
   softFocus: ["Bool", "softFocus"],
   repaintEvaluations: ["Bool", "repaintEvaluations"],
   testSupport: ["Bool", "testSupport"],
+  originalClassNames: ["Bool", "originalClassNames"],
 });
 
 export const asyncStore = asyncStoreHelper("devtools", {


### PR DESCRIPTION
I've put this behind a feature flag and disabled it by default because it may degrade ObjectInspector performance.
Needs RecordReplay/backend#5614 to be deployed first.