### PR TITLE
Update the locations of received analysis points (#6919)

### DIFF
--- a/packages/protocol/thread/analysis.ts
+++ b/packages/protocol/thread/analysis.ts
@@ -1,4 +1,5 @@
 import { AnalysisEntry, Location, PointDescription } from "@replayio/protocol";
+import { ThreadFront } from "protocol/thread";
 import { AnalysisParams } from "../analysisManager";
 import { gAnalysisCallbacks, sendMessage } from "../socket";
 
@@ -60,6 +61,8 @@ export const createAnalysis = async (
     async findPoints() {
       try {
         await sendMessage("Analysis.findAnalysisPoints", { analysisId }, params.sessionId);
+        await ThreadFront.ensureAllSources();
+        points.forEach(point => ThreadFront.updateMappedLocation(point.frame));
         return {
           points,
           error: undefined,


### PR DESCRIPTION
The new analysis code didn't update the locations of received points, which led to failed assertions, which led to the breakpoints-07 e2e test failing.
(We may have multiple identical sources in the recording but want to show them as one source to the user, so we pick one of the identical sources and update all incoming locations to reference that source)