### PR TITLE
Add up and down arrow key shortcuts to net monitor

### DIFF
--- a/src/ui/actions/network.ts
+++ b/src/ui/actions/network.ts
@@ -107,6 +107,11 @@ export function selectAndFetchRequest(requestId: RequestId): UIThunkAction {
       return;
     }
 
+    dispatch({
+      requestId,
+      type: "SHOW_REQUEST_DETAILS",
+    });
+
     const timeStampedPoint = requestSummary.point;
     const pause = ThreadFront.ensurePause(timeStampedPoint.point, timeStampedPoint.time);
     const frames = (await pause.getFrames())?.filter(Boolean) || [];
@@ -122,11 +127,6 @@ export function selectAndFetchRequest(requestId: RequestId): UIThunkAction {
     if (requestSummary.hasRequestBody) {
       ThreadFront.fetchRequestBody(requestId);
     }
-
-    dispatch({
-      requestId,
-      type: "SHOW_REQUEST_DETAILS",
-    });
   };
 }
 


### PR DESCRIPTION
This way you can easily select the next or previous request.

Also, this makes it so that if we take a while to load request or response bodies, we will show "Loading..." instead of just not showing anything (which feels like a bug).