### PR TITLE
FE-240: Simplify `useAppDispatch` definition and replace remaining hooks usages

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,6 +34,18 @@
     "no-nested-ternary": 0,
     "no-param-reassign": 0,
     "no-restricted-syntax": 0,
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          {
+            "name": "react-redux",
+            "importNames": ["useDispatch", "useSelector"],
+            "message": "Please import 'useAppDispatch/useAppSelector' from 'ui/setup/hooks' instead."
+          }
+        ]
+      }
+    ],
     "react/button-has-type": 0,
     "react/forbid-prop-types": 0,
     "react-hooks/rules-of-hooks": "error", // Checks rules of Hooks
@@ -53,7 +65,7 @@
   },
   "settings": {
     "react": {
-      "version": "16.8"
+      "version": "18.1"
     }
   }
 }

--- a/src/devtools/client/webconsole/components/Search/useConsoleSearch.ts
+++ b/src/devtools/client/webconsole/components/Search/useConsoleSearch.ts
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { useSelector } from "react-redux";
+import { useAppSelector } from "ui/setup/hooks";
 import useSearch from "./useSearch";
 import { Message } from "../../reducers/messages";
 import { getMessages } from "../../selectors";
@@ -42,7 +42,7 @@ export type State = SearchState<Message> & {
 };
 
 export default function useConsoleSearch(): [State, Actions] {
-  const messages = useSelector(getMessages);
+  const messages = useAppSelector(getMessages);
   const [state, dispatch] = useSearch<Message>(messages, search);
 
   const [visible, setVisible] = useState<boolean>(false);

--- a/src/devtools/client/webconsole/utils/autocomplete-eager.ts
+++ b/src/devtools/client/webconsole/utils/autocomplete-eager.ts
@@ -3,7 +3,7 @@ import { getSelectedFrame } from "devtools/client/debugger/src/selectors";
 import { GETTERS_FROM_PROTOTYPES } from "devtools/packages/devtools-reps/object-inspector/items";
 import { ThreadFront, ValueFront } from "protocol/thread";
 import { useMemo } from "react";
-import { useSelector } from "react-redux";
+import { useAppSelector } from "ui/setup/hooks";
 import { getPropertiesForObject } from "ui/utils/autocomplete";
 
 // Use eager eval to get the properties of the last complete object in the expression.
@@ -64,7 +64,7 @@ async function eagerEvaluateExpression(
 }
 
 export function useEagerEvaluateExpression() {
-  const frame = useSelector(getSelectedFrame);
+  const frame = useAppSelector(getSelectedFrame);
   const callback = useMemo(
     () => (expression: string) => {
       if (!frame) {

--- a/src/ui/components/Library/Content/TestRuns/TestRuns.tsx
+++ b/src/ui/components/Library/Content/TestRuns/TestRuns.tsx
@@ -1,5 +1,5 @@
 import { createContext, ReactNode, useContext, useEffect, useState } from "react";
-import { useSelector } from "react-redux";
+import { useAppSelector } from "ui/setup/hooks";
 import { TestRun, useGetTestRunsForWorkspace } from "ui/hooks/tests";
 import { getWorkspaceId } from "ui/reducers/app";
 import styles from "../../Library.module.css";
@@ -34,7 +34,7 @@ function TestRunsContextWrapper({ children }: { children: ReactNode }) {
 }
 
 export function TestRuns() {
-  const workspaceId = useSelector(getWorkspaceId);
+  const workspaceId = useAppSelector(getWorkspaceId);
   const { testRuns, loading } = useGetTestRunsForWorkspace(workspaceId!);
   const [initialized, setInitialized] = useState(false);
   const { setPreview } = useContext(LibraryContext);

--- a/src/ui/hooks/tests.ts
+++ b/src/ui/hooks/tests.ts
@@ -1,6 +1,6 @@
 import { gql, useQuery } from "@apollo/client";
 import { orderBy } from "lodash";
-import { useSelector } from "react-redux";
+import { useAppSelector } from "ui/setup/hooks";
 import { getWorkspaceId } from "ui/reducers/app";
 import { WorkspaceId } from "ui/state/app";
 import { Recording, SourceCommit } from "ui/types";
@@ -124,7 +124,7 @@ function unwrapRecordingsData(recordings: any): Recording[] {
 
 export function useGetTestForWorkspace(path: string[]): { test: Test | null; loading: boolean } {
   const serializedPath = encodeURIComponent(JSON.stringify(path));
-  const workspaceId = useSelector(getWorkspaceId);
+  const workspaceId = useAppSelector(getWorkspaceId);
   const { data, loading } = useQuery(GET_TEST, {
     variables: { path: serializedPath, workspaceId },
   });
@@ -143,7 +143,7 @@ export function useGetTestRunForWorkspace(id: string): {
   testRun: TestRun | null;
   loading: boolean;
 } {
-  const workspaceId = useSelector(getWorkspaceId);
+  const workspaceId = useAppSelector(getWorkspaceId);
   const { data, loading } = useQuery(GET_TEST_RUN, {
     variables: { id, workspaceId },
   });

--- a/src/ui/hooks/tracking.ts
+++ b/src/ui/hooks/tracking.ts
@@ -1,11 +1,11 @@
 import { useEffect, useState } from "react";
-import { useSelector } from "react-redux";
+import { useAppSelector } from "ui/setup/hooks";
 import { getUploading } from "ui/reducers/app";
 import { Recording } from "ui/types";
 import { trackTiming } from "ui/utils/telemetry";
 
 export function useTrackLoadingIdleTime(uploadComplete: boolean, recording?: Recording) {
-  const uploading = useSelector(getUploading);
+  const uploading = useAppSelector(getUploading);
   const context = uploadComplete ? "warm" : "cold";
   const [started, setStarted] = useState(false);
   const [uploadProgressShown, setUploadProgressShown] = useState(false);

--- a/src/ui/setup/hooks.ts
+++ b/src/ui/setup/hooks.ts
@@ -3,5 +3,5 @@ import type { AppDispatch } from "./store";
 import type { UIState } from "ui/state";
 
 // Use throughout your app instead of plain `useDispatch` and `useSelector`
-export const useAppDispatch = () => useDispatch<AppDispatch>();
+export const useAppDispatch: () => AppDispatch = useDispatch;
 export const useAppSelector: TypedUseSelectorHook<UIState> = useSelector;

--- a/src/ui/setup/hooks.ts
+++ b/src/ui/setup/hooks.ts
@@ -1,3 +1,6 @@
+// We ban use of `useDispatch/useSelector` in the codebase in favor of the typed hooks,
+// but this is the one file that needs them
+// eslint-disable-next-line no-restricted-imports
 import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
 import type { AppDispatch } from "./store";
 import type { UIState } from "ui/state";

--- a/src/ui/utils/org.ts
+++ b/src/ui/utils/org.ts
@@ -1,4 +1,4 @@
-import { useSelector } from "react-redux";
+import { useAppSelector } from "ui/setup/hooks";
 import { useGetNonPendingWorkspaces } from "ui/hooks/workspaces";
 import { getWorkspaceId } from "ui/reducers/app";
 import { Workspace, WorkspaceSettings } from "ui/types";
@@ -27,7 +27,7 @@ export function getOrganizationSettings(workspaces: Workspace[]) {
 
 export function useIsPublicEnabled() {
   const { workspaces, loading: loadingWorkspaces } = useGetNonPendingWorkspaces();
-  const currentWorkspaceId = useSelector(getWorkspaceId);
+  const currentWorkspaceId = useAppSelector(getWorkspaceId);
 
   if (loadingWorkspaces) {
     return false;


### PR DESCRIPTION
Per suggestion in #7162 , this PR:

- Replaces the `useAppDispatch` definition (copy-pasted from the Redux docs) with an equivalent line that removes the excess function call
- Adds an ESLint rule that forbids imports of `useDispatch/useSelector from "react-redux"` in favor of the typed hooks
- Replaces all remaining usages of the untyped hooks


Example lint rule output:

```
C:\Projects\replay-devtools\src\devtools\client\debugger\src\components\Editor\Footer.tsx
  2:10  error  'useSelector' import from 'react-redux' is restricted. Please import 'useAppDispatch/useAppSelector' from 'ui/setup/hooks' instead  no-restricted-imports
```

![image](https://user-images.githubusercontent.com/1128784/173674643-b914458b-da98-4615-bb7b-b97badad7c8a.png)
