### PR TITLE
Fix "Lint" CI job and remove mostly broken "GQL Typecheck" job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,11 @@
 name: Lint
 
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
 
 jobs:
   trunk_check_runner:
@@ -24,7 +29,7 @@ jobs:
       # Actually install packages with Yarn
       - name: Install packages
         run: yarn install
-      env:
-        YARN_CHECKSUM_BEHAVIOR: "update"
+        env:
+          YARN_CHECKSUM_BEHAVIOR: "update"
       - name: Trunk Check
         uses: trunk-io/trunk-action@v1.0.1

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -4,6 +4,9 @@ on: [pull_request, workflow_dispatch]
 
 jobs:
   typecheck:
+    # Intentionally disabled for now to avoid repeated CI failures
+    # TODO Fix this at some point?
+    if: ${{ false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -27,8 +30,11 @@ jobs:
           YARN_CHECKSUM_BEHAVIOR: "update"
       - name: Run tsc
         run: yarn typecheck
-  gql:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.pull_request.head.repo.full_name, 'replayio/')
+  gql:    
+    # Intentionally disabled for now to avoid repeated CI failures
+    # TODO Fix this at some point?
+    if: ${{ false }}
+    #if: github.event_name == 'workflow_dispatch' || startsWith(github.event.pull_request.head.repo.full_name, 'replayio/')
     name: GraphQL schema types
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR:

- Fixes an indentation error in the "Link/Trunk" job that was keeping it from running
- Intentionally disables the "GraphQL/Typecheck" job because it's been so flaky and isn't providing value