### PR TITLE
Revert "Fix stepping-05 and object_preview-05 e2e tests"

### DIFF
--- a/public/test/scripts/object_preview-05.js
+++ b/public/test/scripts/object_preview-05.js
@@ -12,7 +12,7 @@ Test.describe(`Test scope mapping and switching between generated/original sourc
   await Test.waitForMessage("300");
 
   await Test.toggleMappedSources();
-  await Test.waitForPausedLine(6);
+  await Test.waitForPausedLine(12);
   await Test.waitForScopeValue("e", "Array(3) […]");
   await Test.waitForScopeValue("o", "{…}");
 });

--- a/public/test/scripts/stepping-05.js
+++ b/public/test/scripts/stepping-05.js
@@ -15,10 +15,10 @@ Test.describe(`Test stepping in pretty-printed code.`, async () => {
   await Test.warpToMessage("click");
   await Test.selectDebugger();
 
-  await Test.stepInToLine(1);
-  await Test.stepOutToLine(10);
-  await Test.stepInToLine(6);
-  await Test.stepOutToLine(10);
   await Test.stepInToLine(2);
-  await Test.stepOutToLine(10);
+  await Test.stepOutToLine(15);
+  await Test.stepInToLine(10);
+  await Test.stepOutToLine(15);
+  await Test.stepInToLine(5);
+  await Test.stepOutToLine(15);
 });


### PR DESCRIPTION
This reverts commit 453a1490b6e87f8f055bb0221847c7311ea46612.

After https://github.com/replayio/backend/pull/5915  we use the old pretty-printer for the relevant example files again because the threshold for switching to the new pretty-printer has been increased.