### PR TITLE
Proof of concept: create an RTKQ-based React Suspense cache for the sources list

### DIFF
--- a/packages/markerikson-stack-client-prototype/react.d.ts
+++ b/packages/markerikson-stack-client-prototype/react.d.ts
@@ -1,0 +1,17 @@
+import "react";
+
+declare module "react" {
+  type TransitionCallback = () => void;
+
+  // The following hooks are only available in the experimental react release.
+  export function startTransition(TransitionCallback): void;
+  export function useDeferredValue(value: T): T;
+  export function useTransition(): [
+    isPending: boolean,
+    startTransition: (TransitionCallback) => void
+  ];
+
+  // Unstable Suspense cache API
+  export function unstable_getCacheForType<T>(resourceType: () => T): T;
+  export function unstable_useCacheRefresh(): () => void;
+}

--- a/packages/markerikson-stack-client-prototype/src/app/api.ts
+++ b/packages/markerikson-stack-client-prototype/src/app/api.ts
@@ -13,8 +13,17 @@ import { Dictionary } from "lodash";
 import groupBy from "lodash/groupBy";
 // eslint-disable-next-line no-restricted-imports
 import { client } from "protocol/socket";
+import type { ReplayClientInterface } from "shared/client/types";
 
-interface SourceGroups {
+let sessionId: SessionId;
+let replayClient: ReplayClientInterface;
+
+export const setReplayClient = (_sessionId: SessionId, _replayClient: ReplayClientInterface) => {
+  sessionId = _sessionId;
+  replayClient = _replayClient;
+};
+
+export interface SourceGroups {
   src: newSource[];
   node_modules: newSource[];
   other: newSource[];
@@ -27,8 +36,8 @@ const CACHE_DATA_PERMANENTLY = 10 * 365 * 24 * 60 * 60;
 export const api = createApi({
   baseQuery: fakeBaseQuery(),
   endpoints: build => ({
-    getSources: build.query<SourceGroups, SessionId>({
-      queryFn: async (sessionId: SessionId) => {
+    getSources: build.query<SourceGroups, void>({
+      queryFn: async () => {
         const sources: newSource[] = [];
 
         // Fetch the sources
@@ -60,8 +69,8 @@ export const api = createApi({
       },
       keepUnusedDataFor: CACHE_DATA_PERMANENTLY,
     }),
-    getSourceText: build.query<string, { sessionId: SessionId; sourceId: string }>({
-      queryFn: async ({ sessionId, sourceId }) => {
+    getSourceText: build.query<string, string>({
+      queryFn: async sourceId => {
         const demoSourceText = await client.Debugger.getSourceContents(
           {
             sourceId,
@@ -72,11 +81,8 @@ export const api = createApi({
       },
       keepUnusedDataFor: CACHE_DATA_PERMANENTLY,
     }),
-    getSourceHitCounts: build.query<
-      Dictionary<HitCount[]>,
-      { sessionId: SessionId; sourceId: string }
-    >({
-      queryFn: async ({ sessionId, sourceId }) => {
+    getSourceHitCounts: build.query<Dictionary<HitCount[]>, string>({
+      queryFn: async sourceId => {
         const { lineLocations } = await client.Debugger.getPossibleBreakpoints(
           {
             sourceId,
@@ -98,32 +104,30 @@ export const api = createApi({
       },
       keepUnusedDataFor: CACHE_DATA_PERMANENTLY,
     }),
-    getLineHitPoints: build.query<PointDescription[], { location: Location; sessionId: SessionId }>(
-      {
-        queryFn: async ({ location, sessionId }) => {
-          const data = await new Promise<PointDescription[]>(async resolve => {
-            const { analysisId } = await client.Analysis.createAnalysis(
-              {
-                mapper: "",
-                effectful: false,
-              },
-              sessionId
-            );
+    getLineHitPoints: build.query<PointDescription[], Location>({
+      queryFn: async location => {
+        const data = await new Promise<PointDescription[]>(async resolve => {
+          const { analysisId } = await client.Analysis.createAnalysis(
+            {
+              mapper: "",
+              effectful: false,
+            },
+            sessionId
+          );
 
-            client.Analysis.addLocation({ analysisId, location }, sessionId);
-            client.Analysis.findAnalysisPoints({ analysisId }, sessionId);
-            client.Analysis.addAnalysisPointsListener(({ points }) => {
-              resolve(points);
-              client.Analysis.releaseAnalysis({ analysisId }, sessionId);
-            });
+          client.Analysis.addLocation({ analysisId, location }, sessionId);
+          client.Analysis.findAnalysisPoints({ analysisId }, sessionId);
+          client.Analysis.addAnalysisPointsListener(({ points }) => {
+            resolve(points);
+            client.Analysis.releaseAnalysis({ analysisId }, sessionId);
           });
+        });
 
-          return { data };
-        },
-      }
-    ),
-    getPause: build.query<createPauseResult, { point: PointDescription; sessionId: SessionId }>({
-      queryFn: async ({ point, sessionId }) => {
+        return { data };
+      },
+    }),
+    getPause: build.query<createPauseResult, PointDescription>({
+      queryFn: async point => {
         const pause = await client.Session.createPause({ point: point.point }, sessionId);
         return { data: pause };
       },

--- a/packages/markerikson-stack-client-prototype/src/app/api.ts
+++ b/packages/markerikson-stack-client-prototype/src/app/api.ts
@@ -29,7 +29,7 @@ export interface SourceGroups {
   other: newSource[];
 }
 
-const reIsJsSourceFile = /(js|ts)x?$/;
+const reIsJsSourceFile = /(js|ts)x?(\?[\w\d]+)*$/;
 
 const CACHE_DATA_PERMANENTLY = 10 * 365 * 24 * 60 * 60;
 

--- a/packages/markerikson-stack-client-prototype/src/app/hooks.ts
+++ b/packages/markerikson-stack-client-prototype/src/app/hooks.ts
@@ -1,9 +1,9 @@
 // eslint-disable-next-line no-restricted-imports
-import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
+import { TypedUseSelectorHook, useDispatch, useSelector, useStore } from "react-redux";
 
-import type { AppDispatch, AppState } from "./store";
+import type { AppDispatch, AppState, AppStore } from "./store";
 
 // Use throughout your app instead of plain `useDispatch` and `useSelector`
-export const useAppDispatch = () => useDispatch<AppDispatch>();
-
+export const useAppDispatch: () => AppDispatch = useDispatch;
+export const useAppStore: () => AppStore = useStore;
 export const useAppSelector: TypedUseSelectorHook<AppState> = useSelector;

--- a/packages/markerikson-stack-client-prototype/src/app/store.ts
+++ b/packages/markerikson-stack-client-prototype/src/app/store.ts
@@ -15,8 +15,8 @@ export function makeStore() {
 
 const store = makeStore();
 
+export type AppStore = typeof store;
 export type AppState = ReturnType<typeof store.getState>;
-
 export type AppDispatch = typeof store.dispatch;
 
 export type AppThunk<ReturnType = void> = ThunkAction<

--- a/packages/markerikson-stack-client-prototype/src/components/Initializer.tsx
+++ b/packages/markerikson-stack-client-prototype/src/components/Initializer.tsx
@@ -6,6 +6,7 @@ import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
 import asyncInitializeClient from "../client/asyncInitializeClient";
 import { SessionContext, SessionContextType } from "../contexts/SessionContext";
+import { setReplayClient } from "../app/api";
 
 // HACK Hack around the fact that the initSocket() function is side effectful
 // and writes to an "app" global on the window object.
@@ -25,6 +26,7 @@ export default function Initializer({ children }: { children: ReactNode }) {
     // We only need to initialize them once.
     if (!didInitializeRef.current) {
       asyncInitializeClient(replayClient).then(sessionData => {
+        setReplayClient(sessionData.sessionId, replayClient)
         setContext(sessionData);
       });
     }

--- a/packages/markerikson-stack-client-prototype/src/components/Loader.module.css
+++ b/packages/markerikson-stack-client-prototype/src/components/Loader.module.css
@@ -1,0 +1,4 @@
+.Loader {
+  padding: 0.25rem;
+  background-color: yellow;
+}

--- a/packages/markerikson-stack-client-prototype/src/components/Loader.tsx
+++ b/packages/markerikson-stack-client-prototype/src/components/Loader.tsx
@@ -1,0 +1,5 @@
+import styles from "./Loader.module.css";
+
+export default function Loader() {
+  return <div className={styles.Loader}>Loading… ⏱️</div>;
+}

--- a/packages/markerikson-stack-client-prototype/src/features/sources/SourceContent.tsx
+++ b/packages/markerikson-stack-client-prototype/src/features/sources/SourceContent.tsx
@@ -25,14 +25,11 @@ export const SourceContent = () => {
   const selectedSourceId = useAppSelector(state => state.sources.selectedSourceId);
   const selectedPoint = useAppSelector(state => state.sources.selectedPoint);
 
-  const replayClient = useContext(ReplayClientContext);
-  const sessionId = replayClient.getSessionId()!;
-
   const { currentData: sourceText } = useGetSourceTextQuery(
-    selectedSourceId ? { sessionId, sourceId: selectedSourceId } : skipToken
+    selectedSourceId ? selectedSourceId : skipToken
   );
   const { currentData: sourceHits } = useGetSourceHitCountsQuery(
-    selectedSourceId ? { sessionId, sourceId: selectedSourceId } : skipToken
+    selectedSourceId ? selectedSourceId : skipToken
   );
 
   let closestHitPoint: HitCount | null = null;
@@ -48,17 +45,10 @@ export const SourceContent = () => {
 
   const location = closestHitPoint?.location;
   const { currentData: locationHitPoints } = useGetLineHitPointsQuery(
-    location ? { location, sessionId } : skipToken
+    location ? location : skipToken
   );
 
-  const { currentData: pause } = useGetPauseQuery(
-    selectedPoint
-      ? {
-          point: selectedPoint,
-          sessionId,
-        }
-      : skipToken
-  );
+  const { currentData: pause } = useGetPauseQuery(selectedPoint ? selectedPoint : skipToken);
 
   const domHandler = useMemo(() => {
     return EditorView.domEventHandlers({

--- a/packages/markerikson-stack-client-prototype/src/features/sources/SourcesList.tsx
+++ b/packages/markerikson-stack-client-prototype/src/features/sources/SourcesList.tsx
@@ -1,13 +1,13 @@
-import { useGetSourcesQuery } from "../../app/api";
 import { useAppDispatch, useAppSelector } from "../../app/hooks";
 
 import { sourceEntrySelected } from "./sourcesSlice";
+import { getSourceGroups } from "./sourcesCache";
 
 export const SourcesList = () => {
   const dispatch = useAppDispatch();
   const selectedSourceId = useAppSelector(state => state.sources.selectedSourceId);
 
-  const { data } = useGetSourcesQuery();
+  const data = getSourceGroups();
 
   return (
     <ul>

--- a/packages/markerikson-stack-client-prototype/src/features/sources/SourcesList.tsx
+++ b/packages/markerikson-stack-client-prototype/src/features/sources/SourcesList.tsx
@@ -1,6 +1,3 @@
-import { useContext } from "react";
-import { ReplayClientContext } from "shared/client/ReplayClientContext";
-
 import { useGetSourcesQuery } from "../../app/api";
 import { useAppDispatch, useAppSelector } from "../../app/hooks";
 
@@ -10,9 +7,7 @@ export const SourcesList = () => {
   const dispatch = useAppDispatch();
   const selectedSourceId = useAppSelector(state => state.sources.selectedSourceId);
 
-  const replayClient = useContext(ReplayClientContext);
-  const sessionId = replayClient.getSessionId()!;
-  const { data } = useGetSourcesQuery(sessionId);
+  const { data } = useGetSourcesQuery();
 
   return (
     <ul>

--- a/packages/markerikson-stack-client-prototype/src/features/sources/SourcesList.tsx
+++ b/packages/markerikson-stack-client-prototype/src/features/sources/SourcesList.tsx
@@ -22,7 +22,7 @@ export const SourcesList = () => {
         const onLineClicked = () => dispatch(sourceEntrySelected(entry.sourceId));
         return (
           <li key={entry.sourceId} onClick={onLineClicked}>
-            {entryText}
+            {entryText} ({entry.kind})
           </li>
         );
       })}

--- a/packages/markerikson-stack-client-prototype/src/features/sources/SourcesList.tsx
+++ b/packages/markerikson-stack-client-prototype/src/features/sources/SourcesList.tsx
@@ -1,4 +1,4 @@
-import { useAppDispatch, useAppSelector } from "../../app/hooks";
+import { useAppDispatch, useAppSelector, useAppStore } from "../../app/hooks";
 
 import { sourceEntrySelected } from "./sourcesSlice";
 import { getSourceGroups } from "./sourcesCache";
@@ -6,8 +6,9 @@ import { getSourceGroups } from "./sourcesCache";
 export const SourcesList = () => {
   const dispatch = useAppDispatch();
   const selectedSourceId = useAppSelector(state => state.sources.selectedSourceId);
+  const store = useAppStore();
 
-  const data = getSourceGroups();
+  const data = getSourceGroups(store);
 
   return (
     <ul>

--- a/packages/markerikson-stack-client-prototype/src/features/sources/sourcesCache.ts
+++ b/packages/markerikson-stack-client-prototype/src/features/sources/sourcesCache.ts
@@ -4,7 +4,7 @@ import type { AppStore } from "../../app/store";
 import { api, SourceGroups } from "../../app/api";
 
 /*
- * This entire file is ENTIRELY WIP PROOF OF CONCEPT!
+ * This entire file is _mostly_ WIP PROOF OF CONCEPT!
 
   I've been staring at Brian's `CommentsCache` and `MessagesCache`
   trying to understand the data flow, and reverse-engineer how to 
@@ -14,7 +14,8 @@ import { api, SourceGroups } from "../../app/api";
 
   - The `unstable_createCacheForType` API, which seems to accept a factory function
     that holds the wrapper for a piece of data (such as a `new Map()`, or an object
-    with some field that has the actual value)
+    with some field that has the actual value).  Note: per Brian, that's not needed 
+    for this cache implementation, since we don't need to invalidate the data later.
   - React's undocumented but semi-known "throw a promise" mechanism, where we throw
     a consistent promise reference if the data isn't yet available.  
     (Note: the promise throwing behavior may still be subject to change? per Dan, 
@@ -28,91 +29,37 @@ import { api, SourceGroups } from "../../app/api";
   RTKQ recently added a `getRunningOperationPromise` method, which returns
   a consistent promise reference _if_ there's a request in flight for that
   particular endpoint+args combination.  So, we can use that as the thrown promise.
-
-  I've copy-pasted some of the boolean flag derivation logic from the guts of
-  RTKQ to help figure out if the RTKQ cache entry has data available or not.
  */
-
-let store: AppStore;
-
-export const setStore = (_store: AppStore) => {
-  store = _store;
-};
-
-// Placeholder for the result given to React's Suspense Cache
-interface SourceGroupsResult {
-  groups: SourceGroups | null;
-}
 
 // We know there's only one cache entry, since it's a "list of things" query.
 // Create a selector to read that cache entry from the Redux store.
 const selectSourceGroupsEntry = api.endpoints.getSources.select();
 
-function createSourceGroupsRecord(): SourceGroupsResult {
-  return {
-    groups: null,
-  };
-}
+// Use module-scoped variables for the cache, since this is a one-shot retrieval
+let hasPromiseListenerBeenAttached = false;
+let sourceGroups: SourceGroups | null = null;
 
-export function getSourceGroups(): SourceGroups {
-  // Create or read the cache for this section of the UI (????)
-  const sourceGroupsRecord = getCacheForType(createSourceGroupsRecord);
-
-  // Do we have this data already cached? If so, return it
-  if (sourceGroupsRecord.groups !== null) {
-    console.log("Found existing cached sources data, returning");
-    return sourceGroupsRecord.groups;
+export function getSourceGroups(store: AppStore): SourceGroups {
+  if (sourceGroups !== null) {
+    return sourceGroups;
   }
 
-  // RTKQ side: have we ever tried to request this data?
   let sourcesEntry: ReturnType<typeof selectSourceGroupsEntry> | undefined =
     selectSourceGroupsEntry(store.getState());
 
   if (!sourcesEntry || sourcesEntry.isUninitialized) {
-    console.log("No RTKQ entry found, initiating request");
-    // If not, actually start fetching
     store.dispatch(api.endpoints.getSources.initiate());
-
-    // Now we've got an entry in the store
     sourcesEntry = selectSourceGroupsEntry(store.getState());
   }
 
-  //Copy-pasted from the guts of RTKQ's `buildHooks.ts`,
-  // since this is derived state
+  const promise = api.util.getRunningOperationPromise("getSources", undefined)!;
 
-  // data is the last known good request result we have tracked - or if none has been tracked yet the last good result for the current args
-  let data = sourcesEntry!.data;
-
-  const hasData = data !== undefined;
-
-  // isFetching = true any time a request is in flight
-  const isFetching = sourcesEntry!.isLoading;
-  // isLoading = true only when loading while no data is present yet (initial load with no data in the cache)
-  const isLoading = !hasData && isFetching;
-  // isSuccess = true when data is present
-  const isSuccess = sourcesEntry!.isSuccess || (isFetching && hasData);
-
-  if (isFetching || sourcesEntry!.isUninitialized) {
-    console.log("Getting API promise and throwing");
-    const promise = api.util.getRunningOperationPromise("getSources", undefined)!;
+  if (!hasPromiseListenerBeenAttached) {
+    hasPromiseListenerBeenAttached = true;
     promise.then(result => {
-      // TODO What about timing? Will this happen _after_ React re-renders?
-      // _Looks_ like this runs first, possibly because we add a `.then` right now
-      // before React has a chance to add one, and those run in order added.
-      console.log("Data received, updating sources record");
-      sourceGroupsRecord.groups = result.data as SourceGroups;
+      sourceGroups = result.data as SourceGroups;
     });
-
-    // Let React know the data isn't available yet
-    throw promise;
-  } else if (isSuccess) {
-    // This mutation might be redundant, but shouldn't hurt.
-    sourceGroupsRecord!.groups = data!;
-    console.log("Returning existing successful data");
-    return data!;
-  } else {
-    // TODO How do caches handle errors?
-    console.error("Unexpected error reading a cache entry!");
-    throw new Error("Unexpected error reading a cache entry!");
   }
+
+  throw promise;
 }

--- a/packages/markerikson-stack-client-prototype/src/features/sources/sourcesCache.ts
+++ b/packages/markerikson-stack-client-prototype/src/features/sources/sourcesCache.ts
@@ -1,0 +1,118 @@
+import { unstable_getCacheForType as getCacheForType } from "react";
+import type { AppStore } from "../../app/store";
+
+import { api, SourceGroups } from "../../app/api";
+
+/*
+ * This entire file is ENTIRELY WIP PROOF OF CONCEPT!
+
+  I've been staring at Brian's `CommentsCache` and `MessagesCache`
+  trying to understand the data flow, and reverse-engineer how to 
+  create a valid Suspense cache entry.
+
+  There appear to be two key pieces to know about here:
+
+  - The `unstable_createCacheForType` API, which seems to accept a factory function
+    that holds the wrapper for a piece of data (such as a `new Map()`, or an object
+    with some field that has the actual value)
+  - React's undocumented but semi-known "throw a promise" mechanism, where we throw
+    a consistent promise reference if the data isn't yet available.  
+    (Note: the promise throwing behavior may still be subject to change? per Dan, 
+      https://github.com/facebook/react/issues/22964#issuecomment-1113649154 )
+
+  Brian's example uses synchronous "wakeables" - a plain JS object
+  with a `.then` method, plus `.resolve/reject` methods, and is doing
+  manual "pending/resolved" tracking.  This is apparently to avoid the
+  overhead of promises and microtasks.
+
+  RTKQ recently added a `getRunningOperationPromise` method, which returns
+  a consistent promise reference _if_ there's a request in flight for that
+  particular endpoint+args combination.  So, we can use that as the thrown promise.
+
+  I've copy-pasted some of the boolean flag derivation logic from the guts of
+  RTKQ to help figure out if the RTKQ cache entry has data available or not.
+ */
+
+let store: AppStore;
+
+export const setStore = (_store: AppStore) => {
+  store = _store;
+};
+
+// Placeholder for the result given to React's Suspense Cache
+interface SourceGroupsResult {
+  groups: SourceGroups | null;
+}
+
+// We know there's only one cache entry, since it's a "list of things" query.
+// Create a selector to read that cache entry from the Redux store.
+const selectSourceGroupsEntry = api.endpoints.getSources.select();
+
+function createSourceGroupsRecord(): SourceGroupsResult {
+  return {
+    groups: null,
+  };
+}
+
+export function getSourceGroups(): SourceGroups {
+  // Create or read the cache for this section of the UI (????)
+  const sourceGroupsRecord = getCacheForType(createSourceGroupsRecord);
+
+  // Do we have this data already cached? If so, return it
+  if (sourceGroupsRecord.groups !== null) {
+    console.log("Found existing cached sources data, returning");
+    return sourceGroupsRecord.groups;
+  }
+
+  // RTKQ side: have we ever tried to request this data?
+  let sourcesEntry: ReturnType<typeof selectSourceGroupsEntry> | undefined =
+    selectSourceGroupsEntry(store.getState());
+
+  if (!sourcesEntry || sourcesEntry.isUninitialized) {
+    console.log("No RTKQ entry found, initiating request");
+    // If not, actually start fetching
+    store.dispatch(api.endpoints.getSources.initiate());
+
+    // Now we've got an entry in the store
+    sourcesEntry = selectSourceGroupsEntry(store.getState());
+  }
+
+  //Copy-pasted from the guts of RTKQ's `buildHooks.ts`,
+  // since this is derived state
+
+  // data is the last known good request result we have tracked - or if none has been tracked yet the last good result for the current args
+  let data = sourcesEntry!.data;
+
+  const hasData = data !== undefined;
+
+  // isFetching = true any time a request is in flight
+  const isFetching = sourcesEntry!.isLoading;
+  // isLoading = true only when loading while no data is present yet (initial load with no data in the cache)
+  const isLoading = !hasData && isFetching;
+  // isSuccess = true when data is present
+  const isSuccess = sourcesEntry!.isSuccess || (isFetching && hasData);
+
+  if (isFetching || sourcesEntry!.isUninitialized) {
+    console.log("Getting API promise and throwing");
+    const promise = api.util.getRunningOperationPromise("getSources", undefined)!;
+    promise.then(result => {
+      // TODO What about timing? Will this happen _after_ React re-renders?
+      // _Looks_ like this runs first, possibly because we add a `.then` right now
+      // before React has a chance to add one, and those run in order added.
+      console.log("Data received, updating sources record");
+      sourceGroupsRecord.groups = result.data as SourceGroups;
+    });
+
+    // Let React know the data isn't available yet
+    throw promise;
+  } else if (isSuccess) {
+    // This mutation might be redundant, but shouldn't hurt.
+    sourceGroupsRecord!.groups = data!;
+    console.log("Returning existing successful data");
+    return data!;
+  } else {
+    // TODO How do caches handle errors?
+    console.error("Unexpected error reading a cache entry!");
+    throw new Error("Unexpected error reading a cache entry!");
+  }
+}

--- a/packages/markerikson-stack-client-prototype/src/pages/index.tsx
+++ b/packages/markerikson-stack-client-prototype/src/pages/index.tsx
@@ -8,11 +8,6 @@ import Loader from "../components/Loader";
 import { SourcesList } from "../features/sources/SourcesList";
 import { SourceContent } from "../features/sources/SourceContent";
 
-import store from "../app/store";
-import { setStore } from "../features/sources/sourcesCache";
-
-setStore(store);
-
 const IndexPage: NextPage = () => {
   const sessionData = useContext(SessionContext);
   const { currentUserInfo } = sessionData;

--- a/packages/markerikson-stack-client-prototype/src/pages/index.tsx
+++ b/packages/markerikson-stack-client-prototype/src/pages/index.tsx
@@ -1,11 +1,17 @@
+import React, { Suspense, useContext } from "react";
 import type { NextPage } from "next";
 import styles from "../styles/Home.module.css";
 
 import { SessionContext } from "../contexts/SessionContext";
-import { useContext } from "react";
 
+import Loader from "../components/Loader";
 import { SourcesList } from "../features/sources/SourcesList";
 import { SourceContent } from "../features/sources/SourceContent";
+
+import store from "../app/store";
+import { setStore } from "../features/sources/sourcesCache";
+
+setStore(store);
 
 const IndexPage: NextPage = () => {
   const sessionData = useContext(SessionContext);
@@ -23,7 +29,9 @@ const IndexPage: NextPage = () => {
       <div style={{ display: "flex" }}>
         <div style={{ minWidth: 300 }}>
           <h2>Sources Entries</h2>
-          <SourcesList />
+          <Suspense fallback={<Loader />}>
+            <SourcesList />
+          </Suspense>
         </div>
         <div style={{ marginLeft: 10 }}>
           <h2>Source Contents</h2>


### PR DESCRIPTION
This PR:

- Adds a **HIGHLY EXPERIMENTAL POC** (as in "look I tried to understand Brian's code and hacked on this for a couple hours and it amazingly seems to actually do something useful 🤷‍♂️ ") React Suspense cache built on top of RTK Query's `getRunningOperationPromise` API
- Updates the `<SourcesList>` component to read from that cache, and wraps it in a `<Suspense>` + loader (with an artificial delay added to the RTKQ API endpoint just to see that it's showing the fallback)
- Turns on `strict: true` in the `tsconfig.json` for both prototype folders, because **APPARENTLY WE DIDN'T HAVE TS STRICT MODE ON AND THIS WAS BREAKING THINGS ARGHGHHHHGGH!**