### PR TITLE
[WIP] Fix global expression evaluation

### DIFF
--- a/packages/protocol/thread/thread.ts
+++ b/packages/protocol/thread/thread.ts
@@ -660,6 +660,7 @@ class _ThreadFront {
     if (!this.currentPause) {
       this.currentPause = this.ensurePause(this.currentPoint, this.currentTime);
     }
+    return this.currentPause;
   }
 
   async getFrames() {

--- a/packages/protocol/thread/value.ts
+++ b/packages/protocol/thread/value.ts
@@ -466,7 +466,8 @@ export class ValueFront {
 Object.setPrototypeOf(ValueFront.prototype, new Proxy({}, DisallowEverythingProxyHandler));
 
 export type PrimitiveValue = string | number | boolean | null | undefined;
-export function createPrimitiveValueFront(value: PrimitiveValue, pause: Pause | null = null) {
+export function createPrimitiveValueFront(value: PrimitiveValue) {
+  const pause = ThreadFront.ensureCurrentPause();
   return new ValueFront(pause, { value });
 }
 

--- a/public/test/scripts/console_eval.js
+++ b/public/test/scripts/console_eval.js
@@ -1,5 +1,8 @@
 Test.describe(`Test global console evaluation.`, async () => {
   await Test.selectConsole();
+
+  await Test.app.actions.seekToTime(1570)
+  await Test.executeInConsole("333");
   await Test.warpToMessage("ExampleFinished");
 
   await Test.executeInConsole("number");


### PR DESCRIPTION
This is a significantly larger change than is probably necessary, but I like it because it moves the logic into the protocol where it belongs

The simple fix is to use a default value of 0 for asyncIndex which is what we did in the [old code](https://github.com/replayio/devtools/commit/d7e0e0f98ad08226e0b71aed8d5e6b16aca982a1#diff-66115b293bcb7aa787d41d02330aed02e29aaf80c23ffe1f3c4d5fdef6ea43d0L107).

The other changes here are to minimize the touchpoints on thread front