### PR TITLE
Try to show response bodies when the content is unknown

### DIFF
--- a/src/ui/components/NetworkMonitor/content.ts
+++ b/src/ui/components/NetworkMonitor/content.ts
@@ -59,6 +59,11 @@ export const shouldTryAndTurnIntoText = (contentType: string): boolean => {
   if (contentType.startsWith("text")) {
     return true;
   }
+
+  if (contentType == "unknown") {
+    return true;
+  }
+
   if (TEXTISH_CONTENT_TYPES.includes(withoutCharset(contentType))) {
     return true;
   }


### PR DESCRIPTION
It is fairly common to show a download link and then to see JSON in the response body. This updates our logic so we're a bit more optimistic