### PR TITLE
Less flickery loading screen

### DIFF
--- a/pages/recording/[[...id]].tsx
+++ b/pages/recording/[[...id]].tsx
@@ -169,7 +169,7 @@ function RecordingPage({
     return (
       <>
         {head}
-        <LoadingScreen fallbackMessage="Finding recording..." />
+        <LoadingScreen fallbackMessage="" />
       </>
     );
   }

--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -148,7 +148,7 @@ function App({ children, hideModal, modal, quickOpenEnabled }: AppProps) {
   }, [theme]);
 
   if (auth.isLoading || userInfo.loading) {
-    return <LoadingScreen fallbackMessage="Authenticating..." />;
+    return <LoadingScreen fallbackMessage="" />;
   }
 
   if (

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -55,7 +55,7 @@ function ViewLoader() {
   }
 
   return (
-    <div className="absolute flex h-full w-full items-center justify-center bg-chrome">
+    <div className="absolute flex items-center justify-center w-full h-full bg-chrome">
       <ReplayLogo size="md" color="gray" />
     </div>
   );
@@ -66,8 +66,8 @@ function Body() {
   const viewMode = useAppSelector(getViewMode);
 
   return (
-    <div className="vertical-panels pr-2">
-      <div className="flex h-full flex-row overflow-hidden bg-chrome">
+    <div className="pr-2 vertical-panels">
+      <div className="flex flex-row h-full overflow-hidden bg-chrome">
         <Toolbar />
         <ReduxAnnotationsProvider>
           <SplitBox
@@ -168,11 +168,11 @@ function _DevTools({
   }, [recording]);
 
   if (!loadingFinished) {
-    return <LoadingScreen fallbackMessage="Starting a session..." />;
+    return <LoadingScreen fallbackMessage="" />;
   }
 
   if (loadedRegions === null) {
-    return <LoadingScreen fallbackMessage="Loading timeline..." />;
+    return <LoadingScreen fallbackMessage="" />;
   }
 
   return (

--- a/src/ui/components/shared/LoadingScreen.tsx
+++ b/src/ui/components/shared/LoadingScreen.tsx
@@ -5,6 +5,7 @@ import { UIState } from "ui/state";
 import { LoadingTips } from "./LoadingTips";
 import { BubbleViewportWrapper } from "./Viewport";
 import ReplayLogo from "./ReplayLogo";
+import Spinner from "../shared/Spinner";
 
 export function LoadingScreenTemplate({
   children,
@@ -33,7 +34,7 @@ function LoadingScreen({
   stalledTimeout = 9000,
 }: PropsFromRedux & { fallbackMessage: string; stalledTimeout?: number }) {
   // The backend send events in this order: uploading replay -> uploading sourcemaps.
-  let waitingForMessage = <span className="text-sm">{fallbackMessage}</span>;
+  let waitingForMessage = <Spinner className="w-4 h-4 text-gray-500 animate-spin" />;
   if (awaitingSourcemaps) {
     waitingForMessage = <span className="text-sm">Uploading sourcemaps...</span>;
     stalledTimeout = Infinity;
@@ -55,8 +56,11 @@ function LoadingScreen({
 
   return (
     <LoadingScreenTemplate showTips={true}>
-      <span>{stalled ? "This is taking longer than usual..." : waitingForMessage}</span>
-    </LoadingScreenTemplate>
+    <div className="flex text-xs">
+      <span>{waitingForMessage}</span>
+      <span className="ml-2">{stalled ? "This is taking longer than usual..." : ""}</span>
+    </div>
+  </LoadingScreenTemplate>
   );
 }
 

--- a/src/ui/components/shared/LoadingScreen.tsx
+++ b/src/ui/components/shared/LoadingScreen.tsx
@@ -15,7 +15,7 @@ export function LoadingScreenTemplate({
 }) {
   return (
     <BubbleViewportWrapper>
-      <div className="relative flex w-96 flex-col items-center space-y-8 rounded-lg bg-loadingBoxes p-8 py-4 pb-8 shadow-md">
+      <div className="relative flex flex-col items-center p-8 py-4 pb-8 space-y-8 rounded-lg shadow-md w-96 bg-loadingBoxes">
         <div className="flex flex-col items-center space-y-2">
           <ReplayLogo wide size="lg" />
           {children}
@@ -30,15 +30,15 @@ function LoadingScreen({
   uploading,
   awaitingSourcemaps,
   fallbackMessage,
-  stalledTimeout = 2000,
+  stalledTimeout = 9000,
 }: PropsFromRedux & { fallbackMessage: string; stalledTimeout?: number }) {
   // The backend send events in this order: uploading replay -> uploading sourcemaps.
-  let waitingForMessage = <span>{fallbackMessage}</span>;
+  let waitingForMessage = <span className="text-sm">{fallbackMessage}</span>;
   if (awaitingSourcemaps) {
-    waitingForMessage = <span>Uploading sourcemaps...</span>;
+    waitingForMessage = <span className="text-sm">Uploading sourcemaps...</span>;
     stalledTimeout = Infinity;
   } else if (uploading) {
-    waitingForMessage = <span>Uploading {Math.round(+uploading.amount)}Mb</span>;
+    waitingForMessage = <span className="text-sm">Uploading {Math.round(+uploading.amount)}Mb</span>;
     stalledTimeout = Infinity;
   }
 

--- a/src/ui/components/shared/Onboarding/BubbleBackground.tsx
+++ b/src/ui/components/shared/Onboarding/BubbleBackground.tsx
@@ -2,17 +2,17 @@ import React from "react";
 
 export default function BubbleBackground() {
   return (
-    <div className="pointer-events-none absolute h-full w-full">
-      <div className="top-bubble absolute">
+    <div className="absolute w-full h-full pointer-events-none">
+      <div className="absolute top-bubble">
         <img
           src="/images/bubble.svg"
-          className="-translate-x-1/2 -translate-y-1/2 rotate-90 transform"
+          className="transform rotate-90 -translate-x-1/2 -translate-y-1/2"
         />
       </div>
-      <div className="bottom-bubble absolute">
+      <div className="absolute bottom-bubble">
         <img
           src="/images/bubble.svg"
-          className="-rotate-300 translate-x-1/2 translate-y-1/2 transform"
+          className="transform translate-x-1/2 translate-y-1/2 -rotate-300"
         />
       </div>
     </div>


### PR DESCRIPTION
We have a bunch of status messages that are better suited for the console. Otherwise they cause a lot of flickery jittery loading experience, which doesn't look great.

Different statuses that we were throwing:
* Starting a session...
* Authenticating...
* Finding recording...
* Loading timeline...

Now:
I've put an indeterminate loader in, like so:

![image](https://user-images.githubusercontent.com/9154902/177079471-2ab76879-1062-45a3-92af-eb320a2d619c.png)


--

The "this is taking a while" timer used to trigger after 2 seconds, leading to even more string flicker. I changed it to 9 seconds to be a true edgecase message.

