### PR TITLE
Show GraphQL errors when filtering recordings

### DIFF
--- a/src/ui/components/Library/Team/View/Recordings/RecordingsPage.tsx
+++ b/src/ui/components/Library/Team/View/Recordings/RecordingsPage.tsx
@@ -24,7 +24,7 @@ function MyRecordingsPage({ team }: { team: typeof MY_LIBRARY_TEAM }) {
 
   if (loading || !recordings) {
     return (
-      <div className="flex flex-col flex-grow p-4 overflow-hidden">
+      <div className="flex flex-grow flex-col overflow-hidden p-4">
         <LibrarySpinner />
       </div>
     );

--- a/src/ui/hooks/recordings.ts
+++ b/src/ui/hooks/recordings.ts
@@ -483,7 +483,10 @@ export function useIsOwner() {
 
 export function useGetPersonalRecordings(
   filter: string
-): { recordings: null; loading: true } | { recordings: Recording[]; loading: false } {
+):
+  | { error: null; recordings: null; loading: true }
+  | { error: ApolloError; recordings: null; loading: false }
+  | { error: null; recordings: Recording[]; loading: false } {
   const { data, error, loading } = useQuery<GetMyRecordings, GetMyRecordingsVariables>(
     GET_MY_RECORDINGS,
     {
@@ -493,18 +496,19 @@ export function useGetPersonalRecordings(
   );
 
   if (loading) {
-    return { recordings: null, loading };
+    return { error: null, recordings: null, loading };
   }
 
   if (error) {
     console.error("Failed to fetch recordings:", error);
+    return { error, recordings: null, loading };
   }
 
   let recordings: Recording[] = [];
   if (data?.viewer) {
     recordings = data.viewer.recordings.edges.map(({ node }) => convertRecording(node)!);
   }
-  return { recordings, loading };
+  return { error: null, recordings, loading };
 }
 
 export function useGetWorkspaceRecordings(


### PR DESCRIPTION
Pairs with https://github.com/replayio/backend/pull/6107 to make sure
that we will display GraphQL errors that we get back when filtering
recordings.

https://user-images.githubusercontent.com/5903784/180859234-1dbcb8e3-f57f-4918-a9b5-0caf666a8d5e.mp4

CC'ing @jonbell-lot23 to see if he can suggest any good treatments for the error message.
