### PR TITLE
Keep objects expanded across pauses

### DIFF
--- a/src/devtools/client/debugger/src/actions/pause/paused.js
+++ b/src/devtools/client/debugger/src/actions/pause/paused.js
@@ -3,7 +3,12 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 //
-import { getSelectedFrame, getThreadContext, getSelectedLocation } from "../../selectors";
+import {
+  getSelectedFrame,
+  getExpandedPaths,
+  getThreadContext,
+  getSelectedLocation,
+} from "../../selectors";
 
 import { fetchScopes } from "./fetchScopes";
 import { setFramePositions } from "./setFramePositions";
@@ -55,13 +60,20 @@ function pauseRequestedAt(executionPoint) {
   return { type: "PAUSE_REQUESTED_AT", executionPoint };
 }
 
-/**
- * Debugger has just paused
- *
- * @param {object} pauseInfo
- * @memberof actions/pause
- * @static
- */
+export function setExpandedPath(path, expand) {
+  return (dispatch, getState) => {
+    const expandedPaths = getExpandedPaths(getState());
+    const set = new Set(expandedPaths);
+    if (expand) {
+      set.add(path);
+    } else {
+      set.delete(path);
+    }
+
+    dispatch({ type: "SET_EXPANDED_PATH", paths: Array.from(set) });
+  };
+}
+
 export function paused({ executionPoint, frame, time }) {
   return async function (dispatch, getState, { ThreadFront }) {
     if (!isCurrentTimeInLoadedRegion(getState())) {

--- a/src/devtools/client/debugger/src/reducers/pause.ts
+++ b/src/devtools/client/debugger/src/reducers/pause.ts
@@ -22,6 +22,7 @@ import find from "lodash/find";
 import findLast from "lodash/findLast";
 import { compareNumericStrings } from "protocol/utils";
 import { getSelectedSourceWithContent, getSource } from "./sources";
+import { ReplaySession } from "ui/setup/prefs";
 
 export interface Context {
   isPaused: boolean;
@@ -73,6 +74,7 @@ export interface PauseState {
   lastCommand: string | null;
   previousLocation: Location | null;
   expandedScopes: Set<string>;
+  expandedPaths: string[];
   lastExpandedScopes: [];
   shouldLogExceptions: boolean;
   replayFramePositions?: { positions: UnknownPositions[]; unexecuted: unknown } | null;
@@ -98,6 +100,7 @@ function createPauseState(): PauseState {
     lastCommand: null,
     previousLocation: null,
     expandedScopes: new Set(),
+    expandedPaths: [],
     lastExpandedScopes: [],
     shouldLogExceptions: prefs.logExceptions as boolean,
   };
@@ -122,6 +125,12 @@ function update(state = createPauseState(), action: AnyAction) {
     return state;
   }
   switch (action.type) {
+    case "SET_EXPANDED_PATH": {
+      return {
+        ...state,
+        expandedPaths: action.paths,
+      };
+    }
     case "PAUSE_REQUESTED_AT": {
       return {
         ...state,
@@ -422,6 +431,9 @@ export function getLastExpandedScopes(state: UIState) {
 
 export function getPausePreviewLocation(state: UIState) {
   return state.pause.pausePreviewLocation;
+}
+export function getExpandedPaths(state: UIState) {
+  return state.pause.expandedPaths;
 }
 
 export function getResumePoint(state: UIState, type: string) {


### PR DESCRIPTION
This is a good first pass. It keeps objects expanded, but does not re-load them when you pause. Will look into that next.