### PR TITLE
Remove getDescription

### DIFF
--- a/packages/protocol/socket.ts
+++ b/packages/protocol/socket.ts
@@ -126,6 +126,7 @@ export async function createSession(
   });
 
   gSessionCallbacks = sessionCallbacks;
+
   return sessionId;
 }
 

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -122,6 +122,7 @@ export function createSocket(
   ThreadFront: typeof ThreadFrontType
 ): UIThunkAction {
   return async (dispatch, getState) => {
+    assert(recordingId, "no recordingId");
     try {
       if (ThreadFront.recordingId) {
         assert(

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -93,12 +93,6 @@ export async function setupTimeline(store: UIStore) {
 
 export function jumpToInitialPausePoint(): UIThunkAction {
   return async (dispatch, getState, { ThreadFront }) => {
-    assert(ThreadFront.recordingId, "no recordingId");
-
-    await ThreadFront.waitForSession();
-    const { duration } = await ThreadFront.getRecordingDescription();
-    dispatch(setRecordingDescription(duration));
-
     const { endpoint } = await ThreadFront.getEndpoint();
     dispatch(pointsReceived([endpoint]));
     let { point, time } = endpoint;
@@ -111,7 +105,7 @@ export function jumpToInitialPausePoint(): UIThunkAction {
     );
 
     let hasFrames = false;
-    const initialPausePoint = await getInitialPausePoint(ThreadFront.recordingId);
+    const initialPausePoint = await getInitialPausePoint(ThreadFront.recordingId!);
     if (
       initialPausePoint &&
       isTimeInRegions(initialPausePoint.time, getLoadedRegions(state)!.loading)


### PR DESCRIPTION
Removes the client's dependency on getDescription which will help in cases where the description is not available or slow to return.

It should also have no impact on behavior since it's quickly overwritten.