### PR TITLE
fix: "Large Text" setting results in offset location for line hover button

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/StaticTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/StaticTooltip.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import { useFeature } from "ui/hooks/settings";
+import classNames from "classnames";
 
 type StaticTooltipProps = {
   targetNode: HTMLElement;
@@ -8,8 +10,15 @@ type StaticTooltipProps = {
 };
 
 export default function StaticTooltip({ targetNode, children }: StaticTooltipProps) {
+  const { value: enableLargeText } = useFeature("enableLargeText");
+
   return ReactDOM.createPortal(
-    <div className="absolute z-50 flex flex-row space-x-px transform -right-1 translate-x-full bottom-4 mb-0.5 pointer-events-none">
+    <div
+      className={classNames(
+        "absolute z-50 flex flex-row space-x-px transform -right-1 translate-x-full bottom-4 mb-0.5 pointer-events-none",
+        enableLargeText && "bottom-6"
+      )}
+    >
       {children}
     </div>,
     targetNode

--- a/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
@@ -21,6 +21,7 @@ import { getPointsForHoveredLineNumber } from "ui/reducers/app";
 import { compareNumericStrings } from "protocol/utils";
 import { getExecutionPoint } from "../../reducers/pause";
 import { seek } from "ui/actions/timeline";
+import { useFeature } from "ui/hooks/settings";
 
 const QuickActionButton: FC<{
   showNag: boolean;
@@ -98,6 +99,7 @@ function QuickActions({
   const { nags } = hooks.useGetUserInfo();
   const showNag = shouldShowNag(nags, Nag.FIRST_BREAKPOINT_ADD);
   const { height } = targetNode.getBoundingClientRect();
+  const { value: enableLargeText } = useFeature("enableLargeText");
 
   const onAddLogpoint = () => {
     dispatch(toggleLogpoint(cx, hoveredLineNumber, breakpoint));
@@ -138,7 +140,10 @@ function QuickActions({
 
   return (
     <div
-      className="line-action-button absolute -right-1 z-50 flex translate-x-full transform flex-row space-x-px"
+      className={classNames(
+        "line-action-button absolute -right-1 z-50 flex translate-x-full transform flex-row space-x-px",
+        enableLargeText && "bottom-0.5"
+      )}
       // This is necessary so that we don't move the CodeMirror cursor while clicking.
       onMouseDown={onMouseDown}
       style={{ top: `-${(1 / 2) * (18 - height)}px` }}


### PR DESCRIPTION
fix #7038 

Fixed hover button & toop tip position to fit current selected line, in Large Text mode.

#### ▶️ Large Text
https://user-images.githubusercontent.com/5501268/172023990-296184b2-4eb8-4603-bb9c-1cb1051d98ca.mov

#### ▶️ Default Text

https://user-images.githubusercontent.com/5501268/172024027-636fe408-03a7-4196-9bd4-5285c3a395fe.mov


