### PR TITLE
My daughter found a little typo

### DIFF
--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -126,7 +126,7 @@ export function createSocket(
       if (ThreadFront.recordingId) {
         assert(
           recordingId === ThreadFront.recordingId,
-          "can't create a session for 2 different recordings"
+          "Can't create a session for 2 different recordings"
         );
         return;
       }


### PR DESCRIPTION
This should be capitalised:
![image](https://user-images.githubusercontent.com/9154902/177215054-aed94da9-489c-422e-81a1-5c41e0672749.png)

Here's proud Natalie, fixing her first bug:
![image](https://user-images.githubusercontent.com/9154902/177215044-b3d4549e-9b4e-4b3f-a82a-754e2fef97d5.jpeg)
