### PR TITLE
Console overlay buttons compare time if no paused execution points

### DIFF
--- a/src/devtools/client/webconsole/components/Output/ConsoleOutput.tsx
+++ b/src/devtools/client/webconsole/components/Output/ConsoleOutput.tsx
@@ -19,7 +19,12 @@ import { ContextMenu } from "ui/components/ContextMenu";
 import { Dropdown, DropdownItem } from "ui/components/Library/LibraryDropdown";
 import Icon from "ui/components/shared/Icon";
 import { selectors } from "ui/reducers";
-import { getFocusRegion, getShowFocusModeControls, getZoomRegion } from "ui/reducers/timeline";
+import {
+  getCurrentTime,
+  getFocusRegion,
+  getShowFocusModeControls,
+  getZoomRegion,
+} from "ui/reducers/timeline";
 import type { AppDispatch } from "ui/setup/store";
 import type { UIState } from "ui/state";
 import { isVisible } from "ui/utils/dom";
@@ -185,6 +190,7 @@ class ConsoleOutput extends React.Component<PropsFromRedux, State> {
     const {
       breakpoints,
       closestMessage,
+      currentTime,
       dispatch,
       hoveredItem,
       messages,
@@ -208,6 +214,7 @@ class ConsoleOutput extends React.Component<PropsFromRedux, State> {
       const prefixBadge = matchingBreakpoint?.options.prefixBadge;
 
       return React.createElement(MessageContainer, {
+        currentTime,
         // TODO Reconsider this when we rebuild message grouping
         dispatch,
         isFirstMessageForPoint: this.getIsFirstMessageForPoint(i, visibleMessageIDs),
@@ -338,6 +345,7 @@ function mapStateToProps(state: UIState) {
     // @ts-ignore
     breakpoints: selectors.getBreakpointsList(state),
     closestMessage: selectors.getClosestMessage(state),
+    currentTime: getCurrentTime(state),
     focusRegion: getFocusRegion(state),
     hoveredItem: selectors.getHoveredItem(state),
     lastMessageId: selectors.getLastMessageId(state),

--- a/src/devtools/client/webconsole/components/Output/Message.js
+++ b/src/devtools/client/webconsole/components/Output/Message.js
@@ -162,6 +162,7 @@ class Message extends React.Component {
 
   renderOverlayButton() {
     const {
+      currentTime,
       executionPoint,
       executionPointTime,
       executionPointHasFrames,
@@ -173,7 +174,7 @@ class Message extends React.Component {
       isFirstMessageForPoint,
     } = this.props;
 
-    if (!pausedExecutionPoint || !executionPoint || !frame) {
+    if (!executionPoint || !frame) {
       return undefined;
     }
 
@@ -207,7 +208,17 @@ class Message extends React.Component {
       );
     };
 
-    if (BigInt(executionPoint) > BigInt(pausedExecutionPoint)) {
+    if (!pausedExecutionPoint) {
+      // The user is outside of a loaded region; there's no Pause in this case.
+      // In this case we fall back to comparing the Message's timeStamp to the currentTime.
+      if (executionPointTime > currentTime) {
+        overlayType = "fast-forward";
+        label = "Fast-forward";
+      } else {
+        overlayType = "rewind";
+        label = "Rewind";
+      }
+    } else if (BigInt(executionPoint) > BigInt(pausedExecutionPoint)) {
       overlayType = "fast-forward";
       label = "Fast-forward";
     } else if (BigInt(executionPoint) < BigInt(pausedExecutionPoint)) {

--- a/src/devtools/client/webconsole/components/Output/MessageContainer.js
+++ b/src/devtools/client/webconsole/components/Output/MessageContainer.js
@@ -23,6 +23,7 @@ export class MessageContainer extends React.Component {
   static get propTypes() {
     return {
       badge: PropTypes.number,
+      currentTime: PropTypes.number,
       indent: PropTypes.number,
       isPaused: PropTypes.bool.isRequired,
       isPrimaryHighlighted: PropTypes.bool.isRequired,

--- a/src/devtools/client/webconsole/components/Output/message-types/ConsoleApiCall.js
+++ b/src/devtools/client/webconsole/components/Output/message-types/ConsoleApiCall.js
@@ -32,6 +32,7 @@ ConsoleApiCall.defaultProps = {
 
 export default function ConsoleApiCall(props) {
   const {
+    currentTime,
     dispatch,
     isFirstMessageForPoint,
     isPaused,
@@ -140,6 +141,7 @@ export default function ConsoleApiCall(props) {
     attachment,
     collapseTitle,
     collapsible,
+    currentTime,
     dispatch,
     executionPoint,
     executionPointHasFrames,


### PR DESCRIPTION
The console uses the paused execution point to determine whether to show a "fast-forward" or "rewind" label. There sometimes is no paused execution point though, in which case the UI now falls back to comparing the message's time to the app state currentTime.

Resolves #7108