### PR TITLE
Search results highlighting

### DIFF
--- a/src/devtools/client/themes/dark-theme.css
+++ b/src/devtools/client/themes/dark-theme.css
@@ -183,8 +183,7 @@
   border-left: solid 1px #fff;
 }
 
-.theme-dark .cm-highlight
-{
+.theme-dark .cm-highlight {
   background: rgba(24, 216, 255, 0.2);
 }
 

--- a/src/devtools/client/themes/dark-theme.css
+++ b/src/devtools/client/themes/dark-theme.css
@@ -183,10 +183,14 @@
   border-left: solid 1px #fff;
 }
 
+.theme-dark .cm-highlight
+{
+  background: rgba(24, 216, 255, 0.2);
+}
 
 .theme-dark .cm-s-mozilla.CodeMirror-focused .CodeMirror-selected {
   /* selected text (focused) */
-  background: rgba(255, 255, 255, 0.3);
+  background: rgba(255, 255, 255, 0.7);
 }
 
 .theme-dark .cm-s-mozilla .CodeMirror-selected {

--- a/src/devtools/client/themes/light-theme.css
+++ b/src/devtools/client/themes/light-theme.css
@@ -184,6 +184,11 @@
   background: rgb(210, 210, 210);
 }
 
+.theme-light .cm-highlight
+{
+  background: rgba(255, 247, 3, 0.2);
+}
+
 .theme-light .cm-s-mozilla .CodeMirror-activeline-background {
   /* selected color with alpha */
   background: rgba(185, 215, 253, 0.35);

--- a/src/devtools/client/themes/light-theme.css
+++ b/src/devtools/client/themes/light-theme.css
@@ -184,8 +184,7 @@
   background: rgb(210, 210, 210);
 }
 
-.theme-light .cm-highlight
-{
+.theme-light .cm-highlight {
   background: rgba(255, 247, 3, 0.2);
 }
 


### PR DESCRIPTION
Previously, we only showed the current search result. With this change, we're showing all results but using a different color for the one you're currently on. This aligns us to VS Code and other tools that do a good job with this scenario.

Here's a 30 second Loom explaining it:
https://www.loom.com/share/526564f29a3549adbaa6afc9a04e4118

