### PR TITLE
Teach loadRegion to first unload surrounding regions

### DIFF
--- a/packages/protocol/thread/thread.ts
+++ b/packages/protocol/thread/thread.ts
@@ -678,6 +678,19 @@ class _ThreadFront {
       : this.currentPause;
   }
 
+  async loadRegion(region: TimeRange, endTime: number) {
+    client.Session.unloadRegion(
+      { region: { begin: 0, end: region.begin } },
+      ThreadFront.sessionId!
+    );
+    client.Session.unloadRegion(
+      { region: { begin: region.end, end: endTime } },
+      ThreadFront.sessionId!
+    );
+
+    await client.Session.loadRegion({ region }, ThreadFront.sessionId!);
+  }
+
   async loadAsyncParentFrames() {
     await this.ensureAllSources();
     const basePause = this.lastAsyncPause();
@@ -698,10 +711,6 @@ class _ThreadFront {
     }
     assert(frames, "no frames");
     return frames.slice(1);
-  }
-
-  loadRegion(region: TimeRange) {
-    return client.Session.loadRegion({ region }, ThreadFront.sessionId!);
   }
 
   pauseForAsyncIndex(asyncIndex?: number) {

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -657,15 +657,19 @@ export function syncFocusedRegion(): UIThunkAction {
   return async (dispatch, getState, { ThreadFront }) => {
     const state = getState();
     const focusRegion = getFocusRegion(state) as FocusRegion;
+    const zoomTime = getZoomRegion(state);
 
     if (!focusRegion) {
       return;
     }
 
-    ThreadFront.loadRegion({
-      begin: displayedBeginForFocusRegion(focusRegion),
-      end: displayedEndForFocusRegion(focusRegion),
-    });
+    ThreadFront.loadRegion(
+      {
+        begin: displayedBeginForFocusRegion(focusRegion),
+        end: displayedEndForFocusRegion(focusRegion),
+      },
+      zoomTime.endTime
+    );
 
     const { breakpoints } = state.breakpoints;
     const cx = getThreadContext(state);


### PR DESCRIPTION
Fixes BAC-1813

This PR rolls back some of the changes in #7114

The rationale for this change is two fold
1. the backend will not load a new region if it is at capacity
2. asking the backend to unload a region is cheap because it no longer does unless a controller disconnects.

I imagine that we'll get smarter over time, but this seems like a fine solution for the time being