### PR TITLE
Show comments next to a test result

### DIFF
--- a/src/ui/components/Library/Overview/TestResultListItem.tsx
+++ b/src/ui/components/Library/Overview/TestResultListItem.tsx
@@ -49,6 +49,20 @@ function Title({ recording }: { recording: Recording }) {
   );
 }
 
+function Comments({ recording }: { recording: Recording }) {
+  const numComments = recording?.comments?.length;
+  console.log(recording?.comments);
+  if (numComments == 0) {
+    return null;
+  }
+  return (
+    <div className="align-items-center flex flex-row space-x-1 text-gray-600">
+      <img src="/images/comment-outline.svg" className="w-3" />
+      <span>{numComments}</span>
+    </div>
+  );
+}
+
 export function TestResultListItem({ recording }: { recording: Recording }) {
   const { metadata } = recording;
   const passed = metadata.test?.result === "passed";
@@ -62,8 +76,13 @@ export function TestResultListItem({ recording }: { recording: Recording }) {
       rel="noreferrer noopener"
       title="View Replay"
     >
-      <ViewReplay recordingId={recordingId} passed={passed} />
-      <Title recording={recording} />
+      <div className="flex grow flex-row">
+        <div className="flex grow ">
+          <ViewReplay recordingId={recordingId} passed={passed} />
+          <Title recording={recording} />
+        </div>
+        <Comments recording={recording} />
+      </div>
     </a>
   );
 }

--- a/src/ui/hooks/tests.ts
+++ b/src/ui/hooks/tests.ts
@@ -105,6 +105,12 @@ const GET_TEST_RUN = gql`
                 duration
                 createdAt
                 metadata
+                metadata
+                comments {
+                  user {
+                    id
+                  }
+                }
               }
             }
           }


### PR DESCRIPTION
This is something i found myself wanting in order to be able to go back and find the replays i'd looked at. 

We'll probably want to surface these replays in other ways too (e.g. filters, results view)...

<img width="503" alt="Screen Shot 2022-06-20 at 11 53 58 AM" src="https://user-images.githubusercontent.com/254562/174663206-4fe04576-0072-4831-be30-37af78617323.png">
