### PR TITLE
Use react-window for Console auto complete typeahead

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "react-tooltip": "^4.2.21",
     "react-transition-group": "^4.4.2",
     "react-virtualized-auto-sizer": "^1.0.6",
-    "react-window": "^1.8.6",
+    "react-window": "^1.8.7",
     "reactjs-popup": "^2.0.5",
     "redux": "^4.1.2",
     "reselect": "^4.1.5",

--- a/src/ui/components/shared/CodeEditor/EditorWithAutocomplete.tsx
+++ b/src/ui/components/shared/CodeEditor/EditorWithAutocomplete.tsx
@@ -61,13 +61,16 @@ export function EditorWithAutocomplete({
     autocompleteIndex,
     matches,
     shouldShowAutocomplete,
+    applyMatch,
     applySelectedMatch,
     moveAutocompleteCursor,
     resetAutocompleteIndex,
     setHideAutocomplete,
   } = useAutocomplete(value, onPreviewAvailable, options.isArgument);
 
-  const autocomplete = () => setValue(applySelectedMatch());
+  const autocomplete = (match: string) => {
+    setValue(applyMatch(match));
+  };
   const onSelection = (obj?: any) => {
     const cursorMoved = obj?.origin && ["*mouse", "+move"].includes(obj.origin);
 
@@ -87,7 +90,7 @@ export function EditorWithAutocomplete({
   const onAutocompleteKeyPress = (e: KeyboardEvent) => {
     if ((e.key === Keys.ENTER && !e.shiftKey) || e.key === Keys.TAB || e.key === Keys.ARROW_RIGHT) {
       e.preventDefault();
-      autocomplete();
+      setValue(applySelectedMatch());
     } else if (e.key === Keys.ARROW_DOWN) {
       e.preventDefault();
       moveAutocompleteCursor(-1);

--- a/src/ui/components/shared/CodeEditor/useAutocomplete.tsx
+++ b/src/ui/components/shared/CodeEditor/useAutocomplete.tsx
@@ -125,6 +125,9 @@ export default function useAutocomplete(
   };
   const applySelectedMatch = () => {
     const match = matches[selectedIndex];
+    return applyMatch(match);
+  };
+  const applyMatch = (match: string) => {
     return insertAutocompleteMatch(expression, match, isArgument);
   };
 
@@ -137,6 +140,7 @@ export default function useAutocomplete(
     autocompleteIndex: selectedIndex,
     matches,
     shouldShowAutocomplete: getShouldShowAutocomplete(expression, isHidden, matches),
+    applyMatch,
     applySelectedMatch,
     moveAutocompleteCursor,
     resetAutocompleteIndex: () => setSelectedIndex(0),

--- a/yarn.lock
+++ b/yarn.lock
@@ -8913,6 +8913,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bvaughn-architecture-demo@file:packages/bvaughn-architecture-demo::locator=recordreplay-devtools%40workspace%3A.":
+  version: 0.1.0
+  resolution: "bvaughn-architecture-demo@file:packages/bvaughn-architecture-demo#packages/bvaughn-architecture-demo::hash=1958f7&locator=recordreplay-devtools%40workspace%3A."
+  dependencies:
+    "@replayio/protocol": ^0.31.0
+    date-fns: ^2.28.0
+    lodash: ^4.17.21
+    next: ^12.1.6
+    pretty-ms: ^7.0.1
+    protocol: "workspace:*"
+    react: 0.0.0-experimental-e7d0053e6-20220325
+    react-dom: 0.0.0-experimental-e7d0053e6-20220325
+    shared: "workspace:*"
+  checksum: ee5aee10275eb689c66244b301c03b4eb4d7d27974f62844e6248e6a5d3158fe8ec42b07f07348100f43f89061bb491ea898b3978c1dee145a0d6b455c49b25c
+  languageName: node
+  linkType: hard
+
 "bvaughn-architecture-demo@workspace:packages/bvaughn-architecture-demo":
   version: 0.0.0-use.local
   resolution: "bvaughn-architecture-demo@workspace:packages/bvaughn-architecture-demo"
@@ -19451,8 +19468,8 @@ __metadata:
 
 "protocol@file:packages/protocol::locator=recordreplay-devtools%40workspace%3A.":
   version: 0.0.0
-  resolution: "protocol@file:packages/protocol#packages/protocol::hash=405bf8&locator=recordreplay-devtools%40workspace%3A."
-  checksum: a80548046b133d137bc7d2e9b360b169dbc76bb8e158d8415b84f45cf4387a961d66f8e29d9a938bb49df7fd36a594e1d77a3b18df0b8de7ff7e5cac267f7c16
+  resolution: "protocol@file:packages/protocol#packages/protocol::hash=903b4d&locator=recordreplay-devtools%40workspace%3A."
+  checksum: a590dc76a9f40e9c355defa9196033681c870ccfd0e545e4f9a69f531171ef185ea1aba6a64042cdbb98d4ac11d7c593ad6bb5ebaace6f58ddc873bd61aca16f
   languageName: node
   linkType: hard
 
@@ -20098,7 +20115,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-window@npm:^1.8.6":
+"react-window@npm:^1.8.7":
   version: 1.8.7
   resolution: "react-window@npm:1.8.7"
   dependencies:
@@ -20353,6 +20370,7 @@ __metadata:
     babel-plugin-transform-import-meta: ^2.1.1
     base64-arraybuffer: ^1.0.2
     bufferutil: ^4.0.6
+    bvaughn-architecture-demo: "file:packages/bvaughn-architecture-demo"
     circular-dependency-plugin: ^5.2.2
     classnames: ^2.3.1
     codemirror: ^5.65.2
@@ -20422,7 +20440,7 @@ __metadata:
     react-tooltip: ^4.2.21
     react-transition-group: ^4.4.2
     react-virtualized-auto-sizer: ^1.0.6
-    react-window: ^1.8.6
+    react-window: ^1.8.7
     reactjs-popup: ^2.0.5
     redux: ^4.1.2
     reselect: ^4.1.5
@@ -21415,8 +21433,8 @@ __metadata:
 
 "shared@file:packages/shared::locator=recordreplay-devtools%40workspace%3A.":
   version: 0.0.0
-  resolution: "shared@file:packages/shared#packages/shared::hash=4a86e4&locator=recordreplay-devtools%40workspace%3A."
-  checksum: 210e8e74b25662bbffda0050d45d0ca8d367f68369fbef085df9d2c80b8c146a5a996f7cd756b2c38c5dfc30c8afd27b64a1f52801fe9759e6469834bee6ef9e
+  resolution: "shared@file:packages/shared#packages/shared::hash=26cfb1&locator=recordreplay-devtools%40workspace%3A."
+  checksum: 7e3a088208d0ce062446326a504ab24b441b0a282af6c56446943486bea0b4480488ed60c5fd07f0cbda53ed88601b88cf2e2b0d00df33a4576f8958fa8af9f1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This commit fixes one of the outstanding performance problems with the console type-ahead feature by using [react-window](https://react-window.vercel.app/) to render the list of items.

This PR also fixes a couple of bugs that existed before:
* Clicking on an item selects _the item you clicked_ rather than the one that happened to be keyboard focused.
* If you scroll to an item, and then key up/down, the selected item scrolls back into view.

Loom walk through:
https://www.loom.com/share/07aba245febe41fdac2a036983639398