### PR TITLE
Don't fail-fast on matrixed E2E jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,6 +75,8 @@ jobs:
     runs-on: macos-latest
     needs: [download-browser, download-node, download-driver, preview-branch, generate-test-run-id]
     strategy:
+      # GH cancels other matrixed jobs by default if one fails. We want all E2E jobs to complete.
+      fail-fast: false
       matrix:
         shard: ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]
     timeout-minutes: 20


### PR DESCRIPTION
This PR:

- Changes the E2E test action so that all jobs should be allowed to complete even if one fails, rather than the default "fail-fast" behavior that cancels the others if there's a failure