### PR TITLE
Remove trailing semicolons from log values

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelEditor.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelEditor.tsx
@@ -23,6 +23,9 @@ interface State {
   conditionSyntaxError: string | null;
 }
 
+const stripTrailingSemiColon = (expr: string) =>
+  expr.match(/.*;$/) ? expr.slice(0, expr.length - 1) : expr;
+
 class PanelEditor extends PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);
@@ -48,7 +51,9 @@ class PanelEditor extends PureComponent<Props, State> {
       setShowCondition,
     } = this.props;
     const { logValue, condition } = this.state;
-    const newOptions: { logValue: string; condition?: string; prefixBadge?: string } = { logValue };
+    const newOptions: { logValue: string; condition?: string; prefixBadge?: string } = {
+      logValue: stripTrailingSemiColon(logValue),
+    };
 
     // Bail if there is an error.
     if (this.hasError()) {


### PR DESCRIPTION
I can't believe I have never run into this before, but it's pretty
natural to input an entire line of code from the function into a log
statement, and if you include the semicolon you get this cryptic error about
how you're missing a `]` (because we interpolate the expression into an
array). We could try and give more explicit direction, since you can
still trigger this error by, say, trying to paste multiple statements
separated by `;`, but that seems like a less common case, while just
having a trailing semi seems like it's a thing that could happen
relatively often and be expected to "just work".