### PR TITLE
Move logpoint UI above editor line

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Widget.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Widget.tsx
@@ -22,6 +22,7 @@ export default function Widget({ location, children, editor, insertAt }: WidgetP
     }
     const editorLine = toEditorLine(location.line || 0);
     const _widget = editor.codeMirror.addLineWidget(editorLine, node, {
+      above: true,
       insertAt,
     });
 


### PR DESCRIPTION
This more closely matches what Chrome devtools does _and_ (I think) brings the UI into alignment with how the feature actually works.

Here's a Loom walk through: https://www.loom.com/share/726fe462e65c408ab76a9b4366b31b9b

---

# How do things currently work?

## In Replay

![image](https://user-images.githubusercontent.com/29597/172854727-afa9c6f8-851d-4450-a4ec-b71885f88250.png)

My mental model of this based on the way the UI presents is:
```js
const canShowCount = lastFetchedFocusRange === null && !lastFetchDidOverflow;
console.log(`canShowCount? ${canShowCount} focus window? ${lastFetchedFocusRange === null}`);
```

## In Chrome

![image](https://user-images.githubusercontent.com/29597/172854925-a13058bf-4248-48f6-9a2a-2e57dbd5d2a3.png)

But my intuition from the way the Chrome UI presents things is:
```js
console.log('...'); // I wouldn't expect to be able to log _reactDOM here
var _reactDOM = _interopRequireDefault(require("react-dom"));
```

---

Fixes BAC-1673