### PR TITLE
Jon polishing the test suites

### DIFF
--- a/src/ui/components/Library/Content/TestRuns/AttributeContainer.tsx
+++ b/src/ui/components/Library/Content/TestRuns/AttributeContainer.tsx
@@ -13,7 +13,7 @@ export function AttributeContainer({
 }) {
   return (
     <div
-      className={`mr-4 flex items-center space-x-1 overflow-hidden text-ellipsis`}
+      className={`mr-4 flex items-start space-x-1 overflow-hidden text-ellipsis`}
       title={title || children}
     >
       <div className="w-4">{icon ? <MaterialIcon>{icon}</MaterialIcon> : null}</div>

--- a/src/ui/components/Library/Content/TestRuns/TestRunListItem.tsx
+++ b/src/ui/components/Library/Content/TestRuns/TestRunListItem.tsx
@@ -12,7 +12,7 @@ function Title({ testRun }: { testRun: TestRun }) {
   const title = testRun.commit?.title || "Unknown";
   const formatted = title.length > 80 ? title.slice(0, 80) + "..." : title;
   return (
-    <div className="wrap flex shrink grow-0 flex-nowrap overflow-hidden text-ellipsis pr-2 font-semibold">
+    <div className="wrap flex shrink grow-0 flex-nowrap overflow-hidden text-ellipsis pr-2 font-medium">
       {formatted}
     </div>
   );

--- a/src/ui/components/Library/Overview/RunResults.tsx
+++ b/src/ui/components/Library/Overview/RunResults.tsx
@@ -29,7 +29,7 @@ function TestStatusGroup({ recordings, label }: { recordings: Recording[]; label
   return (
     <div className="flex flex-col">
       <div
-        className=" sticky top-0 bg-gray-100 p-2 pl-3 font-bold hover:cursor-pointer hover:bg-gray-200"
+        className=" top-0 p-2 pl-4 font-medium hover:cursor-pointer hover:bg-gray-50"
         onClick={() => setExpanded(!expanded)}
       >
         {count} {label} Test{count > 1 ? "s" : ""}

--- a/src/ui/components/Library/Overview/RunSummary.tsx
+++ b/src/ui/components/Library/Overview/RunSummary.tsx
@@ -11,7 +11,7 @@ function Title({ testRun }: { testRun: TestRun }) {
   const title = testRun.commit?.title || "";
   const formatted = title.length > 80 ? title.slice(0, 80) + "…" : title;
   return (
-    <div className="flex flex-row items-center space-x-2 text-xl font-semibold">
+    <div className="flex flex-row items-center space-x-2 text-xl font-medium">
       <div>{formatted}</div>
     </div>
   );
@@ -27,7 +27,7 @@ function Attributes({ testRun }: { testRun: TestRun }) {
   const merge = firstRecording.metadata.source?.merge;
 
   return (
-    <div className="items-left flex flex-col flex-wrap space-y-3 text-xs">
+    <div className="flex flex-row flex-wrap items-center text-xs">
       <AttributeContainer icon="schedule">
         {getTruncatedRelativeDate(firstRecording.date)}
       </AttributeContainer>
@@ -51,7 +51,7 @@ export function RunSummary() {
   const testRun = useContext(OverviewContext).testRun!;
 
   return (
-    <div className="flex flex-col space-y-2  p-4">
+    <div className="flex flex-col space-y-2  p-4 border-b mb-2">
       <div className="flex flex-row justify-between">
         <Title testRun={testRun} />
         <RunStats testRun={testRun} />

--- a/src/ui/components/Library/Overview/TestResultListItem.tsx
+++ b/src/ui/components/Library/Overview/TestResultListItem.tsx
@@ -15,7 +15,7 @@ function ViewReplay({ recordingId, passed }: { recordingId: string; passed: bool
         <MaterialIcon
           iconSize="2xl"
           outlined
-          className={passed ? "text-primaryAccent" : "text-red-500"}
+          className={passed ? "text-primaryAccent" : "text-red-400"}
         >
           play_circle
         </MaterialIcon>
@@ -56,7 +56,7 @@ export function TestResultListItem({ recording }: { recording: Recording }) {
 
   return (
     <a
-      className={`group flex items-center pr-2 transition duration-150 hover:bg-gray-50`}
+      className={`group flex items-center px-2 transition duration-150 hover:bg-gray-50`}
       href={`/recording/${recordingId}`}
       target="_blank"
       rel="noreferrer noopener"

--- a/src/ui/components/Library/Overview/TestResultListItem.tsx
+++ b/src/ui/components/Library/Overview/TestResultListItem.tsx
@@ -15,7 +15,7 @@ function ViewReplay({ recordingId, passed }: { recordingId: string; passed: bool
         <MaterialIcon
           iconSize="2xl"
           outlined
-          className={passed ? "text-primaryAccent" : "text-red-400"}
+          className={passed ? "text-primaryAccent" : "text-red-500"}
         >
           play_circle
         </MaterialIcon>


### PR DESCRIPTION
Was:
![image](https://user-images.githubusercontent.com/9154902/174511472-0eaf0ed8-8a26-47a6-856e-de1969c292bd.png)

Now:
![image](https://user-images.githubusercontent.com/9154902/174511489-950c6a9f-1c3a-457b-be6e-4cc0fb044cdd.png)

* Putting stuff on the grid
* Dialling back some of our bold stuff to be medium
* Horizontal alignment (aka flex-row) for our details pane rather than the single column (aka flex-col)