### PR TITLE
Attempt to make the frontend more resilient to pause timing

### DIFF
--- a/src/devtools/client/debugger/src/actions/pause/commands.js
+++ b/src/devtools/client/debugger/src/actions/pause/commands.js
@@ -2,22 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-//
-
 import { getResumePoint, getFramePositions } from "../../selectors";
 import { getLoadedRegions } from "ui/reducers/app";
 import { PROMISE } from "ui/setup/redux/middleware/promise";
-import { recordEvent } from "../../utils/telemetry";
 
 import { setFramePositions } from "./setFramePositions";
 
-/**
- * Debugger commands like stepOver, stepIn, stepUp
- *
- * @param string $0.type
- * @memberof actions/pause
- * @static
- */
 export function command(cx, type) {
   return async (dispatch, getState, { client }) => {
     if (!type) {
@@ -39,12 +29,6 @@ export function command(cx, type) {
   };
 }
 
-/**
- * StepIn
- * @memberof actions/pause
- * @static
- * @returns {Function} {@link command}
- */
 export function stepIn(cx) {
   return dispatch => {
     if (cx.isPaused) {
@@ -53,12 +37,6 @@ export function stepIn(cx) {
   };
 }
 
-/**
- * stepOver
- * @memberof actions/pause
- * @static
- * @returns {Function} {@link command}
- */
 export function stepOver(cx) {
   return dispatch => {
     if (cx.isPaused) {
@@ -67,12 +45,14 @@ export function stepOver(cx) {
   };
 }
 
-/**
- * stepOut
- * @memberof actions/pause
- * @static
- * @returns {Function} {@link command}
- */
+export function reverseStepOver(cx) {
+  return dispatch => {
+    if (cx.isPaused) {
+      return dispatch(command(cx, "reverseStepOver"));
+    }
+  };
+}
+
 export function stepOut(cx) {
   return dispatch => {
     if (cx.isPaused) {
@@ -81,45 +61,10 @@ export function stepOut(cx) {
   };
 }
 
-/**
- * resume
- * @memberof actions/pause
- * @static
- * @returns {Function} {@link command}
- */
 export function resume(cx) {
-  return dispatch => {
-    if (cx.isPaused) {
-      recordEvent("continue");
-      return dispatch(command(cx, "resume"));
-    }
-  };
+  return dispatch => dispatch(command(cx, "resume"));
 }
 
-/**
- * rewind
- * @memberof actions/pause
- * @static
- * @returns {Function} {@link command}
- */
 export function rewind(cx) {
-  return dispatch => {
-    if (cx.isPaused) {
-      return dispatch(command(cx, "rewind"));
-    }
-  };
-}
-
-/**
- * reverseStepOver
- * @memberof actions/pause
- * @static
- * @returns {Function} {@link command}
- */
-export function reverseStepOver(cx) {
-  return dispatch => {
-    if (cx.isPaused) {
-      return dispatch(command(cx, "reverseStepOver"));
-    }
-  };
+  return dispatch => dispatch(command(cx, "rewind"));
 }

--- a/src/devtools/client/debugger/src/actions/pause/paused.js
+++ b/src/devtools/client/debugger/src/actions/pause/paused.js
@@ -8,7 +8,7 @@ import { getSelectedFrame, getThreadContext, getSelectedLocation } from "../../s
 import { fetchScopes } from "./fetchScopes";
 import { setFramePositions } from "./setFramePositions";
 import { trackEvent } from "ui/utils/telemetry";
-import { isCurrentTimeInLoadedRegion } from "ui/reducers/app";
+import { isPointInLoadedRegion } from "ui/reducers/app";
 
 // How many times to fetch an async set of parent frames.
 const MaxAsyncFrames = 5;
@@ -64,13 +64,13 @@ function pauseRequestedAt(executionPoint) {
  */
 export function paused({ executionPoint, frame, time }) {
   return async function (dispatch, getState, { ThreadFront }) {
-    if (!isCurrentTimeInLoadedRegion(getState())) {
+    dispatch(pauseRequestedAt(executionPoint));
+
+    if (!isPointInLoadedRegion(getState(), executionPoint)) {
       return;
     }
 
     trackEvent("paused");
-
-    await dispatch(pauseRequestedAt(executionPoint, time));
 
     const pause = ThreadFront.ensurePause(executionPoint, time);
 

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -370,3 +370,18 @@ export const isCurrentTimeInLoadedRegion = createSelector(
     );
   }
 );
+
+export const isPointInLoadedRegion = createSelector(
+  getLoadedRegions,
+  (state: UIState, executionPoint: string) => executionPoint,
+  (regions: LoadedRegions | null, executionPoint: string) => {
+    return (
+      regions !== null &&
+      regions.loaded.some(
+        ({ begin, end }) =>
+          BigInt(executionPoint) >= BigInt(begin.point) &&
+          BigInt(executionPoint) <= BigInt(end.point)
+      )
+    );
+  }
+);

--- a/src/ui/setup/redux/middleware/context.js
+++ b/src/ui/setup/redux/middleware/context.js
@@ -18,16 +18,6 @@ function validateActionContext(getState, cx, action) {
   }
 }
 
-function actionLogData(action) {
-  switch (action.type) {
-    case "COMMAND":
-      return " " + action.command;
-    case "PAUSED":
-      return " " + JSON.stringify(action.executionPoint);
-  }
-  return "";
-}
-
 // Middleware which looks for actions that have a cx property and ignores
 // them if the context is no longer valid.
 function context(storeApi) {


### PR DESCRIPTION
Changes
1.  general cleanup 
2. move pauseRequestedAt up so it always occurs
3. `isCurrentTimeInLoadedRegion` to `isPointInLoadedRegion` to focus on the new pause point

Hypothesis
1. isPaused will now be set if we receive a pause request
2. rewinding will succeed even if we are not finished loading

Confidnce:
low because if we are still loading regions, the pause request for the new rewind will also fail