### PR TITLE
Store unique possible breakpoints

### DIFF
--- a/packages/protocol/thread/possibleBreakpoints.ts
+++ b/packages/protocol/thread/possibleBreakpoints.ts
@@ -1,4 +1,5 @@
 import { Location, SameLineSourceLocations } from "@replayio/protocol";
+import uniq from "lodash/uniq";
 // eslint-disable-next-line
 import { client } from "protocol/socket";
 import { ThreadFront } from "./thread";
@@ -22,7 +23,7 @@ export const sameLineSourceLocationsToLocationList = (
   sourceId: string
 ): Location[] => {
   return sameLineLocations.flatMap(lineLocations => {
-    return lineLocations.columns.map(column => {
+    return uniq(lineLocations.columns).map(column => {
       return {
         line: lineLocations.line,
         column,


### PR DESCRIPTION
This is a band-aid for a backend problem. See https://linear.app/replay/issue/FE-475/multiple-print-statement-panels. But basically: the backend is returning non-unique locations for possibleBreakpoints, and that is confusing our UI.