### PR TITLE
Cachebreak Earthly Playwright steps

### DIFF
--- a/packages/bvaughn-architecture-demo/playwright.js
+++ b/packages/bvaughn-architecture-demo/playwright.js
@@ -106,7 +106,7 @@ async function runEndToEndTests() {
   // Default to "172.17.0.1" for CI.
   const HOST = process.env.HOST || "172.17.0.1";
 
-  testProcess = spawn("earthly", ["--push", "+playwright", `--HOST=${HOST}`], {
+  testProcess = spawn("earthly", ["+playwright", `--HOST=${HOST}`], {
     ...process.env,
     cwd: join(ROOT_PATH, "playwright"),
   });

--- a/packages/bvaughn-architecture-demo/playwright.js
+++ b/packages/bvaughn-architecture-demo/playwright.js
@@ -106,7 +106,7 @@ async function runEndToEndTests() {
   // Default to "172.17.0.1" for CI.
   const HOST = process.env.HOST || "172.17.0.1";
 
-  testProcess = spawn("earthly", ["+playwright", `--HOST=${HOST}`], {
+  testProcess = spawn("earthly", ["--push", "+playwright", `--HOST=${HOST}`], {
     ...process.env,
     cwd: join(ROOT_PATH, "playwright"),
   });

--- a/packages/bvaughn-architecture-demo/playwright/Earthfile
+++ b/packages/bvaughn-architecture-demo/playwright/Earthfile
@@ -13,10 +13,10 @@ playwright:
     ARG --required HOST
     FROM +install
     ENV HOST $HOST
-    RUN --push node run_tests_for_earthly.js
+    RUN node run_tests_for_earthly.js
     IF [ -f playwright_error ]
         SAVE ARTIFACT ./test-results AS LOCAL ./test-results
-        RUN --push echo "test run failed" && \
+        RUN echo "test run failed" && \
             exit 0
     END
 

--- a/packages/bvaughn-architecture-demo/playwright/Earthfile
+++ b/packages/bvaughn-architecture-demo/playwright/Earthfile
@@ -13,10 +13,10 @@ playwright:
     ARG --required HOST
     FROM +install
     ENV HOST $HOST
-    RUN node run_tests_for_earthly.js
+    RUN --push node run_tests_for_earthly.js
     IF [ -f playwright_error ]
         SAVE ARTIFACT ./test-results AS LOCAL ./test-results
-        RUN echo "test run failed" && \
+        RUN --push echo "test run failed" && \
             exit 0
     END
 
@@ -24,12 +24,12 @@ playwright-update-snapshots:
     ARG --required HOST
     FROM +install
     ENV HOST $HOST
-    RUN yarn test --update-snapshots
+    RUN --push yarn test --update-snapshots
     SAVE ARTIFACT ./snapshots AS LOCAL ./snapshots
 
 playwright-record-video:
     ARG --required HOST
     FROM +install
     ENV HOST $HOST
-    RUN RECORD_VIDEO=true VISUAL_DEBUG=true yarn test
+    RUN --push RECORD_VIDEO=true VISUAL_DEBUG=true yarn test
     SAVE ARTIFACT ./test-results AS LOCAL ./test-results

--- a/packages/bvaughn-architecture-demo/playwright/README.md
+++ b/packages/bvaughn-architecture-demo/playwright/README.md
@@ -13,7 +13,7 @@ Then verify snapshots by running:
 
 ```sh
 # packages/bvaughn-architecture-demo/playwright
-earthly --push +playwright
+earthly +playwright
 ```
 
 ## Locally (to update snapshots)

--- a/packages/bvaughn-architecture-demo/playwright/README.md
+++ b/packages/bvaughn-architecture-demo/playwright/README.md
@@ -13,7 +13,7 @@ Then verify snapshots by running:
 
 ```sh
 # packages/bvaughn-architecture-demo/playwright
-earthly +playwright
+earthly --push +playwright
 ```
 
 ## Locally (to update snapshots)
@@ -29,7 +29,7 @@ Then update snapshots by running:
 
 ```sh
 # packages/bvaughn-architecture-demo/playwright
-earthly +playwright-update-snapshots --HOST=host.docker.internal
+earthly --push +playwright-update-snapshots --HOST=host.docker.internal
 ```
 
 Note that the value passed for `HOST` varies by operating system:
@@ -65,5 +65,5 @@ If tests are failing in the Docker container, it can be helpful to record a vide
 
 ```sh
 # packages/bvaughn-architecture-demo/playwright
-earthly +playwright-record-video --HOST=host.docker.internal
+earthly --push +playwright-record-video --HOST=host.docker.internal
 ```


### PR DESCRIPTION
Make sure the Playwright step always run within the Docker container, even if there were no changes to the tests themselves (aka the content copied into the container).