### PR TITLE
Fix dragging editor tabs

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Tabs.js
+++ b/src/devtools/client/debugger/src/components/Editor/Tabs.js
@@ -101,7 +101,7 @@ class Tabs extends PureComponent {
       return;
     }
 
-    const tabDOM = ReactDOM.findDOMNode(this.refs[`tab_${source.id}`].getWrappedInstance());
+    const tabDOM = ReactDOM.findDOMNode(this.refs[`tab_${source.id}`]);
 
     /* $FlowIgnore: tabDOM.nodeType will always be of Node.ELEMENT_NODE since it comes from a ref;
       however; the return type of findDOMNode is null | Element | Text */


### PR DESCRIPTION
In old versions of react-redux (<6), `connect()` had a `withRef` option that allowed you to get the wrapped instance from a ref using `ref.getWrappedInstance()`. This option was replaced by `forwardRef`, which will give you the wrapped instance directly. When we upgraded to a newer version of react-redux, we replaced the option without realizing that we need to remove the `getWrappedInstance()` call.
Fixes FE-419.