### PR TITLE
Decode filter

### DIFF
--- a/src/ui/components/Library/Overview/TestResultListItem.tsx
+++ b/src/ui/components/Library/Overview/TestResultListItem.tsx
@@ -31,9 +31,7 @@ function Title({ recording }: { recording: Recording }) {
     e.preventDefault();
 
     setView("recordings");
-    setAppliedText(
-      `test-path:${encodeURIComponent(JSON.stringify(recording.metadata.test!.path))}`
-    );
+    setAppliedText(`test-path:${JSON.stringify(recording.metadata.test!.path)}`);
   };
 
   return (

--- a/src/ui/components/Library/useFilters.test.js
+++ b/src/ui/components/Library/useFilters.test.js
@@ -1,0 +1,34 @@
+import { encodeFilter } from "./useFilters";
+import cases from "jest-in-case";
+
+cases("encodeFilters", ({ filter, query }) => expect(encodeFilter(filter)).toEqual(query), [
+  { name: "basic", filter: "", query: "" },
+  { name: "single with '", filter: "test:' foo'", query: "test:'%20foo'" },
+  {
+    name: "two with '",
+    filter: "test:' foo' bar:' bazz'",
+    query: "test:'%20foo' bar:'%20bazz'",
+  },
+  { name: 'single  with "', filter: 'test:" foo"', query: "test:%22%20foo%22" },
+  { name: "single  with word", filter: "test:bazz", query: "test:bazz" },
+  {
+    name: "single  with word",
+    filter: "first:a_wild_🦄_appears second",
+    query: "first:a_wild_🦄_appears second",
+  },
+  {
+    name: "double  with word and '",
+    filter: "first:baz second:' buz'",
+    query: "first:baz second:'%20buz'",
+  },
+  {
+    name: "single [",
+    filter: "first:[ foo ]",
+    query: "first:%5B%20foo%20%5D",
+  },
+  {
+    name: 'double with [ and "',
+    filter: 'first:[ foo ] second:" bar "',
+    query: "first:%5B%20foo%20%5D second:%22%20bar%20%22",
+  },
+]);

--- a/src/ui/components/Library/useFilters.ts
+++ b/src/ui/components/Library/useFilters.ts
@@ -25,6 +25,60 @@ export const LibraryContext = createContext<LibraryContextType>({
   preview: null,
 });
 
+type Surrounder = {
+  [open: string]: string;
+};
+
+const SURROUNDERS: Surrounder = {
+  "'": "'",
+  '"': '"',
+  "[": "]",
+};
+
+const peekUntil = (input: string, until: string): string | void => {
+  return input.match(new RegExp(`^(.*?${until})`))?.[0];
+};
+
+const peekNextWord = (input: string): string => {
+  return input.match(new RegExp(`^(\S+)`))?.[0] ?? "";
+};
+
+export function encodeFilter(str: string) {
+  let encodedStr = "";
+  while (str.length > 0) {
+    const [match] = str.match(/^(.*?:)/) || [];
+    if (match) {
+      encodedStr += match;
+      str = str.substring(match.length);
+
+      const nextChar = str.substring(0, 1);
+      if (Object.keys(SURROUNDERS).includes(nextChar)) {
+        const closingChar = SURROUNDERS[nextChar];
+        const valueMatch = peekUntil(str.substring(1), closingChar);
+
+        if (valueMatch) {
+          encodedStr += encodeURIComponent(`${nextChar}${valueMatch}`);
+          str = str.substring(valueMatch.length + 1);
+        } else {
+          encodedStr += str.substring(1);
+          str = "";
+        }
+      } else {
+        const nextWord = peekNextWord(str);
+        // const [nextWord] = str.match(/^(\w+)/) || [];
+        console.log(`nw`, str, nextWord);
+        encodedStr += nextWord;
+        str = str.substring(nextWord.length);
+      }
+    } else {
+      encodedStr += str;
+      str = "";
+    }
+  }
+
+  return encodedStr;
+}
+
 const useFilterString = (str: string) => {
   const [appliedString, setAppliedString] = useState(str);
   const [displayedString, setDisplayedString] = useState(str);
@@ -35,7 +89,7 @@ const useFilterString = (str: string) => {
   const setAppliedText = (newStr: string) => {
     setAppliedString(newStr);
     setDisplayedString(newStr);
-    updateUrlWithParams({ q: newStr });
+    updateUrlWithParams({ q: encodeFilter(newStr) });
   };
 
   return {
@@ -47,7 +101,7 @@ const useFilterString = (str: string) => {
 };
 
 export function useFilters() {
-  const initialString = getParams().q || "";
+  const initialString = decodeURIComponent(getParams().q || "");
   const { appliedString, displayedString, setDisplayedText, setAppliedText } =
     useFilterString(initialString);
 


### PR DESCRIPTION
We'll probably quite a bit on the frontend query parsing. Today, the goal here is to support values that start with `'`, `"`, and `[`

https://www.loom.com/share/0e0a06563cdb476188f8fa856d06f7cf

### Before

<img width="745" alt="Screen Shot 2022-06-16 at 8 50 07 PM" src="https://user-images.githubusercontent.com/254562/174221250-569ae134-7f8d-4b08-85fc-5eb8bd1ba423.png">

### After

<img width="491" alt="Screen Shot 2022-06-16 at 8 48 11 PM" src="https://user-images.githubusercontent.com/254562/174221240-addc7251-0d48-4485-8da8-67faf19ec59e.png">
