### PR TITLE
Only re-run breakpoint analyses if the latest analysis result doesn't have enough data

### DIFF
--- a/packages/protocol/analysisManager.ts
+++ b/packages/protocol/analysisManager.ts
@@ -16,7 +16,6 @@ import { ThreadFront } from "protocol/thread";
 import { client } from "./socket";
 import { MAX_POINTS_FOR_FULL_ANALYSIS } from "./thread/analysis";
 
-
 import { assert } from "./utils";
 
 // For more information about these params, see:

--- a/packages/protocol/analysisManager.ts
+++ b/packages/protocol/analysisManager.ts
@@ -14,6 +14,8 @@ import {
 import { addEventListener } from "protocol/socket";
 import { ThreadFront } from "protocol/thread";
 import { client } from "./socket";
+import { MAX_POINTS_FOR_FULL_ANALYSIS } from "./thread/analysis";
+
 
 import { assert } from "./utils";
 
@@ -83,7 +85,7 @@ export interface AnalysisHandler<T> {
 }
 
 // When running analyses in batches, limit on the points to use in each batch.
-const MaxPointsPerBatch = 200;
+const MaxPointsPerBatch = MAX_POINTS_FOR_FULL_ANALYSIS;
 
 class AnalysisManager {
   private handlers = new Map<AnalysisId, AnalysisHandler<any>>();

--- a/packages/protocol/thread/analysis.ts
+++ b/packages/protocol/thread/analysis.ts
@@ -3,6 +3,8 @@ import { ThreadFront } from "protocol/thread";
 import { AnalysisParams } from "../analysisManager";
 import { client, gAnalysisCallbacks } from "../socket";
 
+export const MAX_POINTS_FOR_FULL_ANALYSIS = 200;
+
 export interface Analysis {
   analysisId: string;
   addLocation: (location: Location) => Promise<void>;

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.tsx
@@ -23,7 +23,7 @@ import FirstEditNag from "./FirstEditNag";
 import hooks from "ui/hooks";
 import { Nag } from "ui/hooks/users";
 import { prefs } from "ui/utils/prefs";
-import { AnalysisError } from "protocol/thread/analysis";
+import { AnalysisError, MAX_POINTS_FOR_FULL_ANALYSIS } from "protocol/thread/analysis";
 
 function getPanelWidth({ editor }: { editor: $FixTypeLater }) {
   // The indent value is an adjustment for the distance from the gutter's left edge
@@ -79,7 +79,9 @@ function Panel({
   const pausedOnHit = !!points?.some(
     ({ point, time }) => point == executionPoint && time == currentTime
   );
-  const isHot = error === AnalysisError.TooManyPointsToFind || (points?.length || 0) > 200;
+  const isHot =
+    error === AnalysisError.TooManyPointsToFind ||
+    (points?.length || 0) > MAX_POINTS_FOR_FULL_ANALYSIS;
 
   useEffect(() => {
     const updateWidth = () => setWidth(getPanelWidth(editor));

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/SummaryExpression.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/SummaryExpression.tsx
@@ -5,7 +5,7 @@ import escapeHtml from "escape-html";
 import Popup from "./Popup";
 import hooks from "ui/hooks";
 const { getCodeMirror } = require("devtools/client/debugger/src/utils/editor/create-editor");
-const { prefs } = require("ui/utils/prefs");
+import { MAX_POINTS_FOR_FULL_ANALYSIS } from "protocol/thread/analysis";
 
 export interface SummaryExpressionProps {
   value: string;
@@ -50,7 +50,7 @@ export function SummaryExpression({ isEditable, value }: SummaryExpressionProps 
         {isTeamDeveloper ? (
           <>
             This log cannot be edited because <br />
-            it was hit 200+ times
+            it was hit {MAX_POINTS_FOR_FULL_ANALYSIS}+ times
           </>
         ) : (
           "Editing logpoints is available for Developers in the Team plan"

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/index.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/index.tsx
@@ -19,7 +19,7 @@ import Condition from "./Condition";
 import Log from "./Log";
 import Popup from "./Popup";
 import PrefixBadgeButton from "ui/components/PrefixBadge";
-import { prefs } from "ui/utils/prefs";
+import { MAX_POINTS_FOR_FULL_ANALYSIS } from "protocol/thread/analysis";
 
 export type Input = "condition" | "logValue";
 
@@ -112,7 +112,7 @@ function PanelSummary({
           }
         >
           This log cannot be edited because <br />
-          it was hit 200+ times
+          it was hit {MAX_POINTS_FOR_FULL_ANALYSIS}+ times
         </Popup>
         <div className="button-container flex items-center">
           <AddCommentButton onClick={addComment} isPausedOnHit={pausedOnHit} />

--- a/src/devtools/client/debugger/src/reducers/breakpoints.ts
+++ b/src/devtools/client/debugger/src/reducers/breakpoints.ts
@@ -25,6 +25,7 @@ import { getLocationKey, isMatchingLocation, isLogpoint } from "../utils/breakpo
 
 import { getSelectedSource } from "./sources";
 import type { Breakpoint, SourceLocation } from "./types";
+import { FocusRegion } from "ui/state/timeline";
 export type { Breakpoint } from "./types";
 
 type LocationWithoutColumn = Omit<Location, "column">;
@@ -53,6 +54,7 @@ export type AnalysisRequest = {
   id: string;
   location: Location;
   condition?: string;
+  focusRegion: FocusRegion | null;
   points: PointDescription[] | undefined;
   results: AnalysisEntry[] | undefined;
   status: AnalysisStatus;
@@ -170,15 +172,21 @@ const breakpointsSlice = createSlice({
 
     analysisCreated(
       state,
-      action: PayloadAction<{ analysisId: string; location: Location; condition?: string }>
+      action: PayloadAction<{
+        analysisId: string;
+        location: Location;
+        condition?: string;
+        focusRegion: FocusRegion | null;
+      }>
     ) {
-      const { analysisId, location, condition } = action.payload;
+      const { analysisId, location, condition, focusRegion } = action.payload;
 
       analysesAdapter.addOne(state.analyses, {
         error: undefined,
         id: analysisId,
         location,
         condition,
+        focusRegion,
         points: undefined,
         results: undefined,
         status: AnalysisStatus.Created,

--- a/src/devtools/client/debugger/src/reducers/breakpoints.ts
+++ b/src/devtools/client/debugger/src/reducers/breakpoints.ts
@@ -9,7 +9,12 @@ import {
   PayloadAction,
   EntityState,
 } from "@reduxjs/toolkit";
-import { Location, PointDescription, AnalysisEntry } from "@replayio/protocol";
+import {
+  Location,
+  PointDescription,
+  AnalysisEntry,
+  TimeStampedPointRange,
+} from "@replayio/protocol";
 import uniqBy from "lodash/uniqBy";
 import type { Context } from "devtools/client/debugger/src/reducers/pause";
 import string from "devtools/packages/devtools-reps/reps/string";
@@ -54,7 +59,7 @@ export type AnalysisRequest = {
   id: string;
   location: Location;
   condition?: string;
-  focusRegion: FocusRegion | null;
+  timeRange: TimeStampedPointRange | null;
   points: PointDescription[] | undefined;
   results: AnalysisEntry[] | undefined;
   status: AnalysisStatus;
@@ -176,17 +181,17 @@ const breakpointsSlice = createSlice({
         analysisId: string;
         location: Location;
         condition?: string;
-        focusRegion: FocusRegion | null;
+        timeRange: TimeStampedPointRange | null;
       }>
     ) {
-      const { analysisId, location, condition, focusRegion } = action.payload;
+      const { analysisId, location, condition, timeRange } = action.payload;
 
       analysesAdapter.addOne(state.analyses, {
         error: undefined,
         id: analysisId,
         location,
         condition,
-        focusRegion,
+        timeRange,
         points: undefined,
         results: undefined,
         status: AnalysisStatus.Created,

--- a/src/devtools/client/debugger/src/reducers/breakpoints.ts
+++ b/src/devtools/client/debugger/src/reducers/breakpoints.ts
@@ -428,6 +428,14 @@ const customAnalysisResultComparator = (
   return result;
 };
 
+export const getAnalysisMappingForLocation = (state: UIState, location: Location | null) => {
+  if (!location) {
+    return undefined;
+  }
+  const locationKey = getLocationKey(location);
+  return state.breakpoints.analysisMappings.entities[locationKey];
+};
+
 /**
  * Retrieves a unique sorted set of hit points for a given location based on analysis runs.
  * If there is no breakpoint active for the location or no analysis run, returns `undefined`.
@@ -436,13 +444,7 @@ const customAnalysisResultComparator = (
  */
 export const getAnalysisPointsForLocation = createSelector(
   [
-    (state: UIState, location: Location | null) => {
-      if (!location) {
-        return undefined;
-      }
-      const locationKey = getLocationKey(location);
-      return state.breakpoints.analysisMappings.entities[locationKey];
-    },
+    getAnalysisMappingForLocation,
     (state: UIState) => state.breakpoints.analyses,
     (state: UIState) => state.timeline.focusRegion,
     (state: UIState, location: Location | null, condition: string | null = "") => condition,

--- a/src/devtools/client/debugger/src/reducers/breakpoints.ts
+++ b/src/devtools/client/debugger/src/reducers/breakpoints.ts
@@ -18,10 +18,10 @@ import {
 import uniqBy from "lodash/uniqBy";
 import type { Context } from "devtools/client/debugger/src/reducers/pause";
 import string from "devtools/packages/devtools-reps/reps/string";
-import { AnalysisError } from "protocol/thread/analysis";
+import { AnalysisError, MAX_POINTS_FOR_FULL_ANALYSIS } from "protocol/thread/analysis";
 import { compareNumericStrings } from "protocol/utils";
 import type { UIState } from "ui/state";
-import { filterToFocusRegion } from "ui/utils/timeline";
+import { filterToFocusRegion, isFocusRegionSubset } from "ui/utils/timeline";
 
 import { getBreakpointsList } from "../selectors/breakpoints";
 import assert from "../utils/assert";
@@ -30,7 +30,7 @@ import { getLocationKey, isMatchingLocation, isLogpoint } from "../utils/breakpo
 
 import { getSelectedSource } from "./sources";
 import type { Breakpoint, SourceLocation } from "./types";
-import { FocusRegion } from "ui/state/timeline";
+import { FocusRegion, UnsafeFocusRegion } from "ui/state/timeline";
 export type { Breakpoint } from "./types";
 
 type LocationWithoutColumn = Omit<Location, "column">;
@@ -77,6 +77,7 @@ export type LocationAnalysisSummary = {
   error: AnalysisError | undefined;
   status: AnalysisStatus;
   condition?: string;
+  isCompleted: boolean;
 };
 
 export interface BreakpointsState {
@@ -441,6 +442,38 @@ export const getAnalysisMappingForLocation = (state: UIState, location: Location
   return state.breakpoints.analysisMappings.entities[locationKey];
 };
 
+export const getStatusFlagsForAnalysisEntry = (
+  analysisEntry: AnalysisRequest,
+  focusRegion: FocusRegion | null
+) => {
+  const { error, timeRange, status, points = [] } = analysisEntry;
+
+  const analysisErrored = [
+    AnalysisError.TooManyPointsToFind,
+    AnalysisError.TooManyPointsToRun,
+  ].includes(error!);
+
+  const analysisOverflowed =
+    status === AnalysisStatus.PointsRetrieved && points.length > MAX_POINTS_FOR_FULL_ANALYSIS;
+
+  const analysisLoaded = [AnalysisStatus.PointsRetrieved, AnalysisStatus.Completed].includes(
+    status
+  );
+
+  const isFocusSubset = isFocusRegionSubset(timeRange, focusRegion);
+
+  const hasAllDataForFocusRegion =
+    analysisLoaded && !analysisErrored && !analysisOverflowed && isFocusSubset;
+
+  return {
+    analysisLoaded,
+    analysisOverflowed,
+    analysisErrored,
+    isFocusSubset,
+    hasAllDataForFocusRegion,
+  };
+};
+
 /**
  * Retrieves a unique sorted set of hit points for a given location based on analysis runs.
  * If there is no breakpoint active for the location or no analysis run, returns `undefined`.
@@ -522,11 +555,20 @@ export const getAnalysisPointsForLocation = createSelector(
     // TODO `filterToFocusRegion` wants a pre-sorted array, but maybe a bit cheaper to filter first _then_ sort?
     finalPoints = focusRegion ? filterToFocusRegion(uniquePoints, focusRegion) : uniquePoints;
 
+    const {
+      analysisLoaded,
+      analysisErrored,
+      isFocusSubset,
+      analysisOverflowed,
+      hasAllDataForFocusRegion,
+    } = getStatusFlagsForAnalysisEntry(latestAnalysisEntry, focusRegion);
+
     return {
       data: finalPoints,
       error: latestAnalysisEntry.error,
       status: latestAnalysisEntry.status,
       condition: latestAnalysisEntry.condition,
+      isCompleted: hasAllDataForFocusRegion,
     };
   },
   {

--- a/src/ui/actions/logpoint.ts
+++ b/src/ui/actions/logpoint.ts
@@ -254,7 +254,7 @@ async function setMultiSourceLogpoint(
         showPrimitiveLogpoints(logGroupId, points.data || [], primitiveFronts);
       }
       // If we're only displaying only primitives, we can bail out if there's no condition or the condition request is done
-      if (!condition) {
+      if (!condition && points.isCompleted) {
         return;
       }
     }

--- a/src/ui/actions/logpoint.ts
+++ b/src/ui/actions/logpoint.ts
@@ -17,7 +17,12 @@ import analysisManager, { AnalysisHandler, AnalysisParams } from "protocol/analy
 import { logpointGetFrameworkEventListeners } from "./event-listeners";
 import { ThreadFront, ValueFront, Pause, createPrimitiveValueFront } from "protocol/thread";
 import { PrimitiveValue } from "protocol/thread/value";
-import { createAnalysis, Analysis, AnalysisError } from "protocol/thread/analysis";
+import {
+  createAnalysis,
+  Analysis,
+  AnalysisError,
+  MAX_POINTS_FOR_FULL_ANALYSIS,
+} from "protocol/thread/analysis";
 import { assert, compareNumericStrings } from "protocol/utils";
 import {
   analysisCreated,
@@ -59,7 +64,7 @@ export function setupLogpoints(_store: UIStore) {
 }
 
 function showLogpointsLoading(logGroupId: string, points: PointDescription[]) {
-  if (!LogpointHandlers.onPointLoading || points.length >= 200) {
+  if (!LogpointHandlers.onPointLoading || points.length >= MAX_POINTS_FOR_FULL_ANALYSIS) {
     return;
   }
 
@@ -74,7 +79,7 @@ function showLogpointsLoading(logGroupId: string, points: PointDescription[]) {
 }
 
 function showLogpointsResult(logGroupId: string, result: AnalysisEntry[]) {
-  if (!LogpointHandlers.onResult || result.length >= 200) {
+  if (!LogpointHandlers.onResult || result.length >= MAX_POINTS_FOR_FULL_ANALYSIS) {
     return;
   }
 
@@ -313,7 +318,7 @@ async function setMultiSourceLogpoint(
 
     const shouldGetResults = condition || !primitives;
 
-    if (shouldGetResults && points.length <= 200) {
+    if (shouldGetResults && points.length <= MAX_POINTS_FOR_FULL_ANALYSIS) {
       store.dispatch(analysisResultsRequested(analysisId));
 
       const { results, error: runError } = await analysis.runAnalysis();

--- a/src/ui/actions/logpoint.ts
+++ b/src/ui/actions/logpoint.ts
@@ -271,7 +271,7 @@ async function setMultiSourceLogpoint(
     analysis = await createAnalysis(params);
     const { analysisId } = analysis;
 
-    store.dispatch(analysisCreated({ analysisId, location: locations[0], condition }));
+    store.dispatch(analysisCreated({ analysisId, location: locations[0], condition, focusRegion }));
 
     await Promise.all(locations.map(location => analysis.addLocation(location)));
 

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -1,6 +1,11 @@
-import { ExecutionPoint, PauseId } from "@replayio/protocol";
+import { ExecutionPoint, PauseId, Location } from "@replayio/protocol";
 import { setBreakpointOptions } from "devtools/client/debugger/src/actions/breakpoints/modify";
-import { getThreadContext } from "devtools/client/debugger/src/selectors";
+import {
+  analysisResultsReceived,
+  AnalysisStatus,
+  Breakpoint,
+  getThreadContext,
+} from "devtools/client/debugger/src/selectors";
 import { refetchMessages } from "devtools/client/webconsole/actions/messages";
 import sortedIndexBy from "lodash/sortedIndexBy";
 import sortedLastIndexBy from "lodash/sortedLastIndexBy";
@@ -41,7 +46,13 @@ import { getPausePointParams, getTest, updateUrlWithParams } from "ui/utils/envi
 import KeyShortcuts, { isEditableElement } from "ui/utils/key-shortcuts";
 import { features } from "ui/utils/prefs";
 import { trackEvent } from "ui/utils/telemetry";
-import { endTimeForFocusRegion, isTimeInRegions, beginTimeForFocusRegion } from "ui/utils/timeline";
+import {
+  endTimeForFocusRegion,
+  isFocusRegionSubset,
+  isTimeInRegions,
+  beginTimeForFocusRegion,
+} from "ui/utils/timeline";
+import { getAnalysisMappingForLocation } from "devtools/client/debugger/src/selectors";
 
 import {
   setFocusRegion as newFocusRegion,
@@ -52,6 +63,8 @@ import {
 
 import { getLoadedRegions } from "./app";
 import type { UIStore, UIThunkAction } from "./index";
+import { UIState } from "ui/state";
+import { AnalysisError, MAX_POINTS_FOR_FULL_ANALYSIS } from "protocol/thread/analysis";
 
 const DEFAULT_FOCUS_WINDOW_PERCENTAGE = 0.2;
 const DEFAULT_FOCUS_WINDOW_MAX_LENGTH = 5000;
@@ -605,6 +618,59 @@ export function setFocusRegionBeginTime(beginTime: number, sync: boolean): UIThu
   };
 }
 
+const shouldRerunAnalysisForBreakpoint = (
+  state: UIState,
+  bp: Breakpoint,
+  focusRegion: FocusRegion
+): boolean => {
+  // Copy-pasted-tweaked comment from actions/messages.ts:
+  // Soft Focus: The frontend only needs to refetch data if:
+  // 1. The most recent time it requested data "overflowed" (too many hits to send them all), or
+  // 2. The new focus region is outside of the most recent region we ran breakpoint analysis for.
+  //
+  // There are two things to note about the second bullet point above:
+  // 1. When devtools is first opened, there is no focused region.
+  //    This is equivalent to focusing on the entire timeline, so we often won't need to refetch messages when focusing for the first time.
+  // 2. We shouldn't compare the new focus region to the most recent focus region,
+  //    but rather to the most recent focus region that we ran breakpoint analysis for (the entire timeline in many cases).
+  //    If we don't need to re-run analysis after zooming in, then we won't need to refetch after zooming back out either,
+  //    (unless our fetches have overflowed at some point).
+
+  // @ts-expect-error Location type mismatches
+  const mappingEntry = getAnalysisMappingForLocation(state, bp.location);
+  if (!mappingEntry) {
+    return true;
+  }
+
+  const { analyses } = state.breakpoints;
+
+  const latestAnalysisEntry = analyses.entities[mappingEntry.currentAnalysis!];
+
+  if (!latestAnalysisEntry) {
+    return true;
+  }
+
+  const { error, focusRegion: analysisFocusRegion, status, points = [] } = latestAnalysisEntry;
+
+  const analysisErrored = [
+    AnalysisError.TooManyPointsToFind,
+    AnalysisError.TooManyPointsToRun,
+  ].includes(error!);
+
+  const analysisOverflowed =
+    status === AnalysisStatus.PointsRetrieved && points.length > MAX_POINTS_FOR_FULL_ANALYSIS;
+
+  const analysisLoaded = [AnalysisStatus.PointsRetrieved, AnalysisStatus.Completed].includes(
+    status
+  );
+  const isFocusSubset = isFocusRegionSubset(analysisFocusRegion, focusRegion);
+
+  const hasAllDataForFocusRegion =
+    analysisLoaded && !analysisErrored && !analysisOverflowed && isFocusSubset;
+
+  return !hasAllDataForFocusRegion;
+};
+
 export function syncFocusedRegion(): UIThunkAction {
   return async (dispatch, getState, { ThreadFront }) => {
     const state = getState();
@@ -636,11 +702,19 @@ export function syncFocusedRegion(): UIThunkAction {
       ThreadFront.sessionId!
     );
 
-    const breakpoints = state.breakpoints.breakpoints;
+    const { breakpoints } = state.breakpoints;
     const cx = getThreadContext(state);
     for (const b of Object.values(breakpoints)) {
-      // Prod all breakpoints to refetch
-      dispatch(setBreakpointOptions(cx, b.location as any, b.options));
+      const rerunAnalysisForBreakpoint = shouldRerunAnalysisForBreakpoint(state, b, focusRegion);
+
+      if (rerunAnalysisForBreakpoint) {
+        // Prod this breakpoint to refetch, circuitously:
+        // - Setting the breakpoint options calls `client.setBreakpoint`
+        // - That calls `setLogpoint` in `actions/logpoint`
+        // - Which finally runs `setMultiSourceLogpoint` with analysis
+        // @ts-expect-error Location type mismatches
+        dispatch(setBreakpointOptions(cx, b.location, b.options));
+      }
     }
     await dispatch(refetchMessages(focusRegion));
   };

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -650,7 +650,7 @@ const shouldRerunAnalysisForBreakpoint = (
     return true;
   }
 
-  const { error, focusRegion: analysisFocusRegion, status, points = [] } = latestAnalysisEntry;
+  const { error, timeRange: analysisFocusRegion, status, points = [] } = latestAnalysisEntry;
 
   const analysisErrored = [
     AnalysisError.TooManyPointsToFind,


### PR DESCRIPTION
This PR:

- Starts tracking `focusRegion` in analysis entries, for later comparisons
- Extracts a `MAX_POINTS_FOR_FULL_ANALYSIS` constants so we stop hardcoding `200` all over the place
- Updates `syncFocusRegion` to check whether the latest analysis result for each breakpoint already has the data we need for the new focus region

This should tentatively fix #6851 .  

We may want to improve this to also check against earlier analysis entries as well, but this is at least a step in the right direction.