### PR TITLE
Make Soft Focus the Default

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,6 +1,6 @@
 version: 0.1
 cli:
-  version: 0.12.1-beta
+  version: 0.13.0-beta
 lint:
   enabled:
     - actionlint@1.6.8

--- a/src/devtools/client/debugger/src/actions/source-actors.ts
+++ b/src/devtools/client/debugger/src/actions/source-actors.ts
@@ -5,7 +5,7 @@
 import type { UIThunkAction } from "ui/actions";
 import { getFocusRegion } from "ui/reducers/timeline";
 import { PROMISE } from "ui/setup/redux/middleware/promise";
-import { endTimeForFocusRegion, beginTimeForFocusRegion } from "ui/utils/timeline";
+import { displayedEndForFocusRegion, displayedBeginForFocusRegion } from "ui/utils/timeline";
 
 import {
   getSourceActor,
@@ -93,10 +93,10 @@ export const loadSourceActorBreakpointHitCounts = memoizeableAction(
         id,
         Math.floor(lineNumber / MAX_LINE_HITS_TO_FETCH) * MAX_LINE_HITS_TO_FETCH,
         state.timeline.focusRegion
-          ? beginTimeForFocusRegion(state.timeline.focusRegion)
+          ? displayedBeginForFocusRegion(state.timeline.focusRegion)
           : "no_focus_start",
         state.timeline.focusRegion
-          ? endTimeForFocusRegion(state.timeline.focusRegion)
+          ? displayedEndForFocusRegion(state.timeline.focusRegion)
           : "no_focus_end",
       ].join("-");
       return key;

--- a/src/devtools/client/webconsole/components/Output/ConsoleOutput.tsx
+++ b/src/devtools/client/webconsole/components/Output/ConsoleOutput.tsx
@@ -29,7 +29,7 @@ import type { AppDispatch } from "ui/setup/store";
 import type { UIState } from "ui/state";
 import { isVisible } from "ui/utils/dom";
 import { convertPointToTime } from "ui/utils/time";
-import { endTimeForFocusRegion, beginTimeForFocusRegion } from "ui/utils/timeline";
+import { displayedEndForFocusRegion, displayedBeginForFocusRegion } from "ui/utils/timeline";
 
 import ConsoleLoadingBar from "./ConsoleLoadingBar";
 import styles from "./ConsoleOutput.module.css";
@@ -409,11 +409,11 @@ function TrimmedMessageCountRow({ position }: { position: "before" | "after" }) 
     // Don't show a nonsensical message about filtered logs before or after the focus window
     // if the focus window is at the very start or end of the recording.
     if (position === "before") {
-      if (beginTimeForFocusRegion(focusRegion) === 0) {
+      if (displayedBeginForFocusRegion(focusRegion) === 0) {
         return null;
       }
     } else {
-      if (endTimeForFocusRegion(focusRegion) === zoomRegion.endTime) {
+      if (displayedEndForFocusRegion(focusRegion) === zoomRegion.endTime) {
         return null;
       }
     }

--- a/src/devtools/client/webconsole/selectors/messages.ts
+++ b/src/devtools/client/webconsole/selectors/messages.ts
@@ -5,7 +5,7 @@
 import { createSelector } from "reselect";
 
 import type { UIState } from "ui/state";
-import { endTimeForFocusRegion, beginTimeForFocusRegion } from "ui/utils/timeline";
+import { displayedEndForFocusRegion, displayedBeginForFocusRegion } from "ui/utils/timeline";
 import type { Message } from "../reducers/messages";
 import { messagesAdapter } from "../reducers/messages";
 
@@ -50,8 +50,8 @@ export const getVisibleMessageData = createSelector(
     let countAfter = 0;
     let countBefore = 0;
 
-    const focusRegionBeginTime = focusRegion ? beginTimeForFocusRegion(focusRegion) : null;
-    const focusRegionEndTime = focusRegion ? endTimeForFocusRegion(focusRegion) : null;
+    const focusRegionBeginTime = focusRegion ? displayedBeginForFocusRegion(focusRegion) : null;
+    const focusRegionEndTime = focusRegion ? displayedEndForFocusRegion(focusRegion) : null;
 
     visibleMessages.forEach(messageID => {
       const message = messages.entities[messageID]!;

--- a/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
@@ -24,7 +24,7 @@ import CommentSource from "./CommentSource";
 import NetworkRequestPreview from "./NetworkRequestPreview";
 import { FocusContext } from "./FocusContext";
 import { CommentData } from "./types";
-import { isInFocusSpan, beginTimeForFocusRegion } from "ui/utils/timeline";
+import { isInFocusSpan, displayedBeginForFocusRegion } from "ui/utils/timeline";
 
 type PendingCommentProps = {
   comment: Comment;

--- a/src/ui/components/Timeline/FocusInputs.tsx
+++ b/src/ui/components/Timeline/FocusInputs.tsx
@@ -3,10 +3,10 @@ import { useDispatch, useSelector } from "react-redux";
 import { setFocusRegion } from "ui/actions/timeline";
 import { selectors } from "ui/reducers";
 import {
-  endTimeForFocusRegion,
+  displayedEndForFocusRegion,
   getFormattedTime,
   getSecondsFromFormattedTime,
-  beginTimeForFocusRegion,
+  displayedBeginForFocusRegion,
 } from "ui/utils/timeline";
 
 import EditableTimeInput from "./EditableTimeInput";
@@ -26,8 +26,8 @@ export default function FocusInputs() {
   const inputSize = formattedDuration.length;
 
   if (showFocusModeControls && focusRegion !== null) {
-    const formattedEndTime = getFormattedTime(endTimeForFocusRegion(focusRegion));
-    const formattedBeginTime = getFormattedTime(beginTimeForFocusRegion(focusRegion));
+    const formattedEndTime = getFormattedTime(displayedEndForFocusRegion(focusRegion));
+    const formattedBeginTime = getFormattedTime(displayedBeginForFocusRegion(focusRegion));
 
     const validateAndSaveBeginTime = (pending: string) => {
       try {
@@ -36,8 +36,8 @@ export default function FocusInputs() {
           // If the new end time is less than the current start time, the user is probably trying to move the whole range.
           // We can simplify this operation by resetting both the start and end time to the same value.
           const newEndTime =
-            newBeginTime <= endTimeForFocusRegion(focusRegion!)
-              ? endTimeForFocusRegion(focusRegion!)
+            newBeginTime <= displayedEndForFocusRegion(focusRegion!)
+              ? displayedEndForFocusRegion(focusRegion!)
               : newBeginTime;
 
           dispatch(
@@ -58,8 +58,8 @@ export default function FocusInputs() {
           // If the new start time is greater than the current end time, the user is probably trying to move the whole range.
           // We can simplify this operation by resetting both the start and end time to the same value.
           const newBeginTime =
-            newEndTime >= beginTimeForFocusRegion(focusRegion!)
-              ? beginTimeForFocusRegion(focusRegion!)
+            newEndTime >= displayedBeginForFocusRegion(focusRegion!)
+              ? displayedBeginForFocusRegion(focusRegion!)
               : newEndTime;
 
           dispatch(

--- a/src/ui/components/Timeline/Focuser.tsx
+++ b/src/ui/components/Timeline/Focuser.tsx
@@ -5,10 +5,10 @@ import { setFocusRegion, setTimelineToTime } from "ui/actions/timeline";
 import { selectors } from "ui/reducers";
 import { UnsafeFocusRegion } from "ui/state/timeline";
 import {
-  endTimeForFocusRegion,
   getPositionFromTime,
   getTimeFromPosition,
-  beginTimeForFocusRegion,
+  displayedEndForFocusRegion,
+  displayedBeginForFocusRegion,
 } from "ui/utils/timeline";
 
 import { EditMode } from ".";
@@ -92,7 +92,8 @@ function Focuser({ editMode, setEditMode }: Props) {
         // the points we end up going to. Otherwise, because the window always
         // grows when the point is not exact, we end up with an ever-expanding
         // window while dragging it around the timeline.
-        const { beginTime, endTime } = focusRegion as UnsafeFocusRegion;
+        const beginTime = displayedBeginForFocusRegion(focusRegion);
+        const endTime = displayedEndForFocusRegion(focusRegion);
 
         switch (editMode.type) {
           case "drag": {
@@ -208,8 +209,8 @@ function Focuser({ editMode, setEditMode }: Props) {
   const setEditModeToResizeEnd = () => setEditMode({ type: "resize-end" });
   const setEditModeToResizeStart = () => setEditMode({ type: "resize-start" });
 
-  const left = getPositionFromTime(beginTimeForFocusRegion(focusRegion), zoomRegion);
-  const right = getPositionFromTime(endTimeForFocusRegion(focusRegion), zoomRegion);
+  const left = getPositionFromTime(displayedBeginForFocusRegion(focusRegion), zoomRegion);
+  const right = getPositionFromTime(displayedEndForFocusRegion(focusRegion), zoomRegion);
 
   return (
     <div className="relative top-0 left-0 h-full w-full" ref={containerRef}>

--- a/src/ui/components/Timeline/PlaybackControls.tsx
+++ b/src/ui/components/Timeline/PlaybackControls.tsx
@@ -3,7 +3,7 @@ import { clearPendingComment } from "ui/actions/comments";
 import { replayPlayback, startPlayback, stopPlayback } from "ui/actions/timeline";
 import { selectors } from "ui/reducers";
 import { trackEvent } from "ui/utils/telemetry";
-import { endTimeForFocusRegion } from "ui/utils/timeline";
+import { displayedEndForFocusRegion } from "ui/utils/timeline";
 
 export default function PlayPauseButton() {
   const dispatch = useDispatch();
@@ -13,7 +13,7 @@ export default function PlayPauseButton() {
   const recordingDuration = useSelector(selectors.getRecordingDuration);
 
   const isAtEnd = focusRegion
-    ? currentTime === endTimeForFocusRegion(focusRegion)
+    ? currentTime === displayedEndForFocusRegion(focusRegion)
     : currentTime == recordingDuration;
 
   let onClick;

--- a/src/ui/components/Timeline/UnfocusedRegion.tsx
+++ b/src/ui/components/Timeline/UnfocusedRegion.tsx
@@ -3,9 +3,9 @@ import { useSelector } from "react-redux";
 import { selectors } from "ui/reducers";
 import { trackEvent } from "ui/utils/telemetry";
 import {
-  endTimeForFocusRegion,
   getVisiblePosition,
-  beginTimeForFocusRegion,
+  displayedEndForFocusRegion,
+  displayedBeginForFocusRegion,
 } from "ui/utils/timeline";
 
 export default function UnfocusedRegion() {
@@ -16,8 +16,8 @@ export default function UnfocusedRegion() {
     return null;
   }
 
-  const beginTime = beginTimeForFocusRegion(focusRegion);
-  const endTime = endTimeForFocusRegion(focusRegion);
+  const beginTime = displayedBeginForFocusRegion(focusRegion);
+  const endTime = displayedEndForFocusRegion(focusRegion);
   const duration = zoomRegion.endTime - zoomRegion.beginTime;
 
   const start = getVisiblePosition({ time: beginTime, zoom: zoomRegion }) * 100;

--- a/src/ui/components/Timeline/UnloadedRegions.tsx
+++ b/src/ui/components/Timeline/UnloadedRegions.tsx
@@ -4,11 +4,11 @@ import { useSelector } from "react-redux";
 import { getLoadedRegions } from "ui/reducers/app";
 import { getFocusRegion, getZoomRegion } from "ui/reducers/timeline";
 import {
-  endTimeForFocusRegion,
+  displayedEndForFocusRegion,
   getVisiblePosition,
   overlap,
   rangeForFocusRegion,
-  beginTimeForFocusRegion,
+  displayedBeginForFocusRegion,
 } from "ui/utils/timeline";
 
 export const UnloadedRegions: FC = () => {

--- a/src/ui/components/Timeline/index.tsx
+++ b/src/ui/components/Timeline/index.tsx
@@ -1,7 +1,6 @@
 import React, { useLayoutEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { seekToTime, setTimelineToTime } from "ui/actions/timeline";
-import { useFeature } from "ui/hooks/settings";
 import { selectors } from "ui/reducers";
 import { setTimelineState } from "ui/reducers/timeline";
 import { getTimeFromPosition } from "ui/utils/timeline";
@@ -31,7 +30,6 @@ export default function Timeline() {
   const hoverTime = useSelector(selectors.getHoverTime);
   const timelineDimensions = useSelector(selectors.getTimelineDimensions);
   const zoomRegion = useSelector(selectors.getZoomRegion);
-  const { value: showProtocolTimeline } = useFeature("protocolTimeline");
 
   const progressBarRef = useRef<HTMLDivElement>(null);
 

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -25,11 +25,11 @@ import { getNonLoadingRegionTimeRanges } from "ui/utils/app";
 import { compareBigInt } from "ui/utils/helpers";
 import { prefs } from "ui/utils/prefs";
 import {
-  endTimeForFocusRegion,
+  displayedEndForFocusRegion,
   isPointInRegions,
   isTimeInRegions,
   overlap,
-  beginTimeForFocusRegion,
+  displayedBeginForFocusRegion,
 } from "ui/utils/timeline";
 
 export const initialAppState: AppState = {
@@ -342,8 +342,8 @@ export const getFlatEvents = (state: UIState) => {
   return focusRegion
     ? filteredEvents.filter(
         e =>
-          e.time > beginTimeForFocusRegion(focusRegion) &&
-          e.time < endTimeForFocusRegion(focusRegion)
+          e.time > displayedBeginForFocusRegion(focusRegion) &&
+          e.time < displayedEndForFocusRegion(focusRegion)
       )
     : filteredEvents;
 };

--- a/src/ui/reducers/network.ts
+++ b/src/ui/reducers/network.ts
@@ -16,9 +16,9 @@ import sortedUniqBy from "lodash/sortedUniqBy";
 import { getFocusRegion } from "./timeline";
 import { partialRequestsToCompleteSummaries } from "ui/components/NetworkMonitor/utils";
 import {
-  endTimeForFocusRegion,
+  displayedEndForFocusRegion,
   filterToFocusRegion,
-  beginTimeForFocusRegion,
+  displayedBeginForFocusRegion,
 } from "ui/utils/timeline";
 
 export type NetworkState = {
@@ -115,8 +115,8 @@ export const getFocusedEvents = (state: UIState) => {
   if (!focusRegion) {
     return events;
   }
-  const beginTime = beginTimeForFocusRegion(focusRegion);
-  const endTime = endTimeForFocusRegion(focusRegion);
+  const beginTime = displayedBeginForFocusRegion(focusRegion);
+  const endTime = displayedEndForFocusRegion(focusRegion);
   return events.filter(e => e.time > beginTime && e.time <= endTime);
 };
 export const getFocusedRequests = (state: UIState) => {

--- a/src/ui/reducers/timeline.ts
+++ b/src/ui/reducers/timeline.ts
@@ -2,7 +2,7 @@ import { TimeStampedPoint } from "@replayio/protocol";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { UIState } from "ui/state";
 import { FocusRegion, HoveredItem, TimelineState, ZoomRegion } from "ui/state/timeline";
-import { endTimeForFocusRegion, beginTimeForFocusRegion } from "ui/utils/timeline";
+import { displayedEndForFocusRegion, displayedBeginForFocusRegion } from "ui/utils/timeline";
 
 function initialTimelineState(): TimelineState {
   return {
@@ -98,5 +98,5 @@ export const getFocusRegion = (state: UIState) => state.timeline.focusRegion;
 export const getFocusRegionBackup = (state: UIState) => state.timeline.focusRegionBackup;
 export const getIsInFocusMode = (state: UIState) =>
   state.timeline.focusRegion &&
-  (beginTimeForFocusRegion(state.timeline.focusRegion) !== 0 ||
-    endTimeForFocusRegion(state.timeline.focusRegion) !== state.timeline.zoomRegion.endTime);
+  (displayedBeginForFocusRegion(state.timeline.focusRegion) !== 0 ||
+    displayedEndForFocusRegion(state.timeline.focusRegion) !== state.timeline.zoomRegion.endTime);

--- a/src/ui/state/timeline.ts
+++ b/src/ui/state/timeline.ts
@@ -9,8 +9,8 @@ export interface ZoomRegion {
 export interface FocusRegion {
   // We are moving towards using TimeStampedPoints for all ranges on the client,
   // to that end, we should avoid using fields directly from this object, and
-  // instead use the getters `beginTimeForFocusRegion` and
-  // `endTimeForFocusRegion`. If you must access the fields directly, you can
+  // instead use the getters `displayedBeginForFocusRegion` and
+  // `displayedEndForFocusRegion`. If you must access the fields directly, you can
   // cast instead to an `UnsafeFocusRegion`
 }
 

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -31,7 +31,6 @@ pref("devtools.features.logProtocol", false);
 pref("devtools.features.unicornConsole", true);
 pref("devtools.features.showRedux", true);
 pref("devtools.features.enableLargeText", false);
-pref("devtools.features.softFocus", false);
 pref("devtools.features.repaintEvaluations", false);
 pref("devtools.features.testSupport", false);
 pref("devtools.features.originalClassNames", false);
@@ -66,7 +65,6 @@ export const features = new PrefsHelper("devtools.features", {
   unicornConsole: ["Bool", "unicornConsole"],
   showRedux: ["Bool", "showRedux"],
   enableLargeText: ["Bool", "enableLargeText"],
-  softFocus: ["Bool", "softFocus"],
   repaintEvaluations: ["Bool", "repaintEvaluations"],
   testSupport: ["Bool", "testSupport"],
   originalClassNames: ["Bool", "originalClassNames"],

--- a/src/ui/utils/timeline.ts
+++ b/src/ui/utils/timeline.ts
@@ -1,7 +1,6 @@
 import { TimeStampedPoint, TimeStampedPointRange } from "@replayio/protocol";
 import { clamp, sortedIndexBy, sortedLastIndexBy } from "lodash";
 import { FocusRegion, UnsafeFocusRegion, ZoomRegion } from "ui/state/timeline";
-import { features } from "ui/utils/prefs";
 
 import { timelineMarkerWidth } from "../constants";
 
@@ -23,16 +22,14 @@ export function getPixelDistance({
   return Math.abs((toPos - fromPos) * overlayWidth);
 }
 
-export function beginTimeForFocusRegion(focusRegion: FocusRegion) {
-  return features.softFocus
-    ? (focusRegion as UnsafeFocusRegion).begin.time
-    : (focusRegion as UnsafeFocusRegion).beginTime;
+export function displayedBeginForFocusRegion(focusRegion: FocusRegion) {
+  const unsafe = focusRegion as UnsafeFocusRegion;
+  return unsafe.beginTime;
 }
 
-export function endTimeForFocusRegion(focusRegion: FocusRegion) {
-  return features.softFocus
-    ? (focusRegion as UnsafeFocusRegion).end.time
-    : (focusRegion as UnsafeFocusRegion).endTime;
+export function displayedEndForFocusRegion(focusRegion: FocusRegion) {
+  const unsafe = focusRegion as UnsafeFocusRegion;
+  return unsafe.endTime;
 }
 
 // Get the position of a time on the visible part of the timeline,
@@ -220,8 +217,8 @@ export function isSameTimeStampedPointRange(
 }
 
 export function isInFocusSpan(time: number, focusRegion: FocusRegion) {
-  const beginTime = beginTimeForFocusRegion(focusRegion);
-  const endTime = endTimeForFocusRegion(focusRegion);
+  const beginTime = displayedBeginForFocusRegion(focusRegion);
+  const endTime = displayedEndForFocusRegion(focusRegion);
 
   return time >= beginTime && time <= endTime;
 }
@@ -288,8 +285,9 @@ export function isFocusRegionSubset(
     return false;
   } else {
     return (
-      beginTimeForFocusRegion(nextFocusRegion) >= beginTimeForFocusRegion(prevFocusRegion) &&
-      endTimeForFocusRegion(nextFocusRegion) <= endTimeForFocusRegion(prevFocusRegion)
+      displayedBeginForFocusRegion(nextFocusRegion) >=
+        displayedBeginForFocusRegion(prevFocusRegion) &&
+      displayedEndForFocusRegion(nextFocusRegion) <= displayedEndForFocusRegion(prevFocusRegion)
     );
   }
 }
@@ -302,8 +300,8 @@ export function filterToFocusRegion<T extends TimeStampedPoint>(
     return sortedPoints;
   }
 
-  const beginTime = beginTimeForFocusRegion(focusRegion);
-  const endTime = endTimeForFocusRegion(focusRegion);
+  const beginTime = displayedBeginForFocusRegion(focusRegion);
+  const endTime = displayedEndForFocusRegion(focusRegion);
 
   const beginIndex = sortedIndexBy(sortedPoints, { time: beginTime, point: "" }, p => p.time);
   const endIndex = sortedLastIndexBy(sortedPoints, { time: endTime, point: "" }, p => p.time);


### PR DESCRIPTION
I've been saying for the past week that we basically already shipped soft focus, but not technically. I'd like to clarify what I meant by that, because it's confusing. Let's start from the beginning-ish.

I started [a document](https://www.notion.so/replayio/Loading-Region-Problems-b8dc0d03c49840f8b504e967c7ea5778) on April 26th describing an underlying cause for an entire family of problems that I was seeing in the devtools UI. Around that same time, we were also seeing a *lot* of crazy behavior with regions loading and unloading (I'm gonna come back to this). The big takeaway from that document was that we needed methods for focusing at slices more specific than regions. We did a lot of work to support this.

- We added range parameters to backend endpoints, so that front-end requests could send the range they were interested in, rather than always addressing the entirety of all loaded regions
- We reworked how we run, monitor, and store the results of analyses generally
- We built two completely new backend endpoints for converting from times to TimeStampedPoints
- We built a thunk which observed the focus mode, and decided when it should attempt to reload some resources (starting with console messages, and then analyses) based on the newly chosen window and previous fetches

I'd like to pause at that last one. In many ways, that was the ultimate goal at the time I wrote that document. It solves all "edge-piece" and "overflow" problems, and while we can go even farther in the direction of efficiency, I'm quite happy with the soundness of the foundation we've laid, and soundness was the motivator for this project.

We shipped the first version of everything up above one week ago, and sent it out with the newsletter. However, remember how I said that back when I was first scoping this project we were having a lot of trouble with loading and unloading regions? Well, one of the things that I realized early on was that if we correctly handled edge-pieces, it no longer mattered how big the edge pieces were. And if it does not matter how big the edge pieces are, then there's no reason to forcibly unload parts of the recording in order to exclude them. Back when unloading and loading were causing massive headaches both for us and for users, this seemed like a huge win, so I made it the final goal of Soft Focus - be able to move your focus window around, without ever having to unload a region.

My first shot at it was kind of wonky (you'll see just how wonky in a second), and I didn't love it. And while we were busy getting everything ready so we *could* turn this flag on, the rest of the team shipped Turbo Replay, and all of a sudden, it did not matter that much if we forcibly loaded or unloaded regions. It's still a nice performance win I think, for users who are moving their focus window around a lot, and more importantly, we corrected a ton of soundness problems on the way here.

---

OK, so back to this change.

The final solution is probably best explained by this comment I wrote earlier today to explain a type (if you've been deep in the weeds on this stuff already a lot of this will sound familiar):

>  You might be wondering why there are multiple `begin`s and `end`s for a single FocusRegion. Well, this is an artifact of the difference between world-time, which is essentially continuous (and thus, linearly interpolable), and execution time, which is both discrete (in the sense that even though there may be many points "between" points 100 and 200, there may not be any points that are valid for operations like Pausing) and irregularly spaced (the recording might have many valid points between the times 100-150ms, but no valid points between 150-500ms).
> 
> It is very convenient to accept user input in the form of times. The user can click somewhere on the timeline (which is really just a visual interpretation of the continuous, evenly-spaced number line underlying it), and we can try and use that to filter things down to that time.
> 
> And that is where the trouble starts.
> 
>  In order to accurately filter resources that are in memory, or to specify a range to a backend endpoint which accepts ranges, we need to bound our range by *points*, not just *times*. But the user did not give us a point, they only gave us a time. So what should we do? Well, we try to convert from our time to a point. However, because points are discrete and unevenly spaced, this is not an exact translation, it introduces a small amount of error (usually on the order of <100ms, but occasionally more). Also, to be as precise in the conversion as possible we need to hit a backend endpoint (getPointsBoundingTime), which is not horribly expensive, but is significantly more expensive than a simple lookup, for instance.
> 
>  All of this causes problems, especially when the user is dragging around a focus window. This is because:
>  1) The little errors start to add up. If you "snap" the continuous values of
>  the timeline to the discrete values of the pointline, you introduce a little bit of error. Then, maybe the user drags the line another pixel, and you introduce another little error, and so on and so forth and, well screens have many pixels so this can get out of hand quickly.
>  2) A difference of less than 100ms might not be super noticeable on the timeline, but as the errors get larger (or if the recording is quite short, for instance) it will start to be clear to the user that we are not actually putting them at quite the time that they asked for. And, well, we have very good reasons for doing that, but they are very hard to explain (for instance, we might have to subject them to reading something like this comment).
>  3) If we try and do an exact lookup every time the focus window changes while selecting it, we will end up sending a *ton* of protocol messages.
> 
>  The solution I have come up with so far is that we store *two* windows. One window is used for display. It is what we show on timelines, and it is also what we use as the inputs to our time -> point transformation *after* the user has chosen their focus window.
> 
>  The other time is a proper TimeStampedPointRange, which we use to do things like filter resources by point and interact with backend endpoints which accept ranges.

With the above solution, we can ship Soft Focus (in the sense that there does not need to be any forced unloading) without degrading the experience of picking a focus window or having to expose the messiness of the above to the user. Next, will be actually utilizing `Session.getPointsBoundingTime` to be more specific in our mapping, but even now, we are pretty darn specific most of the time, so I wanted to get this in rather than waiting for that optimization piece to be done.

As for the changes this actually makes:

- Deletes the `Soft Focus` flag from experimental settings
- Changes `startTimeForFocusRegion` to `displayedStartForFocusRegion`
- Likewise for `endTimeForFocusRegion` to `displayedEndForFocusRegion`
- Displays the `displayed` time values when choosing a window, rather than the mapped-points' time values

That's it! Not a ton of changes, but building on a much larger set over the past 6 weeks 🏗️ 

Fixes https://linear.app/replay/issue/FE-160/soft-focus