### PR TITLE
Ensure post-upload steps still run when tests fail

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -62,9 +62,11 @@ runs:
         filter: function($v) { $v.metadata.test and $v.status = "onDisk" }
     - name: Get Recording Log ID
       id: log-id
+      if: ${{ always() && inputs.upload == 'true' }}
       run: echo ::set-output name=LOG_ID::$(echo $INPUT_STRIPE | cut -f1 -d /)
       shell: bash
     - uses: actions/upload-artifact@v3
+      if: ${{ always() && inputs.upload == 'true' }}
       with:
         name: recordings-log-${{ steps.log-id.outputs.LOG_ID }}
         path: ${{ steps.upload-recordings.outputs.recordings-path }}


### PR DESCRIPTION
Failed tests are still uploaded but the log id and artifact steps don't run so the commenter doesn't report on the failures.