### PR TITLE
Hit count component properly removes empty-line class

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
@@ -106,6 +106,8 @@ function LineHitCounts({ editor, isCollapsed, setIsCollapsed }: Props) {
             );
           }
           className = styles[`HitsBadge${index + 1}`];
+
+          editor.codeMirror.removeLineClass(lineHandle, "line", "empty-line");
         } else {
           // If this line wasn't hit any, dim the line number,
           // even if it's a line that's technically reachable.


### PR DESCRIPTION
This code wasn't properly handling the case where the `empty-line` class was added _initially_ (because hit count metadata hadn't downloaded yet). That meant that any file opened _before_ hit counts came in would get every line marked as "empty" (which also broke our hover "+" button).