### PR TITLE
Disable markdown linting

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -6,7 +6,6 @@ lint:
     - actionlint@1.6.8
     - eslint@8.13.0
     - gitleaks@8.3.0
-    - markdownlint@0.31.1
     - prettier@2.5.1
   ignore:
     - linters: [ALL]


### PR DESCRIPTION
We have a bunch of violations in our markdown, and while I could invest
time to fix them, it also seems like maybe we don't *need* a markdown
linter?

I'm open to pushback on this, and if people love the markdown linter for
some reason I will fix the violations instead.