### PR TITLE
Send all sources to new reducer

### DIFF
--- a/packages/protocol/thread/thread.ts
+++ b/packages/protocol/thread/thread.ts
@@ -399,11 +399,7 @@ class _ThreadFront {
 
     await this.ensureAllSources();
     for (const [sourceId, source] of this.sources) {
-      // TODO @jcmorrow remove this check when we actually want to capture all
-      // sources in the experimental reducer
-      if (sourceId === this.getCorrespondingSourceIds(sourceId)[0]) {
-        onSource({ sourceId, ...source });
-      }
+      onSource({ sourceId, ...source });
     }
   }
 

--- a/src/devtools/client/debugger/src/client/index.ts
+++ b/src/devtools/client/debugger/src/client/index.ts
@@ -36,17 +36,22 @@ async function setupDebugger() {
   const sourceInfos: $FixTypeLater[] = [];
   const sources: newSource[] = [];
   await ThreadFront.findSources(newSource => {
-    // @ts-expect-error `sourceMapURL` doesn't exist?
-    const { sourceId, url, sourceMapURL } = newSource;
-    sourceInfos.push({
-      type: "generated",
-      data: prepareSourcePayload({
-        actor: sourceId,
-        url,
-        sourceMapURL,
-      }),
-    });
     sources.push(newSource);
+
+    // We only process *one* source for each group of corresponding sources in
+    // the old way. Bail if we are not looking at the first source in this group.
+    if (newSource.sourceId === ThreadFront.getCorrespondingSourceIds(newSource.sourceId)[0]) {
+      // @ts-expect-error `sourceMapURL` doesn't exist?
+      const { sourceId, url, sourceMapURL } = newSource;
+      sourceInfos.push({
+        type: "generated",
+        data: prepareSourcePayload({
+          actor: sourceId,
+          url,
+          sourceMapURL,
+        }),
+      });
+    }
   });
   await store.dispatch(actions.newQueuedSources(sourceInfos));
   store.dispatch(addSources(sources));

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -1,7 +1,6 @@
 import { ApolloError } from "@apollo/client";
 import { uploadedData } from "@replayio/protocol";
 import { findAutomatedTests } from "ui/actions/find-tests";
-import { videoReady } from "protocol/graphics";
 import {
   addEventListener,
   CommandRequest,
@@ -168,7 +167,7 @@ export function createSocket(
 
       const sessionId = await createSession(recordingId, loadPoint, experimentalSettings, {
         onEvent: (event: ProtocolEvent) => {
-          if (features.logProtocol) {
+          if (features.logProtocolEvents) {
             dispatch(eventReceived({ ...event, recordedAt: window.performance.now() }));
           }
         },

--- a/src/ui/reducers/protocolMessages.ts
+++ b/src/ui/reducers/protocolMessages.ts
@@ -3,6 +3,7 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import cloneDeep from "lodash/cloneDeep";
 import { CommandRequest, CommandResponse } from "protocol/socket";
 import { UIState } from "ui/state";
+import { features } from "ui/utils/prefs";
 
 export interface Recorded {
   recordedAt: number;
@@ -76,7 +77,13 @@ export const { errorReceived, eventReceived, requestSent, responseReceived } =
 
 export default protocolMessagesSlice.reducer;
 
-export const getProtocolEvents = (state: UIState) => state.protocolMessages.events;
+export const getProtocolEvents = (_state: UIState) => {
+  if (!features.logProtocolEvents) {
+    console.log("protocol events are disabled");
+  }
+
+  return [];
+};
 export const getProtocolErrorMap = (state: UIState) => state.protocolMessages.idToErrorMap;
 export const getProtocolRequestMap = (state: UIState) => state.protocolMessages.idToRequestMap;
 export const getProtocolResponseMap = (state: UIState) => state.protocolMessages.idToResponseMap;

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -25,6 +25,7 @@ pref("devtools.features.commentAttachments", false);
 pref("devtools.features.enableLargeText", false);
 pref("devtools.features.enableNewObjectInspector", false);
 pref("devtools.features.logProtocol", false);
+pref("devtools.features.logProtocolEvents", false);
 pref("devtools.features.originalClassNames", false);
 pref("devtools.features.protocolTimeline", false);
 pref("devtools.features.repaintEvaluations", false);
@@ -58,6 +59,7 @@ export const features = new PrefsHelper("devtools.features", {
   enableNewObjectInspector: ["Bool", "enableNewObjectInspector"],
   hitCounts: ["Bool", "hitCounts"],
   logProtocol: ["Bool", "logProtocol"],
+  logProtocolEvents: ["Bool", "logProtocolEvents"],
   originalClassNames: ["Bool", "originalClassNames"],
   protocolTimeline: ["Bool", "protocolTimeline"],
   repaintEvaluations: ["Bool", "repaintEvaluations"],


### PR DESCRIPTION
And disable storing events for now. They have not been super useful, and they can really bog down loading. I was investigating some loading stuff and it turns out mostly what my app was doing was writing down events that I never looked at.