### PR TITLE
Small timeline fixes

### DIFF
--- a/packages/protocol/thread/thread.ts
+++ b/packages/protocol/thread/thread.ts
@@ -654,10 +654,6 @@ class _ThreadFront {
       : this.currentPause;
   }
 
-  loadRegion(region: TimeRange) {
-    return client.Session.loadRegion({ region }, ThreadFront.sessionId!);
-  }
-
   async loadAsyncParentFrames() {
     await this.ensureAllSources();
     const basePause = this.lastAsyncPause();
@@ -678,6 +674,10 @@ class _ThreadFront {
     }
     assert(frames, "no frames");
     return frames.slice(1);
+  }
+
+  loadRegion(region: TimeRange) {
+    return client.Session.loadRegion({ region }, ThreadFront.sessionId!);
   }
 
   pauseForAsyncIndex(asyncIndex?: number) {

--- a/src/ui/components/Timeline/Timeline.css
+++ b/src/ui/components/Timeline/Timeline.css
@@ -42,6 +42,10 @@
   background: inherit;
 }
 
+.progress-bar-container:hover {
+  cursor: pointer;
+}
+
 .progress-bar-container {
   display: flex;
   position: relative;

--- a/src/ui/components/Timeline/Tooltip.tsx
+++ b/src/ui/components/Timeline/Tooltip.tsx
@@ -1,8 +1,17 @@
 import React from "react";
 import { useAppSelector } from "ui/setup/hooks";
 import { getNonLoadingTimeRanges } from "ui/reducers/app";
-import { getHoverTime, getShowFocusModeControls, getZoomRegion } from "ui/reducers/timeline";
-import { getVisiblePosition } from "ui/utils/timeline";
+import {
+  getHoverTime,
+  getFocusRegion,
+  getShowFocusModeControls,
+  getZoomRegion,
+} from "ui/reducers/timeline";
+import {
+  getVisiblePosition,
+  displayedBeginForFocusRegion,
+  displayedEndForFocusRegion,
+} from "ui/utils/timeline";
 
 const getTimestamp = (time?: number) => {
   const date = new Date(time || 0);
@@ -17,9 +26,9 @@ export default function Tooltip({ timelineWidth }: { timelineWidth: number }) {
   const zoomRegion = useAppSelector(getZoomRegion);
   const showFocusModeControls = useAppSelector(getShowFocusModeControls);
   const nonLoadingRegion = useAppSelector(getNonLoadingTimeRanges);
-  const shouldHideTooltip = !hoverTime || showFocusModeControls;
+  const focusRegion = useAppSelector(getFocusRegion);
 
-  if (shouldHideTooltip) {
+  if (!hoverTime || showFocusModeControls) {
     return null;
   }
 
@@ -29,8 +38,16 @@ export default function Tooltip({ timelineWidth }: { timelineWidth: number }) {
     ({ start, end }) => start <= hoverTime && end >= hoverTime
   );
 
+  const isHoveredOnUnFocusedRegion =
+    focusRegion &&
+    (displayedBeginForFocusRegion(focusRegion) > hoverTime ||
+      displayedEndForFocusRegion(focusRegion) < hoverTime);
+
   const timestamp = getTimestamp(hoverTime);
-  const message = isHoveredOnNonLoadingRegion ? `${timestamp} (Unloaded)` : timestamp;
+  const message =
+    isHoveredOnNonLoadingRegion || isHoveredOnUnFocusedRegion
+      ? `${timestamp} (Unloaded)`
+      : timestamp;
 
   return (
     <div className="timeline-tooltip" style={{ left: offset }}>

--- a/src/ui/components/Timeline/index.tsx
+++ b/src/ui/components/Timeline/index.tsx
@@ -97,17 +97,14 @@ export default function Timeline() {
 
         <div
           className="progress-bar-container"
+          onClick={onClick}
           onMouseEnter={() => setIsHovered(true)}
           onMouseLeave={() => setIsHovered(false)}
+          onMouseMove={onMouseMove}
         >
           <div className="progress-bar-stack">
             <ProtocolTimeline />
-            <div
-              className="progress-bar"
-              ref={progressBarRef}
-              onClick={onClick}
-              onMouseMove={onMouseMove}
-            >
+            <div className="progress-bar" ref={progressBarRef}>
               <ProgressBars />
               <PreviewMarkers />
               <Comments />


### PR DESCRIPTION
This fixes a couple of timeline interactions 

1. clicking on an unloaded region will now seek to the nearest point (similar to playing the video and pausing
2. hovering on an unloaded region will show unloaded in the tooltip
3. the timeline-container now acts as a click target (not just a hover target)

code
1. DownloadCancelled is no longer logged
2. getPointNearTime is moved to the threadfront