### PR TITLE
Send protocol timings to MixPanel

### DIFF
--- a/src/ui/utils/mixpanel.ts
+++ b/src/ui/utils/mixpanel.ts
@@ -83,6 +83,10 @@ type MixpanelEvent =
   | ["onboarding.started_onboarding"]
   | ["onboarding.team_invite"]
   | ["paused"]
+  | [
+      "protocol_message_completed",
+      { id: number; method: string; start: number; end: number; duration_seconds: number }
+    ]
   | ["quick_open.open_quick_open"]
   | ["session.devtools_start", { userIsAuthor: boolean; workspaceUuid: WorkspaceUuid | null }]
   | ["session_end", { reason: string }]


### PR DESCRIPTION
I know we have a lot of this timing in honeycomb, but it's nice to be able to tie it in with MixPanel stuff as well.