### PR TITLE
Show filter console message count above/below messages

### DIFF
--- a/src/devtools/client/webconsole/components/Output/ConsoleOutput.module.css
+++ b/src/devtools/client/webconsole/components/Output/ConsoleOutput.module.css
@@ -1,0 +1,13 @@
+.TrimmedMessageCountRow {
+  display: block;
+  padding: 0.25rem 0 0.25rem 1.5rem;
+  min-height: 1.5rem;
+  font-family: var(--monospace-font-family);
+  font-size: var(--theme-code-font-size);
+  border-left: 0.25rem solid var(--primary-accent);
+}
+
+.TrimmedMessageLink {
+  cursor: pointer;
+  text-decoration-line: underline;
+}

--- a/src/devtools/client/webconsole/components/Output/ConsoleOutput.tsx
+++ b/src/devtools/client/webconsole/components/Output/ConsoleOutput.tsx
@@ -24,7 +24,6 @@ import type { AppDispatch } from "ui/setup/store";
 import type { UIState } from "ui/state";
 import { isVisible } from "ui/utils/dom";
 import { convertPointToTime } from "ui/utils/time";
-import { getLastFetchedForFocusRegion } from "../../selectors";
 
 import ConsoleLoadingBar from "./ConsoleLoadingBar";
 import styles from "./ConsoleOutput.module.css";
@@ -376,9 +375,7 @@ function TrimmedMessageCountRow({ position }: { position: "before" | "after" }) 
   const dispatch = useDispatch();
   const focusRegion = useSelector(getFocusRegion);
   const showFocusModeControls = useSelector(getShowFocusModeControls);
