### PR TITLE
Rerun when window changes, in a range

### DIFF
--- a/packages/protocol/analysisManager.ts
+++ b/packages/protocol/analysisManager.ts
@@ -9,6 +9,7 @@ import {
   analysisResult,
   ExecutionPoint,
   PointDescription,
+  PointRange,
   SessionId,
 } from "@replayio/protocol";
 import { sendMessage, addEventListener } from "protocol/socket";
@@ -54,6 +55,8 @@ export interface AnalysisParams {
 
   // Apply the analysis to this specific set of points.
   points?: ExecutionPoint[];
+
+  range?: PointRange;
 
   // Body of the reducer function.
   // The reducer function takes two arguments:

--- a/packages/protocol/thread/analysis.ts
+++ b/packages/protocol/thread/analysis.ts
@@ -31,13 +31,17 @@ export const createAnalysis = async (
 ): Promise<Analysis> => {
   // Call to the client and say hey please make an analysis and after that
   // create an Analysis with that result
+  const protocolParams: Omit<AnalysisParams, "sessionId"> = {
+    mapper: params.mapper,
+    reducer: params.reducer,
+    effectful: params.effectful,
+  };
+  if (params.range) {
+    protocolParams.range = params.range;
+  }
   const { analysisId } = await sendMessage(
     "Analysis.createAnalysis",
-    {
-      mapper: params.mapper,
-      reducer: params.reducer,
-      effectful: params.effectful,
-    },
+    protocolParams,
     params.sessionId
   );
   const points: PointDescription[] = [];

--- a/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
@@ -14,6 +14,7 @@ import { Nag } from "ui/hooks/users";
 import { selectors } from "ui/reducers";
 import { setAnalysisPoints, setHoveredLineNumberLocation } from "ui/reducers/app";
 import { AnalysisPayload } from "ui/state/app";
+import { UnsafeFocusRegion } from "ui/state/timeline";
 import { prefs, features } from "ui/utils/prefs";
 import { trackEvent } from "ui/utils/telemetry";
 import { shouldShowNag } from "ui/utils/user";
@@ -115,12 +116,19 @@ function runAnalysisOnLine(line: number): UIThunkAction {
       return;
     }
 
+    const focusRegion = selectors.getFocusRegion(getState());
     const sessionId = await ThreadFront.waitForSession();
     const params: AnalysisParams = {
       sessionId,
       mapper: "",
       effectful: true,
     };
+    if (focusRegion) {
+      params.range = {
+        begin: (focusRegion as UnsafeFocusRegion).start.point,
+        end: (focusRegion as UnsafeFocusRegion).end.point,
+      };
+    }
 
     let analysis: Analysis | undefined = undefined;
 

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -1,4 +1,6 @@
-import { ExecutionPoint, PauseId } from "@replayio/protocol";
+import { ExecutionPoint, Location, PauseId } from "@replayio/protocol";
+import { setBreakpointOptions } from "devtools/client/debugger/src/actions/breakpoints/modify";
+import { getThreadContext } from "devtools/client/debugger/src/selectors";
 import { refetchMessages } from "devtools/client/webconsole/actions/messages";
 import sortedIndexBy from "lodash/sortedIndexBy";
 import sortedLastIndexBy from "lodash/sortedLastIndexBy";
@@ -656,6 +658,12 @@ export function syncFocusedRegion(): UIThunkAction {
       ThreadFront.sessionId!
     );
 
+    const breakpoints = state.breakpoints.breakpoints;
+    const cx = getThreadContext(state);
+    for (const b of Object.values(breakpoints)) {
+      // Prod all breakpoints to refetch
+      dispatch(setBreakpointOptions(cx, b.location as any, b.options));
+    }
     await dispatch(refetchMessages(focusRegion));
   };
 }

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -34,6 +34,7 @@ import {
   startTimeForFocusRegion,
 } from "ui/utils/timeline";
 import { AnalysisError } from "protocol/thread/analysis";
+import { uniqBy } from "lodash";
 
 export const initialAppState: AppState = {
   mode: "devtools",
@@ -166,7 +167,7 @@ const appSlice = createSlice({
       const id = getLocationAndConditionKey(location, condition);
 
       state.analysisPoints[id] = {
-        data: analysisPoints,
+        data: uniqBy([...(state.analysisPoints[id]?.data || []), ...analysisPoints], p => p.point),
         error: undefined,
       };
     },


### PR DESCRIPTION
This is the smallest slice out of the ongoing analysis changes that I could take that would give us:

- Running analyses with the `range` option set when there is a focus window

But in order for that to work, you also need to rerun analyses when the focus window changes. This also adds a naive version of that, which will get a lot better once https://github.com/replayio/devtools/pull/7051/ is in.

We also no longer smash points that are recorded in `app.analysisPoints`, and instead always add on to them (and then they get filtered by the breakpoint timeline).