### PR TITLE
Fixed how `thrownValue` is being rethrown in `Wakeable#resolve`/`Wakeable#reject`

### DIFF
--- a/packages/bvaughn-architecture-demo/src/utils/suspense.ts
+++ b/packages/bvaughn-architecture-demo/src/utils/suspense.ts
@@ -15,34 +15,34 @@ export function createWakeable<T>(): Wakeable<T> {
       rejectCallbacks.add(rejectCallback);
     },
     reject(error: Error) {
+      let thrown = false;
+      let thrownValue;
       rejectCallbacks.forEach(rejectCallback => {
-        let thrownValue = null;
-
         try {
           rejectCallback(error);
         } catch (error) {
+          thrown = true;
           thrownValue = error;
         }
-
-        if (thrownValue !== null) {
-          throw thrownValue;
-        }
       });
+      if (thrown) {
+        throw thrownValue;
+      }
     },
     resolve(value: T) {
+      let thrown = false;
+      let thrownValue;
       resolveCallbacks.forEach(resolveCallback => {
-        let thrownValue = null;
-
         try {
           resolveCallback(value);
         } catch (error) {
+          thrown = true;
           thrownValue = error;
         }
-
-        if (thrownValue !== null) {
-          throw thrownValue;
-        }
       });
+      if (thrown) {
+        throw thrownValue;
+      }
     },
   };
 


### PR DESCRIPTION
The current implementation is almost synonymous with not having a catch block at all - it just throws immediately after calling a single callback (it ignores thrown nulls but that's probably irrelevant here).

I think that my patch matches closer the original intention - we call all callbacks and only throw the last thrown value after we are done with the callbacks.