### PR TITLE
Show unloaded regions on the breakpoint timeline

### DIFF
--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointTimeline.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointTimeline.tsx
@@ -18,9 +18,11 @@ import TimeTooltip from "devtools/client/debugger/src/components/SecondaryPanes/
 import { UIState } from "ui/state";
 import { connect, ConnectedProps, useSelector } from "react-redux";
 import { HoveredItem } from "ui/state/timeline";
-import { UnloadedRegions } from "ui/components/Timeline/UnloadedRegions";
 import { getExecutionPoint } from "../../../selectors";
 import type { Breakpoint } from "../../../reducers/types";
+import UnfocusedRegion from "ui/components/Timeline/UnfocusedRegion";
+import NonLoadingRegions from "ui/components/Timeline/NonLoadingRegions";
+import { UnloadedRegions } from "ui/components/Timeline/UnloadedRegions";
 
 function Points({
   analysisPoints,

--- a/src/ui/components/Timeline/UnloadedRegions.tsx
+++ b/src/ui/components/Timeline/UnloadedRegions.tsx
@@ -6,6 +6,8 @@ import { getFocusRegion, getZoomRegion } from "ui/reducers/timeline";
 import {
   endTimeForFocusRegion,
   getVisiblePosition,
+  overlap,
+  rangeForFocusRegion,
   startTimeForFocusRegion,
 } from "ui/utils/timeline";
 
@@ -29,8 +31,9 @@ export const UnloadedRegions: FC = () => {
   let beginTime = begin.time;
   let endTime = end.time;
   if (focusRegion) {
-    beginTime = startTimeForFocusRegion(focusRegion);
-    endTime = endTimeForFocusRegion(focusRegion);
+    const focusedAndLoaded = overlap([rangeForFocusRegion(focusRegion)], loadedRegions.loading)[0];
+    beginTime = focusedAndLoaded.begin.time;
+    endTime = focusedAndLoaded.end.time;
   }
   const { endTime: recordingEndTime } = zoomRegion;
   const loadedRegionStart = getVisiblePosition({ time: beginTime, zoom: zoomRegion }) * 100;

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -1,6 +1,5 @@
-import { Location, PointDescription } from "@replayio/protocol";
+import { Location } from "@replayio/protocol";
 import { createSelector, createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { getLocationAndConditionKey } from "devtools/client/debugger/src/utils/breakpoint";
 import { RecordingTarget } from "protocol/thread/thread";
 import { getSystemColorSchemePreference } from "ui/utils/environment";
 import { getCurrentTime, getFocusRegion, getZoomRegion } from "ui/reducers/timeline";
@@ -27,14 +26,11 @@ import { compareBigInt } from "ui/utils/helpers";
 import { prefs } from "ui/utils/prefs";
 import {
   endTimeForFocusRegion,
-  filterToFocusRegion,
   isPointInRegions,
   isTimeInRegions,
   overlap,
   startTimeForFocusRegion,
 } from "ui/utils/timeline";
-import { AnalysisError } from "protocol/thread/analysis";
-import { uniqBy } from "lodash";
 
 export const initialAppState: AppState = {
   mode: "devtools",

--- a/src/ui/utils/timeline.ts
+++ b/src/ui/utils/timeline.ts
@@ -236,6 +236,11 @@ export function isTimeInRegions(time: number, regions?: TimeStampedPointRange[])
   return !!regions?.some(region => time >= region.begin.time && time <= region.end.time);
 }
 
+export function rangeForFocusRegion(focusRegion: FocusRegion): TimeStampedPointRange {
+  const unsafe = focusRegion as UnsafeFocusRegion;
+  return { begin: unsafe.start, end: unsafe.end };
+}
+
 export const overlap = (a: TimeStampedPointRange[], b: TimeStampedPointRange[]) => {
   const overlapping: TimeStampedPointRange[] = [];
   a.forEach(aRegion => {


### PR DESCRIPTION
Prior to this change, we would only show *unfocused* regions on the
breakpoint timeline, but unloaded regions would appear as if they were
both loaded and focused. Now, we look at the intersection of the loaded
and focused windows.

We still show hits in the unloaded region, which is unfortunate, but I
think the real solution there is not to do filtering, but rather to
adjust the currently focused window when a region gets unloaded.

Before:

<img width="1640" alt="CleanShot 2022-06-09 at 11 25 02@2x" src="https://user-images.githubusercontent.com/5903784/172814328-8b1068b2-13d0-43df-a9c5-d1db698d8e86.png">

After:

<img width="1636" alt="CleanShot 2022-06-09 at 11 56 25@2x" src="https://user-images.githubusercontent.com/5903784/172820506-2c0cabfe-8cb6-46c6-a053-6f76599bd4cc.png">

