### PR TITLE
Use separate DB's and don't query so much

### DIFF
--- a/src/devtools/shared/async-storage.ts
+++ b/src/devtools/shared/async-storage.ts
@@ -44,16 +44,16 @@
  *
  */
 
-const DBNAME = "devtools-async-storage";
 const DBVERSION = 1;
 const STORENAME = "keyvaluepairs";
 
 const withStore = (
+  dbName: string,
   type: IDBTransactionMode,
   onsuccess: (store: IDBObjectStore, db: IDBDatabase) => void,
   onerror: () => void
 ) => {
-  const dbConn = indexedDB.open(DBNAME, DBVERSION);
+  const dbConn = indexedDB.open(dbName, DBVERSION);
 
   dbConn.onerror = () => {
     onerror();
@@ -72,9 +72,10 @@ const withStore = (
   };
 };
 
-export const getItem = (itemKey: string): Promise<any> => {
+export const getItem = (dbName: string, itemKey: string): Promise<any> => {
   return new Promise((resolve, reject) => {
     withStore(
+      dbName,
       "readonly",
       (store, db) => {
         store.transaction.oncomplete = () => {
@@ -96,9 +97,10 @@ export const getItem = (itemKey: string): Promise<any> => {
   });
 };
 
-export const setItem = (itemKey: string, value: any): Promise<void> => {
+export const setItem = (dbName: string, itemKey: string, value: any): Promise<void> => {
   return new Promise((resolve, reject) => {
     withStore(
+      dbName,
       "readwrite",
       (store, db) => {
         store.transaction.oncomplete = () => {
@@ -116,9 +118,10 @@ export const setItem = (itemKey: string, value: any): Promise<void> => {
   });
 };
 
-export const clear = (): Promise<void> => {
+export const clear = (dbName: string): Promise<void> => {
   return new Promise((resolve, reject) => {
     withStore(
+      dbName,
       "readwrite",
       (store, db) => {
         store.transaction.oncomplete = () => {
@@ -136,9 +139,10 @@ export const clear = (): Promise<void> => {
   });
 };
 
-export const removeItem = (itemKey: string): Promise<void> => {
+export const removeItem = (dbName: string, itemKey: string): Promise<void> => {
   return new Promise((resolve, reject) => {
     withStore(
+      dbName,
       "readwrite",
       (store, db) => {
         store.transaction.oncomplete = () => {
@@ -156,9 +160,10 @@ export const removeItem = (itemKey: string): Promise<void> => {
   });
 };
 
-export const length = (): Promise<number> => {
+export const length = (dbName: string): Promise<number> => {
   return new Promise((resolve, reject) => {
     withStore(
+      dbName,
       "readonly",
       (store, db) => {
         const req = store.count();
@@ -176,7 +181,7 @@ export const length = (): Promise<number> => {
   });
 };
 
-export const key = (n: number): Promise<any> => {
+export const key = (dbName: string, n: number): Promise<any> => {
   return new Promise((resolve, reject) => {
     if (n < 0) {
       resolve(null);
@@ -184,6 +189,7 @@ export const key = (n: number): Promise<any> => {
     }
 
     withStore(
+      dbName,
       "readonly",
       (store, db) => {
         const req = store.openCursor();

--- a/src/devtools/shared/async-store-helper.js
+++ b/src/devtools/shared/async-store-helper.js
@@ -29,11 +29,11 @@ export function asyncStoreHelper(root, mappings) {
   Object.keys(mappings).map(key =>
     Object.defineProperty(store, key, {
       async get() {
-        const value = await asyncStorage.getItem(`${root}.${getMappingKey(key)}`);
+        const value = await asyncStorage.getItem(root, getMappingKey(key));
         return value || getMappingDefaultValue(key);
       },
       set(value) {
-        return asyncStorage.setItem(`${root}.${getMappingKey(key)}`, value);
+        return asyncStorage.setItem(root, getMappingKey(key), value);
       },
     })
   );

--- a/src/test-prep.ts
+++ b/src/test-prep.ts
@@ -12,6 +12,7 @@ requiresWindow(win => {
   // local storage in that case.
   if (test && !url.searchParams.get("navigated")) {
     localStorage.clear();
-    clearAsyncStorage();
+    clearAsyncStorage("debugger");
+    clearAsyncStorage("devtools");
   }
 });

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -72,6 +72,5 @@ export const features = new PrefsHelper("devtools.features", {
 
 export const asyncStore = asyncStoreHelper("devtools", {
   eventListenerBreakpoints: ["event-listener-breakpoints", undefined],
-  replaySessions: ["replay-sessions", {}],
   commandHistory: ["command-history", []],
 });


### PR DESCRIPTION
Maybe fixes https://github.com/replayio/customer-support/issues/108, see that issue for more discussion, but the gist is:

Chrome's indexedDB can be slow, and we `await` a bunch of reads from it when we start up the store. Our theory is that these compete with each other, and slow down all tabs from loading. I suspect it would be even *better* if we just wrote to indexedDB way, way less, because as @gideonred has pointed out - none of the features that we use it to provide are necessities.