### PR TITLE
Improve highlighting in sources dark theme 

### DIFF
--- a/src/devtools/client/debugger/src/components/PrimaryPanes/Sources.css
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/Sources.css
@@ -37,10 +37,6 @@
   padding: 3px 8px 3px 6px;
 }
 
-.sources-list .managed-tree .tree .tree-node:not(.focused):hover {
-  background: var(--theme-toolbar-background-hover);
-}
-
 .sources-list .img {
   margin-inline-end: 4px;
 }

--- a/src/devtools/client/debugger/src/components/shared/tree.css
+++ b/src/devtools/client/debugger/src/components/shared/tree.css
@@ -23,6 +23,11 @@
   display: flex;
 }
 
+.controlled .tree .node
+{
+  cursor: pointer;
+}
+
 .tree .tree-node:not(.focused):hover {
   background-color: var(--theme-selection-background-hover);
 }

--- a/src/devtools/client/debugger/src/components/shared/tree.css
+++ b/src/devtools/client/debugger/src/components/shared/tree.css
@@ -23,8 +23,7 @@
   display: flex;
 }
 
-.controlled .tree .node
-{
+.controlled .tree .node {
   cursor: pointer;
 }
 


### PR DESCRIPTION
Here's a 5 second loom showing the difference:
https://www.loom.com/share/a52bfffc5a534024a607decd32b58b77

Before: we were hovering with a text input cursor while using a very faint background color
Now: pointer cursor and more clear background color
