### PR TITLE
Reload hitCounts when they get cleared due to focus

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
@@ -27,8 +27,10 @@ function LineHitCounts({ cm }: Props) {
 
   useLayoutEffect(() => {
     // HACK Make sure we load hit count metadata; normally this is done in response to a mouseover event.
-    dispatch(setBreakpointHitCounts(sourceId, 0));
-  }, [dispatch, sourceId]);
+    if (hitCounts === null) {
+      dispatch(setBreakpointHitCounts(sourceId, 0));
+    }
+  }, [dispatch, sourceId, hitCounts]);
 
   useLayoutEffect(() => {
     if (!cm) {


### PR DESCRIPTION
When the focus region changes, we clear out the hitCounts because they
are no longer reliable. However, the LineHitCounts component was not
refetching them when they got cleared, so they would not update as focus
changed. This seems like the kind of thing which might be addressed well
with one of the new architecture proposals? Until then, this is a slight
modification to the existing hackiness.