### PR TITLE
use pause.isLoaded() instead of ensureAllSources

### DIFF
--- a/packages/protocol/graphics.ts
+++ b/packages/protocol/graphics.ts
@@ -246,7 +246,7 @@ export async function repaint(force = false) {
   }, 500);
 
   const { mouse } = await getGraphicsAtTime(ThreadFront.currentTime);
-  const pause = ThreadFront.ensureCurrentPause();
+  const pause = ThreadFront.getCurrentPause();
 
   const rv = await pause.repaintGraphics(force);
   graphicsFetched = true;

--- a/packages/protocol/thread/pause.ts
+++ b/packages/protocol/thread/pause.ts
@@ -190,6 +190,10 @@ export class Pause {
     datas.forEach(d => this._updateDataFronts(d));
   }
 
+  ensureLoaded() {
+    return this.createWaiter;
+  }
+
   // we're cheating Typescript here: the objects that we add are of type Frame/Scope/ObjectDescription
   // but we pretend they are of type WiredFrame/WiredScope/WiredObject. These objects will be changed
   // in _updateDataFronts() so that they have the correct type afterwards.

--- a/src/devtools/client/inspector/markup/markup.ts
+++ b/src/devtools/client/inspector/markup/markup.ts
@@ -96,8 +96,7 @@ class MarkupView {
     this.isLoadingPostponed = false;
 
     await ThreadFront.ensureAllSources();
-    ThreadFront.ensureCurrentPause();
-    const pause = ThreadFront.currentPause;
+    const pause = ThreadFront.getCurrentPause();
     if (this.selection.nodeFront && this.selection.nodeFront.pause !== pause) {
       this.selection.setNodeFront(null);
     }

--- a/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
+++ b/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
@@ -127,8 +127,7 @@ class ReplayWall implements Wall {
         case "startInspectingNative": {
           this.initializePicker();
 
-          ThreadFront.ensureCurrentPause();
-          await ThreadFront.currentPause!.createWaiter;
+          await ThreadFront.getCurrentPause().ensureLoaded();
           const rv = await ThreadFront.currentPause!.loadMouseTargets();
 
           if (!rv) {


### PR DESCRIPTION
I'm not sure if this is a good idea, but I think it could be a potential follow on cleanup to #7369 because we now know that we can reliably load a pause after sources are available