### PR TITLE
Don't fetch frame scopes if the pause has changed

### DIFF
--- a/src/devtools/client/debugger/src/actions/pause/paused.ts
+++ b/src/devtools/client/debugger/src/actions/pause/paused.ts
@@ -119,6 +119,10 @@ export function paused({
         dispatch(selectLocation(cx, selectedFrame.location, true));
       }
 
+      if (pause !== ThreadFront.currentPause) {
+        return;
+      }
+
       await Promise.all([
         dispatch(fetchAsyncFrames(cx)),
         dispatch(setFramePositions()),

--- a/src/ui/actions/find-tests.ts
+++ b/src/ui/actions/find-tests.ts
@@ -201,11 +201,15 @@ class JestTestState {
           return;
         }
 
-        const { time, pauseId, location, exception, data } = result.value;
+        const { time, pauseId, exception, data } = result.value;
 
-        const pause = new Pause(ThreadFront);
-        pause.addData(data);
-        pause.instantiate(pauseId, test.errorPoint.point, time, /* hasFrames */ true);
+        const pause = ThreadFront.instantiatePause(
+          pauseId,
+          test.errorPoint.point,
+          time,
+          /* hasFrames */ true,
+          data
+        );
         const exceptionValue = new ValueFront(pause, exception);
 
         const exceptionContents = exceptionValue.previewValueMap();

--- a/src/ui/actions/logpoint.ts
+++ b/src/ui/actions/logpoint.ts
@@ -97,9 +97,7 @@ function showLogpointsResult(logGroupId: string, result: AnalysisEntry[]) {
       value: { time, pauseId, location, values, data, frameworkListeners },
     }) => {
       await ThreadFront.ensureAllSources();
-      const pause = new Pause(ThreadFront);
-      pause.instantiate(pauseId, point, time, /* hasFrames */ true);
-      pause.addData(data);
+      const pause = ThreadFront.instantiatePause(pauseId, point, time, /* hasFrames */ true, data);
       const valueFronts = values.map((v: any) => new ValueFront(pause, v));
       const mappedLocation = await ThreadFront.getPreferredMappedLocation(location[0]);
       assert(mappedLocation, "preferred mapped location not found");


### PR DESCRIPTION
I was looking into why #7382 broke our frontend and found that we were creating two pauses for the same point when seeking to a console message: the first pause was created (using `pause = new Pause(...); pause.instantiate(...);`) when the message was received from the backend and the second pause was created by `Session.ensurePause(...)` in `src/devtools/client/debugger/src/actions/pause/paused.ts`.
We try to prevent creating multiple pauses for the same point by using the `ThreadFront.allPauses` map, but pauses created using the `pause = new Pause(...); pause.instantiate(...);` pattern were not added to that map.