### PR TITLE
Do not register every analysis as a logpoint

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,6 +1,6 @@
 version: 0.1
 cli:
-  version: 0.11.0-beta
+  version: 0.12.1-beta
 lint:
   enabled:
     - actionlint@1.6.8

--- a/packages/protocol/thread/analysis.ts
+++ b/packages/protocol/thread/analysis.ts
@@ -26,7 +26,9 @@ interface RunAnalysisResult {
   error: AnalysisError.TooManyPointsToRun | undefined;
 }
 
-export const createAnalysis = async (params: AnalysisParams): Promise<Analysis> => {
+export const createAnalysis = async (
+  params: Omit<AnalysisParams, "locations">
+): Promise<Analysis> => {
   // Call to the client and say hey please make an analysis and after that
   // create an Analysis with that result
   const { analysisId } = await sendMessage(

--- a/src/devtools/client/debugger/src/actions/breakpoints/breakpoints.ts
+++ b/src/devtools/client/debugger/src/actions/breakpoints/breakpoints.ts
@@ -201,29 +201,6 @@ export function toggleBreakpointAtLine(cx: Context, line: number): UIThunkAction
   };
 }
 
-export function runAnalysisOnLine(line: number): UIThunkAction {
-  return (dispatch, getState) => {
-    const state = getState();
-    const cx = getThreadContext(state);
-    const source = getSelectedSource(state);
-
-    if (!source) {
-      return;
-    }
-
-    const options = { logValue: "dummyValue" };
-    const location = {
-      sourceId: source.id,
-      sourceUrl: source.url,
-      column: undefined,
-      line,
-    };
-
-    // @ts-ignore location field mismatches
-    return dispatch(runAnalysis(cx, location, options));
-  };
-}
-
 export function updateHoveredLineNumber(line: number): UIThunkAction<Promise<void>> {
   return async (dispatch, getState) => {
     const state = getState();

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
@@ -16,8 +16,8 @@ import PanelSummary from "./PanelSummary";
 import FirstEditNag from "./FirstEditNag";
 import hooks from "ui/hooks";
 import { Nag } from "ui/hooks/users";
-import { AnalysisError } from "ui/state/app";
 import { prefs } from "ui/utils/prefs";
+import { AnalysisError } from "protocol/thread/analysis";
 
 function getPanelWidth({ editor }) {
   // The indent value is an adjustment for the distance from the gutter's left edge
@@ -50,7 +50,7 @@ function Panel({
     );
   const isHot =
     analysisPoints &&
-    (analysisPoints.error === AnalysisError.TooManyPoints ||
+    (analysisPoints.error === AnalysisError.TooManyPointsToFind ||
       (analysisPoints.data.length || 0) > prefs.maxHitsDisplayed);
 
   useEffect(() => {

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/index.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/index.tsx
@@ -59,7 +59,7 @@ function PanelSummary({
     if (isEditable) {
       trackEvent("breakpoint.start_edit", {
         input,
-        hitsCount: analysisPoints?.data.length || null,
+        hitsCount: analysisPoints?.data?.length || null,
       });
       toggleEditingOn();
       setInputToFocus(input);

--- a/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
@@ -1,23 +1,32 @@
-import {
-  runAnalysisOnLine,
-  updateHoveredLineNumber,
-} from "devtools/client/debugger/src/actions/breakpoints/index";
+import { updateHoveredLineNumber } from "devtools/client/debugger/src/actions/breakpoints/index";
 import { setBreakpointHitCounts } from "devtools/client/debugger/src/actions/sources";
 import { minBy } from "lodash";
+import { AnalysisParams } from "protocol/analysisManager";
+import { Analysis, AnalysisError, createAnalysis } from "protocol/thread/analysis";
 import React, { useRef, useState, useEffect, ReactNode } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { UIThunkAction } from "ui/actions";
+import { saveAnalysisError } from "ui/actions/logpoint";
 import { KeyModifiers } from "ui/components/KeyModifiers";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
 import hooks from "ui/hooks";
 import { Nag } from "ui/hooks/users";
 import { selectors } from "ui/reducers";
-import { setHoveredLineNumberLocation } from "ui/reducers/app";
-import { AnalysisError, AnalysisPayload } from "ui/state/app";
+import { setAnalysisPoints, setHoveredLineNumberLocation } from "ui/reducers/app";
+import { AnalysisPayload } from "ui/state/app";
 import { prefs, features } from "ui/utils/prefs";
 import { trackEvent } from "ui/utils/telemetry";
 import { shouldShowNag } from "ui/utils/user";
 
 import { getHitCountsForSelectedSource, getSelectedSource } from "../../reducers/sources";
+import {
+  analysisCreated,
+  analysisErrored,
+  analysisPointsReceived,
+  analysisPointsRequested,
+  getFirstBreakpointPosition,
+  getThreadContext,
+} from "../../selectors";
 
 import StaticTooltip from "./StaticTooltip";
 
@@ -27,7 +36,10 @@ function getTextAndWarning(analysisPoints?: AnalysisPayload, analysisPointsCount
   if (analysisPoints?.error) {
     return {
       showWarning: false,
-      text: analysisPoints.error === AnalysisError.TooManyPoints ? "10k+ hits" : "Error",
+      text:
+        (analysisPoints.error as AnalysisError) === AnalysisError.TooManyPointsToFind
+          ? "10k+ hits"
+          : "Error",
     };
   }
 
@@ -71,6 +83,92 @@ function Wrapper({
   return <div className="static-tooltip-content bg-gray-700">{children}</div>;
 }
 
+function runAnalysisOnLine(line: number): UIThunkAction {
+  return async (dispatch, getState, { ThreadFront }) => {
+    // A lot of this logic is reused from logpoint.ts
+    // It is possible to instead repurpose that function here, but increasingly
+    // I want logpoint.ts to be... for logpoints. Part of what has made our
+    // analysis code such a mess is trying to repurpose an analysis runner to
+    // work for many different devtools specific workflows. It would be better
+    // if many components used the primitives from `protocol` instead. If it
+    // turns out that those primitives are getting used the same way all the
+    // time, maybe it's time to add some new things to the `protocol` folder.
+    const state = getState();
+    const source = getSelectedSource(state);
+
+    if (!source) {
+      return;
+    }
+
+    const location = getFirstBreakpointPosition(getState(), {
+      sourceId: source.id,
+      sourceUrl: source.url,
+      column: undefined,
+      line,
+    });
+
+    if (!location) {
+      return;
+    }
+
+    const analysisPoints = selectors.getAnalysisPointsForLocation(getState(), location, undefined);
+    if (analysisPoints) {
+      return;
+    }
+
+    const sessionId = await ThreadFront.waitForSession();
+    const params: AnalysisParams = {
+      sessionId,
+      mapper: "",
+      effectful: true,
+    };
+
+    let analysis: Analysis | undefined = undefined;
+
+    try {
+      analysis = await createAnalysis(params);
+      const { analysisId } = analysis;
+
+      dispatch(analysisCreated({ analysisId, location, condition: undefined }));
+
+      await analysis.addLocation(location);
+
+      dispatch(analysisPointsRequested(analysisId));
+      const { points, error } = await analysis.findPoints();
+
+      if (error) {
+        dispatch(
+          analysisErrored({
+            analysisId,
+            error: AnalysisError.TooManyPointsToFind,
+            points,
+          })
+        );
+
+        // TODO Remove this and change Redux logic to match
+        saveAnalysisError([location], "", AnalysisError.TooManyPointsToFind);
+
+        return;
+      }
+
+      dispatch(
+        analysisPointsReceived({
+          analysisId,
+          points,
+        })
+      );
+      dispatch(
+        setAnalysisPoints({
+          location,
+          analysisPoints: points,
+        })
+      );
+    } finally {
+      analysis?.releaseAnalysis();
+    }
+  };
+}
+
 export default function LineNumberTooltip({
   editor,
   keyModifiers,
@@ -101,7 +199,7 @@ export default function LineNumberTooltip({
       analysisPointsCount = lineHitCounts?.hits;
     }
   } else {
-    analysisPointsCount = analysisPoints?.data.length;
+    analysisPointsCount = analysisPoints?.data?.length;
   }
 
   useEffect(() => {

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointTimeline.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointTimeline.tsx
@@ -35,7 +35,7 @@ function Points({
       return [];
     }
     let previousDisplayed: PointDescription;
-    return analysisPoints.data.filter(p => {
+    return analysisPoints.data?.filter(p => {
       if (
         !previousDisplayed ||
         executionPoint === p.point ||

--- a/src/ui/components/Timeline/PreviewMarkers.tsx
+++ b/src/ui/components/Timeline/PreviewMarkers.tsx
@@ -17,14 +17,14 @@ export default function PreviewMarkers() {
   if (
     !pointsForHoveredLineNumber ||
     pointsForHoveredLineNumber.error ||
-    pointsForHoveredLineNumber.data.length > prefs.maxHitsDisplayed
+    (pointsForHoveredLineNumber.data?.length || 0) > prefs.maxHitsDisplayed
   ) {
     return null;
   }
 
   return (
     <div className="preview-markers-container">
-      {pointsForHoveredLineNumber.data.map((point: PointDescription, index: number) => {
+      {pointsForHoveredLineNumber.data?.map((point: PointDescription, index: number) => {
         const isPrimaryHighlighted = hoveredItem?.point === point.point;
         const isSecondaryHighlighted = getIsSecondaryHighlighted(hoveredItem, point.frame?.[0]);
 

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -6,11 +6,9 @@ import { getSystemColorSchemePreference } from "ui/utils/environment";
 import { getFocusRegion, getZoomRegion } from "ui/reducers/timeline";
 import { UIState } from "ui/state";
 import {
-  AnalysisError,
   AppState,
   AppTheme,
   EventKind,
-  ProtocolError,
   ReplayEvent,
   UploadInfo,
   LoadedRegions,
@@ -35,6 +33,7 @@ import {
   overlap,
   startTimeForFocusRegion,
 } from "ui/utils/timeline";
+import { AnalysisError } from "protocol/thread/analysis";
 
 export const initialAppState: AppState = {
   mode: "devtools",
@@ -168,7 +167,7 @@ const appSlice = createSlice({
 
       state.analysisPoints[id] = {
         data: analysisPoints,
-        error: null,
+        error: undefined,
       };
     },
     setAnalysisError(
@@ -176,19 +175,16 @@ const appSlice = createSlice({
       action: PayloadAction<{
         location: Location;
         condition?: string;
-        errorKey?: number;
+        error: AnalysisError;
       }>
     ) {
-      const { location, condition = "", errorKey } = action.payload;
+      const { location, condition = "", error } = action.payload;
 
       const id = getLocationAndConditionKey(location, condition);
 
       state.analysisPoints[id] = {
-        data: [],
-        error:
-          errorKey === ProtocolError.TooManyPoints
-            ? AnalysisError.TooManyPoints
-            : AnalysisError.Default,
+        data: undefined,
+        error: error,
       };
     },
     setEventsForType(
@@ -378,7 +374,7 @@ export const getAnalysisPointsForLocation = (
   }
   return {
     ...points,
-    data: filterToFocusRegion(points.data, focusRegion),
+    data: filterToFocusRegion(points.data || [], focusRegion),
   };
 };
 

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -10,6 +10,7 @@ import {
   ExecutionPoint,
   TimeStampedPointRange,
 } from "@replayio/protocol";
+import { AnalysisError } from "protocol/thread/analysis";
 import type { RecordingTarget } from "protocol/thread/thread";
 import { Workspace } from "ui/types";
 import { Reply } from "./comments";
@@ -112,13 +113,10 @@ export interface AppState {
 
 export type AnalysisPoints = Record<string, AnalysisPayload>;
 export type AnalysisPayload = {
-  data: PointDescription[];
-  error: AnalysisError | null;
+  data: PointDescription[] | undefined;
+  error: AnalysisError | undefined;
 };
-export enum AnalysisError {
-  TooManyPoints = "too-many-points",
-  Default = "default",
-}
+
 export type AppMode = "devtools" | "sourcemap-visualizer";
 
 interface Events {


### PR DESCRIPTION
In https://github.com/replayio/devtools/commit/3c825b6a95d3b2d5ef6201135ca23c4a7a1c0445 we removed the concept of `showInConsole` with the thinking that "It's a logpoint, all logpoints get shown in the console". But in order for that to be true, we need to not use the logpoint machinery for things that... are not logpoints. Now, this has resulted in some duplication, but I believe it is duplication that is justified at this point in time. We are still figuring out what the best API for these primitive operations is, and if it turns out that we definitely have too much of a low-level API and we are always repeating the same steps, we can extract those, but if we insist on never duplicating code, it's hard to tell what responsibilities are shared and which just happen to be next to each other but get turned on and off by passing in flags to functions (which, in general, I find to be a little code-smelly).