### PR TITLE
Add loading stalled pop-out with link to support channel

### DIFF
--- a/src/ui/components/Timeline/Capsule.module.css
+++ b/src/ui/components/Timeline/Capsule.module.css
@@ -4,6 +4,7 @@
   align-items: stretch;
   column-gap: 1px;
   height: 2rem;
+  position: relative;
 }
 
 .LeftSideLoading,
@@ -48,4 +49,22 @@
 .CircularProgressbar {
   width: 1.5rem;
   height: 1.5rem;
+}
+
+.SlowLoadingPopout {
+  position: absolute;
+  bottom: calc(100% + 0.25rem);
+  left: 0;
+  background: var(--modal-bgcolor);
+  border: 1px solid var(--modal-border);
+  color: var(--theme-text-color-strong);
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  font-size: var(--theme-body-font-size);
+  text-align: center;
+}
+
+.SlowLoadingLink {
+  text-decoration: underline;
+  color: var(--source-link-color);
 }

--- a/src/ui/components/Timeline/Capsule.tsx
+++ b/src/ui/components/Timeline/Capsule.tsx
@@ -13,15 +13,15 @@ import styles from "./Capsule.module.css";
 import { EditFocusButton } from "./EditFocusButton";
 import FocusInputs from "./FocusInputs";
 
