### PR TITLE
Fix the network monitor stack trace

### DIFF
--- a/packages/protocol/thread/thread.ts
+++ b/packages/protocol/thread/thread.ts
@@ -37,6 +37,7 @@ import {
   requestBodyData,
   findAnnotationsResult,
   getHitCountsParameters,
+  Frame,
 } from "@replayio/protocol";
 import groupBy from "lodash/groupBy";
 import uniqueId from "lodash/uniqueId";
@@ -336,7 +337,7 @@ class _ThreadFront {
     return this.recordingTargetWaiter.promise;
   }
 
-  timeWarp(point: ExecutionPoint, time: number, hasFrames?: boolean, force?: boolean) {
+  timeWarp(point: ExecutionPoint, time: number, hasFrames?: boolean, frame?: Frame) {
     log(`TimeWarp ${point}`);
 
     this.currentPoint = point;
@@ -344,7 +345,7 @@ class _ThreadFront {
     this.currentPointHasFrames = !!hasFrames;
     this.currentPause = null;
     this.asyncPauses.length = 0;
-    this.emit("paused", { point, hasFrames, time });
+    this.emit("paused", { point, hasFrames, time, frame });
   }
 
   timeWarpToPause(pause: Pause) {

--- a/src/devtools/client/debugger/src/actions/pause/selectFrame.js
+++ b/src/devtools/client/debugger/src/actions/pause/selectFrame.js
@@ -7,7 +7,6 @@
 import { selectLocation } from "../sources";
 import { fetchScopes } from "./fetchScopes";
 import { setFramePositions } from "./setFramePositions";
-import assert from "../../utils/assert";
 
 /**
  * @memberof actions/pause
@@ -15,8 +14,6 @@ import assert from "../../utils/assert";
  */
 export function selectFrame(cx, frame) {
   return async (dispatch, getState, { client }) => {
-    assert(cx.thread == frame.thread, "Thread mismatch");
-
     // Frames that aren't on-stack do not support evalling and may not
     // have live inspectable scopes, so we do not allow selecting them.
     if (frame.state !== "on-stack") {
@@ -26,7 +23,6 @@ export function selectFrame(cx, frame) {
     dispatch({
       type: "SELECT_FRAME",
       cx,
-      thread: cx.thread,
       frame,
     });
 

--- a/src/devtools/client/debugger/src/client/events.js
+++ b/src/devtools/client/debugger/src/client/events.js
@@ -17,9 +17,9 @@ function setupEvents(dependencies) {
   });
 }
 
-async function paused(_, { point, time }) {
+async function paused(_, { point, time, frame }) {
   log("ThreadFront.paused");
-  actions.paused({ thread: ThreadFront.actor, executionPoint: point, time });
+  actions.paused({ thread: ThreadFront.actor, executionPoint: point, time, frame });
 }
 
 function resumed() {

--- a/src/devtools/client/debugger/src/reducers/sources.ts
+++ b/src/devtools/client/debugger/src/reducers/sources.ts
@@ -1,10 +1,9 @@
 import type { AnyAction, Action } from "@reduxjs/toolkit";
 import uniq from "lodash/uniq";
 import { createSelector } from "reselect";
-import { UIThunkAction } from "ui/actions";
 import type { UIState } from "ui/state";
 
-import { pending, fulfilled, rejected, asSettled, isFulfilled } from "../utils/async-value";
+import { pending, fulfilled, rejected, asSettled } from "../utils/async-value";
 import { findPosition } from "../utils/breakpoint/breakpointPositions";
 import { prefs } from "../utils/prefs";
 import {

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -111,7 +111,7 @@ export function jumpToInitialPausePoint(): UIThunkAction {
       time = initialPausePoint.time;
     }
 
-    ThreadFront.timeWarp(point, time, hasFrames, /* force */ false);
+    ThreadFront.timeWarp(point, time, hasFrames);
     ThreadFront.initializedWaiter.resolve();
   };
 }
@@ -217,7 +217,7 @@ export function seek(
       const regions = getLoadedRegions(getState());
       const isTimeInLoadedRegion = regions !== null && isTimeInRegions(time, regions.loaded);
       if (isTimeInLoadedRegion) {
-        ThreadFront.timeWarp(point, time, hasFrames, false);
+        ThreadFront.timeWarp(point, time, hasFrames);
       } else {
         // We can't time-wrap in this case because trying to pause outside of a loaded region will throw.
         // In this case the best we can do is update the current time and the "video" frame.

--- a/src/ui/components/NetworkMonitor/RequestDetails.tsx
+++ b/src/ui/components/NetworkMonitor/RequestDetails.tsx
@@ -5,8 +5,7 @@ import sortBy from "lodash/sortBy";
 import { WiredFrame } from "protocol/thread/pause";
 import React, { FC, ReactNode, useEffect, useMemo, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { actions } from "ui/actions";
-import { hideRequestDetails } from "ui/actions/network";
+import { hideRequestDetails, seekToRequestFrame } from "ui/actions/network";
 import { useFeature } from "ui/hooks/settings";
 import { getLoadedRegions } from "ui/reducers/app";
 import { getFormattedFrames } from "ui/reducers/network";
@@ -144,15 +143,24 @@ const Cookies = ({ request }: { request: RequestSummary }) => {
   );
 };
 
-const StackTrace = ({ cx, frames }: { cx: any; frames: WiredFrame[] }) => {
+const StackTrace = ({
+  cx,
+  frames,
+  request,
+}: {
+  cx: any;
+  frames: WiredFrame[];
+  request: RequestSummary;
+}) => {
   const dispatch = useDispatch();
-  const selectFrame = (cx: any, frame: WiredFrame) => dispatch(actions.selectFrame(cx, frame));
-
+  const selectFrame = async (cx: any, frame: any) => {
+    dispatch(seekToRequestFrame(request, frame, cx));
+  };
   return (
     <div>
       <h1 className="py-2 px-4 font-bold">Stack Trace</h1>
       <div className="px-2">
-        <Frames cx={cx} framesLoading={true} frames={frames} selectFrame={selectFrame} />
+        <Frames cx={cx} frames={frames} selectFrame={selectFrame} />
       </div>
     </div>
   );
@@ -327,7 +335,7 @@ const RequestDetails = ({ cx, request }: { cx: any; request: RequestSummary }) =
           {activeTab === "cookies" && <Cookies request={request} />}
           {activeTab === "response" && <ResponseBody request={request} />}
           {activeTab === "request" && <RequestBody request={request} />}
-          {activeTab === "stackTrace" && <StackTrace cx={cx} frames={frames} />}
+          {activeTab === "stackTrace" && <StackTrace cx={cx} frames={frames} request={request} />}
           {activeTab === "timings" && <Timing request={request} />}
         </div>
       </div>

--- a/src/ui/reducers/network.ts
+++ b/src/ui/reducers/network.ts
@@ -144,6 +144,8 @@ export const getSummaryById = (state: UIState, id: string) => {
   );
   return summaries.find(s => s.id === id);
 };
+export const getRequestById = (state: UIState, id: string) =>
+  state.network.requests.find(request => request.id === id);
 
 export const getSelectedResponseBody = (state: UIState) => {
   const requestId = getSelectedRequestId(state);


### PR DESCRIPTION
Two things were off here:

1. We were passing in `framesLoading={true}` which resulted in that component always displaying `Loading...`. This made sense before https://github.com/replayio/devtools/commit/9175df71c382bdb228b601cbd7b1a875e3d11803. But now we don't need to pass that anymore. 
2. When selecting a frame from this frame stack, there is no guarantee that we are already paused there (because you can open a request's details without warping to it), so we need to both seek to this request, and then select the frame.

Fixes https://github.com/replayio/devtools/issues/7094