### PR TITLE
Fix broken SourcesTree state usage

### DIFF
--- a/src/devtools/client/debugger/src/components/PrimaryPanes/SourcesTree.tsx
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/SourcesTree.tsx
@@ -114,7 +114,7 @@ class SourcesTree extends Component<PropsFromRedux, STState> {
     if (props.selectedSource) {
       const highlightItems = getDirectories(
         props.selectedSource,
-        this.state.sourceTree as TreeDirectory
+        state.sourceTree as TreeDirectory
       );
       state.highlightItems = highlightItems;
     }


### PR DESCRIPTION
This PR:

- Fixes a typo I left in that still referred to `this.state` in `SourcesTree.tsx`, causing a crash