### PR TITLE
Experimental sources reducer

### DIFF
--- a/src/devtools/client/debugger/src/reducers/sources.ts
+++ b/src/devtools/client/debugger/src/reducers/sources.ts
@@ -231,7 +231,7 @@ function update(state = initialSourcesState(), action: AnyAction) {
     case "SET_FOCUSED_SOURCE_ITEM":
       return { ...state, focusedItem: action.item };
 
-    case "SOURCES_LOADED":
+    case "sources/allSourcesReceived":
       return { ...state, sourcesLoading: false };
   }
 

--- a/src/ui/reducers/sources.ts
+++ b/src/ui/reducers/sources.ts
@@ -1,0 +1,71 @@
+import {
+  createEntityAdapter,
+  createSelector,
+  createSlice,
+  EntityState,
+  PayloadAction,
+} from "@reduxjs/toolkit";
+import { newSource, SourceKind } from "@replayio/protocol";
+import { getSelectedSourceId } from "devtools/client/debugger/src/selectors";
+import { UIState } from "ui/state";
+import { newSourcesToCompleteSourceDetails } from "ui/utils/sources";
+
+export interface SourceDetails {
+  canonicalId: string;
+  correspondingSourceIds: string[];
+  generated: string[];
+  generatedFrom: string[];
+  id: string;
+  kind: SourceKind;
+  contentHash?: string;
+  prettyPrinted?: string;
+  prettyPrintedFrom?: string;
+  url?: string;
+}
+
+const sourceDetailsAdapter = createEntityAdapter<SourceDetails>();
+const sourcesAdapter = createEntityAdapter<newSource>({ selectId: source => source.sourceId });
+const sourceSelectors = sourcesAdapter.getSelectors();
+
+export interface SourcesState {
+  sourceDetails: EntityState<SourceDetails>;
+  sources: EntityState<newSource>;
+}
+
+const initialState: SourcesState = {
+  sourceDetails: sourceDetailsAdapter.getInitialState(),
+  sources: sourcesAdapter.getInitialState(),
+};
+
+const sourcesSlice = createSlice({
+  name: "sources",
+  initialState,
+  reducers: {
+    addSource: (state, action: PayloadAction<newSource>) => {
+      // Store the raw protocol information. Once we have recieved all sources
+      // we will run over this and build it into the shape we want.
+      sourcesAdapter.addOne(state.sources, action.payload);
+    },
+    allSourcesReceived: state => {
+      sourceDetailsAdapter.addMany(
+        state.sourceDetails,
+        newSourcesToCompleteSourceDetails(sourceSelectors.selectAll(state.sources))
+      );
+    },
+  },
+});
+
+export const getSelectedSourceDetails = createSelector(
+  (state: UIState) => state.experimentalSources.sourceDetails,
+  getSelectedSourceId,
+  (sourceDetails, id) => {
+    if (id === null || id === undefined) {
+      return null;
+    }
+
+    return sourceDetails.entities[id];
+  }
+);
+
+export const { addSource, allSourcesReceived } = sourcesSlice.actions;
+export default sourcesSlice.reducer;

--- a/src/ui/setup/store.ts
+++ b/src/ui/setup/store.ts
@@ -22,6 +22,7 @@ import { messages as messagesReducer } from "devtools/client/webconsole/reducers
 import { promise } from "ui/setup/redux/middleware/promise";
 import { context } from "ui/setup/redux/middleware/context";
 import protocolMessages from "ui/reducers/protocolMessages";
