### PR TITLE
Fix logout to return to login page

### DIFF
--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -12,5 +12,5 @@ export default function LoginPage() {
     dispatch(clearExpectedError());
   }, [dispatch]);
 
-  return <Login returnToPath={"" + router.query.returnTo} />;
+  return <Login returnToPath={"" + (router.query.returnTo || "/")} />;
 }

--- a/src/ui/components/LoginButton.tsx
+++ b/src/ui/components/LoginButton.tsx
@@ -7,7 +7,10 @@ const LoginButton = () => {
 
   if (isAuthenticated) {
     return (
-      <button className="row logout" onClick={() => logout()}>
+      <button
+        className="row logout"
+        onClick={() => logout({ returnTo: window.location.origin + "/login" })}
+      >
         <Avatar player={user} isFirstPlayer={true} />
         <span>Sign Out</span>
       </button>

--- a/src/ui/components/shared/UserSettingsModal/UserSettingsModal.tsx
+++ b/src/ui/components/shared/UserSettingsModal/UserSettingsModal.tsx
@@ -59,7 +59,7 @@ function Personal() {
       </div>
       <div>
         <button
-          onClick={() => logout()}
+          onClick={() => logout({ returnTo: window.location.origin + "/login" })}
           className="max-w-max items-center rounded-md border border-transparent bg-primaryAccent px-3 py-1.5 font-medium text-white shadow-sm hover:bg-primaryAccentHover focus:outline-none focus:ring-2 focus:ring-primaryAccent focus:ring-offset-2"
         >
           Log Out


### PR DESCRIPTION
## Issue

Logging out of replay redirected to `http://localhost:3000`. This was cause both by a bad default configuration in auth0 and the absence of `returnTo` in the `logout()` call.

## Resolution

* Update Auth0 config to prioritize the production app for a logout without a `returnTo`
* This PR to add a `returnTo` pointing at the login page for logout actions