### PR TITLE
Fix stepping-05 and object_preview-05 e2e tests

### DIFF
--- a/public/test/scripts/object_preview-05.js
+++ b/public/test/scripts/object_preview-05.js
@@ -12,7 +12,7 @@ Test.describe(`Test scope mapping and switching between generated/original sourc
   await Test.waitForMessage("300");
 
   await Test.toggleMappedSources();
-  await Test.waitForPausedLine(12);
+  await Test.waitForPausedLine(6);
   await Test.waitForScopeValue("e", "Array(3) […]");
   await Test.waitForScopeValue("o", "{…}");
 });

--- a/public/test/scripts/stepping-05.js
+++ b/public/test/scripts/stepping-05.js
@@ -12,13 +12,13 @@ Test.describe(`Test stepping in pretty-printed code.`, async () => {
   await Test.selectConsole();
   await Test.addEventListenerLogpoints(["event.mouse.click"]);
 
-  await Test.warpToMessage("click", 14);
+  await Test.warpToMessage("click");
   await Test.selectDebugger();
 
+  await Test.stepInToLine(1);
+  await Test.stepOutToLine(10);
+  await Test.stepInToLine(6);
+  await Test.stepOutToLine(10);
   await Test.stepInToLine(2);
-  await Test.stepOutToLine(15);
-  await Test.stepInToLine(10);
-  await Test.stepOutToLine(15);
-  await Test.stepInToLine(5);
-  await Test.stepOutToLine(15);
+  await Test.stepOutToLine(10);
 });


### PR DESCRIPTION
We enabled a new pretty-printer in the backend,
so some line numbers in the tests needed to be adjusted.
(and I removed an unused parameter in a `Test.warpToMessage()` call)