### PR TITLE
disable `incremental` TypeScript feature

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
     /* Basic Options */
-    "incremental": true /* Enable incremental compilation */,
+    "incremental": false /* Enable incremental compilation */,
     "target": "es2015" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     "lib": [


### PR DESCRIPTION
We (at Vercel) were looking into the TypeScript failure [mentioned on Twitter](https://twitter.com/brian_d_vaughn/status/1551936568465694722).

---

This seems to be caused by an error in TypeScript itself related to the `incremental: true` setting. We were able to reproduce it locally using this repo, but only some of the time. It is a flakey issue.

Turning the `incremental` setting off or deleting the `tsconfig.tsbuildinfo` file seems to mitigate the problem.

---

We suggest:

* turning off `incremental` in the `tsconfig.json` seems to mitigate the issue (which is what this PR does)
* try upgrading TypeScript to see if that resolves the issue. It looks like there have been some merged PRs that address issues with this setting in TypeScript itself since the project version of 4.6.3. ([Example](https://github.com/microsoft/TypeScript/issues/49527))
* if the issue persists, let us know, but you may also want to report the issue to TypeScript