### PR TITLE
Don't fetch frame scopes if the pause has changed

### DIFF
--- a/src/devtools/client/debugger/src/actions/pause/paused.ts
+++ b/src/devtools/client/debugger/src/actions/pause/paused.ts
@@ -116,6 +116,10 @@ export function paused({
         dispatch(selectLocation(cx, selectedFrame.location, true));
       }
 
+      if (pause !== ThreadFront.currentPause) {
+        return;
+      }
+
       await Promise.all([
         dispatch(fetchAsyncFrames(cx)),
         dispatch(setFramePositions()),


### PR DESCRIPTION
Fixes FE-417