-const SHOW_SLOW_LOADING_POPOUT_AFTER_DELAY = 1000;
+const SHOW_SLOW_LOADING_POP_OUT_AFTER_DELAY = 1000;
 
 export default function Capsule({
   setShowLoadingProgress,
 }: {
   setShowLoadingProgress: React.Dispatch<React.SetStateAction<boolean>>;
 }) {
-  let progress = Math.round(useSelector(getLoadedAndIndexedProgress) * 100);
-  let loadingStatusSlow = useSelector(getLoadingStatusSlow);
+  const progress = Math.round(useSelector(getLoadedAndIndexedProgress) * 100);
+  const loadingStatusSlow = useSelector(getLoadingStatusSlow);
   const showFocusModeControls = useSelector(getShowFocusModeControls);
 
   return (
@@ -70,7 +70,7 @@ function LoadingState({
 
 function SlowLoadingIcon() {
   const ref = useRef<HTMLDivElement>(null);
-  const [showSlowLoadingPopout, setShowSlowLoadingPopout] = useState<boolean>(false);
+  const [showSlowLoadingPopOut, setShowSlowLoadingPopOut] = useState<boolean>(false);
 
   useEffect(() => {
     const div = ref.current;
@@ -84,8 +84,8 @@ function SlowLoadingIcon() {
       timeoutID = setTimeout(() => {
         timeoutID = null;
 
-        setShowSlowLoadingPopout(true);
-      }, SHOW_SLOW_LOADING_POPOUT_AFTER_DELAY);
+        setShowSlowLoadingPopOut(true);
+      }, SHOW_SLOW_LOADING_POP_OUT_AFTER_DELAY);
     };
 
     const clearPendingTimeout = () => {
@@ -109,11 +109,11 @@ function SlowLoadingIcon() {
 
   return (
     <>
-      <div ref={ref} onClick={() => setShowSlowLoadingPopout(true)}>
+      <div ref={ref} onClick={() => setShowSlowLoadingPopOut(true)}>
         <Icon className={styles.SlowIcon} filename="turtle" size="extra-large" />
       </div>
-      {showSlowLoadingPopout && (
-        <SlowLoadingPopOut dismiss={() => setShowSlowLoadingPopout(false)} />
+      {showSlowLoadingPopOut && (
+        <SlowLoadingPopOut dismiss={() => setShowSlowLoadingPopOut(false)} />
       )}
     </>
   );
@@ -125,7 +125,7 @@ function SlowLoadingPopOut({ dismiss }: { dismiss: () => void }) {
   useModalDismissSignal(ref, dismiss);
 
   return (
-    <div ref={ref} className={styles.SlowLoadingPopout}>
+    <div ref={ref} className={styles.SlowLoadingPopOut}>
       Please{" "}
       <ExternalLink
         className={styles.SlowLoadingLink}

--- a/src/ui/components/Timeline/Capsule.tsx
+++ b/src/ui/components/Timeline/Capsule.tsx
@@ -1,8 +1,10 @@
 import classNames from "classnames";
-import React from "react";
+import React, { MutableRefObject, useEffect, useRef, useState } from "react";
 import { CircularProgressbar, buildStyles } from "react-circular-progressbar";
 import { useSelector } from "react-redux";
 import { getLoadedAndIndexedProgress, getLoadingStatusSlow } from "ui/actions/app";
+import ExternalLink from "ui/components/shared/ExternalLink";
+import useModalDismissSignal from "ui/hooks/useModalDismissSignal";
 import { getShowFocusModeControls } from "ui/reducers/timeline";
 
 import Icon from "../shared/Icon";
@@ -11,13 +13,15 @@ import styles from "./Capsule.module.css";
 import { EditFocusButton } from "./EditFocusButton";
 import FocusInputs from "./FocusInputs";
 
+const SHOW_SLOW_LOADING_POPOUT_AFTER_DELAY = 1000;
+
 export default function Capsule({
   setShowLoadingProgress,
 }: {
   setShowLoadingProgress: React.Dispatch<React.SetStateAction<boolean>>;
 }) {
-  const progress = Math.round(useSelector(getLoadedAndIndexedProgress) * 100);
-  const loadingStatusSlow = useSelector(getLoadingStatusSlow);
+  let progress = Math.round(useSelector(getLoadedAndIndexedProgress) * 100);
+  let loadingStatusSlow = useSelector(getLoadingStatusSlow);
   const showFocusModeControls = useSelector(getShowFocusModeControls);
 
   return (
@@ -55,13 +59,82 @@ function LoadingState({
   const onMouseLeave = () => setShowLoadingProgress(false);
 
   return (
-    <div className={styles.LoadingState} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
-      {loadingStatusSlow ? (
+    <>
+      <div className={styles.LoadingState} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+        {loadingStatusSlow ? <SlowLoadingIcon /> : <RadialProgress progress={progress} />}
+        <div className={styles.LoadingText}>{Math.round(progress)}%</div>
+      </div>
+    </>
+  );
+}
+
+function SlowLoadingIcon() {
+  const ref = useRef<HTMLDivElement>(null);
+  const [showSlowLoadingPopout, setShowSlowLoadingPopout] = useState<boolean>(false);
+
+  useEffect(() => {
+    const div = ref.current;
+    if (!div) {
+      return;
+    }
+
+    let timeoutID: NodeJS.Timeout | null = null;
+
+    const showAfterTimeout = () => {
+      timeoutID = setTimeout(() => {
+        timeoutID = null;
+
+        setShowSlowLoadingPopout(true);
+      }, SHOW_SLOW_LOADING_POPOUT_AFTER_DELAY);
+    };
+
+    const clearPendingTimeout = () => {
+      if (timeoutID !== null) {
+        clearTimeout(timeoutID);
+      }
+    };
+
+    div.addEventListener("click", clearPendingTimeout);
+    div.addEventListener("mouseenter", showAfterTimeout);
+    div.addEventListener("mouseleave", clearPendingTimeout);
+
+    return () => {
+      clearPendingTimeout();
+
+      div.removeEventListener("click", clearPendingTimeout);
+      div.removeEventListener("mouseenter", showAfterTimeout);
+      div.removeEventListener("mouseleave", clearPendingTimeout);
+    };
+  }, []);
+
+  return (
+    <>
+      <div ref={ref} onClick={() => setShowSlowLoadingPopout(true)}>
         <Icon className={styles.SlowIcon} filename="turtle" size="extra-large" />
-      ) : (
-        <RadialProgress progress={progress} />
+      </div>
+      {showSlowLoadingPopout && (
+        <SlowLoadingPopOut dismiss={() => setShowSlowLoadingPopout(false)} />
       )}
-      <div className={styles.LoadingText}>{Math.round(progress)}%</div>
+    </>
+  );
+}
+
+function SlowLoadingPopOut({ dismiss }: { dismiss: () => void }) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useModalDismissSignal(ref, dismiss);
+
+  return (
+    <div ref={ref} className={styles.SlowLoadingPopout}>
+      Please{" "}
+      <ExternalLink
+        className={styles.SlowLoadingLink}
+        href="https://discord.gg/n2dTK6kcRX"
+        onClick={dismiss}
+      >
+        let us know
+      </ExternalLink>{" "}
+      if there is a problem.
     </div>
   );
 }

--- a/src/ui/hooks/useModalDismissSignal.ts
+++ b/src/ui/hooks/useModalDismissSignal.ts
@@ -1,14 +1,15 @@
-import { MutableRefObject, useEffect } from "react";
+import { MutableRefObject, RefObject, useEffect } from "react";
 
 // Closes a modal dialog if the user clicks outside of it or types "Escape"
 export default function useModalDismissSignal(
-  modalRef: MutableRefObject<HTMLDivElement>,
+  modalRef: MutableRefObject<HTMLDivElement> | RefObject<HTMLDivElement>,
   dismissCallback: () => void,
   dismissOnClickOutside: boolean = true
 ) {
   useEffect(() => {
-    if (modalRef.current === null) {
-      return () => {};
+    const element = modalRef.current;
+    if (element === null) {
+      return;
     }
 
     const handleDocumentKeyDown = (event: KeyboardEvent) => {
@@ -18,7 +19,7 @@ export default function useModalDismissSignal(
     };
 
     const handleDocumentClick = (event: MouseEvent) => {
-      if (modalRef.current !== null && !modalRef.current.contains(event.target as Node)) {
+      if (!element.contains(event.target as Node)) {
         event.stopPropagation();
         event.preventDefault();
 
@@ -36,7 +37,7 @@ export default function useModalDismissSignal(
 
       // It's important to listen to the ownerDocument to support browser extensions.
       // The root document might belong to a different window.
-      ownerDocument = modalRef.current.ownerDocument;
+      ownerDocument = element.ownerDocument;
       ownerDocument.addEventListener("keydown", handleDocumentKeyDown);
       if (dismissOnClickOutside) {
         ownerDocument.addEventListener("click", handleDocumentClick, true);


### PR DESCRIPTION
Relates to #6913 and https://github.com/replayio/design/issues/64

Loom: https://www.loom.com/share/e92ccf7b7629404e9d2ac10f0436a9ff

<img width="296" alt="Modal popout screenshot" src="https://user-images.githubusercontent.com/29597/171870626-fbad4904-c68a-457e-896b-24388c7fe176.png">

cc @jonbell-lot23 for wording