### PR TITLE
Persist console filter drawer Fixes FE-292

### DIFF
--- a/src/ui/reducers/layout.ts
+++ b/src/ui/reducers/layout.ts
@@ -5,7 +5,7 @@ import { LayoutState, ViewMode } from "ui/state/layout";
 import { features, prefs } from "ui/utils/prefs";
 
 export const syncInitialLayoutState: LayoutState = {
-  consoleFilterDrawerExpanded: true,
+  consoleFilterDrawerExpanded: prefs.consoleFilterDrawerExpanded as boolean,
   showCommandPalette: false,
   selectedPrimaryPanel: "events",
   viewMode: prefs.defaultMode as ViewMode,

--- a/src/ui/setup/index.ts
+++ b/src/ui/setup/index.ts
@@ -81,10 +81,6 @@ export async function getInitialLayoutState(): Promise<LayoutState> {
 
   return {
     ...syncInitialLayoutState,
-    consoleFilterDrawerExpanded:
-      "consoleFilterDrawerExpanded" in session
-        ? session.consoleFilterDrawerExpanded
-        : consoleFilterDrawerExpanded,
     viewMode: initialViewMode,
     selectedPanel: "selectedPanel" in session ? session.selectedPanel : selectedPanel,
     selectedPrimaryPanel: getDefaultSelectedPrimaryPanel(session, recording),

--- a/src/ui/setup/prefs.ts
+++ b/src/ui/setup/prefs.ts
@@ -70,6 +70,12 @@ const updateDebuggerAsyncPrefs = createPrefsUpdater(debuggerAsyncPrefs);
 
 export const updatePrefs = (state: UIState, oldState: UIState) => {
   updateStandardPrefs(state, oldState, "theme", getTheme);
+  updateStandardPrefs(
+    state,
+    oldState,
+    "consoleFilterDrawerExpanded",
+    getConsoleFilterDrawerExpanded
+  );
 
   updateAsyncPrefs(
     state,
@@ -180,7 +186,6 @@ async function maybeUpdateReplaySessions(state: UIState) {
 
   const currentReplaySession = {
     viewMode: getViewMode(state),
-    consoleFilterDrawerExpanded: getConsoleFilterDrawerExpanded(state),
     toolboxLayout: getToolboxLayout(state),
     showVideoPanel: getShowVideoPanel(state),
     selectedPrimaryPanel: getSelectedPrimaryPanel(state),

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -16,6 +16,7 @@ pref("devtools.showRedactions", false);
 pref("devtools.sidePanelSize", "240px");
 pref("devtools.theme", "system");
 pref("devtools.toolbox-size", "50%");
+pref("devtools.consoleFilterDrawerExpanded", true);
 
 // app features
 pref("devtools.features.breakpointPanelAutocomplete", true);
@@ -49,6 +50,7 @@ export const prefs = new PrefsHelper("devtools", {
   sidePanelSize: ["String", "sidePanelSize"],
   theme: ["String", "theme"],
   toolboxSize: ["String", "toolbox-size"],
+  consoleFilterDrawerExpanded: ["Bool", "consoleFilterDrawerExpanded"],
 });
 
 export const features = new PrefsHelper("devtools.features", {


### PR DESCRIPTION
This switches us from a replay session storage approach which had a weird bug to a global storage that works well. In general, i think this setting makes more sense globally since most times i dont want to see the drawer for new replays.