### PR TITLE
If the user is already logged in, redirect

### DIFF
--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -3,14 +3,20 @@ import React, { useEffect } from "react";
 import { useAppDispatch } from "ui/setup/hooks";
 import Login from "ui/components/shared/Login/Login";
 import { clearExpectedError } from "ui/reducers/app";
+import useAuth0 from "ui/utils/useAuth0";
 
 export default function LoginPage() {
   const router = useRouter();
+  const { user } = useAuth0();
   const dispatch = useAppDispatch();
+
+  if (user && typeof router.query.returnTo === "string") {
+    router.push(router.query.returnTo);
+  }
 
   useEffect(() => {
     dispatch(clearExpectedError());
   }, [dispatch]);
 
-  return <Login returnToPath={"" + (router.query.returnTo || "/")} />;
+  return <Login returnToPath={String(router.query.returnTo || "/")} />;
 }

--- a/src/ui/components/shared/Login/Login.tsx
+++ b/src/ui/components/shared/Login/Login.tsx
@@ -15,6 +15,7 @@ const isOSX = Services.appinfo.OS === "Darwin";
 import { PrimaryLgButton } from "../Button";
 import { OnboardingContentWrapper, OnboardingModalContainer } from "../Onboarding";
 import { GetConnection, GetConnectionVariables } from "graphql/GetConnection";
+import { useRouter } from "next/router";
 
 enum LoginReferrer {
   default = "default",


### PR DESCRIPTION
Immediately, without asking them to sign in again. This comes up when
the Replay browser is authing to app.replay.io. It has a query string to
return to some other path, but then it opens Chrome to auth, and Chrome
then reopens Replay browser, but with a new tab on the Home page. The
old tab is still there, pointed at `/login?returnTo=asdklfjkdlsjkl`, but
if you refresh it looks like you *still* need to log in, even though it
clearly says "Rec" and not "Sign in" in the browser. If we land on that
login page, but we have a user, we should just redirect them to the
`returnTo` path.

I'm gonna need a thorough @ryanjduffy check on this logic though because this stuff always confuses the crap out of me.