### PR TITLE
Restrict uses of the client and sendMessage to the protocol directory

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -42,6 +42,11 @@
             "name": "react-redux",
             "importNames": ["useDispatch", "useSelector"],
             "message": "Please import 'useAppDispatch/useAppSelector' from 'ui/setup/hooks' instead."
+          },
+          {
+            "name": "protocol/socket",
+            "importNames": ["client", "sendMessage"],
+            "message": "Please use ThreadFront."
           }
         ]
       }

--- a/packages/bvaughn-architecture-demo/src/client/ReplayClient.ts
+++ b/packages/bvaughn-architecture-demo/src/client/ReplayClient.ts
@@ -5,6 +5,7 @@ import {
   TimeStampedPoint,
   TimeStampedPointRange,
 } from "@replayio/protocol";
+// eslint-disable-next-line no-restricted-imports
 import { client, initSocket } from "protocol/socket";
 import type { ThreadFront } from "protocol/thread";
 import { compareNumericStrings } from "protocol/utils";

--- a/packages/markerikson-stack-client-prototype/src/app/api.ts
+++ b/packages/markerikson-stack-client-prototype/src/app/api.ts
@@ -1,7 +1,6 @@
 import { createApi, fakeBaseQuery } from "@reduxjs/toolkit/query/react";
 import type {
   newSource,
-  ProtocolClient,
   Location,
   PointDescription,
   HitCount,
@@ -9,8 +8,8 @@ import type {
 } from "@replayio/protocol";
 import { Dictionary } from "lodash";
 import groupBy from "lodash/groupBy";
-
-import { client, initSocket } from "protocol/socket";
+// eslint-disable-next-line no-restricted-imports
+import { client } from "protocol/socket";
 import { replayClient } from "../client/ReplayClient";
 
 interface SourceGroups {

--- a/packages/markerikson-stack-client-prototype/src/client/ReplayClient.ts
+++ b/packages/markerikson-stack-client-prototype/src/client/ReplayClient.ts
@@ -5,6 +5,7 @@ import {
   TimeStampedPoint,
   TimeStampedPointRange,
 } from "@replayio/protocol";
+// eslint-disable-next-line no-restricted-imports
 import { client, initSocket } from "protocol/socket";
 import { compareNumericStrings } from "protocol/utils";
 import { UserInfo } from "../graphql/types";

--- a/pages/recording/[id]/sourcemap/[sourceId].tsx
+++ b/pages/recording/[id]/sourcemap/[sourceId].tsx
@@ -1,5 +1,6 @@
 import { useRouter } from "next/router";
 import React, { useEffect, useState } from "react";
+// eslint-disable-next-line no-restricted-imports
 import { initSocket, client } from "protocol/socket";
 import { useStore } from "react-redux";
 import { useAppDispatch } from "ui/setup/hooks";

--- a/src/devtools/client/webconsole/actions/messages.ts
+++ b/src/devtools/client/webconsole/actions/messages.ts
@@ -12,7 +12,6 @@ import {
 import { loadValue } from "devtools/packages/devtools-reps/object-inspector/items/utils";
 import { TestMessageHandlers } from "ui/actions/find-tests";
 import { LogpointHandlers } from "ui/actions/logpoint";
-import { client } from "protocol/socket";
 import { Pause, ValueFront, ThreadFront as ThreadFrontType } from "protocol/thread";
 import { WiredMessage, wireUpMessage } from "protocol/thread/thread";
 import type { UIStore, UIThunkAction } from "ui/actions";
@@ -278,16 +277,13 @@ export function refetchMessages(focusRegion: FocusRegion | null): UIThunkAction 
 
     dispatch(clearMessages());
 
-    const sessionEndpoint = await client.Session.getEndpoint({}, ThreadFront.sessionId!);
+    const sessionEndpoint = await ThreadFront.getEndpoint();
     const begin = focusRegion ? (focusRegion as UnsafeFocusRegion).begin.point : "0";
     const end = focusRegion
       ? (focusRegion as UnsafeFocusRegion).end.point
       : sessionEndpoint.endpoint.point;
 
-    const { messages, overflow } = await client.Console.findMessagesInRange(
-      { range: { begin, end } },
-      ThreadFront.sessionId!
-    );
+    const { messages, overflow } = await ThreadFront.findMessagesInRange({ begin, end });
 
     // Store the result of the new analysis window for "soft focus" comparison next time.
     dispatch(setLastFetchedForFocusRegion(focusRegion));

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -2,7 +2,6 @@ import { UIStore, UIThunkAction } from ".";
 import { unprocessedRegions, KeyboardEvent } from "@replayio/protocol";
 import * as selectors from "ui/reducers/app";
 import { Canvas, ReplayEvent, ReplayNavigationEvent } from "ui/state/app";
-import { client, sendMessage } from "protocol/socket";
 import groupBy from "lodash/groupBy";
 import { compareBigInt } from "ui/utils/helpers";
 import tokenManager from "ui/utils/tokenManager";
@@ -58,7 +57,7 @@ export function setupApp(store: UIStore, ThreadFront: typeof ThreadFrontType) {
   if (!isTest()) {
     tokenManager.addListener(({ token }) => {
       if (token) {
-        sendMessage("Authentication.setAccessToken", { accessToken: token });
+        ThreadFront.setAccessToken(token);
       }
     });
     tokenManager.getToken();
@@ -67,11 +66,8 @@ export function setupApp(store: UIStore, ThreadFront: typeof ThreadFrontType) {
   ThreadFront.waitForSession().then(sessionId => {
     store.dispatch(setSessionId(sessionId));
 
-    client.Session.findKeyboardEvents({}, sessionId);
-    client.Session.addKeyboardEventsListener(({ events }) => onKeyboardEvents(events, store));
-
-    client.Session.findNavigationEvents({}, sessionId);
-    client.Session.addNavigationEventsListener(({ events }) =>
+    ThreadFront.findKeyboardEvents(({ events }) => onKeyboardEvents(events, store));
+    ThreadFront.findNavigationEvents(({ events }) =>
       onNavigationEvents(events as ReplayNavigationEvent[], store)
     );
   });

--- a/src/ui/actions/find-tests.ts
+++ b/src/ui/actions/find-tests.ts
@@ -6,7 +6,6 @@ import { assert } from "protocol/utils";
 import analysisManager, { AnalysisHandler, AnalysisParams } from "protocol/analysisManager";
 import { comparePoints, pointPrecedes } from "protocol/execution-point-utils";
 import { Helpers } from "./logpoint";
-import { client } from "protocol/socket";
 import { Pause, ThreadFront, ValueFront } from "protocol/thread";
 import { WiredMessage } from "protocol/thread/thread";
 
@@ -124,10 +123,7 @@ class JestTestState {
 
     await Promise.all(
       analysisResults.map(async ({ key: callPoint, value: { names } }) => {
-        const { target } = await client.Debugger.findStepInTarget(
-          { point: callPoint },
-          this.sessionId
-        );
+        const { target } = await ThreadFront.findStepInTarget(callPoint);
         if (target.frame) {
           this.tests.push({ names, startPoint: target });
         }

--- a/src/ui/components/Events/eventKinds.tsx
+++ b/src/ui/components/Events/eventKinds.tsx
@@ -1,5 +1,3 @@
-import type { ReplayEvent } from "ui/state/app";
-
 export const EVENT_KINDS: { [key: string]: EventKind } = {
   keydown: { icon: "keyboard", label: "Key Down", key: "event.keyboard.keydown" },
   keyup: { icon: "keyboard", label: "Key Up", key: "event.keyboard.keyup" },

--- a/src/ui/setup/helpers.ts
+++ b/src/ui/setup/helpers.ts
@@ -1,6 +1,8 @@
 import { UIStore } from "ui/actions";
 import { getRecordingId } from "ui/utils/recording";
 import { prefs, features, asyncStore } from "ui/utils/prefs";
+
+// eslint-disable-next-line no-restricted-imports
 import { triggerEvent, sendMessage } from "protocol/socket";
 import { getReplaySession, ReplaySession } from "./prefs";
 

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -1,6 +1,5 @@
 import {
   SessionId,
-  PointDescription,
   Location,
   MouseEvent,
   KeyboardEvent,
@@ -10,7 +9,6 @@ import {
   ExecutionPoint,
   TimeStampedPointRange,
 } from "@replayio/protocol";
-import { AnalysisError } from "protocol/thread/analysis";
 import type { RecordingTarget } from "protocol/thread/thread";
 import { Workspace } from "ui/types";
 import { Reply } from "./comments";
@@ -24,6 +22,7 @@ export type ModalOptionsType = {
   comment?: Reply;
   instructions?: string;
 } | null;
+
 export type ModalType =
   | "sharing"
   | "login"


### PR DESCRIPTION
This PR restricts uses of protocol/socket's client and sendMessage to the protocol directory. This is a nice win because it reduces the number of ways in which the application can talk to the protocol.

NOTE: this would not have been possible a couple of months ago before Brian and Mark started refactoring our protocol