### PR TITLE
Add a button for copying a test run link

### DIFF
--- a/src/ui/components/Library/Overview/RunSummary.tsx
+++ b/src/ui/components/Library/Overview/RunSummary.tsx
@@ -1,4 +1,7 @@
 import { useContext } from "react";
+import { useSelector } from "react-redux";
+import { getWorkspaceId } from "ui/actions/app";
+import MaterialIcon from "ui/components/shared/MaterialIcon";
 import { TestRun } from "ui/hooks/tests";
 import { AttributeContainer } from "../Content/TestRuns/AttributeContainer";
 import { RunStats } from "../Content/TestRuns/RunStats";
@@ -7,11 +10,21 @@ import { getTruncatedRelativeDate } from "../RecordingRow";
 import { OverviewContext } from "./OverviewContainer";
 
 function Title({ testRun }: { testRun: TestRun }) {
+  const workspaceId = useSelector(getWorkspaceId);
   const title = testRun.commit?.title || "";
   const formatted = title.length > 80 ? title.slice(0, 80) + "…" : title;
+
+  const handleCopyLink = () => {
+    const url = `${window.location.origin}/team/${workspaceId}/test-run/${testRun.id}`;
+    navigator.clipboard.writeText(url);
+  };
+
   return (
     <div className="flex flex-row items-center space-x-2 text-xl font-medium">
       <div>{formatted}</div>
+      <button className="flex" onClick={handleCopyLink}>
+        <MaterialIcon>content_copy</MaterialIcon>
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
This adds a button in the test run overview for copying out the link. We can polish it later, but for now, it's there to help with getting the URL out easily for testing purposes.