### PR TITLE
Ensure correct Codemirror mode for typescript sources

### DIFF
--- a/src/devtools/client/debugger/src/utils/source.ts
+++ b/src/devtools/client/debugger/src/utils/source.ts
@@ -296,7 +296,7 @@ export function getMode(
   const { contentType, value: text } = content!;
 
   if (extension === "jsx" || (symbols && symbols.hasJsx)) {
-    if (symbols && symbols.hasTypes) {
+    if (extension === "tsx" || (symbols && symbols.hasTypes)) {
       return { name: "text/typescript-jsx" };
     }
     return { name: "jsx" };
@@ -311,6 +311,8 @@ export function getMode(
   }
 
   const languageMimeMap = [
+    { ext: "ts", mode: "text/typescript" },
+    { ext: "tsx", mode: "text/typescript-jsx" },
     { ext: "c", mode: "text/x-csrc" },
     { ext: "kt", mode: "text/x-kotlin" },
     { ext: "cpp", mode: "text/x-c++src" },


### PR DESCRIPTION
It turns out that I was wrong blaming [FE-165](https://linear.app/replay/issue/FE-165/variables-show-as-undefined-on-hover) on Codemirror, we were setting the wrong source mode for some sources: we relied solely on the `hasTypes` flag that we get from the parser worker, but that flag was built for flow types, so it's sometimes not set for typescript sources.