### PR TITLE
Color + layout tweaks to test suite

### DIFF
--- a/src/ui/components/Library/Content/TestRuns/RunStats.tsx
+++ b/src/ui/components/Library/Content/TestRuns/RunStats.tsx
@@ -15,8 +15,8 @@ export function RunStats({ testRun }: { testRun: TestRun }) {
 
   return (
     <div className="flex shrink space-x-2">
-      {failed > 0 && <Pill styles="text-red-50 bg-red-400" value={failed} />}
-      {passed > 0 && <Pill styles="bg-green-400 text-green-50" value={passed} />}
+      {failed > 0 && <Pill styles="text-red-50 bg-red-500" value={failed} />}
+      {passed > 0 && <Pill styles="bg-green-500 text-green-50" value={passed} />}
     </div>
   );
 }

--- a/src/ui/components/Library/Content/TestRuns/TestRunList.tsx
+++ b/src/ui/components/Library/Content/TestRuns/TestRunList.tsx
@@ -32,7 +32,7 @@ export function TestRunList() {
   };
 
   return (
-    <div className="recording-list flex flex-col space-y-1 overflow-y-auto   text-sm shadow-md">
+    <div className="recording-list flex flex-col space-y-0 overflow-y-auto text-sm shadow-md rounded-xl">
       {testRuns?.map((t, i) => (
         <TestRunListItem testRun={t} key={i} onClick={() => onClick(t)} />
       ))}

--- a/src/ui/components/Library/Content/TestRuns/TestRunListItem.tsx
+++ b/src/ui/components/Library/Content/TestRuns/TestRunListItem.tsx
@@ -59,12 +59,12 @@ export function TestRunListItem({ testRun, onClick }: { testRun: TestRun; onClic
   const failCount = testRun.recordings.filter(r => r.metadata.test?.result !== "passed").length;
   const isSelected = preview?.id.toString() === testRun.id;
   const style = {
-    backgroundColor: isSelected ? "rgb(209 238 255)" : "",
+    backgroundColor: isSelected ? "rgb(233 246 255)" : "",
   };
 
   return (
     <div
-      className="flex flex-grow cursor-pointer flex-row items-center space-x-3 overflow-hidden rounded-md border-b bg-white px-4 py-3 hover:bg-gray-100"
+      className="flex flex-grow cursor-pointer flex-row items-center space-x-3 overflow-hidden rounded-sm border-b bg-white px-4 py-3 hover:bg-gray-50"
       style={style}
       onClick={onClick}
     >

--- a/src/ui/components/Library/Overview/TestResultListItem.tsx
+++ b/src/ui/components/Library/Overview/TestResultListItem.tsx
@@ -56,7 +56,7 @@ export function TestResultListItem({ recording }: { recording: Recording }) {
 
   return (
     <a
-      className={`group flex items-center pr-2 transition duration-150 hover:bg-gray-100 hover:bg-gray-100`}
+      className={`group flex items-center pr-2 transition duration-150 hover:bg-gray-50`}
       href={`/recording/${recordingId}`}
       target="_blank"
       rel="noreferrer noopener"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9154902/174500799-016645d2-ac16-472e-b33b-6c65eab04dd5.png)

* Contrast improvements
   * Dialled back our selected blue
   * Dialled back our hover gray
   * Pulled our red and greens forward to align closer to GitHub and provide better contrast
* Layout improvements
   * Removed the gap between each row
   * Dialled down the rounded edge per row
   * Increased rounded edge for the column