### PR TITLE
Convert getBreakpointsForSource to memoized selector

### DIFF
--- a/src/devtools/client/debugger/src/actions/breakpoints/breakpoints.ts
+++ b/src/devtools/client/debugger/src/actions/breakpoints/breakpoints.ts
@@ -9,8 +9,8 @@ import { trackEvent } from "ui/utils/telemetry";
 
 import {
   Breakpoint,
+  getBreakpointsForSelectedSource,
   getBreakpointsForSource,
-  getBreakpointsForSourceId,
 } from "../../reducers/breakpoints";
 import {
   removeRequestedBreakpoint,
@@ -43,7 +43,7 @@ import {
 
 export function addBreakpointAtLine(cx: Context, line: number): UIThunkAction {
   return (dispatch, getState) => {
-    const logpoints = getBreakpointsForSourceId(getState());
+    const logpoints = getBreakpointsForSelectedSource(getState());
     const breakpoint = logpoints.find(ps => ps.location.line === line);
     const logValue = isLogpoint(breakpoint);
 

--- a/src/devtools/client/debugger/src/actions/breakpoints/logpoints.ts
+++ b/src/devtools/client/debugger/src/actions/breakpoints/logpoints.ts
@@ -2,7 +2,7 @@ import type { Context } from "devtools/client/debugger/src/reducers/pause";
 import { UIThunkAction } from "ui/actions";
 import { trackEvent } from "ui/utils/telemetry";
 
-import { Breakpoint, getBreakpointsForSourceId } from "../../reducers/breakpoints";
+import { Breakpoint, getBreakpointsForSelectedSource } from "../../reducers/breakpoints";
 import { getLogpointsForSource } from "../../reducers/breakpoints";
 import { removeRequestedBreakpoint } from "../../reducers/breakpoints";
 import { Source } from "../../reducers/sources";
@@ -41,7 +41,7 @@ export function toggleLogpoint(cx: Context, line: number, bp?: Breakpoint): UITh
 
 export function addLogpoint(cx: Context, line: number): UIThunkAction {
   return (dispatch, getState) => {
-    const logpoints = getBreakpointsForSourceId(getState());
+    const logpoints = getBreakpointsForSelectedSource(getState());
     const breakpoint = logpoints.find(ps => ps.location.line === line);
     const shouldPause = isBreakable(breakpoint);
 

--- a/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
@@ -1,13 +1,12 @@
 import { PointDescription } from "@replayio/protocol";
 import ReactDOM from "react-dom";
-import React, { useState, useEffect, MouseEventHandler, FC, ReactNode } from "react";
+import React, { useState, useEffect, MouseEventHandler, FC, ReactNode, useRef } from "react";
 import { connect, ConnectedProps } from "react-redux";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
 import { selectors } from "ui/reducers";
 import { UIState } from "ui/state";
-import { Breakpoint, getBreakpointsForSource } from "../../reducers/breakpoints";
-import { getSelectedSource } from "../../reducers/sources";
+import { Breakpoint, getBreakpointsForSelectedSource } from "../../reducers/breakpoints";
 import classNames from "classnames";
 import { toggleLogpoint } from "../../actions/breakpoints/logpoints";
 import hooks from "ui/hooks";
@@ -228,9 +227,8 @@ function ToggleWidgetButton({
 
 const connector = connect(
   (state: UIState) => ({
-    indexed: selectors.getIsIndexed(state),
     cx: selectors.getThreadContext(state),
-    breakpoints: getBreakpointsForSource(state, getSelectedSource(state)!.id),
+    breakpoints: getBreakpointsForSelectedSource(state),
   }),
   {}
 );

--- a/src/devtools/client/debugger/src/reducers/breakpoints.ts
+++ b/src/devtools/client/debugger/src/reducers/breakpoints.ts
@@ -356,15 +356,20 @@ export function getBreakpointsDisabled(state: UIState) {
   return breakpoints.every(breakpoint => breakpoint.disabled);
 }
 
-export function getBreakpointsForSourceId(state: UIState, line?: number) {
-  const { id: sourceId } = getSelectedSource(state)!;
+export const getBreakpointsForSelectedSource = createSelector(
+  getBreakpointsList,
+  getSelectedSource,
+  (breakpoints, selectedSource) => {
+    if (!selectedSource) {
+      return [];
+    }
 
-  if (!sourceId) {
-    return [];
+    const sourceId = selectedSource.id;
+    return breakpoints.filter(bp => {
+      return bp.location.sourceId === sourceId;
+    });
   }
-
-  return getBreakpointsForSource(state, sourceId, line);
-}
+);
 
 export function getBreakpointsForSource(state: UIState, sourceId: string, line?: number) {
   if (!sourceId) {


### PR DESCRIPTION
This was causing a lot of unnecessary renders in the Editor.