### PR TITLE
Say 0 when hits is 0

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
@@ -128,7 +128,7 @@ export default function LineNumberTooltip({
     return null;
   }
 
-  if (!hits) {
+  if (hits === undefined) {
     return (
       <StaticTooltip targetNode={targetNode}>
         <Wrapper loading>Loading…</Wrapper>


### PR DESCRIPTION
Good old "0 is falsey!" bug.

Fixes https://github.com/replayio/devtools/issues/7110