### PR TITLE
fix print statement panel buttons spilling offscreen

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.tsx
@@ -140,7 +140,7 @@ function Panel({
             }}
           >
             <PrefixBadgeButton breakpoint={breakpoint!} />
-            <div className="flex-1">
+            <div className="min-w-0 flex-1">
               {editing ? (
                 <PanelEditor
                   breakpoint={breakpoint}


### PR DESCRIPTION
Oh Flexbox why don't you have fractional units like Grid 🤪. This is a reminder for me to use Grid for our layout components.