### PR TITLE
Fix broken node tests

### DIFF
--- a/test/e2e/getExample.ts
+++ b/test/e2e/getExample.ts
@@ -5,6 +5,7 @@ import config from "./config";
 import { recordNodeExample } from "./recordNode";
 import { recordPlaywright, uploadLastRecording } from "./recordPlaywright";
 import { waitUntilMessage } from "./utils";
+const manifest = require("../manifest");
 
 const exampleFile = path.resolve(__dirname, "../../test/example-recordings.json");
 
@@ -12,9 +13,15 @@ export async function getExampleRecordingId(
   example: string,
   isNodeExample = false
 ): Promise<string | undefined> {
+  let entry = manifest.find(
+    (entry: { example: string; preRecordedRecordingId?: string }) => entry.example === example
+  );
+
   // Recording ID to load in the viewer. If not set, we will record the example
   // in the browser or node before stopping and switching to the viewer.
-  let exampleRecordingId = config.useExampleFile ? readExampleFile()[example] : undefined;
+  let exampleRecordingId =
+    entry.preRecordedRecordingId ||
+    (config.useExampleFile ? readExampleFile()[example] : undefined);
 
   if (!exampleRecordingId) {
     if (isNodeExample) {

--- a/test/manifest.js
+++ b/test/manifest.js
@@ -325,6 +325,7 @@ module.exports = [
     example: "node/spawn.js",
     script: "node_spawn-01.js",
     targets: ["node"],
+    preRecordedRecordingId: "b95e9c4a-0154-47ac-aa58-75c5086841d4",
   },
   {
     example: "node/run_worker.js",

--- a/test/manifest.js
+++ b/test/manifest.js
@@ -54,6 +54,7 @@ module.exports = [
     example: "node/control_flow.js",
     script: "node_control_flow.js",
     targets: ["node"],
+    preRecordedRecordingId: "052bd569-243f-441e-863b-62a98f437e41",
   },
 
   //////////////////////////////////////////////////////////////////////////////
@@ -96,6 +97,7 @@ module.exports = [
     example: "node/async.js",
     script: "node_stepping-01.js",
     targets: ["node"],
+    preRecordedRecordingId: "7273ad84-cf2c-40db-b855-5f1cbb92b1bf",
   },
 
   //////////////////////////////////////////////////////////////////////////////
@@ -149,11 +151,13 @@ module.exports = [
     example: "node/basic.js",
     script: "node_console-01.js",
     targets: ["node"],
+    preRecordedRecordingId: "0a98dd16-7ae2-4ef0-b6b2-6f75e7b0a819",
   },
   {
     example: "node/error.js",
     script: "node_console-02.js",
     targets: ["node"],
+    preRecordedRecordingId: "aadb6e3d-a8fc-4916-90a2-40a409ca2e94",
   },
 
   //////////////////////////////////////////////////////////////////////////////
@@ -191,11 +195,13 @@ module.exports = [
     example: "node/basic.js",
     script: "node_logpoint-01.js",
     targets: ["node"],
+    preRecordedRecordingId: "ba058b85-655b-4acc-a456-a880c6a9deae",
   },
   {
     example: "node/exceptions.js",
     script: "node_logpoint-02.js",
     targets: ["node"],
+    preRecordedRecordingId: "617840a2-531d-427b-a518-a93436c5ad03",
   },
 
   //////////////////////////////////////////////////////////////////////////////
@@ -228,6 +234,7 @@ module.exports = [
     example: "node/objects.js",
     script: "node_object_preview-01.js",
     targets: ["node"],
+    preRecordedRecordingId: "e04863a1-1197-4259-9a4d-754f054a6269",
   },
 
   //////////////////////////////////////////////////////////////////////////////
@@ -331,6 +338,7 @@ module.exports = [
     example: "node/run_worker.js",
     script: "node_worker-01.js",
     targets: ["node"],
+    preRecordedRecordingId: "d427c1c6-6163-42bd-b105-49bf93dbc7d2",
   },
   {
     // Disabled because we can't record the example

--- a/test/src/getExample.js
+++ b/test/src/getExample.js
@@ -6,6 +6,7 @@ const _ = require("lodash");
 
 const { recordNode } = require("./recordNode");
 const { elapsedTime, waitUntilMessage } = require("./utils");
+const manifest = require("../manifest");
 
 async function recordToCloud(state, browserName, exampleUrl) {
   console.log(`Recording Example:`, exampleUrl, browserName);
@@ -122,7 +123,11 @@ async function recordExample(state, example, target) {
 async function getExample(state, example, target) {
   // Recording ID to load in the viewer. If not set, we will record the example
   // in the browser before stopping and switching to the viewer.
-  let exampleRecordingId = state.shouldRecordExamples ? null : state.exampleRecordings[example];
+
+  let exampleRecordingId =
+    manifest[example].preRecordedRecordingId || state.shouldRecordExamples
+      ? null
+      : state.exampleRecordings[example];
 
   if (!exampleRecordingId) {
     switch (target) {


### PR DESCRIPTION
If this works for this one I'll do the rest

I know we have a thing for this already (`example-recordings.json`), but I kind of want to make it clear that this is a jerry-rigged patch that we should not run with, and I feel like just checking that file in might mean that we stay reliant on this for longer. (Also, anyone's workflow that might be reliant on `test/example-recordings.json` being in `.gitignore` would break)