### PR TITLE
Small speedup so that we no longer wait on sources to load

### DIFF
--- a/packages/protocol/graphics.ts
+++ b/packages/protocol/graphics.ts
@@ -246,14 +246,7 @@ export async function repaint(force = false) {
   }, 500);
 
   const { mouse } = await getGraphicsAtTime(ThreadFront.currentTime);
-  const point = ThreadFront.currentPoint;
-  await ThreadFront.ensureAllSources();
-  if (point !== ThreadFront.currentPoint) {
-    return;
-  }
-  ThreadFront.ensureCurrentPause();
-  const pause = ThreadFront.currentPause;
-  assert(pause, "no pause");
+  const pause = ThreadFront.ensureCurrentPause();
 
   const rv = await pause.repaintGraphics(force);
   graphicsFetched = true;

--- a/packages/protocol/thread/thread.ts
+++ b/packages/protocol/thread/thread.ts
@@ -667,6 +667,7 @@ class _ThreadFront {
     if (!this.currentPause) {
       this.currentPause = this.ensurePause(this.currentPoint, this.currentTime);
     }
+    return this.currentPause;
   }
 
   async getFrames() {


### PR DESCRIPTION
Was looking into why the video sometimes takes awhile to initially load and found this small perf win.

~My current theory is that we try to fetch the graphic before the region the pause is in has loaded and fail. This would explain why if you click somewhere else you do see the video.~ Josh, reminded me that the backend will block until the region is loaded, so that's probably not it, but we could look at the session logs and see if they give us reasons why a graphics call might otherwise fail