### PR TITLE
Feature flag the print statement panel

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Widget.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Widget.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { prefs } from "ui/utils/prefs";
 import ReactDOM from "react-dom";
 const { toEditorLine } = require("devtools/client/debugger/src/utils/editor");
 
@@ -22,7 +23,7 @@ export default function Widget({ location, children, editor, insertAt }: WidgetP
     }
     const editorLine = toEditorLine(location.line || 0);
     const _widget = editor.codeMirror.addLineWidget(editorLine, node, {
-      above: true,
+      above: prefs.showPanelAbove,
       insertAt,
     });
 

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -17,6 +17,7 @@ pref("devtools.listenForMetrics", false);
 pref("devtools.disableCache", false);
 pref("devtools.sidePanelSize", "240px");
 pref("devtools.theme", "system");
+pref("devtools.showPanelAbove", false);
 
 // app features
 pref("devtools.features.columnBreakpoints", false);
@@ -50,6 +51,7 @@ export const prefs = new PrefsHelper("devtools", {
   disableCache: ["Bool", "disableCache"],
   theme: ["String", "theme"],
   colorScheme: ["String", "colorScheme"],
+  showPanelAbove: ["Bool", "showPanelAbove"],
 });
 
 export const features = new PrefsHelper("devtools.features", {


### PR DESCRIPTION
Moves https://github.com/replayio/devtools/pull/7122 to a feature flag so we can continue exploring options for communicating where the expression is evaluated. 

Positioning the panel above or below does not solve this problem it just suggests that it comes before the end of the line. Additionally, placing the panel above the line and not adjusting the add/close button is currently awkward.

Lastly, this is a significant enough change, that it would be nice to package it up with Travis' work and update the docs and share a changelog post when it lands