### PR TITLE
Use the backend limits for displaying and running analyses

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.tsx
@@ -75,8 +75,7 @@ function Panel({
   const pausedOnHit = !!points?.some(
     ({ point, time }) => point == executionPoint && time == currentTime
   );
-  const isHot =
-    error === AnalysisError.TooManyPointsToFind || (points?.length || 0) > prefs.maxHitsDisplayed;
+  const isHot = error === AnalysisError.TooManyPointsToFind || (points?.length || 0) > 200;
 
   useEffect(() => {
     const updateWidth = () => setWidth(getPanelWidth(editor));

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/SummaryExpression.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/SummaryExpression.tsx
@@ -50,7 +50,7 @@ export function SummaryExpression({ isEditable, value }: SummaryExpressionProps 
         {isTeamDeveloper ? (
           <>
             This log cannot be edited because <br />
-            it was hit {prefs.maxHitsDisplayed}+ times
+            it was hit 200+ times
           </>
         ) : (
           "Editing logpoints is available for Developers in the Team plan"

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/index.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/index.tsx
@@ -111,7 +111,7 @@ function PanelSummary({
           }
         >
           This log cannot be edited because <br />
-          it was hit {prefs.maxHitsDisplayed}+ times
+          it was hit 200+ times
         </Popup>
         <div className="button-container flex items-center">
           <AddCommentButton onClick={addComment} isPausedOnHit={pausedOnHit} />

--- a/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
@@ -45,7 +45,7 @@ function getTextAndWarning(analysisPoints?: AnalysisPayload, analysisPointsCount
 
   const points = analysisPointsCount || 0;
   const text = `${points} hit${points == 1 ? "" : "s"}`;
-  const showWarning = points > prefs.maxHitsDisplayed;
+  const showWarning = points > 200;
   return { showWarning, text };
 }
 

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/EventListeners.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/EventListeners.js
@@ -297,7 +297,7 @@ class EventListeners extends Component {
       return null;
     }
 
-    const isHot = count > prefs.maxHitsEditable || count > maxAnalysisPoints;
+    const isHot = count > maxAnalysisPoints;
     const title = isHot ? `Cannot view ${event.name} events` : `View ${event.name} events`;
 
     return (

--- a/src/ui/actions/logpoint.ts
+++ b/src/ui/actions/logpoint.ts
@@ -58,7 +58,7 @@ export function setupLogpoints(_store: UIStore) {
 }
 
 function showLogpointsLoading(logGroupId: string, points: PointDescription[]) {
-  if (!LogpointHandlers.onPointLoading || points.length >= prefs.maxHitsDisplayed) {
+  if (!LogpointHandlers.onPointLoading || points.length >= 200) {
     return;
   }
 
@@ -73,7 +73,7 @@ function showLogpointsLoading(logGroupId: string, points: PointDescription[]) {
 }
 
 function showLogpointsResult(logGroupId: string, result: AnalysisEntry[]) {
-  if (!LogpointHandlers.onResult || result.length >= prefs.maxHitsDisplayed) {
+  if (!LogpointHandlers.onResult || result.length >= 200) {
     return;
   }
 
@@ -104,7 +104,7 @@ async function showPrimitiveLogpoints(
   pointDescriptions: PointDescription[],
   values: ValueFront[]
 ) {
-  if (!LogpointHandlers.onResult || pointDescriptions.length >= prefs.maxHitsDisplayed) {
+  if (!LogpointHandlers.onResult || pointDescriptions.length >= 200) {
     return;
   }
 

--- a/src/ui/components/Timeline/PreviewMarkers.tsx
+++ b/src/ui/components/Timeline/PreviewMarkers.tsx
@@ -17,7 +17,7 @@ export default function PreviewMarkers() {
   if (
     !pointsForHoveredLineNumber ||
     pointsForHoveredLineNumber.error ||
-    (pointsForHoveredLineNumber.data?.length || 0) > prefs.maxHitsDisplayed
+    (pointsForHoveredLineNumber.data?.length || 0) > 200
   ) {
     return null;
   }

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -8,8 +8,6 @@ pref("devtools.event-listeners-breakpoints", true);
 pref("devtools.toolbox-size", "50%");
 pref("devtools.view-mode", "non-dev");
 pref("devtools.dev-secondary-panel-height", "375px");
-pref("devtools.maxHitsDisplayed", 500);
-pref("devtools.maxHitsEditable", 200);
 pref("devtools.logTelemetryEvent", false);
 pref("devtools.showRedactions", false);
 pref("devtools.disableLogRocket", false);
@@ -42,8 +40,6 @@ export const prefs = new PrefsHelper("devtools", {
   toolboxSize: ["String", "toolbox-size"],
   viewMode: ["String", "view-mode"],
   secondaryPanelHeight: ["String", "dev-secondary-panel-height"],
-  maxHitsDisplayed: ["Int", "maxHitsDisplayed"],
-  maxHitsEditable: ["Int", "maxHitsEditable"],
   logTelemetryEvent: ["Bool", "logTelemetryEvent"],
   showRedactions: ["Bool", "showRedactions"],
   disableLogRocket: ["Bool", "disableLogRocket"],


### PR DESCRIPTION
We can't run analyses for more than 200 points, so we should never be displaying more than that many in the console, or letting the user try to edit the statement. We do still show them on the timeline, since we now significantly thin out clumps.