### PR TITLE
Iterate over editor lines in 1000 line increments

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/EmptyLines.js
+++ b/src/devtools/client/debugger/src/components/Editor/EmptyLines.js
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-//
-
 import { connect } from "react-redux";
 import { Component } from "react";
 import { fromEditorLine } from "../../utils/editor";
 import { getBreakableLinesForSelectedSource } from "ui/reducers/possibleBreakpoints";
+import { getBoundsForLineNumber } from "ui/reducers/hitCounts";
 
 class EmptyLines extends Component {
   componentDidMount() {
@@ -19,20 +18,20 @@ class EmptyLines extends Component {
   }
 
   componentWillUnmount() {
-    const { editor } = this.props;
+    const { editor, lower, upper } = this.props;
 
     editor.codeMirror.operation(() => {
-      editor.codeMirror.eachLine(lineHandle => {
+      editor.codeMirror.eachLine(lower, upper, lineHandle => {
         editor.codeMirror.removeLineClass(lineHandle, "line", "empty-line");
       });
     });
   }
 
   disableEmptyLines() {
-    const { breakableLines, editor } = this.props;
+    const { breakableLines, editor, lower, upper } = this.props;
 
     editor.codeMirror.operation(() => {
-      editor.codeMirror.eachLine(lineHandle => {
+      editor.codeMirror.eachLine(lower, upper, lineHandle => {
         const line = fromEditorLine(editor.codeMirror.getLineNumber(lineHandle));
 
         if (breakableLines?.includes(line)) {
@@ -52,8 +51,12 @@ class EmptyLines extends Component {
 const mapStateToProps = state => {
   const breakableLines = getBreakableLinesForSelectedSource(state);
 
+  const { lower, upper } = getBoundsForLineNumber(state.app.hoveredLineNumberLocation?.line || 0);
+
   return {
     breakableLines,
+    lower,
+    upper,
   };
 };
 


### PR DESCRIPTION
We've been discussing this off and on today, but huge documents (100k+ lines) don't load well in our editor. From profiling I found that there are two places where we loop over every line in the document. But we had this problem already when I first built heat counts, and the solution was to set bounds for how far we would render things and then react to the user scrolling. Since we already have the infrastructure for that, this just teaches the components doing the looping to only loop over the increments that are *close-ish* to what the user is viewing. It's not perfect, but it's a *lot* better than the other things I've come up with so far 😆 