### PR TITLE
Add rainbow picker to console context menu

### DIFF
--- a/packages/components/PrefixBadgePicker/PrefixBadgePicker.module.css
+++ b/packages/components/PrefixBadgePicker/PrefixBadgePicker.module.css
@@ -71,47 +71,23 @@
   --badge-background--active: #474c52;
 }
 
-:root:global(.theme-light) .unicorn {
-  --primary-color: #ff6ddf;
-  color: #fff;
+.green {
+  --primary-color: var(--badge-green-color);
+  color: var(--badge-green-contrast-color);
 }
-:root:global(.theme-dark) .unicorn {
-  --primary-color: #e110b3;
-  color: #fff;
+.orange {
+  --primary-color: var(--badge-orange-color);
+  color: var(--badge-orange-contrast-color);
 }
-
-:root:global(.theme-light) .purple {
-  --primary-color: #a973cd;
-  color: #fff;
+.purple {
+  --primary-color: var(--badge-purple-color);
+  color: var(--badge-purple-contrast-color);
 }
-:root:global(.theme-dark) .purple {
-  --primary-color: #cc81ff;
-  color: #fff;
+.yellow {
+  --primary-color: var(--badge-yellow-color);
+  color: var(--badge-yellow-contrast-color);
 }
-
-:root:global(.theme-light) .green {
-  --primary-color: #73cc6d;
-  color: #fff;
-}
-:root:global(.theme-dark) .green {
-  --primary-color: #69e261;
-  color: #050;
-}
-
-:root:global(.theme-light) .orange {
-  --primary-color: #da7c04;
-  color: #fff;
-}
-:root:global(.theme-dark) .orange {
-  --primary-color: #ff9a19;
-  color: #fff;
-}
-
-:root:global(.theme-light) .yellow {
-  --primary-color: #e4cd00;
-  color: rgb(99, 79, 5);
-}
-:root:global(.theme-dark) .yellow {
-  --primary-color: #fee608;
-  color: rgb(99, 79, 5);
+.unicorn {
+  --primary-color: var(--badge-unicorn-color);
+  color: var(--badge-unicorn-contrast-color);
 }

--- a/src/devtools/client/themes/variables.css
+++ b/src/devtools/client/themes/variables.css
@@ -119,6 +119,18 @@
   - (Previous styles; to organise)
   */
 
+  /* Badge colors */
+  --badge-green-color: #73cc6d;
+  --badge-green-contrast-color: #fff;
+  --badge-orange-color: #da7c04;
+  --badge-orange-contrast-color: #fff;
+  --badge-purple-color: #a973cd;
+  --badge-purple-contrast-color: #fff;
+  --badge-unicorn-color: #ff6ddf;
+  --badge-unicorn-contrast-color: #fff;
+  --badge-yellow-color: #e4cd00;
+  --badge-yellow-contrast-color: rgb(99, 79, 5);
+
   /* Color ramp (Light) */
   --theme-base-100: hsl(0, 0%, 100%);
   --theme-base-95: hsl(0, 0%, 95%);
@@ -363,6 +375,18 @@
   - To Organise
   - (Previous styles; to organise)
   */
+
+  /* Badge colors */
+  --badge-green-color: #69e261;
+  --badge-green-contrast-color: #050;
+  --badge-orange-color: #ff9a19;
+  --badge-orange-contrast-color: #fff;
+  --badge-purple-color: #cc81ff;
+  --badge-purple-contrast-color: #fff;
+  --badge-unicorn-color: #e110b3;
+  --badge-unicorn-contrast-color: #fff;
+  --badge-yellow-color: #fee608;
+  --badge-yellow-contrast-color: rgb(99, 79, 5);
 
   /* Color ramp (Dark) */
   --theme-base-100: #000; /* background chrome */

--- a/src/devtools/client/webconsole/components/Output/ConsoleOutput.module.css
+++ b/src/devtools/client/webconsole/components/Output/ConsoleOutput.module.css
@@ -11,3 +11,72 @@
   cursor: pointer;
   text-decoration-line: underline;
 }
+
+.ColorPickerRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1ch;
+}
+
+.UnicornBadge {
+  background-image: url(~devtools/client/debugger/images/sources/unicorn-pixel.svg) !important;
+  background-size: auto 100%;
+  width: 1rem;
+  height: 1rem;
+}
+
+.ColorBadge {
+  border-radius: 100%;
+  position: relative;
+  width: 0.75rem;
+  height: 0.75rem;
+}
+.ColorBadge::before {
+  content: " ";
+  display: block;
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  left: -4px;
+  right: -4px;
+  background-color: var(--badge-color);
+  border-radius: 100%;
+  transition: opacity 0.18s ease-out;
+  opacity: 0;
+}
+.ColorBadge:hover::before {
+  opacity: 0.2;
+}
+
+.EmptyBadge {
+  border-radius: 100%;
+  width: 0.75rem;
+  height: 0.75rem;
+  border: 2px solid var(--theme-base-70);
+}
+.EmptyBadge:hover {
+  border-color: var(--theme-base-60);
+  transition: border-color 0.18s ease-out;
+}
+
+.green {
+  --badge-color: var(--badge-green-color);
+  background-color: var(--badge-color);
+}
+.orange {
+  --badge-color: var(--badge-orange-color);
+  background-color: var(--badge-color);
+}
+.purple {
+  --badge-color: var(--badge-purple-color);
+  background-color: var(--badge-color);
+}
+.yellow {
+  --badge-color: var(--badge-yellow-color);
+  background-color: var(--badge-color);
+}
+.unicorn {
+  --badge-color: var(--badge-unicorn-color);
+  background-color: var(--badge-color);
+}

--- a/src/devtools/client/webconsole/components/Output/ConsoleOutput.tsx
+++ b/src/devtools/client/webconsole/components/Output/ConsoleOutput.tsx
@@ -2,8 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Dispatch } from "@reduxjs/toolkit";
-import { SourceLocation } from "devtools/client/debugger/src/reducers/types";
+import classNames from "classnames";
+import { badges } from "components/PrefixBadgePicker/PrefixBadgePicker";
+import { PrefixBadge, SourceLocation } from "devtools/client/debugger/src/reducers/types";
 import { MessageContainer } from "devtools/client/webconsole/components/Output/MessageContainer";
 import { StateContext } from "devtools/client/webconsole/components/Search";
 import constants from "devtools/client/webconsole/constants";
@@ -17,7 +18,7 @@ import {
   setFocusRegionBeginTime,
 } from "ui/actions/timeline";
 import { ContextMenu } from "ui/components/ContextMenu";
-import { Dropdown, DropdownItem } from "ui/components/Library/LibraryDropdown";
+import { Dropdown, DropdownDivider, DropdownItem } from "ui/components/Library/LibraryDropdown";
 import Icon from "ui/components/shared/Icon";
 import { selectors } from "ui/reducers";
 import {
@@ -36,6 +37,7 @@ import ConsoleLoadingBar from "./ConsoleLoadingBar";
 import styles from "./ConsoleOutput.module.css";
 
 import type { State as ConsoleSearchState } from "../Search/useConsoleSearch";
+import { setBreakpointPrefixBadge } from "devtools/client/debugger/src/actions/breakpoints";
 
 function compareLocation(locA: Frame | undefined, locB: SourceLocation) {
   if (!locA) {
@@ -250,7 +252,7 @@ class ConsoleOutput extends React.Component<PropsFromRedux, State> {
         </div>
         {contextMenu !== null && (
           <ContextMenu x={contextMenu.pageX} y={contextMenu.pageY} close={this.closeContextMenu}>
-            <Dropdown>
+            <Dropdown widthClass="">
               <DropdownItem onClick={this.setFocusStart}>
                 <>
                   <Icon filename="set-focus-start" className="mr-4 bg-iconColor" size="large" />
@@ -262,6 +264,23 @@ class ConsoleOutput extends React.Component<PropsFromRedux, State> {
                   <Icon filename="set-focus-end" className="mr-4 bg-iconColor" size="large" />
                   Set focus end
                 </>
+              </DropdownItem>
+              <DropdownDivider />
+              <DropdownItem onClick={noop}>
+                <div className={styles.ColorPickerRow}>
+                  {badges.map(badge => (
+                    <div
+                      key={badge}
+                      className={
+                        badge === "unicorn"
+                          ? styles.UnicornBadge
+                          : classNames(styles.ColorBadge, styles[badge])
+                      }
+                      onClick={() => this.selectBadge(badge)}
+                    />
+                  ))}
+                  <div className={styles.EmptyBadge} onClick={() => this.selectBadge(undefined)} />
+                </div>
               </DropdownItem>
             </Dropdown>
           </ContextMenu>
@@ -306,8 +325,23 @@ class ConsoleOutput extends React.Component<PropsFromRedux, State> {
     });
   };
 
+  selectBadge = (badge: PrefixBadge | undefined) => {
+    const { breakpoints, dispatch } = this.props;
+    const { message } = this.state.contextMenu!;
+
+    const matchingBreakpoint = breakpoints.find(breakpoint =>
+      compareLocation(message.frame, breakpoint.location)
+    );
+
+    if (matchingBreakpoint != null) {
+      dispatch(setBreakpointPrefixBadge(matchingBreakpoint, badge));
+    }
+
+    this.closeContextMenu();
+  };
+
   setFocusEnd = async () => {
-    const { dispatch, focusRegion } = this.props;
+    const { dispatch } = this.props;
     const { message } = this.state.contextMenu!;
 
     this.setState({ contextMenu: null });
@@ -318,7 +352,7 @@ class ConsoleOutput extends React.Component<PropsFromRedux, State> {
       return;
     }
 
-    (dispatch as AppDispatch)(setFocusRegionEndTime(time, true));
+    dispatch(setFocusRegionEndTime(time, true));
   };
 
   setFocusStart = async () => {
@@ -333,7 +367,7 @@ class ConsoleOutput extends React.Component<PropsFromRedux, State> {
       return;
     }
 
-    (dispatch as AppDispatch)(setFocusRegionBeginTime(time, true));
+    dispatch(setFocusRegionBeginTime(time, true));
   };
 }
 
@@ -362,7 +396,7 @@ function mapStateToProps(state: UIState) {
   };
 }
 
-const mapDispatchToProps = (dispatch: Dispatch) => ({
+const mapDispatchToProps = (dispatch: AppDispatch) => ({
   dispatch,
 });
 
@@ -464,3 +498,5 @@ function TrimmedMessageCountRow({ position }: { position: "before" | "after" }) 
     );
   }
 }
+
+function noop() {}

--- a/src/ui/components/Library/Library.module.css
+++ b/src/ui/components/Library/Library.module.css
@@ -32,7 +32,7 @@
 }
 
 :root:global(.theme-dark) .dropdownDivider {
-  border-bottom: 1px solid var(--theme-base-80);
+  border-bottom: 1px solid var(--chrome);
 }
 
 :root:global(.theme-dark) .editButton {

--- a/src/ui/components/Library/LibraryDropdown.tsx
+++ b/src/ui/components/Library/LibraryDropdown.tsx
@@ -35,7 +35,7 @@ export function Dropdown({
 }: {
   children: React.ReactNode;
   menuItemsClassName?: string;
-  widthClass?: "w-56" | "w-64" | "w-80";
+  widthClass?: "" | "w-56" | "w-64" | "w-80";
   fontSizeClass?: "text-sm" | "text-base";
 }) {
   return (

--- a/src/ui/components/PrefixBadge.tsx
+++ b/src/ui/components/PrefixBadge.tsx
@@ -20,6 +20,7 @@ export default function PrefixBadgeButton({ breakpoint }: { breakpoint: Breakpoi
 
   return (
     <PrefixBadgePicker
+      key={breakpoint.options.prefixBadge}
       initialValue={breakpoint.options.prefixBadge}
       onSelect={newPrefixBadge => dispatch(setBreakpointPrefixBadge(breakpoint, newPrefixBadge))}
     />


### PR DESCRIPTION


Things to sort out:
- [ ] Using `key` to reset derived state of `PrefixBadgePicker` picker fixed out-of-sync issue but causes the picker opening interaction to be awkward. More info [on this Loom](https://discord.com/channels/@me/974438142125953034/986364129797349378).