-  const { countAfter, countBefore, countInUnloadedRegions, messageIDs } = useSelector(
-    selectors.getVisibleMessageData
-  );
+  const { countAfter, countBefore, messageIDs } = useSelector(selectors.getVisibleMessageData);
 
   // If the user has no focus region, there's nothing for this component to show.
   if (focusRegion === null) {
@@ -393,15 +390,14 @@ function TrimmedMessageCountRow({ position }: { position: "before" | "after" }) 
   // (like the architecture proof of concept does with the MessagesCache).
   // I'd prefer to wait and address this as part of the architectural overhaul though.
   // See https://github.com/replayio/devtools/discussions/6932
-  const canShowFilteredMessageCounts =
-    countAfter >= 0 && countBefore >= 0 && countInUnloadedRegions >= 0;
+  const canShowFilteredMessageCounts = countAfter >= 0 && countBefore >= 0;
 
   // If there are no visible messages after filtering, show a single row for both before and after counts.
   let count = position === "before" ? countBefore : countAfter;
   let label: string = position;
   if (messageIDs.length === 0) {
     if (position === "before") {
-      count = countBefore + countAfter + countInUnloadedRegions;
+      count = countBefore + countAfter;
       label = "outside of";
     } else {
       return null;

--- a/src/devtools/client/webconsole/selectors/messages.ts
+++ b/src/devtools/client/webconsole/selectors/messages.ts
@@ -5,7 +5,7 @@
 import { createSelector } from "reselect";
 
 import type { UIState } from "ui/state";
-import { isTimeInRegions } from "ui/utils/timeline";
+import { endTimeForFocusRegion, isTimeInRegions, startTimeForFocusRegion } from "ui/utils/timeline";
 import type { Message } from "../reducers/messages";
 import { messagesAdapter } from "../reducers/messages";
 
@@ -32,39 +32,81 @@ export const { selectTotal: getTotalMessagesCount } = messagesAdapter.getSelecto
   (state: UIState) => state.messages.messages
 );
 
-export const getVisibleMessages = createSelector(
+export const getVisibleMessageData = createSelector(
   getAllMessagesById,
   (state: UIState) => state.messages.visibleMessages,
   getFocusRegion,
+  getLastFetchedForFocusRegion,
+  getConsoleOverflow,
   (state: UIState) => state.app.loadedRegions,
-  (messages, visibleMessages, focusRegion, loadedRegions) => {
-    const msgs = visibleMessages.filter(messageId => {
-      const message = messages.entities[messageId]!;
-      const executionPointTime = message.executionPointTime!;
+  (
+    messages,
+    visibleMessages,
+    focusRegion,
+    lastFetchedFocusRange,
+    lastFetchDidOverflow,
+    loadedRegions
+  ) => {
+    const filteredMessageIDs: string[] = [];
+
+    // We can only reliably show counts for the number of messages filtered (before/after) if:
+    // 1) We're doing in-memory filtering for the entire recording (aka no focus mode) and
+    // 2) Our request to fetch all messages didn't overflow (so we're filtering the entire set of them).
+    //
+    // Otherwise the best thing we can show is a "maybe".
+    const canShowCount = lastFetchedFocusRange === null && !lastFetchDidOverflow;
+
+    let countAfter = 0;
+    let countBefore = 0;
+    let countInUnloadedRegions = 0;
+
+    const focusRegionStartTime = focusRegion ? startTimeForFocusRegion(focusRegion) : null;
+    const focusRegionEndTime = focusRegion ? endTimeForFocusRegion(focusRegion) : null;
+
+    visibleMessages.forEach(messageID => {
+      const message = messages.entities[messageID]!;
+      const messageTime = message.executionPointTime!;
 
       // Filter out messages that aren't within the focused region.
       if (focusRegion) {
-        if (!isInFocusSpan(executionPointTime, focusRegion)) {
-          return false;
+        if (messageTime < (focusRegionStartTime as number)) {
+          countBefore++;
+          return;
+        } else if (messageTime > (focusRegionEndTime as number)) {
+          countAfter++;
+          return;
         }
       }
 
       // Filter out messages that haven't yet been loaded.
-      if (!isTimeInRegions(executionPointTime, loadedRegions!.loaded)) {
-        return false;
+      if (!isTimeInRegions(messageTime, loadedRegions!.loaded)) {
+        // This is an edge case.
+        // We have fetched console messages for the entire recording,
+        // but after the user focused, the backend unloaded some regions.
+        // We can easily track the number of messages BUT they aren't being filtered out before or after the focus window,
+        // so it's not clear where this number should be shown, with one exception:
+        // when all console logs are filtered out, we can show a single total (before, after, and unloaded regions).
+        countInUnloadedRegions++;
+        return;
       }
 
-      return true;
+      filteredMessageIDs.push(messageID);
     });
 
-    return msgs;
+    return {
+      countAfter: canShowCount ? countAfter : -1,
+      countBefore: canShowCount ? countBefore : -1,
+      countInUnloadedRegions: canShowCount ? countInUnloadedRegions : -1,
+      messageIDs: filteredMessageIDs,
+    };
   }
 );
 
 export const getMessages = createSelector(
   getAllMessagesById,
-  getVisibleMessages,
-  (messagesById, visibleMessages) => visibleMessages.map(id => messagesById.entities[id]!)
+  getVisibleMessageData,
+  (messagesById, visibleMessages) =>
+    visibleMessages.messageIDs.map(id => messagesById.entities[id]!)
 );
 
 export const getMessagesForTimeline = createSelector(getMessages, messages =>
@@ -77,21 +119,22 @@ function messageExecutionPoint(msg: Message) {
 }
 
 export const getClosestMessage = createSelector(
-  getVisibleMessages,
+  getVisibleMessageData,
   getAllMessagesById,
   getExecutionPoint,
   getCurrentTime,
   (visibleMessages, messages, executionPoint, currentTime) => {
-    if ((!executionPoint && !currentTime) || !visibleMessages || !visibleMessages.length) {
+    const messageIDs = visibleMessages?.messageIDs;
+    if ((!executionPoint && !currentTime) || !messageIDs || !messageIDs.length) {
       return null;
     }
 
     // If the pause location is before the first message, the first message is
     // marked as the paused one. This allows later messages to be grayed out but
     // isn't consistent with behavior for those other messages.
-    let last = messages.entities[visibleMessages[0]]!;
+    let last = messages.entities[messageIDs[0]]!;
 
-    for (const id of visibleMessages) {
+    for (const id of messageIDs) {
       const msg = messages.entities[id]!;
 
       // Skip evaluations, which will always occur at the same evaluation point as

--- a/src/ui/components/shared/Nags/Nags.tsx
+++ b/src/ui/components/shared/Nags/Nags.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import { getVisibleMessages } from "devtools/client/webconsole/selectors";
+import { getVisibleMessageData } from "devtools/client/webconsole/selectors";
 import React from "react";
 import { useSelector } from "react-redux";
 import hooks from "ui/hooks";
@@ -61,11 +61,11 @@ export function EditorNag() {
 }
 
 export function ConsoleNag() {
-  const visibleMessages = useSelector(getVisibleMessages);
+  const { messageIDs } = useSelector(getVisibleMessageData);
 
   // Don't show the console nag that directs the user to click on one of the console messages
   // if there aren't any console messages to begin with.
-  if (!visibleMessages.length) {
+  if (!messageIDs.length) {
     return null;
   }
 


### PR DESCRIPTION
Relates to #6913 and https://github.com/replayio/design/issues/65

When possible, show a count above and below console messages that indicates how many have been filtered due to focus region.

Loom videos:
* [Simple case (in-memory filtering)](https://www.loom.com/share/b836eea183de4c3db8f023896ba8193c)
* [When there are too many messages to load them all in memory](https://www.loom.com/share/1f149d668937457487be6c325cac5330)