### PR TITLE
Only show one loading message at a time

### DIFF
--- a/src/devtools/client/debugger/src/components/QuickOpenModal.tsx
+++ b/src/devtools/client/debugger/src/components/QuickOpenModal.tsx
@@ -462,7 +462,7 @@ export class QuickOpenModal extends Component<PropsFromRedux, QOMState> {
           size="big"
         />
         {sourcesLoading && <div className="px-2 py-1">Sources Loading…</div>}
-        {showLoadingResults ? <div className="px-2 py-1">Loading results…</div> : null}
+        {!sourcesLoading && showLoadingResults && <div className="px-2 py-1">Loading results…</div>}
         {results && items && (
           <ResultList
             key="results"


### PR DESCRIPTION
Right now we will show "Loading sources..." and "Loading results..." at the same time in the quick find modal. We should only show one. Ideally, we would have a `status` local state here rather than these complex if statements, but this is a quick fix for the problem.