### PR TITLE
New Console experimental integration

### DIFF
--- a/packages/protocol/thread/thread.ts
+++ b/packages/protocol/thread/thread.ts
@@ -112,7 +112,7 @@ function getRecordingTarget(buildId: string): RecordingTarget {
   return RecordingTarget.unknown;
 }
 
-type ThreadFrontEvent = "currentPause" | "paused" | "resumed";
+type ThreadFrontEvent = "currentPause" | "evaluation" | "paused" | "resumed";
 
 declare global {
   interface Window {
@@ -345,7 +345,15 @@ class _ThreadFront {
     }
   }
 
+  _accessToken: string | null = null;
+
+  getAccessToken(): string | null {
+    return this._accessToken;
+  }
+
   setAccessToken(accessToken: string) {
+    this._accessToken = accessToken;
+
     return client.Authentication.setAccessToken({ accessToken });
   }
 
@@ -728,6 +736,7 @@ class _ThreadFront {
   }) {
     const pause = await this.pauseForAsyncIndex(asyncIndex);
     assert(pause, "no pause for asyncIndex");
+
     const rv = await pause.evaluate(frameId, text, pure);
     if (rv.returned) {
       rv.returned = new ValueFront(pause, rv.returned);

--- a/src/devtools/client/debugger/src/reducers/pause.ts
+++ b/src/devtools/client/debugger/src/reducers/pause.ts
@@ -420,6 +420,10 @@ export function getLastExpandedScopes(state: UIState) {
   return state.pause.lastExpandedScopes;
 }
 
+export function getPauseId(state: UIState) {
+  return state.pause.id;
+}
+
 export function getPausePreviewLocation(state: UIState) {
   return state.pause.pausePreviewLocation;
 }

--- a/src/devtools/client/debugger/src/selectors/breakpoints.ts
+++ b/src/devtools/client/debugger/src/selectors/breakpoints.ts
@@ -5,10 +5,15 @@
 import type { UIState } from "ui/state";
 
 import { createSelector } from "reselect";
+import { isLogpoint } from "../utils/breakpoint";
 
 export const getBreakpointsList = createSelector(
   (state: UIState) => state.breakpoints.breakpoints,
   breakpoints => Object.values(breakpoints)
+);
+
+export const getLogPointsList = createSelector(getBreakpointsList, breakpoints =>
+  breakpoints.filter(point => isLogpoint(point))
 );
 
 export const getRequestedBreakpointLocations = (state: UIState) =>

--- a/src/devtools/client/shared/components/ResponsiveTabs.tsx
+++ b/src/devtools/client/shared/components/ResponsiveTabs.tsx
@@ -47,7 +47,7 @@ export const ResponsiveTabs = ({
     // check if maybe we don't need a dropdown at all
     let totalTabsWidth = 0;
     for (const tab of tabsRef.current) {
-      totalTabsWidth += tab.clientWidth;
+      totalTabsWidth += tab?.clientWidth ?? 0;
     }
 
     if (totalTabsWidth <= containerWidth) {

--- a/src/ui/components/SecondaryToolbox/NewConsole.module.css
+++ b/src/ui/components/SecondaryToolbox/NewConsole.module.css
@@ -1,0 +1,3 @@
+.JSTermWrapper {
+  border-top: 1px solid var(--background-color-default);
+}

--- a/src/ui/components/SecondaryToolbox/NewConsole.tsx
+++ b/src/ui/components/SecondaryToolbox/NewConsole.tsx
@@ -1,0 +1,388 @@
+import {
+  ExecutionPoint,
+  MappedLocation,
+  PauseId,
+  Value as ProtocolValue,
+} from "@replayio/protocol";
+import NewConsole from "bvaughn-architecture-demo/components/console";
+import { SearchContext } from "bvaughn-architecture-demo/components/console/SearchContext";
+import { FocusContext } from "bvaughn-architecture-demo/src/contexts/FocusContext";
+import { InspectorContext } from "@bvaughn/src/contexts/InspectorContext";
+import { Point, PointsContext } from "bvaughn-architecture-demo/src/contexts/PointsContext";
+import { TerminalContext, TerminalExpression } from "@bvaughn/src/contexts/TerminalContext";
+import {
+  TimelineContext,
+  TimelineContextType,
+} from "bvaughn-architecture-demo/src/contexts/TimelineContext";
+import React, {
+  KeyboardEvent,
+  PropsWithChildren,
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useState,
+  useTransition,
+} from "react";
+import {
+  SessionContext,
+  SessionContextType,
+} from "bvaughn-architecture-demo/src/contexts/SessionContext";
+import { Range } from "bvaughn-architecture-demo/src/types";
+import { getLogPointsList, getPauseId } from "devtools/client/debugger/src/selectors";
+import {
+  messagesClearEvaluations,
+  onViewSourceInDebugger,
+  openNodeInInspector,
+} from "devtools/client/webconsole/actions";
+import { EvaluationEventPayload } from "devtools/client/webconsole/actions/input";
+import JSTerm from "devtools/client/webconsole/components/Input/JSTerm";
+import { Pause, ThreadFront, ValueFront } from "protocol/thread";
+import { useGetRecordingId } from "ui/hooks/recordings";
+import { getCurrentPoint, getLoadedRegions } from "ui/reducers/app";
+import { getCurrentTime, getFocusRegion } from "ui/reducers/timeline";
+import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
+import { FocusRegion } from "ui/state/timeline";
+import { displayedBeginForFocusRegion, displayedEndForFocusRegion } from "ui/utils/timeline";
+
+import styles from "./NewConsole.module.css";
+import { seek } from "ui/actions/timeline";
+import number from "devtools/packages/devtools-reps/reps/number";
+
+// Adapter that connects the legacy app Redux stores to the newer React Context providers.
+export default function NewConsoleRoot() {
+  const recordingId = useGetRecordingId();
+
+  const sessionContext = useMemo<SessionContextType>(
+    () => ({
+      accessToken: ThreadFront.getAccessToken(),
+      recordingId,
+      sessionId: ThreadFront.sessionId!,
+
+      // Current user info is only used by the new Comments UI (which isn't included yet)
+      currentUserInfo: null as any,
+
+      // Duration info is only used by the focus editor (not imported yet)
+      duration: null as any,
+      endPoint: null as any,
+    }),
+    [recordingId]
+  );
+
+  return (
+    <SessionContext.Provider value={sessionContext}>
+      <TimelineContextAdapter>
+        <InspectorContextReduxAdapter>
+          <TerminalContextReduxAdapter>
+            <FocusContextReduxAdapter>
+              <PointsContextReduxAdapter>
+                <NewConsole showSearchInputByDefault={false} terminalInput={<JSTermWrapper />} />
+              </PointsContextReduxAdapter>
+            </FocusContextReduxAdapter>
+          </TerminalContextReduxAdapter>
+        </InspectorContextReduxAdapter>
+      </TimelineContextAdapter>
+    </SessionContext.Provider>
+  );
+}
+
+function JSTermWrapper() {
+  const [_, searchActions] = useContext(SearchContext);
+
+  const onKeyDown = (event: KeyboardEvent) => {
+    switch (event.key) {
+      case "Escape":
+        searchActions.hide();
+
+        event.preventDefault();
+        event.stopPropagation();
+        break;
+      case "f":
+      case "F":
+        if (event.metaKey) {
+          searchActions.show();
+
+          event.preventDefault();
+          event.stopPropagation();
+        }
+        break;
+    }
+  };
+
+  return (
+    <div className={styles.JSTermWrapper} onKeyDown={onKeyDown}>
+      <JSTerm />
+    </div>
+  );
+}
+
+// Adapter that reads focus region (from Redux) and passes it to the FocusContext.
+function FocusContextReduxAdapter({ children }: PropsWithChildren) {
+  const loadedRegions = useAppSelector(getLoadedRegions);
+  const focusRegion = useAppSelector(getFocusRegion);
+
+  const [isPending, startTransition] = useTransition();
+  const [deferredFocusRegion, setDeferredFocusRegion] = useState<FocusRegion | null>(null);
+
+  useEffect(() => {
+    if (focusRegion === null) {
+      return;
+    }
+
+    const updateFocusRegionOnceLoaded = () => {
+      const focusBegin = displayedBeginForFocusRegion(focusRegion);
+      const focusEnd = displayedEndForFocusRegion(focusRegion);
+      const isLoaded = loadedRegions?.loaded?.some(region => {
+        return region.begin.time <= focusBegin && region.end.time >= focusEnd;
+      });
+      if (isLoaded) {
+        startTransition(() => {
+          setDeferredFocusRegion(focusRegion);
+        });
+      } else {
+        timeoutId = setTimeout(updateFocusRegionOnceLoaded, 250);
+      }
+    };
+
+    let timeoutId = setTimeout(updateFocusRegionOnceLoaded, 250);
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, [focusRegion, loadedRegions]);
+
+  const context = useMemo(
+    () => ({
+      isTransitionPending: isPending,
+      range: focusRegionToRange(deferredFocusRegion),
+      rangeForDisplay: focusRegionToRange(focusRegion),
+
+      // This context adapter is read-only.
+      // Focus is set by the legacy Timeline component.
+      update: () => {},
+    }),
+    [deferredFocusRegion, isPending, focusRegion]
+  );
+
+  return <FocusContext.Provider value={context}>{children}</FocusContext.Provider>;
+}
+
+// Adapter that connects inspect-function and inspect-html-element actions with Redux.
+function InspectorContextReduxAdapter({ children }: PropsWithChildren) {
+  const dispatch = useAppDispatch();
+
+  const inspectFunctionDefinition = useCallback(
+    (mappedLocation: MappedLocation) => {
+      const location = mappedLocation.length > 0 ? mappedLocation[mappedLocation.length - 1] : null;
+      if (location) {
+        const url = ThreadFront.getSourceURLRaw(location.sourceId);
+        if (url) {
+          dispatch(
+            onViewSourceInDebugger({
+              url,
+              line: location.line,
+              column: location.column,
+            })
+          );
+        }
+      }
+    },
+    [dispatch]
+  );
+
+  // TODO (FE-337) Make this function work, then pass it down through the context.
+  const inspectHTMLElement = useCallback(
+    (
+      protocolValue: ProtocolValue,
+      pauseId: PauseId,
+      executionPoint: ExecutionPoint,
+      time: number
+    ) => {
+      (async () => {
+        if (pauseId) {
+          let pause = Pause.getById(pauseId);
+          if (!pause) {
+            pause = new Pause(ThreadFront);
+            pause.instantiate(pauseId, executionPoint, time, false);
+            await pause.ensureLoaded();
+          }
+
+          if (pause) {
+            // The new Console does not use ValueFronts; it uses Suspense to load preview data.
+            // Legacy Devtools expects ValueFronts (with loaded previews) though, so we need to do the conversion here.
+            // Be sure to clone the protocol value data first, because ValueFront deeply mutates the object it's passed,
+            // which includes changing its structure in ways that breaks the new Console.
+            const clonedValue = JSON.parse(JSON.stringify(protocolValue));
+            const valueFront = new ValueFront(pause, clonedValue);
+            await valueFront.loadIfNecessary();
+
+            // The node inspector expects the node and all of its parents to have been loaded.
+            // Since the new Console doesn't use ValueFronts, we have to manually load them here.
+            let objectId = clonedValue.object;
+            while (objectId) {
+              const object = await pause.getObjectPreview(clonedValue.object);
+              const valueFront = new ValueFront(pause, object);
+              await valueFront.loadIfNecessary();
+
+              objectId = object.preview?.node?.parentNode;
+            }
+
+            dispatch(openNodeInInspector(valueFront));
+          }
+        }
+      })();
+    },
+    [dispatch]
+  );
+
+  const context = useMemo(
+    () => ({ inspectFunctionDefinition, inspectHTMLElement: null }),
+    [inspectFunctionDefinition]
+  );
+
+  return <InspectorContext.Provider value={context}>{children}</InspectorContext.Provider>;
+}
+
+// Adapter that reads log points (from Redux) and passes them to the PointsContext.
+function PointsContextReduxAdapter({ children }: PropsWithChildren) {
+  const logpoints = useAppSelector(getLogPointsList);
+
+  // Convert to the Point[] format required by the new Console.
+  const points = useMemo<Point[]>(
+    () =>
+      logpoints.map(logpoint => ({
+        badge: logpoint.options.prefixBadge || null,
+        condition: null, // TODO
+        content: logpoint.options.logValue!,
+        enableBreaking: false,
+        enableLogging: true,
+        id: logpoint.id,
+        location: logpoint.location,
+      })),
+    [logpoints]
+  );
+
+  const [isPending, startTransition] = useTransition();
+  const [deferredPoints, setDeferredPoints] = useState<Point[]>([]);
+
+  // Update derived analysis points in a transition (so it's safe to Suspend) when points change.
+  useEffect(() => {
+    startTransition(() => {
+      setDeferredPoints(points);
+    });
+  }, [points]);
+
+  const context = useMemo(
+    () => ({
+      isPending,
+      points,
+      pointsForAnalysis: deferredPoints,
+
+      // PointsContext is read-only in this context.
+      // Log points are added by the legacy source Editor component.
+      addPoint: () => {},
+      deletePoint: () => {},
+      editPoint: () => {},
+    }),
+    [deferredPoints, isPending, points]
+  );
+
+  return <PointsContext.Provider value={context}>{children}</PointsContext.Provider>;
+}
+
+// Adapter that reads console evaluations (from Redux) and passes them to the TerminalContext.
+function TerminalContextReduxAdapter({ children }: PropsWithChildren) {
+  const [isPending, startTransition] = useTransition();
+  const [messages, setMessages] = useState<TerminalExpression[]>([]);
+
+  const dispatch = useAppDispatch();
+
+  const clearMessages = useCallback(() => {
+    dispatch(messagesClearEvaluations);
+    setMessages([]);
+  }, [dispatch]);
+
+  // Update derived terminal expressions in a transition (so it's safe to Suspend) when they change.
+  useEffect(() => {
+    const onEvaluation = (data: EvaluationEventPayload) => {
+      startTransition(() => {
+        setMessages(prevMessages => [
+          ...prevMessages,
+          {
+            ...data,
+            type: "TerminalExpression",
+          },
+        ]);
+      });
+    };
+
+    ThreadFront.on("evaluation", onEvaluation);
+    return () => {
+      ThreadFront.off("evaluation", onEvaluation);
+    };
+  }, []);
+
+  const context = useMemo(
+    () => ({
+      clearMessages,
+      isPending,
+      messages: messages,
+
+      // New terminal expressions can only be added via JSTerm (and Redux) in this context.
+      addMessage: () => {},
+    }),
+    [clearMessages, isPending, messages]
+  );
+
+  return <TerminalContext.Provider value={context}>{children}</TerminalContext.Provider>;
+}
+
+// Adapter that reads the current execution point and time (from Redux) and passes them to the TimelineContext.
+function TimelineContextAdapter({ children }: PropsWithChildren) {
+  const [state, setState] = useState<Omit<TimelineContextType, "isPending" | "update">>({
+    executionPoint: null,
+    pauseId: null,
+    time: 0,
+  });
+
+  const [isPending, startTransition] = useTransition();
+
+  const dispatch = useAppDispatch();
+  const pauseId = useAppSelector(getPauseId);
+  const time = useAppSelector(getCurrentTime);
+  const executionPoint = useAppSelector(getCurrentPoint);
+
+  const update = useCallback(
+    (time: number, executionPoint: ExecutionPoint, pauseId: PauseId) => {
+      dispatch(seek(executionPoint, time, false /* hasFrames */, pauseId));
+    },
+    [dispatch]
+  );
+
+  useLayoutEffect(() => {
+    if (pauseId) {
+      startTransition(() => {
+        setState({ executionPoint, time, pauseId });
+      });
+    }
+  }, [executionPoint, pauseId, time]);
+
+  const context = useMemo<TimelineContextType>(
+    () => ({
+      ...state,
+      isPending,
+      update,
+    }),
+    [isPending, state, update]
+  );
+
+  return <TimelineContext.Provider value={context}>{children}</TimelineContext.Provider>;
+}
+
+function focusRegionToRange(focusRegion: FocusRegion | null): Range | null {
+  if (focusRegion === null) {
+    return null;
+  }
+
+  return [displayedBeginForFocusRegion(focusRegion), displayedEndForFocusRegion(focusRegion)];
+}

--- a/src/ui/components/SecondaryToolbox/index.tsx
+++ b/src/ui/components/SecondaryToolbox/index.tsx
@@ -26,6 +26,8 @@ import SourcesTabLabel from "./SourcesTabLabel";
 import { setSelectedPanel } from "ui/actions/layout";
 import { getRecordingTarget } from "ui/reducers/app";
 import { ReduxAnnotationsContext } from "./redux-devtools/redux-annotations";
+import NewConsoleRoot from "./NewConsole";
+import { useFeature } from "ui/hooks/settings";
 
 const InspectorApp = React.lazy(() => import("devtools/client/inspector/components/App"));
 
@@ -86,10 +88,11 @@ const PanelButtons: FC<PanelButtonsProps> = ({
 };
 
 function ConsolePanel() {
+  const { value: enableNewConsole } = useFeature("enableNewConsole");
   return (
     <div className="toolbox-bottom-panels">
       <div className={classnames("toolbox-panel")} id="toolbox-content-console">
-        <WebConsoleApp />
+        {enableNewConsole ? <NewConsoleRoot /> : <WebConsoleApp />}
       </div>
     </div>
   );

--- a/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
+++ b/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
@@ -19,6 +19,11 @@ const EXPERIMENTAL_SETTINGS: ExperimentalSetting[] = [
     key: "enableColumnBreakpoints",
   },
   {
+    label: "New Console",
+    description: "View and inspect logs with the new console",
+    key: "enableNewConsole",
+  },
+  {
     label: "New Object Inspector",
     description: "Preview objects with the new inspector",
     key: "enableNewObjectInspector",
@@ -67,6 +72,8 @@ export default function ExperimentalSettings({}) {
 
   const { value: enableResolveRecording, update: updateEnableResolveRecording } =
     useFeature("resolveRecording");
+  const { value: enableNewConsole, update: updateEnableNewConsole } =
+    useFeature("enableNewConsole");
   const { value: enableNewObjectInspector, update: updateEnableNewObjectInspector } = useFeature(
     "enableNewObjectInspector"
   );
@@ -78,6 +85,8 @@ export default function ExperimentalSettings({}) {
       updateEnableColumnBreakpoints(!enableColumnBreakpoints);
     } else if (key == "enableResolveRecording") {
       updateEnableResolveRecording(!enableResolveRecording);
+    } else if (key === "enableNewConsole") {
+      updateEnableNewConsole(!enableNewConsole);
     } else if (key === "enableNewObjectInspector") {
       updateEnableNewObjectInspector(!enableNewObjectInspector);
     } else if (key === "hitCounts") {
@@ -89,6 +98,7 @@ export default function ExperimentalSettings({}) {
     enableColumnBreakpoints,
     enableResolveRecording,
     hitCounts,
+    enableNewConsole,
     enableNewObjectInspector,
   };
 
@@ -100,7 +110,7 @@ export default function ExperimentalSettings({}) {
 
   return (
     <div className="space-y-6 overflow-auto">
-      <div className="flex flex-col p-1 space-y-2">
+      <div className="flex flex-col space-y-2 p-1">
         {EXPERIMENTAL_SETTINGS.map(setting => (
           <Experiment
             onChange={onChange}
@@ -111,7 +121,7 @@ export default function ExperimentalSettings({}) {
         ))}
         {RISKY_EXPERIMENTAL_SETTINGS.length > 0 && (
           <div>
-            <div className="flex items-center my-4 ">
+            <div className="my-4 flex items-center ">
               <Icon
                 filename="warning"
                 className="mr-2"

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -16,6 +16,7 @@ export type ExperimentalUserSettings = {
 
 export type LocalExperimentalUserSettings = {
   enableColumnBreakpoints: boolean;
+  enableNewConsole: boolean;
   enableNewObjectInspector: boolean;
   enableResolveRecording: boolean;
   hitCounts: boolean;

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -23,6 +23,7 @@ pref("devtools.hitCounts", "hide-counts");
 pref("devtools.features.columnBreakpoints", false);
 pref("devtools.features.commentAttachments", false);
 pref("devtools.features.enableLargeText", false);
+pref("devtools.features.enableNewConsole", false);
 pref("devtools.features.enableNewObjectInspector", false);
 pref("devtools.features.logProtocol", false);
 pref("devtools.features.logProtocolEvents", false);
@@ -56,6 +57,7 @@ export const features = new PrefsHelper("devtools.features", {
   commentAttachments: ["Bool", "commentAttachments"],
   disableUnHitLines: ["Bool", "disableUnHitLines"],
   enableLargeText: ["Bool", "enableLargeText"],
+  enableNewConsole: ["Bool", "enableNewConsole"],
   enableNewObjectInspector: ["Bool", "enableNewObjectInspector"],
   hitCounts: ["Bool", "hitCounts"],
   logProtocol: ["Bool", "logProtocol"],


### PR DESCRIPTION
Loom overview:
https://www.loom.com/share/e0ca04227b364b50856876162d3cd3f3

- [x] Track down "_This part of the recording has been unloaded_" error that sometimes gets thrown by `getPointNearTime` if you slide the focus window around. For some reason, the new architecture test app never triggers this error but the legacy devtools _does_ when the new Console feature is enabled. Why?