### PR TITLE
Remove Add Comment context menu

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/index.js
+++ b/src/devtools/client/debugger/src/components/Editor/index.js
@@ -244,10 +244,6 @@ class Editor extends PureComponent {
       return;
     }
 
-    if (target.classList.contains("CodeMirror-linenumber")) {
-      return;
-    }
-
     if (target.getAttribute("id") === "columnmarker") {
       return;
     }
@@ -262,24 +258,6 @@ class Editor extends PureComponent {
   onGutterClick = (cm, line, gutter, ev) => {
     const { cx, selectedSource, addBreakpointAtLine, toggleBlackBox } = this.props;
     const sourceLocation = getSourceLocationFromMouseEvent(this.state.editor, selectedSource, ev);
-
-    // Open the context menu then bail if the user clicks on a non-breakable line
-    if (ev.target.closest(".empty-line")) {
-      // I am pretty morally opposed to this code, but without it codemirror
-      // breaks in a myriad of ways.
-      setTimeout(() => {
-        this.props.openContextMenu({
-          x: ev.x,
-          y: ev.y,
-          contextMenuItem: {
-            location: sourceLocation,
-            sourceUrl: selectedSource.url,
-          },
-        });
-      }, 100);
-
-      return;
-    }
 
     // ignore right clicks in the gutter
     if ((ev.ctrlKey && ev.button === 0) || ev.button === 2 || !selectedSource) {


### PR DESCRIPTION
This PR temporarily removes the "Add comment" dropdown because it was fighting with the old editor context menu. We can upgrade the old editor context menu and add an "Add comment" item going forward.

It might be possible to get these two dropdowns to be be friends, but it doesnt seem worth the effort. 

[loom](https://www.loom.com/share/b9dc94e472eb4651b5a4077fbebd5f3d)