### PR TITLE
test: print which stripe we're running in

### DIFF
--- a/test/src/state.js
+++ b/test/src/state.js
@@ -105,6 +105,9 @@ function processEnvironmentVariables(state) {
     const match = /(\d+)\/(\d+)/.exec(process.env.INPUT_STRIPE);
     state.stripeIndex = +match[1];
     state.stripeCount = +match[2];
+    console.log(`Running stripe ${state.stripeIndex} of ${state.stripeCount}`);
+  } else {
+    console.log("Running all tests");
   }
 }
 


### PR DESCRIPTION
otherwise print that we're running all tests

This will help me to debug some speed improvements I want to make to the
e2e tests in the backend.