### PR TITLE
Fix misbehaving SourcemapToggle

### DIFF
--- a/src/devtools/client/debugger/src/actions/sources/select.ts
+++ b/src/devtools/client/debugger/src/actions/sources/select.ts
@@ -242,18 +242,21 @@ export function showAlternateSource(
       ThreadFront.preferSource(oldSourceId, false);
     }
 
-    let isPausedInSource = false;
+    let selectSourceByPausing = false;
     const state = getState();
     const frames = getFrames(state);
     if (frames) {
       const selectedFrameId = getSelectedFrameId(state);
       const selectedFrame = frames.find(f => f.id == selectedFrameId);
-      if (selectedFrame?.location.sourceId === oldSourceId) {
-        isPausedInSource = true;
+      if (
+        selectedFrame?.location.sourceId === oldSourceId &&
+        selectedFrame?.alternateLocation?.sourceId === newSourceId
+      ) {
+        selectSourceByPausing = true;
       }
     }
 
-    if (isPausedInSource) {
+    if (selectSourceByPausing) {
       const executionPoint = getExecutionPoint(state);
       await dispatch(paused({ executionPoint: executionPoint! }));
     } else {

--- a/src/devtools/client/debugger/src/utils/sourceVisualizations.ts
+++ b/src/devtools/client/debugger/src/utils/sourceVisualizations.ts
@@ -97,8 +97,10 @@ export function getUniqueAlternateSourceId(sourceId: string): {
   if (sourcemappedSourceIds.length > 1) {
     return { why: "not-unique" };
   }
-  return {
-    sourceId:
-      ThreadFront.getPrettyPrintedSourceId(sourcemappedSourceIds[0]) || sourcemappedSourceIds[0],
-  };
+
+  let alternateSourceId = sourcemappedSourceIds[0];
+  alternateSourceId = ThreadFront.getPrettyPrintedSourceId(alternateSourceId) || alternateSourceId;
+  alternateSourceId = ThreadFront.getCorrespondingSourceIds(alternateSourceId)[0];
+
+  return { sourceId: alternateSourceId };
 }


### PR DESCRIPTION
This fixes 2 SourcemapToggle issues:
- when there are identical original sources for different generated sources (see [this Loom](https://www.loom.com/share/206149f7b5aa41378d1b4119cb075445) at 4:35)
- FE-407 