### PR TITLE
Use a memoized selector for fetching breakable lines

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
@@ -9,7 +9,7 @@ import styles from "./LineHitCounts.module.css";
 import { features } from "ui/utils/prefs";
 
 import { resizeBreakpointGutter } from "../../utils/ui";
-import { fetchHitCounts, getHitCountsForSelectedSource, HitCount } from "ui/reducers/hitCounts";
+import { fetchHitCounts, HitCount, getHitCountsForSource } from "ui/reducers/hitCounts";
 
 type Props = {
   editor: any;
@@ -29,7 +29,7 @@ export default function LineHitCountsWrapper(props: Props) {
 function LineHitCounts({ editor }: Props) {
   const dispatch = useAppDispatch();
   const sourceId = useAppSelector(getSelectedSourceId)!;
-  const hitCounts = useAppSelector(getHitCountsForSelectedSource);
+  const hitCounts = useAppSelector(state => getHitCountsForSource(state, sourceId));
   const { value: hitCountsMode, update: updateHitCountsMode } = useStringPref("hitCounts");
   const isCollapsed = hitCountsMode == "hide-counts";
 

--- a/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
@@ -13,7 +13,7 @@ import { shouldShowNag } from "ui/utils/user";
 import { getSelectedSource } from "../../reducers/sources";
 
 import StaticTooltip from "./StaticTooltip";
-import { fetchHitCounts, getHitCountsForSelectedSource } from "ui/reducers/hitCounts";
+import { fetchHitCounts, getHitCountsForSource } from "ui/reducers/hitCounts";
 
 export const AWESOME_BACKGROUND = `linear-gradient(116.71deg, #FF2F86 21.74%, #EC275D 83.58%), linear-gradient(133.71deg, #01ACFD 3.31%, #F155FF 106.39%, #F477F8 157.93%, #F33685 212.38%), #007AFF`;
 
@@ -65,9 +65,11 @@ function LineNumberTooltip({ editor, keyModifiers }: Props) {
   const [targetNode, setTargetNode] = useState<HTMLElement | null>(null);
   const lastHoveredLineNumber = useRef<number | null>(null);
   const isMetaActive = keyModifiers.meta;
-
-  const hitCounts = useAppSelector(getHitCountsForSelectedSource);
   const source = useAppSelector(getSelectedSource);
+
+  const hitCounts = useAppSelector(state =>
+    getHitCountsForSource(state, source!.id, lastHoveredLineNumber.current || 0)
+  );
 
   let hits: number | undefined;
 

--- a/src/devtools/client/debugger/src/components/SourceOutline/SourceOutline.tsx
+++ b/src/devtools/client/debugger/src/components/SourceOutline/SourceOutline.tsx
@@ -16,7 +16,7 @@ import { actions } from "ui/actions";
 import { UIState } from "ui/state";
 import Spinner from "ui/components/shared/Spinner";
 import { isFunctionSymbol } from "./isFunctionSymbol";
-import { fetchHitCounts, getHitCountsForSelectedSource } from "ui/reducers/hitCounts";
+import { fetchHitCounts, getHitCountsForSource } from "ui/reducers/hitCounts";
 
 export function SourceOutline({
   cx,
@@ -160,7 +160,7 @@ export function SourceOutline({
 const mapStateToProps = (state: UIState) => {
   const selectedSource = selectors.getSelectedSourceWithContent(state);
   const symbols = selectedSource ? selectors.getSymbols(state, selectedSource) : null;
-  const hitCounts = selectedSource ? getHitCountsForSelectedSource(state) : null;
+  const hitCounts = selectedSource ? getHitCountsForSource(state, selectedSource.id) : null;
   return {
     cursorPosition: selectors.getCursorPosition(state),
     cx: selectors.getContext(state),

--- a/src/ui/reducers/hitCounts.ts
+++ b/src/ui/reducers/hitCounts.ts
@@ -1,4 +1,10 @@
-import { createEntityAdapter, createSlice, EntityState, PayloadAction } from "@reduxjs/toolkit";
+import {
+  createSelector,
+  createEntityAdapter,
+  createSlice,
+  EntityState,
+  PayloadAction,
+} from "@reduxjs/toolkit";
 import { Location } from "@replayio/protocol";
 import { UIThunkAction } from "ui/actions";
 import { UIState } from "ui/state";
@@ -161,18 +167,9 @@ export const fetchHitCounts = (sourceId: string, lineNumber: number): UIThunkAct
 
 export const { hitCountsRequested, hitCountsReceived, hitCountsFailed } = hitCountsSlice.actions;
 
-export const getHitCountsForSource = (state: UIState, sourceId: string) => {
-  const cacheKey = getCacheKeyForSourceHitCounts(state, sourceId);
+export const getHitCountsForSource = (state: UIState, sourceId: string, line: number = 0) => {
+  const cacheKey = getCacheKeyForSourceHitCounts(state, sourceId, line);
   return hitCountsSelectors.selectById(state, cacheKey)?.hitCounts || null;
-};
-
-export const getHitCountsForSelectedSource = (state: UIState) => {
-  const id = getSelectedSourceId(state);
-  if (!id) {
-    return null;
-  }
-
-  return getHitCountsForSource(state, id);
 };
 
 export default hitCountsSlice.reducer;


### PR DESCRIPTION
- I wouldn't mind storing these in the store just to avoid potential
  cache misses, but this also works
- For hitCounts, we were not sending the line number to the selector, so
  it was not always grabbing the right line segments. We should make a
  selector that merges those, but again, this works for now.