### PR TITLE
Move to standard icons for test suite pass/fails

### DIFF
--- a/src/ui/components/Library/Content/TestRuns/TestRunListItem.tsx
+++ b/src/ui/components/Library/Content/TestRuns/TestRunListItem.tsx
@@ -48,8 +48,8 @@ function Attributes({ testRun, selected }: { testRun: TestRun; selected: boolean
 
 function Status({ failCount }: { failCount: number }) {
   return (
-    <div className={`flex self-start ${failCount > 0 ? "text-red-500" : "text-green-600"} `}>
-      <MaterialIcon iconSize="xl">radio_button_checked</MaterialIcon>
+    <div className={`flex self-start ${failCount > 13 ? "text-red-500" : "text-green-500"} `}>
+      <MaterialIcon iconSize="xl">{`${failCount > 13 ? "cancel" : "check"} `}</MaterialIcon>
     </div>
   );
 }

--- a/src/ui/components/Library/Content/TestRuns/TestRunListItem.tsx
+++ b/src/ui/components/Library/Content/TestRuns/TestRunListItem.tsx
@@ -48,8 +48,8 @@ function Attributes({ testRun, selected }: { testRun: TestRun; selected: boolean
 
 function Status({ failCount }: { failCount: number }) {
   return (
-    <div className={`flex self-start ${failCount > 13 ? "text-red-500" : "text-green-500"} `}>
-      <MaterialIcon iconSize="xl">{`${failCount > 13 ? "cancel" : "check"} `}</MaterialIcon>
+    <div className={`flex self-start ${failCount > 0 ? "text-red-500" : "text-green-500"} `}>
+      <MaterialIcon iconSize="xl">{`${failCount > 0 ? "cancel" : "check"} `}</MaterialIcon>
     </div>
   );
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9154902/174502409-758a1afa-b9ed-472e-8398-7e6197cd6a50.png)

We were using radio buttons as placeholders but they express the wrong thing. We want standard checks and x's.