### PR TITLE
Add authenticate checks to every place where comments are created

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/index.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/index.tsx
@@ -7,7 +7,6 @@ import "reactjs-popup/dist/index.css";
 import { useAppDispatch } from "ui/setup/hooks";
 import { createFloatingCodeComment, createFrameComment } from "ui/actions/comments";
 import { enterFocusMode } from "ui/actions/timeline";
-import PrefixBadgeButton from "ui/components/PrefixBadge";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
 import hooks from "ui/hooks";
 import { useGetRecordingId } from "ui/hooks/recordings";
@@ -16,6 +15,7 @@ import { trackEvent } from "ui/utils/telemetry";
 import Condition from "./Condition";
 import Log from "./Log";
 import Popup from "./Popup";
+import useAuth0 from "ui/utils/useAuth0";
 
 export type Input = "condition" | "logValue";
 
@@ -43,6 +43,7 @@ export default function PanelSummary({
   const logValue = breakpoint.options.logValue;
 
   const dispatch = useAppDispatch();
+  const { isAuthenticated } = useAuth0();
 
   const isLoaded = Boolean(analysisPoints && !isHot);
   const isEditable = isLoaded && isTeamDeveloper;
@@ -60,6 +61,11 @@ export default function PanelSummary({
 
   const addComment = (e: React.MouseEvent) => {
     e.stopPropagation();
+
+    // Un-authenticated users can't comment on Replays.
+    if (!isAuthenticated) {
+      return null;
+    }
 
     trackEvent("breakpoint.add_comment");
 
@@ -90,7 +96,8 @@ export default function PanelSummary({
           This log cannot be edited because <br />
           it was hit {MAX_POINTS_FOR_FULL_ANALYSIS}+ times
         </Popup>
-        <AddCommentButton onClick={addComment} isPausedOnHit={pausedOnHit} />
+
+        {isAuthenticated && <AddCommentButton onClick={addComment} isPausedOnHit={pausedOnHit} />}
       </div>
     );
   }
@@ -121,7 +128,7 @@ export default function PanelSummary({
           </Popup>
         ) : null}
       </div>
-      <AddCommentButton onClick={addComment} isPausedOnHit={pausedOnHit} />
+      {isAuthenticated && <AddCommentButton onClick={addComment} isPausedOnHit={pausedOnHit} />}
     </div>
   );
 }

--- a/src/devtools/client/webconsole/components/Output/Message.js
+++ b/src/devtools/client/webconsole/components/Output/Message.js
@@ -57,6 +57,7 @@ class Message extends React.Component {
           frame: PropTypes.any,
         })
       ),
+      isAuthenticated: PropTypes.bool.isRequired,
       isPaused: PropTypes.bool,
       maybeScrollToBottom: PropTypes.func,
       message: PropTypes.object.isRequired,
@@ -170,6 +171,7 @@ class Message extends React.Component {
       type,
       frame,
       message,
+      isAuthenticated,
       isFirstMessageForPoint,
     } = this.props;
 
@@ -188,6 +190,11 @@ class Message extends React.Component {
       dismissNag(Nag.FIRST_CONSOLE_NAVIGATE);
     };
     let handleAddComment = async () => {
+      // Un-authenticated users can't comment on Replays.
+      if (!isAuthenticated) {
+        return null;
+      }
+
       trackEvent("console.add_comment");
       const opts = {
         hasFrames: true,
@@ -225,6 +232,11 @@ class Message extends React.Component {
       // Handle cases where executionPoint is the same as pauseExecutionPoint.
       return;
     } else if (!["command", "result"].includes(type)) {
+      // Un-authenticated users can't comment on Replays.
+      if (!isAuthenticated) {
+        return null;
+      }
+
       overlayType = "debug";
       label = "Debug";
 

--- a/src/devtools/client/webconsole/components/Output/message-types/ConsoleApiCall.js
+++ b/src/devtools/client/webconsole/components/Output/message-types/ConsoleApiCall.js
@@ -4,6 +4,8 @@
 
 "use strict";
 
+import useAuth0 from "ui/utils/useAuth0";
+
 // React & Redux
 const React = require("react");
 const PropTypes = require("prop-types");
@@ -65,6 +67,8 @@ export default function ConsoleApiCall(props) {
     prefix,
     userProvidedStyles,
   } = message;
+
+  const { isAuthenticated } = useAuth0();
 
   let messageBody;
   const messageBodyConfig = {
@@ -148,6 +152,7 @@ export default function ConsoleApiCall(props) {
     executionPointTime,
     frame,
     indent,
+    isAuthenticated,
     isFirstMessageForPoint,
     isPaused,
     isPrimaryHighlighted,

--- a/src/devtools/client/webconsole/components/Output/message-types/ConsoleCommand.js
+++ b/src/devtools/client/webconsole/components/Output/message-types/ConsoleCommand.js
@@ -4,6 +4,8 @@
 
 "use strict";
 
+import useAuth0 from "ui/utils/useAuth0";
+
 // React & Redux
 const React = require("react");
 const PropTypes = require("prop-types");
@@ -25,6 +27,8 @@ export default function ConsoleCommand(props) {
   const { indent, source, type, level, timeStamp, executionPointTime } = message;
   const messageText = trimCode(message.messageText);
 
+  const { isAuthenticated } = useAuth0();
+
   // This uses a Custom Element to syntax highlight when possible. If it's not
   // (no CodeMirror editor), then it will just render text.
   const messageBody = React.createElement("syntax-highlighted", null, messageText);
@@ -41,6 +45,7 @@ export default function ConsoleCommand(props) {
     executionPointTime,
     maybeScrollToBottom,
     message,
+    isAuthenticated,
     isPaused,
     dispatch,
   });

--- a/src/devtools/client/webconsole/components/Output/message-types/EvaluationResult.js
+++ b/src/devtools/client/webconsole/components/Output/message-types/EvaluationResult.js
@@ -4,6 +4,8 @@
 
 "use strict";
 
+import useAuth0 from "ui/utils/useAuth0";
+
 // React & Redux
 const React = require("react");
 const PropTypes = require("prop-types");
@@ -49,6 +51,8 @@ export default function EvaluationResult(props) {
     parameters,
     notes,
   } = message;
+
+  const { isAuthenticated } = useAuth0();
 
   let messageBody;
   if (typeof message.messageText !== "undefined" && message.messageText !== null) {
@@ -99,6 +103,7 @@ export default function EvaluationResult(props) {
     timestampsVisible,
     maybeScrollToBottom,
     message,
+    isAuthenticated,
     isPaused,
   });
 }

--- a/src/devtools/client/webconsole/components/Output/message-types/PageError.js
+++ b/src/devtools/client/webconsole/components/Output/message-types/PageError.js
@@ -4,6 +4,8 @@
 
 "use strict";
 
+import useAuth0 from "ui/utils/useAuth0";
+
 // React & Redux
 const React = require("react");
 const PropTypes = require("prop-types");
@@ -53,6 +55,8 @@ export default function PageError(props) {
     notes,
   } = message;
 
+  const { isAuthenticated } = useAuth0();
+
   const messageBody = REPS.StringRep.rep({
     object: createPrimitiveValueFront(messageText),
     mode: MODE.LONG,
@@ -86,6 +90,7 @@ export default function PageError(props) {
     maybeScrollToBottom,
     message,
     pausedExecutionPoint,
+    isAuthenticated,
     isFirstMessageForPoint,
   });
 }

--- a/src/devtools/client/webconsole/components/Output/message-types/PaywallMessage.js
+++ b/src/devtools/client/webconsole/components/Output/message-types/PaywallMessage.js
@@ -4,6 +4,8 @@
 
 "use strict";
 
+import useAuth0 from "ui/utils/useAuth0";
+
 // React & Redux
 const React = require("react");
 const PropTypes = require("prop-types");
@@ -23,6 +25,7 @@ export default function PaywallMessage(props) {
   const { message, timestampsVisible, maybeScrollToBottom, isPaused, dispatch, topLevelClassName } =
     props;
   const { indent, source, level, timeStamp, executionPointTime } = message;
+  const { isAuthenticated } = useAuth0();
 
   return React.createElement(Message, {
     source,
@@ -39,6 +42,7 @@ export default function PaywallMessage(props) {
     executionPointTime,
     maybeScrollToBottom,
     message,
+    isAuthenticated,
     isPaused,
     dispatch,
   });

--- a/src/ui/components/Comments/CommentReplyButton.tsx
+++ b/src/ui/components/Comments/CommentReplyButton.tsx
@@ -19,6 +19,7 @@ export default function CommentReplyButton({ comment }: { comment: Comment }) {
   // This should be replaced with useTransition() once we're using Suspense for comment data.
   const [isPending, setIsPending] = useState(false);
 
+  // Un-authenticated users can't comment on Replays.
   if (!isAuthenticated) {
     return null;
   }

--- a/src/ui/components/ContextMenu/GutterContextMenu.tsx
+++ b/src/ui/components/ContextMenu/GutterContextMenu.tsx
@@ -8,6 +8,7 @@ import { trackEvent } from "ui/utils/telemetry";
 import { Dropdown, DropdownItem } from "../Library/LibraryDropdown";
 
 import { ContextMenu } from "./index";
+import useAuth0 from "ui/utils/useAuth0";
 
 export default function GutterContextMenu({
   close,
@@ -17,7 +18,7 @@ export default function GutterContextMenu({
   contextMenu: ContextMenuType;
 }) {
   const recordingId = useGetRecordingId();
-
+  const { isAuthenticated } = useAuth0();
   const dispatch = useAppDispatch();
 
   const addComment = (e: React.MouseEvent) => {
@@ -30,6 +31,11 @@ export default function GutterContextMenu({
     );
     close();
   };
+
+  // Un-authenticated users can't comment on Replays.
+  if (!isAuthenticated) {
+    return null;
+  }
 
   return (
     <ContextMenu close={close} x={contextMenu.x} y={contextMenu.y}>

--- a/src/ui/components/KeyboardShortcuts.tsx
+++ b/src/ui/components/KeyboardShortcuts.tsx
@@ -14,6 +14,7 @@ import { deselectSource } from "devtools/client/debugger/src/actions/sources/sel
 import { getCommandPaletteInput } from "./CommandPalette/SearchInput";
 import { isEditableElement, addGlobalShortcut, removeGlobalShortcut } from "ui/utils/key-shortcuts";
 import { useGetRecordingId } from "ui/hooks/recordings";
+import useAuth0 from "ui/utils/useAuth0";
 
 const closeOpenModalsOnEscape = (e: KeyboardEvent): UIThunkAction => {
   return (dispatch, getState) => {
@@ -55,6 +56,7 @@ function KeyboardShortcuts({
   closeOpenModalsOnEscape,
 }: PropsFromRedux) {
   const recordingId = useGetRecordingId();
+  const { isAuthenticated } = useAuth0();
   const { value: protocolTimeline, update: updateProtocolTimeline } =
     useFeature("protocolTimeline");
   const globalKeyboardShortcuts = useMemo(() => {
@@ -119,6 +121,11 @@ function KeyboardShortcuts({
     };
 
     const addComment = (e: KeyboardEvent) => {
+      // Un-authenticated users can't comment on Replays.
+      if (!isAuthenticated) {
+        return;
+      }
+
       if (!e.target || !isEditableElement(e.target)) {
         e.preventDefault();
         createFrameComment(null, recordingId);
@@ -165,6 +172,7 @@ function KeyboardShortcuts({
 
     return shortcuts;
   }, [
+    isAuthenticated,
     showCommandPaletteInEditor,
     setSelectedPrimaryPanel,
     focusFullTextInput,

--- a/src/ui/components/NetworkMonitor/AddNetworkRequestCommentButton.tsx
+++ b/src/ui/components/NetworkMonitor/AddNetworkRequestCommentButton.tsx
@@ -1,9 +1,9 @@
 import { useAppDispatch } from "ui/setup/hooks";
 import { createNetworkRequestComment } from "ui/actions/comments";
 import { useGetRecordingId } from "ui/hooks/recordings";
-import { useFeature } from "ui/hooks/settings";
 import { AddCommentButton } from "../../../../packages/components";
 import { RequestSummary } from "./utils";
+import useAuth0 from "ui/utils/useAuth0";
 
 export default function AddNetworkRequestCommentButton({
   request,
@@ -14,10 +14,16 @@ export default function AddNetworkRequestCommentButton({
 }) {
   const dispatch = useAppDispatch();
   const recordingId = useGetRecordingId();
+  const { isAuthenticated } = useAuth0();
 
   const addRequestComment = () => {
     dispatch(createNetworkRequestComment(request, recordingId));
   };
+
+  // Un-authenticated users can't comment on Replays.
+  if (!isAuthenticated) {
+    return null;
+  }
 
   return <AddCommentButton className={className} onClick={addRequestComment} />;
 }

--- a/src/ui/components/shared/CommentTool.tsx
+++ b/src/ui/components/shared/CommentTool.tsx
@@ -7,6 +7,7 @@ import { setSelectedPrimaryPanel } from "ui/actions/layout";
 import { useGetRecordingId } from "ui/hooks/recordings";
 import { Canvas } from "ui/state/app";
 import { Comment, Reply } from "ui/state/comments";
+import useAuth0 from "ui/utils/useAuth0";
 
 const mouseEventCanvasPosition = (e: MouseEvent) => {
   const canvas = document.getElementById("graphics");
@@ -61,6 +62,7 @@ type Coordinates = {
 export default function CommentTool({ comments }: { comments: (Comment | Reply)[] }) {
   const canvas = useAppSelector(getCanvas);
   const areMouseTargetsLoading = useAppSelector(getAreMouseTargetsLoading);
+  const { isAuthenticated } = useAuth0();
 
   const dispatch = useAppDispatch();
 
@@ -77,7 +79,11 @@ export default function CommentTool({ comments }: { comments: (Comment | Reply)[
           return;
         }
 
-        dispatch(createFrameComment(mouseEventCanvasPosition(e), recordingId));
+        // Un-authenticated users can't comment on Replays.
+        if (isAuthenticated) {
+          dispatch(createFrameComment(mouseEventCanvasPosition(e), recordingId));
+        }
+
         dispatch(setSelectedPrimaryPanel("comments"));
       };
 
@@ -100,7 +106,12 @@ export default function CommentTool({ comments }: { comments: (Comment | Reply)[
         videoNode.removeEventListener("mouseleave", onMouseLeave);
       };
     }
-  }, [comments, dispatch, recordingId]);
+  }, [comments, dispatch, isAuthenticated, recordingId]);
+
+  // Un-authenticated users can't comment on Replays.
+  if (!isAuthenticated) {
+    return null;
+  }
 
   if (!mousePosition) {
     return null;

--- a/src/ui/components/shared/NewAttachment.tsx
+++ b/src/ui/components/shared/NewAttachment.tsx
@@ -5,6 +5,7 @@ import * as actions from "ui/actions/app";
 import { selectors } from "ui/reducers";
 import { UIState } from "ui/state";
 import Modal from "./NewModal";
+import useAuth0 from "ui/utils/useAuth0";
 
 function addLoomComment(loom: string) {
   return JSON.stringify({
@@ -22,6 +23,7 @@ function NewAttachment({ hideModal, modalOptions }: PropsFromRedux) {
   const addCommentReply = hooks.useAddCommentReply();
   const [url, setUrl] = useState("");
   const loom = url.match(/loom\.com\/share\/(\S*?)(\"|\?|$)/)?.[1];
+  const { isAuthenticated } = useAuth0();
 
   const onChange = (e: any) => {
     setUrl(e.target.value);
@@ -40,6 +42,11 @@ function NewAttachment({ hideModal, modalOptions }: PropsFromRedux) {
   };
 
   const color = !loom ? "bg-gray-300" : "bg-primaryAccent";
+
+  // Un-authenticated users can't comment on Replays.
+  if (!isAuthenticated) {
+    return null;
+  }
 
   return (
     <Modal options={{ maskTransparency: "translucent" }} onMaskClick={hideModal}>


### PR DESCRIPTION
Follow up to #7124

It's kind of unfortunate how many different places this touches (because of the mix of imperative/declarative, hooks/graphQL mutations, etc) but I think I got them all.

Loom https://www.loom.com/share/bac5e1c3f9c94446a152cee919cc4a66