+import sources from "ui/reducers/sources";
 
 type UIStateReducers = {
   [key in keyof UIState]: Reducer<UIState[key]>;
@@ -39,6 +40,7 @@ type ReduxDevToolsOptions = Exclude<
 // slice reducers we know will be added, to get the right state type.
 let reducers = {
   app: appReducer,
+  experimentalSources: sources,
   layout: layoutReducer,
   messages: messagesReducer,
   protocolMessages: protocolMessages,

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -12,7 +12,6 @@ import {
 import type { RecordingTarget } from "protocol/thread/thread";
 import { Workspace } from "ui/types";
 import { Reply } from "./comments";
-import { PanelName } from "./layout";
 
 export type ModalOptionsType = {
   recordingId?: string;

--- a/src/ui/state/index.ts
+++ b/src/ui/state/index.ts
@@ -29,6 +29,7 @@ import type { WebconsoleUIState } from "devtools/client/webconsole/reducers/ui";
 import type { UISliceState } from "devtools/client/debugger/src/reducers/ui";
 
 import { LayoutState } from "./layout";
+import type { SourcesState as NewSourcesState } from "ui/reducers/sources";
 import { ProtocolMessagesState } from "ui/reducers/protocolMessages";
 
 // TODO Ideally this should be inferred from store setup
@@ -44,6 +45,7 @@ export interface UIState {
   consoleUI: WebconsoleUIState;
   contextMenus: ContextMenusState;
   eventListenerBreakpoints: EventListenersState;
+  experimentalSources: NewSourcesState;
   fileSearch: FileSearchState;
   inspector: InspectorState;
   layout: LayoutState;
@@ -57,11 +59,11 @@ export interface UIState {
   quickOpen: QuickOpenState;
   reactDevTools: ReactDevToolsState;
   rules: RulesState;
-  sources: SourcesState;
   sourceActors: SourceActorsState;
   sourceTree: SourceTreeState;
+  sources: SourcesState;
   tabs: TabsState;
-  timeline: TimelineState;
   threads: ThreadsState;
+  timeline: TimelineState;
   ui: UISliceState;
 }

--- a/src/ui/utils/graph.test.ts
+++ b/src/ui/utils/graph.test.ts
@@ -1,0 +1,30 @@
+import newGraph from "./graph";
+
+describe("Graph", () => {
+  it("can have a node added", () => {
+    const graph = newGraph();
+    graph.addNode("a");
+    expect(graph.from("a")).toEqual([]);
+    expect(graph.to("a")).toEqual([]);
+  });
+
+  it("can have a connection added", () => {
+    const graph = newGraph();
+
+    graph.connectNode("a", "b");
+
+    expect(graph.from("a")).toEqual(["b"]);
+    expect(graph.to("b")).toEqual(["a"]);
+    expect(graph.to("a")).toEqual([]);
+    expect(graph.from("b")).toEqual([]);
+  });
+
+  it("can have a node connected to itself", () => {
+    const graph = newGraph();
+
+    graph.connectNode("a", "a");
+
+    expect(graph.from("a")).toEqual(["a"]);
+    expect(graph.to("a")).toEqual(["a"]);
+  });
+});

--- a/src/ui/utils/graph.ts
+++ b/src/ui/utils/graph.ts
@@ -1,0 +1,37 @@
+export interface Graph {
+  addNode(node: string): void;
+  connectNode(from: string, to: string): void;
+  from: (node: string) => string[];
+  to: (node: string) => string[];
+}
+
+const newGraph = (): Graph & { inspect: () => string } => {
+  const incoming: Record<string, string[]> = {};
+  const outgoing: Record<string, string[]> = {};
+
+  const addNode = (node: string) => {
+    incoming[node] = incoming[node] || [];
+    outgoing[node] = outgoing[node] || [];
+  };
+
+  const connectNode = (from: string, to: string) => {
+    addNode(from);
+    addNode(to);
+    outgoing[from].push(to);
+    incoming[to].push(from);
+  };
+
+  const inspect = () => {
+    return JSON.stringify({ outgoing, incoming }, null, 2);
+  };
+
+  return {
+    from: (node: string) => outgoing[node],
+    to: (node: string) => incoming[node],
+    addNode,
+    connectNode,
+    inspect,
+  };
+};
+
+export default newGraph;

--- a/src/ui/utils/sources.test.ts
+++ b/src/ui/utils/sources.test.ts
@@ -1,0 +1,292 @@
+import { newSourcesToCompleteSourceDetails } from "./sources";
+
+describe("newSourcesToCompleteSourceDetails", () => {
+  it("should return empty array when no sources", () => {
+    expect(newSourcesToCompleteSourceDetails([])).toEqual({});
+  });
+
+  it("should be able to return a complete source from a single newSource event", () => {
+    expect(
+      newSourcesToCompleteSourceDetails([
+        {
+          contentHash: "contentHash#1",
+          kind: "scriptSource",
+          sourceId: "1",
+          url: "/index.js",
+        },
+      ])
+    ).toEqual({
+      "1": {
+        canonicalId: "1",
+        contentHash: "contentHash#1",
+        correspondingSourceIds: ["1"],
+        generated: [],
+        generatedFrom: [],
+        id: "1",
+        kind: "scriptSource",
+        prettyPrinted: undefined,
+        prettyPrintedFrom: undefined,
+        url: "/index.js",
+      },
+    });
+  });
+
+  it("can backlink generated sources properly", () => {
+    expect(
+      newSourcesToCompleteSourceDetails([
+        {
+          contentHash: "contentHash#1",
+          kind: "scriptSource",
+          sourceId: "1",
+          url: "/index.js",
+        },
+        {
+          contentHash: "contentHash#o1",
+          kind: "sourceMapped",
+          sourceId: "o1",
+          generatedSourceIds: ["1"],
+          url: "/index.ts",
+        },
+      ])
+    ).toEqual({
+      "1": {
+        canonicalId: "o1",
+        contentHash: "contentHash#1",
+        correspondingSourceIds: ["1"],
+        generated: [],
+        generatedFrom: ["o1"],
+        id: "1",
+        kind: "scriptSource",
+        prettyPrinted: undefined,
+        prettyPrintedFrom: undefined,
+        url: "/index.js",
+      },
+      o1: {
+        canonicalId: "o1",
+        contentHash: "contentHash#o1",
+        correspondingSourceIds: ["o1"],
+        generated: ["1"],
+        generatedFrom: [],
+        id: "o1",
+        kind: "sourceMapped",
+        prettyPrinted: undefined,
+        prettyPrintedFrom: undefined,
+        url: "/index.ts",
+      },
+    });
+  });
+
+  it("can link pretty-printed and minified sources", () => {
+    expect(
+      newSourcesToCompleteSourceDetails([
+        {
+          contentHash: "contentHash#1",
+          kind: "scriptSource",
+          sourceId: "1",
+          url: "/index.js",
+        },
+        {
+          generatedSourceIds: ["1"],
+          kind: "prettyPrinted",
+          sourceId: "pp1",
+          url: "/src/index.js",
+        },
+      ])
+    ).toEqual({
+      "1": {
+        canonicalId: "1",
+        contentHash: "contentHash#1",
+        correspondingSourceIds: ["1"],
+        generated: [],
+        generatedFrom: [],
+        id: "1",
+        kind: "scriptSource",
+        prettyPrinted: "pp1",
+        prettyPrintedFrom: undefined,
+        url: "/index.js",
+      },
+      pp1: {
+        canonicalId: "1",
+        contentHash: undefined,
+        correspondingSourceIds: ["pp1"],
+        generated: [],
+        generatedFrom: [],
+        id: "pp1",
+        kind: "prettyPrinted",
+        prettyPrinted: undefined,
+        prettyPrintedFrom: "1",
+        url: "/src/index.js",
+      },
+    });
+  });
+
+  it("can combine original, generated, and pretty-printed sources", () => {
+    expect(
+      newSourcesToCompleteSourceDetails([
+        {
+          contentHash: "contentHash#1",
+          kind: "scriptSource",
+          sourceId: "1",
+          url: "/index.js",
+        },
+        {
+          contentHash: "contentHash#o1",
+          generatedSourceIds: ["1"],
+          kind: "sourceMapped",
+          sourceId: "o1",
+          url: "/src/index.ts",
+        },
+        {
+          generatedSourceIds: ["1"],
+          kind: "prettyPrinted",
+          sourceId: "pp1",
+          url: "/src/index.js",
+        },
+        {
+          generatedSourceIds: ["o1"],
+          kind: "prettyPrinted",
+          sourceId: "ppo1",
+          url: "/src/index.ts",
+        },
+      ])
+    ).toEqual({
+      "1": {
+        canonicalId: "o1",
+        contentHash: "contentHash#1",
+        correspondingSourceIds: ["1"],
+        generated: [],
+        generatedFrom: ["o1"],
+        id: "1",
+        kind: "scriptSource",
+        prettyPrinted: "pp1",
+        prettyPrintedFrom: undefined,
+        url: "/index.js",
+      },
+      o1: {
+        canonicalId: "o1",
+        contentHash: "contentHash#o1",
+        correspondingSourceIds: ["o1"],
+        generated: ["1"],
+        generatedFrom: [],
+        id: "o1",
+        kind: "sourceMapped",
+        prettyPrinted: "ppo1",
+        prettyPrintedFrom: undefined,
+        url: "/src/index.ts",
+      },
+      pp1: {
+        canonicalId: "o1",
+        contentHash: undefined,
+        correspondingSourceIds: ["pp1"],
+        generated: [],
+        generatedFrom: [],
+        id: "pp1",
+        kind: "prettyPrinted",
+        prettyPrinted: undefined,
+        prettyPrintedFrom: "1",
+        url: "/src/index.js",
+      },
+      ppo1: {
+        canonicalId: "o1",
+        contentHash: undefined,
+        correspondingSourceIds: ["ppo1"],
+        generated: [],
+        generatedFrom: [],
+        id: "ppo1",
+        kind: "prettyPrinted",
+        prettyPrinted: undefined,
+        prettyPrintedFrom: "o1",
+        url: "/src/index.ts",
+      },
+    });
+  });
+
+  it("can put together HTML sources and their extracted scripts", () => {
+    expect(
+      newSourcesToCompleteSourceDetails([
+        {
+          contentHash: "contentHash#h1",
+          kind: "html",
+          sourceId: "h1",
+          generatedSourceIds: ["2"],
+          url: "/index.html",
+        },
+        {
+          contentHash: "contentHash#2",
+          kind: "inlineScript",
+          sourceId: "2",
+          url: "/index.html",
+        },
+      ])
+    ).toEqual({
+      "2": {
+        canonicalId: "h1",
+        contentHash: "contentHash#2",
+        correspondingSourceIds: ["2"],
+        generated: [],
+        generatedFrom: ["h1"],
+        id: "2",
+        kind: "inlineScript",
+        prettyPrinted: undefined,
+        prettyPrintedFrom: undefined,
+        url: "/index.html",
+      },
+      h1: {
+        canonicalId: "h1",
+        contentHash: "contentHash#h1",
+        correspondingSourceIds: ["h1"],
+        generated: ["2"],
+        generatedFrom: [],
+        id: "h1",
+        kind: "html",
+        prettyPrinted: undefined,
+        prettyPrintedFrom: undefined,
+        url: "/index.html",
+      },
+    });
+  });
+});
+
+it("can link corresponding sources", () => {
+  expect(
+    newSourcesToCompleteSourceDetails([
+      {
+        contentHash: "contentHash",
+        kind: "html",
+        sourceId: "h1",
+        url: "/index.html",
+      },
+      {
+        contentHash: "contentHash",
+        kind: "html",
+        sourceId: "h2",
+        url: "/index.html",
+      },
+    ])
+  ).toEqual({
+    h1: {
+      canonicalId: "h1",
+      contentHash: "contentHash",
+      correspondingSourceIds: ["h1", "h2"],
+      generated: [],
+      generatedFrom: [],
+      id: "h1",
+      kind: "html",
+      prettyPrinted: undefined,
+      prettyPrintedFrom: undefined,
+      url: "/index.html",
+    },
+    h2: {
+      canonicalId: "h2",
+      contentHash: "contentHash",
+      correspondingSourceIds: ["h1", "h2"],
+      generated: [],
+      generatedFrom: [],
+      id: "h2",
+      kind: "html",
+      prettyPrinted: undefined,
+      prettyPrintedFrom: undefined,
+      url: "/index.html",
+    },
+  });
+});

--- a/src/ui/utils/sources.ts
+++ b/src/ui/utils/sources.ts
@@ -1,0 +1,104 @@
+import { EntityId } from "@reduxjs/toolkit";
+import { newSource, SourceKind } from "@replayio/protocol";
+import groupBy from "lodash/groupBy";
+import omit from "lodash/omit";
+import { SourceDetails } from "ui/reducers/sources";
+import newGraph from "./graph";
+
+const fullSourceDetails = (
+  attributes: Partial<SourceDetails> & {
+    id: string;
+    kind: SourceKind;
+  }
+): SourceDetails => {
+  return {
+    canonicalId: attributes.id,
+    correspondingSourceIds: [],
+    generated: [],
+    generatedFrom: [],
+    ...attributes,
+  };
+};
+
+export const keyForSource = (source: newSource): string => {
+  return `${source.url!}:${source.contentHash}`;
+};
+
+export const newSourcesToCompleteSourceDetails = (
+  newSources: newSource[]
+): Record<EntityId, SourceDetails> => {
+  const returnValue: Record<EntityId, SourceDetails> = {};
+  const prettyPrinted = newGraph();
+  const canonical = newGraph();
+  const corresponding: Record<string, string[]> = {};
+
+  // Canonical links can go across multiple links
+  const findCanonicalId = (id: string) => {
+    let current = id;
+    let nextNode = canonical.from(current)?.[0];
+
+    while (nextNode && nextNode !== current) {
+      current = nextNode;
+      nextNode = canonical.from(current)?.[0];
+    }
+
+    return current;
+  };
+
+  const generated = newGraph();
+  newSources.forEach((source: newSource) => {
+    const key = keyForSource(source);
+    if (corresponding[key] === undefined) {
+      corresponding[key] = [];
+    }
+    corresponding[key].push(source.sourceId);
+
+    // We handle pretty-printed (pp) files and their generated links a little
+    // differently. Because Replay makes the pp sources, their structure is
+    // predictable. All pp sources will have one generatedSourceId, and it will
+    // be the minified source.
+    if (source.kind === "prettyPrinted") {
+      return;
+    }
+
+    source.generatedSourceIds?.map(generatedId => {
+      generated.connectNode(source.sourceId, generatedId);
+    });
+  });
+
+  // Sources are processed by kind. So first we go through the whole list once
+  // just to group things properly.
+  const byKind = groupBy(newSources, source => source.kind);
+
+  const inlineScripts = byKind["inlineScript"] || [];
+  inlineScripts.forEach(source => {
+    canonical.connectNode(source.sourceId, generated.to(source.sourceId)![0]);
+  });
+
+  const sourceMapped = byKind["sourceMapped"] || [];
+  sourceMapped.forEach(source => {
+    canonical.connectNode(generated.from(source.sourceId)![0], source.sourceId);
+  });
+
+  const prettyPrintedSources = byKind["prettyPrinted"] || [];
+  prettyPrintedSources.forEach(source => {
+    const nonPrettyPrintedVersionId = source.generatedSourceIds![0];
+    prettyPrinted.connectNode(nonPrettyPrintedVersionId, source.sourceId);
+    canonical.connectNode(source.sourceId, nonPrettyPrintedVersionId);
+  });
+
+  newSources.forEach(source => {
+    returnValue[source.sourceId] = fullSourceDetails({
+      ...omit(source, "sourceId", "generatedSourceIds"),
+      correspondingSourceIds: corresponding[keyForSource(source)],
+      id: source.sourceId,
+      prettyPrinted: prettyPrinted.from(source.sourceId)?.[0],
+      prettyPrintedFrom: prettyPrinted.to(source.sourceId)?.[0],
+      generated: generated.from(source.sourceId) || [],
+      generatedFrom: generated.to(source.sourceId) || [],
+      canonicalId: findCanonicalId(source.sourceId),
+    });
+  });
+
+  return returnValue;
+};


### PR DESCRIPTION
Changes
---
- Adds a very simply entity adapter for storing raw protocol `newSource`s
- Adds a more opinionated, detailed store for source data called `SourceDetails` (also has an entity adapter)
- Add sources to the `newSource` entity adapter as they come in from the backend
- Once all sources are in (we can tell because the request has resolved) dispatch one action which kicks off a single call to `newSourcesToCompleteSourceDetails`. Build the simple maps first - `correspondingId`s and `generatedId`s (except for prettyPrinted sources)
- Then fix up canonical references (by type)
- A word on canonical IDs: I’ve made it so that the `canonicalId` for a source is always the non-pretty-printed version. I don’t feel super strongly about this. To me it just makes sense to split the world into `canonical/non-canonical` and `pretty-printed/unpretty-printed`
- Bundled files are still complicated! You can tell if a file is a bundle if it’s `generatedFrom` array has more than a single element. In that case, a sourceId is not enough to jump to a canonical file. You need a location. I think in the future when toggling between original and generated for bundled ID’s we should have some concept of a shallow `location` stack which we can traverse backwards so that we can make sure we are returning to the proper original source.
- We don’t currently link `eval`ed snippets as generated properly, we need to fix this on the backend.
- We don’t currently include `contentHash` for all sourceIds, but I think we should strive to (at the very least for pretty-printed ones, but also maybe for others that might not have it?)
- I’m not sure what an `other` source is or what to do with it
- Generally speaking, when asking questions of a source, like getting the generatedTo or generatedFrom, or getting corresponding ID’s, we should use the canonical source

Next Steps
---
- Use this in some places!