### PR TITLE
Changed filtered message count wording

### DIFF
--- a/src/devtools/client/webconsole/components/Output/ConsoleOutput.tsx
+++ b/src/devtools/client/webconsole/components/Output/ConsoleOutput.tsx
@@ -377,22 +377,14 @@ function TrimmedMessageCountRow({ position }: { position: "before" | "after" }) 
   const focusRegion = useSelector(getFocusRegion);
   const zoomRegion = useSelector(getZoomRegion);
   const showFocusModeControls = useSelector(getShowFocusModeControls);
-  const { countAfter, countBefore, messageIDs } = useSelector(selectors.getVisibleMessageData);
+  const { countAfter, countBefore, isFilteredCountExact, messageIDs } = useSelector(
+    selectors.getVisibleMessageData
+  );
 
   // If the user has no focus region, there's nothing for this component to show.
   if (focusRegion === null) {
     return null;
   }
-
-  // We can only calculate the number of messages before and after a focus region
-  // if we fetched all messages for the recording and did the filtering locally.
-  // Otherwise the best we can do is show a generic, "maybe" message.
-  //
-  // This is a bit of a HACK and should probably be modeled by the messages/focus state itself,
-  // (like the architecture proof of concept does with the MessagesCache).
-  // I'd prefer to wait and address this as part of the architectural overhaul though.
-  // See https://github.com/replayio/devtools/discussions/6932
-  const canShowFilteredMessageCounts = countAfter >= 0 && countBefore >= 0;
 
   // If there are no visible messages after filtering, show a single row for both before and after counts.
   let count = position === "before" ? countBefore : countAfter;
@@ -419,31 +411,38 @@ function TrimmedMessageCountRow({ position }: { position: "before" | "after" }) 
     }
   }
 
-  // If we're confident there are no filtered messages, there's nothing for this component to show.
-  if (canShowFilteredMessageCounts && count === 0) {
-    return null;
-  }
-
   const showFocusEditor = () => {
     if (!showFocusModeControls) {
       dispatch(enterFocusMode());
     }
   };
 
-  if (canShowFilteredMessageCounts) {
-    return (
-      <div className={styles.TrimmedMessageCountRow}>
-        There are {count} logs {label}{" "}
-        <span className={styles.TrimmedMessageLink} onClick={showFocusEditor}>
-          your debugging window
-        </span>
-        .
-      </div>
-    );
+  if (count === 0) {
+    if (isFilteredCountExact) {
+      // If we're confident there are no filtered messages, there's nothing for this component to show.
+      return null;
+    } else {
+      return (
+        <div className={styles.TrimmedMessageCountRow}>
+          There may be some logs {label}{" "}
+          <span className={styles.TrimmedMessageLink} onClick={showFocusEditor}>
+            your debugging window
+          </span>
+          .
+        </div>
+      );
+    }
   } else {
+    let description;
+    if (count === 1) {
+      description = `There is ${isFilteredCountExact ? "" : "at least"} ${count} log ${label}`;
+    } else {
+      description = `There are ${isFilteredCountExact ? "" : "at least"} ${count} logs ${label}`;
+    }
+
     return (
       <div className={styles.TrimmedMessageCountRow}>
-        There may be some logs {label}{" "}
+        {description}{" "}
         <span className={styles.TrimmedMessageLink} onClick={showFocusEditor}>
           your debugging window
         </span>

--- a/src/devtools/client/webconsole/selectors/messages.ts
+++ b/src/devtools/client/webconsole/selectors/messages.ts
@@ -37,15 +37,7 @@ export const getVisibleMessageData = createSelector(
   getFocusRegion,
   getLastFetchedForFocusRegion,
   getConsoleOverflow,
-  (state: UIState) => state.app.loadedRegions,
-  (
-    messages,
-    visibleMessages,
-    focusRegion,
-    lastFetchedFocusRange,
-    lastFetchDidOverflow,
-    loadedRegions
-  ) => {
+  (messages, visibleMessages, focusRegion, lastFetchedFocusRange, lastFetchDidOverflow) => {
     const filteredMessageIDs: string[] = [];
 
     // We can only reliably show counts for the number of messages filtered (before/after) if:
@@ -53,7 +45,7 @@ export const getVisibleMessageData = createSelector(
     // 2) Our request to fetch all messages didn't overflow (so we're filtering the entire set of them).
     //
     // Otherwise the best thing we can show is a "maybe".
-    const canShowCount = lastFetchedFocusRange === null && !lastFetchDidOverflow;
+    const isFilteredCountExact = lastFetchedFocusRange === null && !lastFetchDidOverflow;
 
     let countAfter = 0;
     let countBefore = 0;
@@ -80,8 +72,9 @@ export const getVisibleMessageData = createSelector(
     });
 
     return {
-      countAfter: canShowCount ? countAfter : -1,
-      countBefore: canShowCount ? countBefore : -1,
+      countAfter,
+      countBefore,
+      isFilteredCountExact,
       messageIDs: filteredMessageIDs,
     };
   }


### PR DESCRIPTION
Resolves #7090

Improve edge case messaging for when we know _some_ messages were filtered (but not if there were more filtered messages on the server). We still fall back to saying "some may" if we didn't filter any locally, otherwise we say "at least X".

![Video of new filtered message count behavior](https://user-images.githubusercontent.com/29597/172703810-1d4ec83a-47f4-4724-a453-1e74d4bfa98b.gif)

cc @jonbell-lot23