### PR TITLE
[DRAFT] Try adding a "line heatmaps" feature to our editor

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Editor.css
+++ b/src/devtools/client/debugger/src/components/Editor/Editor.css
@@ -222,3 +222,8 @@ separately stack the pause line visuals and the code. */
 .visible {
   visibility: visible;
 }
+
+.editor-wrapper.showLineHits .CodeMirror-gutters .hit-markers {
+  /*min-width: 30px;*/
+  width: 30px;
+}

--- a/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
@@ -1,0 +1,68 @@
+import { classMethod } from "@babel/types";
+import minBy from "lodash/minBy";
+import React, { useState, useMemo, useLayoutEffect } from "react";
+import { useSelector } from "react-redux";
+import { selectors } from "ui/reducers";
+import { prefs, features } from "ui/utils/prefs";
+
+import { getHitCountsForSelectedSource, getSelectedSource } from "../../reducers/sources";
+
+interface LHCProps {
+  // make this better!
+  cm: any;
+}
+
+export const LineHitCounts = ({ cm }: LHCProps) => {
+  const [codeHeatMaps, setCodeHeatMaps] = useState(features.codeHeatMaps);
+  const indexed = useSelector(selectors.getIsIndexed);
+  const hitCounts = useSelector(getHitCountsForSelectedSource);
+  const source = useSelector(getSelectedSource);
+  const analysisPoints = useSelector(selectors.getPointsForHoveredLineNumber);
+  const breakpoints = useSelector(selectors.getBreakpointsList);
+
+  /*
+  let analysisPointsCount = useMemo(() => {
+    if (hitCounts) {
+      const lineHitCounts = minBy(
+        hitCounts.filter(hitCount => hitCount.location.line === lastHoveredLineNumber.current),
+        b => b.location.column
+      );
+      return lineHitCounts?.hits;
+    } else {
+      return analysisPoints?.data.length;
+    }
+  }, [hitCounts, analysisPoints]);
+  */
+
+  useLayoutEffect(() => {
+    if (!cm) {
+      return;
+    }
+
+    const doc = cm.editor.getDoc();
+    const drawLines = () => {
+      cm.editor.setOption("gutters", ["breakpoints", "CodeMirror-linenumbers", "hit-markers"]);
+      doc.eachLine((lineHandle: any) => {
+        const markerNode = document.createElement("div");
+        markerNode.innerHTML = "25x";
+        markerNode.style.zIndex = "0";
+        markerNode.style.backgroundColor = "green";
+        doc.setGutterMarker(lineHandle, "hit-markers", markerNode);
+      });
+    };
+
+    doc.on("change", drawLines);
+    doc.on("swapDoc", drawLines);
+
+    drawLines();
+
+    return () => {
+      cm.editor.setOption("gutters", ["breakpoints", "CodeMirror-linenumbers"]);
+      doc.off("change", drawLines);
+      doc.off("swapDoc", drawLines);
+    };
+  }, [cm]);
+
+  // We're just here for the hooks!
+  return null;
+};

--- a/src/devtools/client/debugger/src/components/Editor/StaticTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/StaticTooltip.tsx
@@ -9,7 +9,10 @@ type StaticTooltipProps = {
 
 export default function StaticTooltip({ targetNode, children }: StaticTooltipProps) {
   return ReactDOM.createPortal(
-    <div className="absolute z-50 flex flex-row space-x-px transform -right-1 translate-x-full bottom-4 mb-0.5 pointer-events-none">
+    <div
+      className="pointer-events-none absolute -right-1 bottom-4 z-50 mb-0.5 flex translate-x-full transform flex-row space-x-px"
+      style={{ zIndex: 1500 }}
+    >
       {children}
     </div>,
     targetNode

--- a/src/devtools/client/debugger/src/components/Editor/index.js
+++ b/src/devtools/client/debugger/src/components/Editor/index.js
@@ -55,6 +55,7 @@ import {
   endOperation,
   clearDocuments,
 } from "../../utils/editor";
+import { LineHitCounts } from "./LineHitCounts";
 
 import { resizeToggleButton, resizeBreakpointGutter } from "../../utils/ui";
 
@@ -455,6 +456,7 @@ class Editor extends PureComponent {
           />
         }
         <ColumnBreakpoints editor={editor} />
+        <LineHitCounts cm={editor} />
       </div>
     );
   }
@@ -476,6 +478,7 @@ class Editor extends PureComponent {
       <div
         className={classnames("editor-wrapper", {
           blackboxed: selectedSource && selectedSource.isBlackBoxed,
+          showLineHits: true,
         })}
         ref={c => (this.$editorWrapper = c)}
       >

--- a/src/devtools/client/debugger/src/utils/editor/create-editor.js
+++ b/src/devtools/client/debugger/src/utils/editor/create-editor.js
@@ -29,7 +29,7 @@ export function getCodeMirror() {
 
 export function createEditor() {
   assert(SourceEditor, "CodeMirror must have been loaded");
-  const gutters = ["breakpoints", "hit-markers", "CodeMirror-linenumbers"];
+  const gutters = ["breakpoints", "CodeMirror-linenumbers", "hit-markers"];
 
   return new SourceEditor({
     mode: "javascript",


### PR DESCRIPTION
This is an initial attempt to add a "line heatmaps" feature per #6856 .

So far I've figured out how to add another gutter to CodeMirror and insert text on each line's gutter.

However, I'm stuck in that our line hover tooltips are showing up _behind_ the new gutter, and I can't immediately figure out how to get them to pop out over top.

Rough appearance so far:

![image](https://user-images.githubusercontent.com/1128784/169418653-88727cc1-e312-423b-94c0-11d0f3b07bbb.png)

If I can get the hover tooltips sorted out, I then ought to be able to loop over each line, create a `SourceLocation` entry, query the Redux store for any hit counts on that line, do some data munging, and display the hits on each line.