### PR TITLE
add unfurl comment button to all network detail panes

### DIFF
--- a/packages/components/AddCommentButton/AddCommentButton.tsx
+++ b/packages/components/AddCommentButton/AddCommentButton.tsx
@@ -1,5 +1,6 @@
 import type { MouseEventHandler } from "react";
 import { forwardRef, useRef, useState } from "react";
+import classNames from "classnames";
 import mergeRefs from "react-merge-refs";
 import { Transition } from "react-transition-group";
 import styled from "styled-components";
@@ -15,13 +16,15 @@ interface AddCommentButtonProps {
 
   /** Whether the button should submit a form or not. */
   type?: "button" | "submit";
+
+  className?: string;
 }
 
 /**
  * Initiate adding a comment from a button.
  */
 export const AddCommentButton = forwardRef<HTMLButtonElement, AddCommentButtonProps>(
-  function AddCommentButton({ type, isPausedOnHit = false, onClick }, ref) {
+  function AddCommentButton({ type, isPausedOnHit = false, onClick, className }, ref) {
     const localRef = useRef<HTMLButtonElement>(null);
     const mergedRefs = mergeRefs([localRef, ref]);
     const [isHovered, setIsHovered] = useState(false);
@@ -44,7 +47,10 @@ export const AddCommentButton = forwardRef<HTMLButtonElement, AddCommentButtonPr
         onMouseLeave={clearHover}
         $isOpened={isHovered}
         $isPausedOnHit={isPausedOnHit}
-        className="font-sans font-medium outline-none focus-visible:ring-2 focus-visible:ring-primaryAccent focus-visible:ring-offset-2"
+        className={classNames(
+          "font-sans font-medium outline-none focus-visible:ring-2 focus-visible:ring-primaryAccent focus-visible:ring-offset-2",
+          className
+        )}
       >
         <Icon name="comment-plus" fill="currentColor" />
         <TextFade visible={isHovered}>Add Comment</TextFade>

--- a/src/ui/components/NetworkMonitor/AddNetworkRequestCommentButton.tsx
+++ b/src/ui/components/NetworkMonitor/AddNetworkRequestCommentButton.tsx
@@ -2,7 +2,7 @@ import { useAppDispatch } from "ui/setup/hooks";
 import { createNetworkRequestComment } from "ui/actions/comments";
 import { useGetRecordingId } from "ui/hooks/recordings";
 import { useFeature } from "ui/hooks/settings";
-import { AddCommentButton } from "components/AddCommentButton";
+import { AddCommentButton } from "../../../../packages/components";
 import { RequestSummary } from "./utils";
 
 export default function AddNetworkRequestCommentButton({

--- a/src/ui/components/NetworkMonitor/AddNetworkRequestCommentButton.tsx
+++ b/src/ui/components/NetworkMonitor/AddNetworkRequestCommentButton.tsx
@@ -2,6 +2,7 @@ import { useAppDispatch } from "ui/setup/hooks";
 import { createNetworkRequestComment } from "ui/actions/comments";
 import { useGetRecordingId } from "ui/hooks/recordings";
 import { useFeature } from "ui/hooks/settings";
+import { AddCommentButton } from "components/AddCommentButton";
 import { RequestSummary } from "./utils";
 
 export default function AddNetworkRequestCommentButton({ request }: { request: RequestSummary }) {
@@ -17,13 +18,5 @@ export default function AddNetworkRequestCommentButton({ request }: { request: R
     return null;
   }
 
-  return (
-    <button
-      className="inline-flex items-center space-x-2 rounded-md border border-transparent bg-primaryAccent px-1 text-xs font-medium leading-4 text-white shadow-sm focus:outline-none focus:ring-2 focus:ring-primaryAccent focus:ring-offset-2"
-      onClick={addRequestComment}
-    >
-      <div className="material-icons add-comment-icon text-base text-white">add_comment</div>
-      <div>Add a comment</div>
-    </button>
-  );
+  return <AddCommentButton onClick={addRequestComment} />;
 }

--- a/src/ui/components/NetworkMonitor/AddNetworkRequestCommentButton.tsx
+++ b/src/ui/components/NetworkMonitor/AddNetworkRequestCommentButton.tsx
@@ -5,7 +5,13 @@ import { useFeature } from "ui/hooks/settings";
 import { AddCommentButton } from "components/AddCommentButton";
 import { RequestSummary } from "./utils";
 
-export default function AddNetworkRequestCommentButton({ request }: { request: RequestSummary }) {
+export default function AddNetworkRequestCommentButton({
+  request,
+  className,
+}: {
+  request: RequestSummary;
+  className?: string;
+}) {
   const { value: networkRequestComments } = useFeature("networkRequestComments");
   const dispatch = useAppDispatch();
   const recordingId = useGetRecordingId();
@@ -18,5 +24,5 @@ export default function AddNetworkRequestCommentButton({ request }: { request: R
     return null;
   }
 
-  return <AddCommentButton onClick={addRequestComment} />;
+  return <AddCommentButton className={className} onClick={addRequestComment} />;
 }

--- a/src/ui/components/NetworkMonitor/RequestDetails.tsx
+++ b/src/ui/components/NetworkMonitor/RequestDetails.tsx
@@ -227,7 +227,6 @@ const HeadersPanel = ({ request }: { request: RequestSummary }) => {
           <TriangleToggle open={requestExpanded} />
           General
         </div>
-        <AddNetworkRequestCommentButton request={request} />
       </div>
       {requestExpanded && <DetailTable className={styles.request} details={details} />}
       <div
@@ -362,8 +361,11 @@ const RequestDetails = ({
         <PanelTabs tabs={tabs} activeTab={activeTab} setActiveTab={setActiveTab} />
         <CloseButton buttonClass="mr-2" handleClick={closePanel} tooltip={"Close tab"} />
       </RequestDetailsTabs>
-      <div className={classNames("requestDetails", styles.requestDetails)}>
+      <div className={classNames("requestDetails relative", styles.requestDetails)}>
         <div>
+          <div className="absolute top-1 right-1">
+            <AddNetworkRequestCommentButton request={request} />
+          </div>
           {activeTab === "headers" && <HeadersPanel request={request} />}
           {activeTab === "cookies" && <Cookies request={request} />}
           {activeTab === "response" && <ResponseBody request={request} />}

--- a/src/ui/components/NetworkMonitor/RequestDetails.tsx
+++ b/src/ui/components/NetworkMonitor/RequestDetails.tsx
@@ -363,9 +363,7 @@ const RequestDetails = ({
       </RequestDetailsTabs>
       <div className={classNames("requestDetails relative", styles.requestDetails)}>
         <div>
-          <div className="absolute top-1 right-1">
-            <AddNetworkRequestCommentButton request={request} />
-          </div>
+          <AddNetworkRequestCommentButton request={request} className="absolute top-1 right-1" />
           {activeTab === "headers" && <HeadersPanel request={request} />}
           {activeTab === "cookies" && <Cookies request={request} />}
           {activeTab === "response" && <ResponseBody request={request} />}


### PR DESCRIPTION
This PR adds our newer unfurl comment button that's visible on all Network detail panes. I think we should eventually store the tab you were commenting on, but not sure how to add that to the database 😇.

closes FE-255

https://www.loom.com/share/5b724006aab54469851fe1438695f673