### PR TITLE
Fix sporadic failures of two of our e2e tests

### DIFF
--- a/public/test/scripts/region_loading-01.js
+++ b/public/test/scripts/region_loading-01.js
@@ -15,7 +15,7 @@ Test.describe(
     });
 
     await Test.selectConsole();
-    let messages = await Test.waitForMessageCount("Part1Logpoint", totalMessageCount);
+    let messages = await Test.waitForMessageCount("Part1Logpoint", totalMessageCount, 2);
     assert(!Test.findMessages("Loading").length, "No loading messages should be left.");
     assert(messages.length == totalMessageCount, "Should have gotten all expected logpoing messages.");
     await Test.removeAllBreakpoints();
@@ -45,6 +45,6 @@ Test.describe(
     await Test.addBreakpoint("doc_rr_region_loading.html", 20, undefined, {
       logValue: `"Part3Logpoint Number " + number`,
     });
-    messages = await Test.waitForMessageCount("Part3Logpoint", totalMessageCount);
+    messages = await Test.waitForMessageCount("Part3Logpoint", totalMessageCount, 2);
   }
 );

--- a/src/test/harness.js
+++ b/src/test/harness.js
@@ -349,8 +349,21 @@ async function checkEvaluateInTopFrame(text, expected) {
     { waitingFor: `message with text "${expected}"` }
   );
 
-  await clickElement(".devtools-clear-icon");
+  await clearConsoleEvaluations();
   selectDebugger();
+}
+
+async function clearConsoleEvaluations() {
+  const clearButton = await waitUntil(
+    () => {
+      const btn = document.querySelector(".devtools-clear-icon");
+      if (btn && !btn.disabled) {
+        return btn;
+      }
+    },
+    { waitingFor: "clear console evaluations button to be enabled" }
+  );
+  clearButton.click();
 }
 
 async function waitForScopeValue(name, value) {
@@ -439,13 +452,16 @@ function checkPausedMessage(text) {
   return waitForMessage(text, ".paused");
 }
 
-function waitForMessageCount(text, count) {
+function waitForMessageCount(text, count, timeoutFactor = 1) {
   return waitUntil(
     () => {
       const messages = findMessages(text);
       return messages.length == count ? messages : null;
     },
-    { waitingFor: `${count} messages with text: "${text}"` }
+    {
+      waitingFor: `${count} messages with text: "${text}"`,
+      timeout: defaultWaitTimeout() * timeoutFactor,
+    }
   );
 }
 


### PR DESCRIPTION
- region_loading-01 was failing because it ran into a timeout waiting for 50 logpoint results - I increased the timeout
- breakpoints-01 was failing to clear evaluations in the console because the button was disabled - now it waits for it to become enabled