### PR TITLE
Make sure that all error values will be truthy

### DIFF
--- a/packages/protocol/thread/analysis.ts
+++ b/packages/protocol/thread/analysis.ts
@@ -11,9 +11,9 @@ export interface Analysis {
 }
 
 export enum AnalysisError {
-  TooManyPointsToFind,
-  TooManyPointsToRun,
-  Unknown,
+  TooManyPointsToFind = "too-many-points-to-find",
+  TooManyPointsToRun = "too-many-points-to-run",
+  Unknown = "unknown",
 }
 
 interface FindAnalysisPointsResult {


### PR DESCRIPTION
I had never considered the fact that testing enums for truthiness might
get you in trouble, but we should be using strings here to make sure
they are all truthy.