### PR TITLE
add test info to replay info panels

### DIFF
--- a/src/ui/components/Events/ReplayInfo.tsx
+++ b/src/ui/components/Events/ReplayInfo.tsx
@@ -49,6 +49,7 @@ function ReplayInfo({ setModal }: PropsFromRedux) {
     setModal("privacy");
   };
 
+  const isTest = recording.metadata.test;
   return (
     <div className="flex-column flex flex items-center overflow-hidden border-splitter bg-bodyBgcolor">
       <div className="my-1.5 flex w-full cursor-default flex-col self-stretch overflow-hidden px-1.5 pb-0 text-xs">
@@ -73,7 +74,7 @@ function ReplayInfo({ setModal }: PropsFromRedux) {
           ) : null}
         </div>
         <div className="group">
-          {recording.url ? (
+          {!isTest && recording.url ? (
             <Row>
               <Icon
                 filename="external"
@@ -89,6 +90,40 @@ function ReplayInfo({ setModal }: PropsFromRedux) {
               </div>
             </Row>
           ) : null}
+        </div>
+        <div className="group">
+          {recording.metadata && (
+            <>
+              <Row>
+                <MaterialIcon>schedule</MaterialIcon>
+                <div
+                  className="overflow-hidden overflow-ellipsis whitespace-pre"
+                  title={recording.metadata.source?.branch}
+                >
+                  {time} ago
+                </div>
+              </Row>
+
+              <Row>
+                <MaterialIcon>person</MaterialIcon>
+                <div
+                  className="overflow-hidden overflow-ellipsis whitespace-pre"
+                  title={recording.metadata.source?.branch}
+                >
+                  {recording.metadata.source?.trigger?.user}
+                </div>
+              </Row>
+              <Row>
+                <MaterialIcon>fork_right</MaterialIcon>
+                <div
+                  className="overflow-hidden overflow-ellipsis whitespace-pre"
+                  title={recording.metadata.source?.branch}
+                >
+                  {recording.metadata.source?.branch}
+                </div>
+              </Row>
+            </>
+          )}
         </div>
         {recording.operations ? (
           <OperationsRow operations={recording.operations} onClick={showOperations} />

--- a/src/ui/components/Header/Header.tsx
+++ b/src/ui/components/Header/Header.tsx
@@ -122,6 +122,11 @@ function HeaderTitle({
     }
   }, [editing, hasTitle, recording.title]);
 
+  const testName = recording.metadata?.test?.title;
+  if (testName) {
+    return <span className={className}>{testName}</span>;
+  }
+
   if (!canEditTitle) {
     return <span className={className}>{displayTitle}</span>;
   }

--- a/src/ui/components/Header/RecordingTrialEnd.tsx
+++ b/src/ui/components/Header/RecordingTrialEnd.tsx
@@ -8,7 +8,15 @@ export function RecordingTrialEnd() {
   const { recording, loading } = hooks.useGetRecording(recordingId);
 
   const workspace = recording?.workspace;
-  if (loading || !workspace || !inUnpaidFreeTrial(workspace) || workspace.hasPaymentMethod) {
+  const metadata = recording?.metadata;
+
+  if (
+    loading ||
+    !workspace ||
+    metadata?.test ||
+    !inUnpaidFreeTrial(workspace) ||
+    workspace.hasPaymentMethod
+  ) {
     return null;
   }
 

--- a/src/ui/hooks/recordings.ts
+++ b/src/ui/hooks/recordings.ts
@@ -8,7 +8,6 @@ import { GET_RECORDING, GET_RECORDING_USER_ID } from "ui/graphql/recordings";
 import { useRouter } from "next/router";
 import { extractIdAndSlug } from "ui/utils/helpers";
 import { getRecordingId } from "ui/utils/recording";
-import { ColorSwatchIcon } from "@heroicons/react/solid";
 import { RecordingId } from "@replayio/protocol";
 import {
   SetRecordingIsPrivate,


### PR DESCRIPTION
Small tweak to make it easier to see which test you're looking at
* show test name in title
* update info panel
* hide trial date 

### before
<img width="1438" alt="Screen Shot 2022-07-05 at 5 48 21 PM" src="https://user-images.githubusercontent.com/254562/177439703-7b43636e-3429-4922-9a7a-a618744e19a5.png">



### after
<img width="1436" alt="Screen Shot 2022-07-05 at 5 47 57 PM" src="https://user-images.githubusercontent.com/254562/177439722-de7248f4-eaa6-4af7-811a-63422d2823ce.png">

