### PR TITLE
Turn on strict null checks in both prototype folders

### DIFF
--- a/packages/bvaughn-architecture-demo/tsconfig.json
+++ b/packages/bvaughn-architecture-demo/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "incremental": true,

--- a/packages/markerikson-stack-client-prototype/tsconfig.json
+++ b/packages/markerikson-stack-client-prototype/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,


### PR DESCRIPTION
This PR:

- Turns on `strict: true` in the `tsconfig.json` for both prototype folders, because **APPARENTLY WE DIDN'T HAVE TS STRICT MODE ON AND THIS WAS BREAKING THINGS ARGHGHHHHGGH!**

(extracted from #7205 )