### PR TITLE
Re-enable wrongly disabled TSC check

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -4,9 +4,6 @@ on: [pull_request, workflow_dispatch]
 
 jobs:
   typecheck:
-    # Intentionally disabled for now to avoid repeated CI failures
-    # TODO Fix this at some point?
-    if: ${{ false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR:

- Re-enables the actual TS typecheck job, which I wrongly disabled yesterday while disabling the GQL+TS job