### PR TITLE
Add additional TS "paths" resolutions for subpackage files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -52,9 +52,13 @@
         "node_modules/*"
       ],
       "components": ["packages/components/index.ts"],
+      "components/*": ["packages/components/*"],
       "icons": ["packages/icons/index.tsx"],
+      "icons/*": ["packages/icons/*"],
       "protocol": ["packages/protocol/index.ts"],
-      "shared": ["packages/shared/index.ts"]
+      "protocol/*": ["packages/protocol/*"],
+      "shared": ["packages/shared/index.ts"],
+      "shared/*": ["packages/shared/*"]
     } /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */,
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */


### PR DESCRIPTION
This allows TS to correctly do "Find References" on types in folders
like `packages/protocol/`, and return results from the main app code
in `src/`.