### PR TITLE
Update GraphQL types (FE-232)

### DIFF
--- a/src/graphql/globalTypes.ts
+++ b/src/graphql/globalTypes.ts
@@ -10,6 +10,7 @@
 export interface AddCommentInput {
   content: string;
   hasFrames: boolean;
+  isPublished?: boolean | null;
   networkRequestId?: string | null;
   point: string;
   position?: any | null;
@@ -23,6 +24,7 @@ export interface AddCommentInput {
 export interface AddCommentReplyInput {
   commentId: string;
   content: string;
+  isPublished?: boolean | null;
 }
 
 //==============================================================


### PR DESCRIPTION
@bvaughn We forgot to run `npm run gql` to regenerate the typescript types from the GraphQL schema after the last GraphQL deploy.