### PR TITLE
Only run GraphQL Typecheck job on local PRs

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -13,6 +13,7 @@ jobs:
       - name: Run tsc
         run: npm run typecheck
   gql:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.pull_request.head.repo.full_name, 'replayio/')
     name: GraphQL schema types
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Issue

This job fails for any PR opened from a fork because it requires a secret which is not available for a fork.

## Resolution

Add an `if` check to the job so it only runs when the PR is opened from the replayio org