### PR TITLE
Remove global lodash imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -47,6 +47,10 @@
             "name": "protocol/socket",
             "importNames": ["client", "sendMessage"],
             "message": "Please use ThreadFront."
+          },
+          {
+            "name": "lodash",
+            "message": "Please import lodash functions directly."
           }
         ]
       }

--- a/packages/bvaughn-architecture-demo/src/utils/time.ts
+++ b/packages/bvaughn-architecture-demo/src/utils/time.ts
@@ -4,7 +4,7 @@ import differenceInWeeks from "date-fns/differenceInWeeks";
 import differenceInMonths from "date-fns/differenceInMonths";
 import differenceInYears from "date-fns/differenceInYears";
 import { TimeStampedPointRange } from "@replayio/protocol";
-import { padStart } from "lodash";
+import padStart from "lodash/padStart";
 import prettyMilliseconds from "pretty-ms";
 
 export function formatDuration(ms: number) {

--- a/packages/markerikson-stack-client-prototype/src/app/api.ts
+++ b/packages/markerikson-stack-client-prototype/src/app/api.ts
@@ -6,6 +6,8 @@ import type {
   HitCount,
   createPauseResult,
 } from "@replayio/protocol";
+
+// eslint-disable-next-line no-restricted-imports
 import { Dictionary } from "lodash";
 import groupBy from "lodash/groupBy";
 // eslint-disable-next-line no-restricted-imports

--- a/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
@@ -1,6 +1,6 @@
 import { updateHoveredLineNumber } from "devtools/client/debugger/src/actions/breakpoints/index";
 import { setBreakpointHitCounts } from "devtools/client/debugger/src/actions/sources";
-import { minBy } from "lodash";
+import minBy from "lodash/minBy";
 import React, { useRef, useState, useEffect, ReactNode } from "react";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { KeyModifiers } from "ui/components/KeyModifiers";

--- a/src/devtools/client/debugger/src/components/SourceOutline/getOutlineSymbols.tsx
+++ b/src/devtools/client/debugger/src/components/SourceOutline/getOutlineSymbols.tsx
@@ -1,8 +1,8 @@
 import { fuzzySearch } from "../../utils/function";
-import { groupBy, keyBy } from "lodash";
+import groupBy from "lodash/groupBy";
+import keyBy from "lodash/keyBy";
 import { SourceSymbols, ClassSymbol, FunctionSymbol } from "../../types";
 import { HitCount } from "../../reducers/sources";
-import { features } from "ui/utils/prefs";
 
 function addHitCountsToFunctions(functions: FunctionSymbol[], hitCounts: HitCount[] | null) {
   if (!hitCounts) {

--- a/src/ui/components/Library/Content/Recordings.tsx
+++ b/src/ui/components/Library/Content/Recordings.tsx
@@ -1,5 +1,5 @@
 import { RecordingId } from "@replayio/protocol";
-import { sortBy } from "lodash";
+import sortBy from "lodash/sortBy";
 import { ReactNode, useContext, useMemo, useState } from "react";
 import { PrimaryButton, SecondaryButton } from "ui/components/shared/Button";
 import { Recording } from "ui/types";
@@ -29,7 +29,7 @@ function RecordingsError() {
 
   return (
     <section
-      className={`flex flex-col flex-grow space-y-2 items-center justify-center text-lg ${styles.recordingsBackground}`}
+      className={`flex flex-grow flex-col items-center justify-center space-y-2 text-lg ${styles.recordingsBackground}`}
     >
       {msg}
     </section>

--- a/src/ui/components/Library/Overview/RunResults.tsx
+++ b/src/ui/components/Library/Overview/RunResults.tsx
@@ -1,4 +1,4 @@
-import { orderBy } from "lodash";
+import orderBy from "lodash/orderBy";
 import { useContext, useState } from "react";
 import { TestResultListItem } from "./TestResultListItem";
 import { OverviewContext } from "./OverviewContainer";

--- a/src/ui/components/NetworkMonitor/index.tsx
+++ b/src/ui/components/NetworkMonitor/index.tsx
@@ -1,6 +1,5 @@
 import { getThreadContext } from "devtools/client/debugger/src/selectors";
 import SplitBox from "devtools/client/shared/components/splitter/SplitBox";
-import { findIndex } from "lodash";
 import React, { useEffect, useRef, useState } from "react";
 import { connect, ConnectedProps } from "react-redux";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";

--- a/src/ui/components/Timeline/LoadingProgressBars.tsx
+++ b/src/ui/components/Timeline/LoadingProgressBars.tsx
@@ -1,4 +1,4 @@
-import { clamp } from "lodash";
+import clamp from "lodash/clamp";
 import { useAppSelector } from "ui/setup/hooks";
 import { getLoadedRegions } from "ui/reducers/app";
 import { getZoomRegion } from "ui/reducers/timeline";

--- a/src/ui/components/Timeline/ProgressBars.tsx
+++ b/src/ui/components/Timeline/ProgressBars.tsx
@@ -1,4 +1,4 @@
-import { clamp } from "lodash";
+import clamp from "lodash/clamp";
 import React from "react";
 import { useAppSelector } from "ui/setup/hooks";
 import {

--- a/src/ui/components/Timeline/UnfocusedRegion.tsx
+++ b/src/ui/components/Timeline/UnfocusedRegion.tsx
@@ -1,4 +1,4 @@
-import { clamp } from "lodash";
+import clamp from "lodash/clamp";
 import { useAppSelector } from "ui/setup/hooks";
 import { selectors } from "ui/reducers";
 import { trackEvent } from "ui/utils/telemetry";

--- a/src/ui/hooks/sessions.ts
+++ b/src/ui/hooks/sessions.ts
@@ -4,7 +4,6 @@ import { User } from "ui/state/session";
 import { useGetUserId } from "./users";
 import { GET_ACTIVE_SESSIONS } from "ui/graphql/sessions";
 import { GetActiveSessions, GetActiveSessionsVariables } from "graphql/GetActiveSessions";
-import { filter } from "lodash";
 
 interface SessionUser extends User {
   sessionId?: string;

--- a/src/ui/hooks/tests.ts
+++ b/src/ui/hooks/tests.ts
@@ -1,5 +1,5 @@
 import { gql, useQuery } from "@apollo/client";
-import { orderBy } from "lodash";
+import orderBy from "lodash/orderBy";
 import { useAppSelector } from "ui/setup/hooks";
 import { getWorkspaceId } from "ui/reducers/app";
 import { WorkspaceId } from "ui/state/app";

--- a/src/ui/utils/time.ts
+++ b/src/ui/utils/time.ts
@@ -1,5 +1,5 @@
 import { ExecutionPoint, PointDescription } from "@replayio/protocol";
-import { padStart } from "lodash";
+import padStart from "lodash/padStart";
 import prettyMilliseconds from "pretty-ms";
 import analysisManager from "protocol/analysisManager";
 

--- a/src/ui/utils/timeline.ts
+++ b/src/ui/utils/timeline.ts
@@ -1,5 +1,7 @@
 import { TimeStampedPoint, TimeStampedPointRange } from "@replayio/protocol";
-import { clamp, sortedIndexBy, sortedLastIndexBy } from "lodash";
+import clamp from "lodash/clamp";
+import sortedIndexBy from "lodash/sortedIndexBy";
+import sortedLastIndexBy from "lodash/sortedLastIndexBy";
 import { FocusRegion, UnsafeFocusRegion, ZoomRegion } from "ui/state/timeline";
 
 import { timelineMarkerWidth } from "../constants";

--- a/test/e2e/recordPlaywright.ts
+++ b/test/e2e/recordPlaywright.ts
@@ -1,6 +1,6 @@
 import playwright from "@recordreplay/playwright";
 import * as cli from "@replayio/replay";
-import { findLast } from "lodash";
+import findLast from "lodash/findLast";
 
 import config from "./config";
 


### PR DESCRIPTION
In the past, this has typically resulted in a pretty big bundle size improvement