### PR TITLE
Use a subscription instead of polling/refetching comments and sessions

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,7 @@
 # Configures the graphql endpoint
 NEXT_PUBLIC_API_URL=https://api.replay.io/v1/graphql
+# Configures the graphql endpoint for subscriptions
+NEXT_PUBLIC_API_SUBSCRIPTION_URL=wss://api.replay.io/v1/graphql
 # Configures the dispatcher websocket endpoint
 NEXT_PUBLIC_DISPATCH_URL=wss://dispatch.replay.io
 # Configures the host in local environments. Will be populated by Vercel in deployments

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "escape-html": "^1.0.3",
     "framer-motion": "^6.3.6",
     "fuzzaldrin-plus": "^0.6.0",
+    "graphql-ws": "^5.9.0",
     "immer": "^9.0.7",
     "jwt-decode": "^3.1.2",
     "launchdarkly-js-client-sdk": "^2.21.0",

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -23,7 +23,7 @@ const csp = (props: any) => {
   const hash = cspHashOf(NextScript.getInlineScriptSource(props));
   return [
     `default-src 'self'`,
-    `connect-src 'self' https://api.replay.io wss://dispatch.replay.io ws://*.replay.prod http://*.replay.prod https://telemetry.replay.io https://webreplay.us.auth0.com https://api-js.mixpanel.com https://*.sentry.io https://*.launchdarkly.com https://*.logrocket.io https://*.lr-ingest.io https://*.logrocket.com https://*.lr-in.com https://api.stripe.com https://vitals.vercel-insights.com ${
+    `connect-src 'self' https://api.replay.io wss://api.replay.io wss://dispatch.replay.io ws://*.replay.prod http://*.replay.prod https://telemetry.replay.io https://webreplay.us.auth0.com https://api-js.mixpanel.com https://*.sentry.io https://*.launchdarkly.com https://*.logrocket.io https://*.lr-ingest.io https://*.logrocket.com https://*.lr-in.com https://api.stripe.com https://vitals.vercel-insights.com ${
       // Required to talk to local backend in development. Enabling
       // localhost:8000 for prod to support the ?dispatch parameter when running
       // the local backend

--- a/pages/recording/[[...id]].tsx
+++ b/pages/recording/[[...id]].tsx
@@ -15,6 +15,7 @@ import {
   useGetRecording,
   useGetRecordingId,
   useGetRawRecordingIdWithSlug,
+  useSubscribeRecording,
 } from "ui/hooks/recordings";
 import setup from "ui/setup/dynamic/devtools";
 import { Recording as RecordingInfo } from "ui/types";
@@ -127,6 +128,7 @@ function RecordingPage({
   const recordingId = useGetRecordingId();
   const rawRecordingId = useGetRawRecordingIdWithSlug();
   useRecordingSlug(recordingId);
+  useSubscribeRecording(recordingId);
   const [recording, setRecording] = useState<RecordingInfo | null>();
   const [uploadComplete, setUploadComplete] = useState(false);
   useEffect(() => {

--- a/src/graphql/GetRecording.ts
+++ b/src/graphql/GetRecording.ts
@@ -7,9 +7,60 @@
 // GraphQL query operation: GetRecording
 // ====================================================
 
+export interface GetRecording_recording_comments_user {
+  __typename: "User";
+  id: string;
+  name: string | null;
+  picture: string | null;
+}
+
+export interface GetRecording_recording_comments_replies_user {
+  __typename: "User";
+  id: string;
+  name: string | null;
+  picture: string | null;
+}
+
+export interface GetRecording_recording_comments_replies {
+  __typename: "CommentReply";
+  id: string;
+  isPublished: boolean | null;
+  content: string;
+  createdAt: any;
+  updatedAt: any;
+  user: GetRecording_recording_comments_replies_user | null;
+}
+
 export interface GetRecording_recording_comments {
   __typename: "Comment";
   id: string;
+  isPublished: boolean | null;
+  content: string;
+  primaryLabel: string | null;
+  secondaryLabel: string | null;
+  createdAt: any;
+  updatedAt: any;
+  hasFrames: boolean;
+  sourceLocation: any | null;
+  time: number;
+  point: string;
+  position: any | null;
+  networkRequestId: string | null;
+  user: GetRecording_recording_comments_user | null;
+  replies: GetRecording_recording_comments_replies[];
+}
+
+export interface GetRecording_recording_activeSessions_user {
+  __typename: "User";
+  id: string;
+  name: string | null;
+  picture: string | null;
+}
+
+export interface GetRecording_recording_activeSessions {
+  __typename: "ActiveSession";
+  id: string;
+  user: GetRecording_recording_activeSessions_user | null;
 }
 
 export interface GetRecording_recording_owner {
@@ -99,6 +150,7 @@ export interface GetRecording_recording {
   resolution: any | null;
   metadata: any | null;
   comments: GetRecording_recording_comments[];
+  activeSessions: GetRecording_recording_activeSessions[] | null;
   owner: GetRecording_recording_owner | null;
   workspace: GetRecording_recording_workspace | null;
   collaborators: GetRecording_recording_collaborators | null;

--- a/src/graphql/SubscribeRecording.ts
+++ b/src/graphql/SubscribeRecording.ts
@@ -1,0 +1,90 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL subscription operation: SubscribeRecording
+// ====================================================
+
+export interface SubscribeRecording_recording_comments_user {
+  __typename: "User";
+  id: string;
+  name: string | null;
+  picture: string | null;
+}
+
+export interface SubscribeRecording_recording_comments_replies_user {
+  __typename: "User";
+  id: string;
+  name: string | null;
+  picture: string | null;
+}
+
+export interface SubscribeRecording_recording_comments_replies {
+  __typename: "CommentReply";
+  id: string;
+  isPublished: boolean | null;
+  content: string;
+  createdAt: any;
+  updatedAt: any;
+  user: SubscribeRecording_recording_comments_replies_user | null;
+}
+
+export interface SubscribeRecording_recording_comments {
+  __typename: "Comment";
+  id: string;
+  isPublished: boolean | null;
+  content: string;
+  primaryLabel: string | null;
+  secondaryLabel: string | null;
+  createdAt: any;
+  updatedAt: any;
+  hasFrames: boolean;
+  sourceLocation: any | null;
+  time: number;
+  point: string;
+  position: any | null;
+  networkRequestId: string | null;
+  user: SubscribeRecording_recording_comments_user | null;
+  replies: SubscribeRecording_recording_comments_replies[];
+}
+
+export interface SubscribeRecording_recording_activeSessions_user {
+  __typename: "User";
+  id: string;
+  name: string | null;
+  picture: string | null;
+}
+
+export interface SubscribeRecording_recording_activeSessions {
+  __typename: "ActiveSession";
+  id: string;
+  user: SubscribeRecording_recording_activeSessions_user | null;
+}
+
+export interface SubscribeRecording_recording {
+  __typename: "Recording";
+  uuid: any;
+  url: string | null;
+  title: string | null;
+  duration: number | null;
+  createdAt: any;
+  private: boolean;
+  isInitialized: boolean;
+  ownerNeedsInvite: boolean;
+  userRole: string;
+  operations: any | null;
+  resolution: any | null;
+  metadata: any | null;
+  comments: SubscribeRecording_recording_comments[];
+  activeSessions: SubscribeRecording_recording_activeSessions[] | null;
+}
+
+export interface SubscribeRecording {
+  recording: SubscribeRecording_recording | null;
+}
+
+export interface SubscribeRecordingVariables {
+  recordingId: any;
+}

--- a/src/ui/actions/comments.ts
+++ b/src/ui/actions/comments.ts
@@ -48,7 +48,6 @@ export function createComment(
 
     const response = await mutate({
       mutation: ADD_COMMENT_MUTATION,
-      refetchQueries: ["GetComments"],
       variables: {
         input: {
           content: "",

--- a/src/ui/graphql/recordings.ts
+++ b/src/ui/graphql/recordings.ts
@@ -28,6 +28,43 @@ export const GET_RECORDING = gql`
       metadata
       comments {
         id
+        isPublished
+        content
+        primaryLabel
+        secondaryLabel
+        createdAt
+        updatedAt
+        hasFrames
+        sourceLocation
+        time
+        point
+        position
+        networkRequestId
+        user {
+          id
+          name
+          picture
+        }
+        replies {
+          id
+          isPublished
+          content
+          createdAt
+          updatedAt
+          user {
+            id
+            name
+            picture
+          }
+        }
+      }
+      activeSessions {
+        id
+        user {
+          id
+          name
+          picture
+        }
       }
       owner {
         id
@@ -68,6 +105,65 @@ export const GET_RECORDING = gql`
               }
             }
           }
+        }
+      }
+    }
+  }
+`;
+
+export const SUBSCRIBE_RECORDING = gql`
+  subscription SubscribeRecording($recordingId: UUID!) {
+    recording(uuid: $recordingId) {
+      uuid
+      url
+      title
+      duration
+      createdAt
+      private
+      isInitialized
+      ownerNeedsInvite
+      userRole
+      operations
+      resolution
+      metadata
+      comments {
+        id
+        isPublished
+        content
+        primaryLabel
+        secondaryLabel
+        createdAt
+        updatedAt
+        hasFrames
+        sourceLocation
+        time
+        point
+        position
+        networkRequestId
+        user {
+          id
+          name
+          picture
+        }
+        replies {
+          id
+          isPublished
+          content
+          createdAt
+          updatedAt
+          user {
+            id
+            name
+            picture
+          }
+        }
+      }
+      activeSessions {
+        id
+        user {
+          id
+          name
+          picture
         }
       }
     }

--- a/src/ui/hooks/comments/comments.ts
+++ b/src/ui/hooks/comments/comments.ts
@@ -17,7 +17,6 @@ export function useGetComments(recordingId: RecordingId): {
 } {
   const { data, loading, error } = useQuery<GetComments, GetCommentsVariables>(GET_COMMENTS, {
     variables: { recordingId },
-    pollInterval: 5000,
   });
 
   if (error) {
@@ -58,10 +57,7 @@ export function useUpdateComment() {
           success
         }
       }
-    `,
-    {
-      refetchQueries: ["GetComments"],
-    }
+    `
   );
 
   return async (
@@ -91,10 +87,7 @@ export function useUpdateCommentReply() {
           success
         }
       }
-    `,
-    {
-      refetchQueries: ["GetComments"],
-    }
+    `
   );
 
   return async (id: string, newContent: string, newIsPublished: boolean) =>

--- a/src/ui/hooks/comments/useAddComment.tsx
+++ b/src/ui/hooks/comments/useAddComment.tsx
@@ -18,15 +18,12 @@ export const ADD_COMMENT_MUTATION = gql`
 `;
 
 export default function useAddComment(): AddCommentMutation {
-  const [addComment] = useMutation<AddComment, AddCommentVariables>(ADD_COMMENT_MUTATION, {
-    refetchQueries: ["GetComments"],
-  });
+  const [addComment] = useMutation<AddComment, AddCommentVariables>(ADD_COMMENT_MUTATION);
 
   return async (comment: Comment) => {
     trackEvent("comments.create");
 
     return addComment({
-      awaitRefetchQueries: true,
       variables: {
         input: {
           ...omit(comment, ["id", "createdAt", "updatedAt", "replies", "user"]),

--- a/src/ui/hooks/comments/useAddCommentReply.tsx
+++ b/src/ui/hooks/comments/useAddCommentReply.tsx
@@ -12,10 +12,7 @@ export default function useAddCommentReply() {
           }
         }
       }
-    `,
-    {
-      refetchQueries: ["GetComments"],
-    }
+    `
   );
 
   return async ({
@@ -28,7 +25,6 @@ export default function useAddCommentReply() {
     isPublished: boolean;
   }) => {
     return addCommentReply({
-      awaitRefetchQueries: true,
       variables: {
         input: {
           commentId,

--- a/src/ui/hooks/comments/useDeleteComment.tsx
+++ b/src/ui/hooks/comments/useDeleteComment.tsx
@@ -9,15 +9,11 @@ export default function useDeleteComment() {
           success
         }
       }
-    `,
-    {
-      refetchQueries: ["GetComments"],
-    }
+    `
   );
 
   return async (commentId: string) => {
     return deleteComment({
-      awaitRefetchQueries: true,
       variables: { commentId },
     });
   };

--- a/src/ui/hooks/comments/useDeleteCommentReply.tsx
+++ b/src/ui/hooks/comments/useDeleteCommentReply.tsx
@@ -9,15 +9,11 @@ export default function useDeleteCommentReply() {
           success
         }
       }
-    `,
-    {
-      refetchQueries: ["GetComments"],
-    }
+    `
   );
 
   return async (commentReplyId: string) => {
     return deleteCommentReply({
-      awaitRefetchQueries: true,
       variables: { commentReplyId },
     });
   };

--- a/src/ui/hooks/sessions.ts
+++ b/src/ui/hooks/sessions.ts
@@ -19,7 +19,6 @@ export function useGetActiveSessions(recordingId: RecordingId) {
     GET_ACTIVE_SESSIONS,
     {
       variables: { recordingId },
-      pollInterval: 5000,
     }
   );
 

--- a/test/mock/src/graphql/recordings.ts
+++ b/test/mock/src/graphql/recordings.ts
@@ -74,6 +74,7 @@ export function createGetRecordingMock(opts: {
     duration: 10,
     isInitialized: true,
     operations: { scriptDomains: [] },
+    activeSessions: null,
     owner: {
       __typename: "User",
       id: "mock-user-id",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13703,7 +13703,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql-ws@npm:^5.4.1":
+"graphql-ws@npm:^5.4.1, graphql-ws@npm:^5.9.0":
   version: 5.9.0
   resolution: "graphql-ws@npm:5.9.0"
   peerDependencies:
@@ -20694,6 +20694,7 @@ __metadata:
     fuzzaldrin-plus: ^0.6.0
     glob: ^8.0.3
     graphql: 15.8.0
+    graphql-ws: ^5.9.0
     graphqurl: ^1.0.1
     identity-obj-proxy: ^3.0.0
     immer: ^9.0.7


### PR DESCRIPTION
To test this you need to run a local GraphQL API using Replayio/backend#5990 and point the app to that API by setting the URLs in `.env`, e.g.
```
NEXT_PUBLIC_API_URL=http://localhost:8081/v1/graphql
NEXT_PUBLIC_API_SUBSCRIPTION_URL=ws://localhost:8081/v1/graphql
```