### PR TITLE
Do not ignore mixpanel types

### DIFF
--- a/packages/protocol/thread/thread.ts
+++ b/packages/protocol/thread/thread.ts
@@ -399,6 +399,8 @@ class _ThreadFront {
 
     await this.ensureAllSources();
     for (const [sourceId, source] of this.sources) {
+      // TODO @jcmorrow remove this check when we actually want to capture all
+      // sources in the experimental reducer
       if (sourceId === this.getCorrespondingSourceIds(sourceId)[0]) {
         onSource({ sourceId, ...source });
       }

--- a/src/devtools/client/debugger/src/actions/breakpoints/breakpoints.ts
+++ b/src/devtools/client/debugger/src/actions/breakpoints/breakpoints.ts
@@ -133,7 +133,6 @@ export function enableBreakpointsInSource(
   source: Source
 ): UIThunkAction<Promise<void>> {
   return async (dispatch, getState) => {
-    // @ts-ignore Mixpanel events
     trackEvent("breakpoints.remove_all_in_source");
     const breakpoints = getBreakpointsForSource(getState(), source.id);
     for (const breakpoint of breakpoints) {
@@ -152,7 +151,6 @@ export function enableBreakpointsInSource(
  */
 export function removeAllBreakpoints(cx: Context): UIThunkAction<Promise<void>> {
   return async (dispatch, getState) => {
-    // @ts-ignore Mixpanel events
     trackEvent("breakpoints.remove_all");
 
     const breakpointList = getBreakpointsList(getState());
@@ -247,7 +245,6 @@ export function _addBreakpointAtLine(
       return;
     }
 
-    // @ts-ignore Mixpanel events
     trackEvent("breakpoint.add");
 
     const breakpointLocation = {
@@ -292,7 +289,6 @@ export function addBreakpointAtColumn(cx: Context, location: Location): UIThunkA
       logValue: getLogValue(source, state, location),
     };
 
-    // @ts-ignore Mixpanel events
     trackEvent("breakpoint.add_column");
 
     // @ts-expect-error Breakpoint location field mismatches

--- a/src/devtools/client/debugger/src/actions/sources/select.ts
+++ b/src/devtools/client/debugger/src/actions/sources/select.ts
@@ -143,7 +143,6 @@ export function selectLocation(
 ): UIThunkAction<Promise<{ type: string; cx: Context } | undefined>> {
   return async (dispatch, getState, { client, ThreadFront }) => {
     const currentSource = getSelectedSource(getState());
-    // @ts-ignore MixpanelEvent mismatch
     trackEvent("sources.select_location");
 
     if (!client) {

--- a/src/ui/actions/logpoint.ts
+++ b/src/ui/actions/logpoint.ts
@@ -247,7 +247,6 @@ async function setMultiSourceLogpoint(
   const primitiveFronts = primitives?.map(literal => createPrimitiveValueFront(literal));
 
   if (primitiveFronts) {
-    // TODO We're getting an _array_ of locations, but only using the first one?
     const points = getAnalysisPointsForLocation(store.getState(), locations[0], condition);
     if (points) {
       if (!points.error) {
@@ -517,7 +516,6 @@ export async function setEventLogpoint(
   points?: PointDescription[]
 ) {
   const mapper = eventLogpointMapper(/* getFrameworkListeners */ true);
-  const sessionId = await ThreadFront.waitForSession();
   const params: AnalysisParams = {
     mapper,
     effectful: true,

--- a/src/ui/utils/mixpanel.ts
+++ b/src/ui/utils/mixpanel.ts
@@ -15,6 +15,8 @@ import { Input } from "devtools/client/debugger/src/components/Editor/Breakpoint
 
 type MixpanelEvent =
   | ["breakpoint.add_comment"]
+  | ["breakpoint.add"]
+  | ["breakpoint.add_column"]
   | ["breakpoint.edit"]
   | ["breakpoint.minus_click"]
   | ["breakpoint.plus_click"]
@@ -25,6 +27,8 @@ type MixpanelEvent =
   | ["breakpoint.preview_has_hits"]
   | ["breakpoint.preview_no_hits"]
   | ["breakpoint.remove"]
+  | ["breakpoints.remove_all"]
+  | ["breakpoints.remove_all_in_source"]
   | ["breakpoint.set_condition"]
   | ["breakpoint.set_log"]
   | ["breakpoint.start_edit", { input: Input; hitsCount: number | null }]
@@ -87,6 +91,7 @@ type MixpanelEvent =
   | ["share_modal.set_private"]
   | ["share_modal.set_public"]
   | ["share_modal.set_team"]
+  | ["sources.select_location"]
   | ["team_change", { workspaceId: WorkspaceId | null }]
   | ["team.change_default", { workspaceUuid: WorkspaceUuid | null }]
   | ["timeline.comment_select"]

--- a/test/e2e/runTest.ts
+++ b/test/e2e/runTest.ts
@@ -22,38 +22,36 @@ function pingTestMetrics(
   const runId = process.env.TEST_RUN_ID;
   const webhookUrl = process.env.RECORD_REPLAY_WEBHOOK_URL;
 
-  try {
-    if (!webhookUrl) {
-      console.log("RECORD_REPLAY_WEBHOOK_URL is undefined. Skipping test metrics");
-      return;
-    }
-
-    if (!runId) {
-      console.log("TEST_RUN_ID is undefined. Skipping test metrics");
-      return;
-    }
-
-    const body = JSON.stringify(
-      {
-        type: "test.finished",
-        recordingId,
-        test: {
-          ...test,
-          runId,
-        },
-      },
-      undefined,
-      2
-    );
-
-    return fetch(`${webhookUrl}/api/metrics`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body,
-    });
-  } catch (e) {
-    console.log("Failed to send test metrics", e);
+  if (!webhookUrl) {
+    console.log("RECORD_REPLAY_WEBHOOK_URL is undefined. Skipping test metrics");
+    return;
   }
+
+  if (!runId) {
+    console.log("TEST_RUN_ID is undefined. Skipping test metrics");
+    return;
+  }
+
+  const body = JSON.stringify(
+    {
+      type: "test.finished",
+      recordingId,
+      test: {
+        ...test,
+        runId,
+      },
+    },
+    undefined,
+    2
+  );
+
+  return fetch(`${webhookUrl}/api/metrics`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+  }).catch(e => {
+    console.log("Failed to send test metrics", e);
+  });
 }
 
 function setTestId(file: string) {


### PR DESCRIPTION
We added mixpanel types so that we would get some extra tsc assistance on things like spelling, deduplicating, etc. If we find that we are regularly ignoring these instead of adding type definitions, then it might be time to rip the types out. Personally, I think they add something, so I opted to keep them.