### PR TITLE
Allow points to be undefined

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
@@ -42,16 +42,13 @@ function Panel({
   const [width, setWidth] = useState(getPanelWidth(editor)); // nosemgrep
   const [inputToFocus, setInputToFocus] = useState("logValue");
   const dismissNag = hooks.useDismissNag();
-  const pausedOnHit =
-    analysisPoints &&
-    !analysisPoints.error &&
-    !!analysisPoints?.data.find(
-      ({ point, time }) => point == executionPoint && time == currentTime
-    );
+  const points = analysisPoints?.data;
+  const error = analysisPoints?.error;
+  const pausedOnHit = points?.some(
+    ({ point, time }) => point == executionPoint && time == currentTime
+  );
   const isHot =
-    analysisPoints &&
-    (analysisPoints.error === AnalysisError.TooManyPointsToFind ||
-      (analysisPoints.data.length || 0) > prefs.maxHitsDisplayed);
+    error === AnalysisError.TooManyPointsToFind || (points?.length || 0) > prefs.maxHitsDisplayed;
 
   useEffect(() => {
     const updateWidth = () => setWidth(getPanelWidth(editor));

--- a/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
@@ -25,7 +25,6 @@ import {
   analysisPointsReceived,
   analysisPointsRequested,
   getFirstBreakpointPosition,
-  getThreadContext,
 } from "../../selectors";
 
 import StaticTooltip from "./StaticTooltip";

--- a/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
@@ -105,9 +105,12 @@ function QuickActions({
 
   let next: PointDescription | undefined, prev: PointDescription | undefined;
 
-  if (analysisPoints && !analysisPoints.error && executionPoint) {
-    prev = findLast(analysisPoints.data, p => compareNumericStrings(p.point, executionPoint) < 0);
-    next = find(analysisPoints.data, p => compareNumericStrings(p.point, executionPoint) > 0);
+  let points = analysisPoints?.data;
+  let error = analysisPoints?.error;
+
+  if (points && !error && executionPoint) {
+    prev = findLast(points, p => compareNumericStrings(p.point, executionPoint) < 0);
+    next = find(points, p => compareNumericStrings(p.point, executionPoint) > 0);
   }
 
   const onContinueToNext = () => {
@@ -123,11 +126,11 @@ function QuickActions({
 
   let button;
 
-  if (analysisPoints && isMetaActive && isShiftActive) {
+  if (points && isMetaActive && isShiftActive) {
     button = (
       <ContinueToPrevious showNag={showNag} onClick={onContinueToPrevious} disabled={!prev} />
     );
-  } else if (analysisPoints && isMetaActive) {
+  } else if (points && isMetaActive) {
     button = <ContinueToNext showNag={showNag} onClick={onContinueToNext} disabled={!next} />;
   } else {
     button = <AddLogpoint breakpoint={breakpoint} showNag={showNag} onClick={onAddLogpoint} />;

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.js
@@ -30,22 +30,24 @@ function BreakpointNavigation({
       seek(point.point, point.time, true);
     }
   };
-  const isEmpty = analysisPoints && (analysisPoints.error || analysisPoints.data.length == 0);
+  const points = analysisPoints?.data || [];
+  const error = analysisPoints?.error;
+  const isEmpty = error || points.length === 0;
 
   let next, prev;
 
-  if (executionPoint && !analysisPoints?.error && analysisPoints?.data.length > 0) {
-    prev = findLast(analysisPoints.data, p => compareNumericStrings(p.point, executionPoint) < 0);
-    next = find(analysisPoints.data, p => compareNumericStrings(p.point, executionPoint) > 0);
+  if (executionPoint && !error && points.length > 0) {
+    prev = findLast(points, p => compareNumericStrings(p.point, executionPoint) < 0);
+    next = find(points, p => compareNumericStrings(p.point, executionPoint) > 0);
   }
 
   useEffect(() => {
     if (analysisPoints) {
-      trackEvent(analysisPoints.data.length > 0 ? "breakpoint.has_hits" : "breakpoint.no_hits", {
-        hits: analysisPoints.data.length,
+      trackEvent(points.length > 0 ? "breakpoint.has_hits" : "breakpoint.no_hits", {
+        hits: points.length,
       });
     }
-  }, [analysisPoints]);
+  }, [analysisPoints, points.length]);
 
   if (editing) {
     return (

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/PanelStatus.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/PanelStatus.tsx
@@ -27,22 +27,21 @@ export function PanelStatus({
   const time = useSelector(getCurrentTime);
   let status = "";
 
+  const points = analysisPoints?.data;
+  const error = analysisPoints?.error;
+
   if (!isIndexed || !analysisPoints) {
     status = "Loading";
-  } else if (analysisPoints.error) {
-    status =
-      (analysisPoints.error as AnalysisError) === AnalysisError.TooManyPointsToFind ||
-      analysisPoints.error === AnalysisError.Unknown
-        ? "10k+ hits"
-        : "Error";
-  } else if (analysisPoints.data?.length == 0) {
+  } else if (error) {
+    status = (error as AnalysisError) === AnalysisError.TooManyPointsToFind ? "10k+ hits" : "Error";
+  } else if (points?.length == 0) {
     status = "No hits";
   } else {
     const previousTimeIndex = sortedLastIndex(
-      analysisPoints.data?.map(p => p.time),
+      points?.map(p => p.time),
       time
     );
-    status = numberStatus(previousTimeIndex, analysisPoints.data?.length || 0);
+    status = numberStatus(previousTimeIndex, points?.length || 0);
   }
 
   return (
@@ -54,7 +53,7 @@ export function PanelStatus({
       >
         <div
           className="text-center"
-          style={{ width: `${maxStatusLength(analysisPoints?.data?.length || 0)}ch` }}
+          style={{ width: `${maxStatusLength(points?.length || 0)}ch` }}
         ></div>
         {status}
       </div>


### PR DESCRIPTION
I made a change last night that allows `analysisPoints.data` to be
undefined rather than being an empty array. I still think this makes
sense, because there is a difference between "we got those points and
there were none" vs. "we hit an error and never retrieved those points".
But there were a couple of places where we needed to check for presence
now that I missed.