### PR TITLE
Fix O(N^2) look up for hitcounts

### DIFF
--- a/src/devtools/client/debugger/src/components/SourceOutline/SourceOutline.tsx
+++ b/src/devtools/client/debugger/src/components/SourceOutline/SourceOutline.tsx
@@ -17,7 +17,7 @@ import { getSelectedSource } from "ui/reducers/sources";
 import Spinner from "ui/components/shared/Spinner";
 import { isFunctionDeclaration } from "./isFunctionSymbol";
 import { FunctionDeclaration, ClassDeclaration } from "../../reducers/ast";
-import { fetchHitCounts, getHitCountsForSource } from "ui/reducers/hitCounts";
+import { fetchHitCounts, getHitCountsForSourceByLine } from "ui/reducers/hitCounts";
 import { LoadingStatus } from "ui/utils/LoadingStatus";
 
 export function SourceOutline({
@@ -163,7 +163,7 @@ export function SourceOutline({
 const mapStateToProps = (state: UIState) => {
   const selectedSource = getSelectedSource(state);
   const symbols = selectedSource ? selectors.getSymbols(state, selectedSource) : null;
-  const hitCounts = selectedSource ? getHitCountsForSource(state, selectedSource.id) : null;
+  const hitCounts = selectedSource ? getHitCountsForSourceByLine(state, selectedSource.id) : null;
   return {
     cursorPosition: selectors.getCursorPosition(state),
     cx: selectors.getContext(state),

--- a/src/ui/reducers/index.ts
+++ b/src/ui/reducers/index.ts
@@ -10,6 +10,7 @@ import consoleReducers from "devtools/client/webconsole/reducers";
 import * as consoleSelectors from "devtools/client/webconsole/selectors";
 import * as debuggerSelectors from "devtools/client/debugger/src/selectors";
 import * as inspectorReducers from "devtools/client/inspector/reducers";
+import * as hitCountsSelectors from "./hitCounts";
 import { selectors as possibleBreakpointsSelectors } from "./possibleBreakpoints";
 import { selectors as sourcesSelectors } from "./sources";
 import protocolMessages from "./protocolMessages";
@@ -32,6 +33,7 @@ export const selectors = {
   ...consoleSelectors,
   ...debuggerSelectors,
   ...eventListenerBreakpointsSelectors,
+  ...hitCountsSelectors,
   ...layoutSelectors,
   ...possibleBreakpointsSelectors,
   ...networkSelectors,

--- a/src/ui/reducers/sources.ts
+++ b/src/ui/reducers/sources.ts
@@ -1,6 +1,5 @@
 import {
   createEntityAdapter,
-  createSelector,
   createSlice,
   Dictionary,
   EntityState,


### PR DESCRIPTION
This fixes an issue we were seeing for 100k line files where looking up the hitcounts for a source location was O(N^2)

### Before
<img width="1221" alt="Screen Shot 2022-07-29 at 10 44 11 PM" src="https://user-images.githubusercontent.com/254562/181995616-3b19df9c-cdc2-45d7-aefb-1f9638ecb3f6.png">

### After
(can't find it in the profile)