### PR TITLE
Add hover styles and target new tabs

### DIFF
--- a/src/ui/components/Library/Team/View/TestRuns/Overview/TestResultListItem.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/Overview/TestResultListItem.tsx
@@ -8,11 +8,11 @@ import styles from "../../../../Library.module.css";
 function ViewReplay({ recordingId, passed }: { recordingId: string; passed: boolean }) {
   return (
     <Link href={`/recording/${recordingId}`}>
-      <a className="flex items-center justify-center p-2 transition">
+      <a className="flex items-center justify-center p-2 transition" rel="noreferrer noopener" target="_blank">
         <MaterialIcon
           iconSize="2xl"
           outlined
-          className={passed ? "text-primaryAccent" : "text-red-500"}
+          className={passed ? "text-primaryAccent hover:text-blue-500" : "text-red-500 hover:text-red-700"}
         >
           play_circle
         </MaterialIcon>

--- a/src/ui/components/Library/Team/View/TestRuns/Overview/TestResultListItem.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/Overview/TestResultListItem.tsx
@@ -12,7 +12,7 @@ function ViewReplay({ recordingId, passed }: { recordingId: string; passed: bool
         <MaterialIcon
           iconSize="2xl"
           outlined
-          className={passed ? "text-primaryAccent hover:text-blue-500" : "text-red-500 hover:text-red-700"}
+          className={passed ? "text-green-500 hover:text-green-700" : "text-red-500 hover:text-red-700"}
         >
           play_circle
         </MaterialIcon>


### PR DESCRIPTION
* When clicking a Replay from test suites, it opens a new tab (heavy or out of context links should target new tabs)
* We were using both blue and green to mean success, which was inconsistent. Standardised on green.
* Added hover states to the "view replay" play button