### PR TITLE
Fix SourcemapToggle and SourcemapVisualizerLink

### DIFF
--- a/packages/protocol/thread/thread.ts
+++ b/packages/protocol/thread/thread.ts
@@ -1224,8 +1224,12 @@ class _ThreadFront {
 
   // Return whether sourceId is minified and has a pretty printed alternate.
   isMinifiedSource(sourceId: SourceId) {
+    return !!this.getPrettyPrintedSourceId(sourceId);
+  }
+
+  getPrettyPrintedSourceId(sourceId: SourceId) {
     const originalIds = this.originalSources.map.get(sourceId) || [];
-    return originalIds.some(id => {
+    return originalIds.find(id => {
       const info = this.sources.get(id);
       return info && info.kind == "prettyPrinted";
     });

--- a/src/devtools/client/debugger/src/components/Editor/SourcemapVisualizerLink.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/SourcemapVisualizerLink.tsx
@@ -10,7 +10,7 @@ import { getSelectedSourceWithContent } from "../../reducers/sources";
 export default function SourcemapVisualizerLink() {
   const selectedSource = useAppSelector(getSelectedSourceWithContent);
   const alternateSource = useAppSelector(getAlternateSource);
-  if (!selectedSource || !alternateSource) {
+  if (!selectedSource) {
     return null;
   }
 


### PR DESCRIPTION
Both SourcemapToggle and SourcemapVisualizerLink need to find the alternate source to switch to but the logic for that was broken.

In this recording the SourcemapToggle should say "No sourcemaps found" because the recording doesn't contain sourcemaps:
Original recording: https://app.replay.io/recording/9e0910b1-43a4-478b-ba99-b6dbf9ba37a5
Recording showing the bug (from FE-143): https://app.replay.io/recording/use-sourcemap-click-bug--fed936ac-f1f9-4447-bbc4-f39911dda46f
Here's another recording with the same bug: https://app.replay.io/recording/minified2--82ae7e80-692d-4b0c-8d03-23292a96c3ff

In this recording the SourcemapToggle says "No sourcemaps found" for "exceptions_bundle.js" even though there is a sourcemap:
Original recording: https://app.replay.io/recording/replay-of-localhost8080--244a43ab-a6b7-4d3d-85c0-1684439ed280
Recording showing the bug: https://app.replay.io/recording/why-no-sourcemap-found--444cc3eb-1a3f-4494-8f09-e8c3d99ea358

I've rebuilt that logic, now it explicitly follows the links in the source(map) graph to find the alternate source.
Note that if we're paused in the selected source then we don't need that logic as we can rely on the alternate source that we get from the `MappedLocation` of the paused frame.

Fixes FE-143
Fixes FE-251