### PR TITLE
Use real ellipse characters

### DIFF
--- a/packages/bvaughn-architecture-demo/components/Loader.tsx
+++ b/packages/bvaughn-architecture-demo/components/Loader.tsx
@@ -1,5 +1,5 @@
 import styles from "./Loader.module.css";
 
 export default function Loader() {
-  return <div className={styles.Loader}>Loading...</div>;
+  return <div className={styles.Loader}>Loading…</div>;
 }

--- a/public/test/scripts/region_loading-01.js
+++ b/public/test/scripts/region_loading-01.js
@@ -27,7 +27,7 @@ Test.describe(
       logValue: `"Part2Logpoint Number " + number`,
     });
 
-    // Wait until we see "Loading..." messages.
+    // Wait until we see "Loading…" messages.
     await Test.waitUntil(() => Test.findMessages("Loading").length > 0);
 
     // Then wait until they all go away.

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/index.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/index.js
@@ -141,7 +141,7 @@ class Frames extends Component {
     if (framesLoading || pauseLoading) {
       return (
         <div className="pane frames">
-          <div className="pane-info empty">Loading...</div>
+          <div className="pane-info empty">Loading…</div>
         </div>
       );
     }

--- a/src/devtools/client/inspector/markup/components/Node.tsx
+++ b/src/devtools/client/inspector/markup/components/Node.tsx
@@ -90,7 +90,7 @@ class _Node extends PureComponent<NodeProps & PropsFromRedux> {
     const children = node.children || [];
 
     if (node.isLoadingChildren) {
-      return <span>Loading...</span>;
+      return <span>Loading…</span>;
     }
 
     if (!children.length || node.isInlineTextChild) {

--- a/src/devtools/client/webconsole/actions/input.ts
+++ b/src/devtools/client/webconsole/actions/input.ts
@@ -106,7 +106,7 @@ export function evaluateExpression(expression: string): UIThunkAction {
       messagesActions.messagesAdd([
         {
           type: "evaluationResult",
-          result: createPrimitiveValueFront("Loading...", pause),
+          result: createPrimitiveValueFront("Loading…", pause),
           evalId,
         },
       ])

--- a/src/devtools/client/webconsole/actions/messages.ts
+++ b/src/devtools/client/webconsole/actions/messages.ts
@@ -151,7 +151,7 @@ function onLogpointLoading(
 ): UIThunkAction {
   return async (dispatch, getState, { ThreadFront }) => {
     const packet = {
-      errorMessage: "Loading...",
+      errorMessage: "Loading…",
       sourceName: await ThreadFront.getSourceURL(sourceId),
       sourceId: sourceId,
       lineNumber: line,

--- a/src/ui/components/Library/PendingTeamPrompt.tsx
+++ b/src/ui/components/Library/PendingTeamPrompt.tsx
@@ -60,7 +60,7 @@ function PendingTeamPrompt({ workspace, setWorkspaceId }: PendingTeamPromptProps
         </div>
         <div className="flex flex-row space-x-2 text-base">
           {loading ? (
-            "Loading..."
+            "Loading…"
           ) : (
             <>
               <PrimaryButton color="blue" onClick={handleAccept}>

--- a/src/ui/components/Video.tsx
+++ b/src/ui/components/Video.tsx
@@ -109,7 +109,7 @@ function Video({
           )}
         </CommentsOverlay>
       ) : null}
-      {isNodePickerInitializing ? <Tooltip label="Loading..." targetID="video" /> : null}
+      {isNodePickerInitializing ? <Tooltip label="Loading…" targetID="video" /> : null}
       <div id="highlighter-root"></div>
       {viewMode === "dev" ? <HideVideoButton /> : null}
     </div>


### PR DESCRIPTION
This is a silly nitpick, but I noticed that in some places we use the ellipse character (…) and in some places we use three periods (...). It's nice to standardize on one of these tokens for consistency throughout the UI, because in some type faces they look pretty different.