### PR TITLE
Add a "Default to Dev Tools" experimental option

### DIFF
--- a/src/devtools/client/debugger/src/components/SourceOutline/getOutlineSymbols.tsx
+++ b/src/devtools/client/debugger/src/components/SourceOutline/getOutlineSymbols.tsx
@@ -23,7 +23,7 @@ function addHitCountsToFunctions(functions: FunctionSymbol[], hitCounts: HitCoun
       return hitCount.location.line === end.line && hitCount.location.column! >= start.column;
     });
 
-    return { ...functionSymbol, hits: features.codeHeatMaps ? hitCount?.hits : undefined };
+    return { ...functionSymbol, hits: hitCount?.hits };
   });
 }
 

--- a/src/ui/actions/layout.ts
+++ b/src/ui/actions/layout.ts
@@ -1,4 +1,3 @@
-import { RecordingId } from "@replayio/protocol";
 import { Action } from "redux";
 import {
   getLocalNags,
@@ -6,7 +5,7 @@ import {
   getSelectedPrimaryPanel,
   getShowCommandPalette,
 } from "ui/reducers/layout";
-import { getReplaySession, LocalNag } from "ui/setup/prefs";
+import { LocalNag } from "ui/setup/prefs";
 import {
   ViewMode,
   PrimaryPanelName,
@@ -14,7 +13,6 @@ import {
   VIEWER_PANELS,
   ToolboxLayout,
 } from "ui/state/layout";
-import { asyncStore } from "ui/utils/prefs";
 import { trackEvent } from "ui/utils/telemetry";
 import { UIThunkAction } from ".";
 
@@ -115,19 +113,4 @@ export function setConsoleFilterDrawerExpanded(
   expanded: boolean
 ): SetConsoleFilterDrawerExpandedAction {
   return { type: "set_console_filter_drawer_expanded", expanded };
-}
-
-export function loadReplayPrefs(recordingId: RecordingId): UIThunkAction {
-  return async dispatch => {
-    const session = await getReplaySession(recordingId);
-
-    if (recordingId && session) {
-      const { viewMode, showVideoPanel, toolboxLayout, selectedPrimaryPanel } = session;
-
-      dispatch(setViewMode(viewMode));
-      dispatch(setToolboxLayout(toolboxLayout));
-      dispatch(setShowVideoPanel(showVideoPanel));
-      dispatch(setSelectedPrimaryPanel(selectedPrimaryPanel));
-    }
-  };
 }

--- a/src/ui/components/Library/RecordingRow.tsx
+++ b/src/ui/components/Library/RecordingRow.tsx
@@ -61,20 +61,20 @@ function RowWrapper({
   );
 }
 
-type RecordingRowProps = PropsFromRedux & {
-  recording: Recording;
-  isEditing: boolean;
-  selected: boolean;
+type RecordingRowProps = {
   addSelectedId: (recordingId: RecordingId) => void;
+  isEditing: boolean;
+  recording: Recording;
   removeSelectedId: (recordingId: RecordingId) => void;
+  selected: boolean;
 };
 
 function RecordingRow({
-  recording,
-  isEditing,
-  selected,
-  removeSelectedId,
   addSelectedId,
+  isEditing,
+  recording,
+  removeSelectedId,
+  selected,
 }: RecordingRowProps) {
   const { permissions, loading: permissionsLoading } = useGetUserPermissions(recording);
   const allowSelecting =
@@ -101,20 +101,20 @@ function RecordingRow({
       <div
         className={`group flex cursor-pointer flex-row border-b border-themeBorder ${styles.libraryRow}`}
       >
-        <div className="flex flex-row items-center flex-shrink-0 w-12 px-4 py-3 overflow-hidden whitespace-pre overflow-ellipsis">
+        <div className="flex w-12 flex-shrink-0 flex-row items-center overflow-hidden overflow-ellipsis whitespace-pre px-4 py-3">
           {allowSelecting ? (
             <input
               type="checkbox"
               onClick={e => e.stopPropagation()}
               onChange={toggleChecked}
               checked={selected}
-              className="w-4 h-4 rounded focus:primaryAccentHover border-themeBorder text-primaryAccent"
+              className="focus:primaryAccentHover h-4 w-4 rounded border-themeBorder text-primaryAccent"
             />
           ) : null}
         </div>
-        <div className="flex-grow px-1 py-3 overflow-hidden whitespace-pre overflow-ellipsis">
+        <div className="flex-grow overflow-hidden overflow-ellipsis whitespace-pre px-1 py-3">
           <div className="flex flex-row items-center space-x-4 overflow-hidden">
-            <div className="flex-shrink-0 w-16 overflow-hidden rounded-sm h-9 bg-chrome">
+            <div className="h-9 w-16 flex-shrink-0 overflow-hidden rounded-sm bg-chrome">
               <LazyLoad height={36} scrollContainer=".recording-list" once>
                 <ItemScreenshot recordingId={recording.id} />
               </LazyLoad>
@@ -129,24 +129,24 @@ function RecordingRow({
               </div>
               <div className="flex flex-row space-x-4 font-light text-gray-400">
                 <div
-                  className="flex flex-row items-center space-x-1 overflow-hidden whitespace-pre overflow-ellipsis"
+                  className="flex flex-row items-center space-x-1 overflow-hidden overflow-ellipsis whitespace-pre"
                   style={{ minWidth: "5rem" }}
                 >
                   <img src="/images/timer.svg" className="w-3" />
                   <span>{getDurationString(recording.duration)}</span>
                 </div>
                 <div
-                  className="flex flex-row items-center space-x-1 overflow-hidden whitespace-pre overflow-ellipsis"
+                  className="flex flex-row items-center space-x-1 overflow-hidden overflow-ellipsis whitespace-pre"
                   style={{ minWidth: "6rem" }}
                 >
                   <img src="/images/today.svg" className="w-3" />
                   <span>{getRelativeDate(recording.date)}</span>
                 </div>
-                <div className="overflow-hidden font-light text-gray-400 whitespace-pre overflow-ellipsis">
+                <div className="overflow-hidden overflow-ellipsis whitespace-pre font-light text-gray-400">
                   {getDisplayedUrl(recording.url)}
                 </div>
                 {recording.metadata?.test?.file ? (
-                  <div className="overflow-hidden font-light text-gray-400 whitespace-pre overflow-ellipsis">
+                  <div className="overflow-hidden overflow-ellipsis whitespace-pre font-light text-gray-400">
                     {recording.metadata.test.file}
                   </div>
                 ) : null}
@@ -155,13 +155,13 @@ function RecordingRow({
           </div>
         </div>
 
-        <div className="flex-shrink-0 w-20 px-3 py-3 my-auto overflow-hidden text-right min-w-min overflow-ellipsis whitespace-nowrap">
+        <div className="my-auto w-20 min-w-min flex-shrink-0 overflow-hidden overflow-ellipsis whitespace-nowrap px-3 py-3 text-right">
           {recording.private ? "Private" : "Public"}
         </div>
-        <div className="flex-shrink-0 min-w-0 px-3 py-3 my-auto overflow-hidden w-36 overflow-ellipsis whitespace-nowrap">
+        <div className="my-auto w-36 min-w-0 flex-shrink-0 overflow-hidden overflow-ellipsis whitespace-nowrap px-3 py-3">
           {recording.user ? recording.user.name : "Unknown"}
         </div>
-        <div className="flex flex-row items-center flex-shrink-0 w-12 px-3 py-3 overflow-hidden whitespace-pre">
+        <div className="flex w-12 flex-shrink-0 flex-row items-center overflow-hidden whitespace-pre px-3 py-3">
           {recording.comments.length ? (
             <div className="inline-block">
               <div className="flex flex-row space-x-1">
@@ -170,11 +170,11 @@ function RecordingRow({
               </div>
             </div>
           ) : (
-            <div className="flex flex-row items-center flex-shrink-0 w-12 px-3 py-3 overflow-hidden overflow-ellipsis whitespace-nowrap" />
+            <div className="flex w-12 flex-shrink-0 flex-row items-center overflow-hidden overflow-ellipsis whitespace-nowrap px-3 py-3" />
           )}
         </div>
         <div
-          className="relative flex flex-row items-center justify-center flex-shrink-0 w-6 py-3 pr-4"
+          className="relative flex w-6 flex-shrink-0 flex-row items-center justify-center py-3 pr-4"
           onClick={e => e.stopPropagation()}
         >
           {!isEditing ? <RecordingOptionsDropdown {...{ recording }} /> : null}
@@ -188,11 +188,9 @@ export function ItemScreenshot({ recordingId }: { recordingId: RecordingId }) {
   const { screenData } = hooks.useGetRecordingPhoto(recordingId);
   return (
     <Redacted>
-      <div>{screenData && <img className="object-contain w-full h-9" src={screenData} />}</div>
+      <div>{screenData && <img className="h-9 w-full object-contain" src={screenData} />}</div>
     </Redacted>
   );
 }
 
-const connector = connect(() => ({}), { loadReplayPrefs: actions.loadReplayPrefs });
-type PropsFromRedux = ConnectedProps<typeof connector>;
-export default connector(RecordingRow);
+export default RecordingRow;

--- a/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
+++ b/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
@@ -44,9 +44,9 @@ const EXPERIMENTAL_SETTINGS: ExperimentalSetting[] = [
     key: "enableBreakpointPanelAutocomplete",
   },
   {
-    label: "Code Heatmaps",
-    description: "Calculate hit counts for editor files all at once",
-    key: "codeHeatMaps",
+    label: "Default to Dev Tools",
+    description: "Open DevTools by default instead of the Viewer",
+    key: "defaultToDevTools",
   },
   {
     label: "Large Text",
@@ -106,6 +106,8 @@ export default function ExperimentalSettings({}) {
   } = useFeature("breakpointPanelAutocomplete");
   const { value: enableColumnBreakpoints, update: updateEnableColumnBreakpoints } =
     useFeature("columnBreakpoints");
+  const { value: defaultToDevTools, update: updateDefaultToDevTools } =
+    useFeature("defaultToDevTools");
   const { value: enableNetworkRequestComments, update: updateEnableNetworkRequestComments } =
     useFeature("networkRequestComments");
   const { value: enableTurboReplay, update: updateEnableTurboReplay } = useFeature("turboReplay");
@@ -113,7 +115,6 @@ export default function ExperimentalSettings({}) {
     useFeature("unicornConsole");
   const { value: enableReduxDevtools, update: updateEnableReduxDevtools } = useFeature("showRedux");
 
-  const { value: codeHeatMaps, update: updateCodeHeatMaps } = useFeature("codeHeatMaps");
   const { value: enableResolveRecording, update: updateEnableResolveRecording } =
     useFeature("resolveRecording");
   const { value: enableLargeText, update: updateEnableLargeText } = useFeature("enableLargeText");
@@ -131,8 +132,8 @@ export default function ExperimentalSettings({}) {
       updateEnableNetworkRequestComments(!enableNetworkRequestComments);
     } else if (key == "turboReplay") {
       updateEnableTurboReplay(!enableTurboReplay);
-    } else if (key == "codeHeatMaps") {
-      updateCodeHeatMaps(!codeHeatMaps);
+    } else if (key == "defaultToDevTools") {
+      updateDefaultToDevTools(!defaultToDevTools);
     } else if (key == "enableResolveRecording") {
       updateEnableResolveRecording(!enableResolveRecording);
     } else if (key == "unicornConsole") {
@@ -145,7 +146,7 @@ export default function ExperimentalSettings({}) {
   };
 
   const localSettings = {
-    codeHeatMaps,
+    defaultToDevTools,
     enableBreakpointPanelAutocomplete,
     enableColumnBreakpoints,
     enableNetworkRequestComments,

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -33,10 +33,10 @@ import {
 } from "ui/utils/timeline";
 
 export const initialAppState: AppState = {
-  mode: "devtools",
   // analysisPoints: {},
   awaitingSourcemaps: false,
   canvas: null,
+  currentPoint: null,
   defaultSettingsTab: "Preferences",
   displayedLoadingProgress: null,
   events: {},
@@ -48,10 +48,11 @@ export const initialAppState: AppState = {
   loadedRegions: null,
   loading: 4,
   loadingFinished: false,
-  loadingStatusSlow: false,
   loadingPageTipIndex: 0,
+  loadingStatusSlow: false,
   modal: null,
   modalOptions: null,
+  mode: "devtools",
   mouseTargetsLoading: false,
   recordingDuration: 0,
   recordingTarget: null,
@@ -63,7 +64,6 @@ export const initialAppState: AppState = {
   uploading: null,
   videoUrl: null,
   workspaceId: null,
-  currentPoint: null,
 };
 
 const appSlice = createSlice({

--- a/src/ui/reducers/layout.ts
+++ b/src/ui/reducers/layout.ts
@@ -2,12 +2,13 @@ import { sourcesDisplayed } from "devtools/client/debugger/src/reducers/ui";
 import { LayoutAction } from "ui/actions/layout";
 import { UIState } from "ui/state";
 import { LayoutState } from "ui/state/layout";
+import { features, prefs } from "ui/utils/prefs";
 
 export const syncInitialLayoutState: LayoutState = {
   consoleFilterDrawerExpanded: true,
   showCommandPalette: false,
   selectedPrimaryPanel: "events",
-  viewMode: "non-dev",
+  viewMode: features.defaultToDevTools ? "dev" : "non-dev",
   showVideoPanel: true,
   toolboxLayout: "ide",
   selectedPanel: "console",

--- a/src/ui/setup/prefs.ts
+++ b/src/ui/setup/prefs.ts
@@ -70,7 +70,6 @@ const updateDebuggerPrefs = createPrefsUpdater(debuggerPrefs);
 const updateDebuggerAsyncPrefs = createPrefsUpdater(debuggerAsyncPrefs);
 
 export const updatePrefs = (state: UIState, oldState: UIState) => {
-  updateStandardPrefs(state, oldState, "viewMode", getViewMode);
   updateStandardPrefs(state, oldState, "theme", getTheme);
 
   updateAsyncPrefs(

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -16,7 +16,7 @@ export type ExperimentalUserSettings = {
 };
 
 export type LocalExperimentalUserSettings = {
-  codeHeatMaps: boolean;
+  defaultToDevTools: boolean;
   enableBreakpointPanelAutocomplete: boolean;
   enableColumnBreakpoints: boolean;
   enableNetworkRequestComments: boolean;

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -4,74 +4,72 @@ import { pref } from "devtools/shared/services";
 const { asyncStoreHelper } = require("devtools/shared/async-store-helper");
 
 // app prefs.
-pref("devtools.event-listeners-breakpoints", true);
-pref("devtools.toolbox-size", "50%");
-pref("devtools.view-mode", "non-dev");
 pref("devtools.dev-secondary-panel-height", "375px");
-pref("devtools.logTelemetryEvent", false);
-pref("devtools.showRedactions", false);
-pref("devtools.disableLogRocket", false);
-pref("devtools.listenForMetrics", false);
 pref("devtools.disableCache", false);
+pref("devtools.disableLogRocket", false);
+pref("devtools.event-listeners-breakpoints", true);
+pref("devtools.listenForMetrics", false);
+pref("devtools.logTelemetryEvent", false);
+pref("devtools.showPanelAbove", false);
+pref("devtools.showRedactions", false);
 pref("devtools.sidePanelSize", "240px");
 pref("devtools.theme", "system");
-pref("devtools.showPanelAbove", false);
+pref("devtools.toolbox-size", "50%");
 
 // app features
-pref("devtools.features.columnBreakpoints", false);
-pref("devtools.features.httpBodies", true);
-pref("devtools.features.commentAttachments", false);
-pref("devtools.features.networkRequestComments", true);
-pref("devtools.features.turboReplay", false);
 pref("devtools.features.breakpointPanelAutocomplete", true);
-pref("devtools.features.codeHeatMaps", true);
-pref("devtools.features.resolveRecording", false);
-pref("devtools.features.protocolTimeline", false);
-pref("devtools.features.logProtocol", false);
-pref("devtools.features.unicornConsole", true);
-pref("devtools.features.showRedux", true);
+pref("devtools.features.columnBreakpoints", false);
+pref("devtools.features.commentAttachments", false);
+pref("devtools.features.defaultToDevTools", false);
 pref("devtools.features.enableLargeText", false);
-pref("devtools.features.repaintEvaluations", false);
-pref("devtools.features.testSupport", false);
+pref("devtools.features.httpBodies", true);
+pref("devtools.features.logProtocol", false);
+pref("devtools.features.networkRequestComments", true);
 pref("devtools.features.originalClassNames", false);
+pref("devtools.features.protocolTimeline", false);
+pref("devtools.features.repaintEvaluations", false);
+pref("devtools.features.resolveRecording", false);
+pref("devtools.features.showRedux", true);
+pref("devtools.features.testSupport", false);
+pref("devtools.features.turboReplay", false);
+pref("devtools.features.unicornConsole", true);
 
 export const prefs = new PrefsHelper("devtools", {
-  eventListenersBreakpoints: ["Bool", "event-listeners-breakpoints"],
-  toolboxSize: ["String", "toolbox-size"],
-  viewMode: ["String", "view-mode"],
-  secondaryPanelHeight: ["String", "dev-secondary-panel-height"],
-  logTelemetryEvent: ["Bool", "logTelemetryEvent"],
-  showRedactions: ["Bool", "showRedactions"],
-  disableLogRocket: ["Bool", "disableLogRocket"],
-  sidePanelSize: ["String", "sidePanelSize"],
-  listenForMetrics: ["Bool", "listenForMetrics"],
-  disableCache: ["Bool", "disableCache"],
-  theme: ["String", "theme"],
   colorScheme: ["String", "colorScheme"],
+  disableCache: ["Bool", "disableCache"],
+  disableLogRocket: ["Bool", "disableLogRocket"],
+  eventListenersBreakpoints: ["Bool", "event-listeners-breakpoints"],
+  listenForMetrics: ["Bool", "listenForMetrics"],
+  logTelemetryEvent: ["Bool", "logTelemetryEvent"],
+  secondaryPanelHeight: ["String", "dev-secondary-panel-height"],
   showPanelAbove: ["Bool", "showPanelAbove"],
+  showRedactions: ["Bool", "showRedactions"],
+  sidePanelSize: ["String", "sidePanelSize"],
+  theme: ["String", "theme"],
+  toolboxSize: ["String", "toolbox-size"],
 });
 
 export const features = new PrefsHelper("devtools.features", {
-  turboReplay: ["Bool", "turboReplay"],
-  columnBreakpoints: ["Bool", "columnBreakpoints"],
-  httpBodies: ["Bool", "httpBodies"],
-  commentAttachments: ["Bool", "commentAttachments"],
-  networkRequestComments: ["Bool", "networkRequestComments"],
   breakpointPanelAutocomplete: ["Bool", "breakpointPanelAutocomplete"],
-  codeHeatMaps: ["Bool", "codeHeatMaps"],
-  resolveRecording: ["Bool", "resolveRecording"],
-  protocolTimeline: ["Bool", "protocolTimeline"],
-  logProtocol: ["Bool", "logProtocol"],
-  unicornConsole: ["Bool", "unicornConsole"],
-  showRedux: ["Bool", "showRedux"],
+  columnBreakpoints: ["Bool", "columnBreakpoints"],
+  commentAttachments: ["Bool", "commentAttachments"],
+  defaultToDevTools: ["Bool", "defaultToDevTools"],
   enableLargeText: ["Bool", "enableLargeText"],
-  repaintEvaluations: ["Bool", "repaintEvaluations"],
-  testSupport: ["Bool", "testSupport"],
+  httpBodies: ["Bool", "httpBodies"],
+  logProtocol: ["Bool", "logProtocol"],
+  networkRequestComments: ["Bool", "networkRequestComments"],
   originalClassNames: ["Bool", "originalClassNames"],
+  protocolTimeline: ["Bool", "protocolTimeline"],
+  repaintEvaluations: ["Bool", "repaintEvaluations"],
+  resolveRecording: ["Bool", "resolveRecording"],
+  showRedux: ["Bool", "showRedux"],
+  testSupport: ["Bool", "testSupport"],
+  turboReplay: ["Bool", "turboReplay"],
+  unicornConsole: ["Bool", "unicornConsole"],
 });
 
 export const asyncStore = asyncStoreHelper("devtools", {
+  commandHistory: ["command-history", []],
   eventListenerBreakpoints: ["event-listener-breakpoints", undefined],
   replaySessions: ["replay-sessions", {}],
-  commandHistory: ["command-history", []],
 });


### PR DESCRIPTION
### Issues
- We want to have an option for people to default to opening all Replays to dev mode
- We had a `prefs.viewMode` option... but it was not used anywhere, and it was a `string` value, which did not play as nicely with the API I wanted for this flag (boolean)
- We still had `codeHeatMaps` options, even though we've stopped those from doing anything recently
- `RecordingRow` was adding an action prop `loadReplayPrefs`, which was the only thing it was getting from redux, and that prop was not used, so that component does not need to be connected
- The prefs file, which has many arbitrarily sorted lists, had things in pretty haphazard order. I think sorting lines alphabetically is not *always* the right call, but in this place, I think it's a good fit

### Changes
- Add a `Default to Devtools Mode` flag and UI in the experimental preferences section
- Delete `prefs.viewMode`
- Delete `loadReplayPrefs`
- Disconnect `RecordingRow`
- Delete `codeHeatMaps`
- Sort lists of values in the prefs file