### PR TITLE
Remove null check for comment execution point

### DIFF
--- a/src/ui/actions/comments.ts
+++ b/src/ui/actions/comments.ts
@@ -34,7 +34,7 @@ export function setHoveredComment(comment: any): SetHoveredComment {
 
 export function createComment(
   time: number,
-  point: string,
+  point: string | null,
   recordingId: RecordingId,
   options: CommentOptions
 ): UIThunkAction {
@@ -80,9 +80,6 @@ export function createFrameComment(
     const state = getState();
     const currentTime = getCurrentTime(state);
     const executionPoint = getExecutionPoint(state);
-    if (executionPoint == null) {
-      return;
-    }
 
     // Only try to generate a sourceLocation if there's a corresponding breakpoint for this frame comment.
     const sourceLocation = breakpoint
@@ -111,9 +108,6 @@ export function createFloatingCodeComment(
     const state = getState();
     const currentTime = getCurrentTime(state);
     const executionPoint = getExecutionPoint(state);
-    if (executionPoint == null) {
-      return;
-    }
 
     dispatch(
       createComment(currentTime, executionPoint, recordingId, {
@@ -133,9 +127,6 @@ export function createNetworkRequestComment(
     const state = getState();
     const time = request.triggerPoint?.time ?? getCurrentTime(state);
     const executionPoint = request.triggerPoint?.point || getExecutionPoint(state);
-    if (executionPoint == null) {
-      return;
-    }
 
     dispatch(
       createComment(time, executionPoint, recordingId, {


### PR DESCRIPTION
This regressed in #7138 due to a misunderstanding that `point` was a required parameter for comments. The code _suggested_ that it was:
```js
export function createComment(
  time: number,
  point: string,
  recordingId: RecordingId,
  options: CommentOptions
): UIThunkAction {
```

But the old code used to cheat a bit with `!` and sneak in `null` values:
```js
const point = request.triggerPoint?.point || executionPoint!;
```

The "fix" here is just to recognize the fact that it's an optional param and remove the early bailouts I added as part of #7138