### PR TITLE
Always import material icon fonts

### DIFF
--- a/public/fonts/material_icons/material_icons.css
+++ b/public/fonts/material_icons/material_icons.css
@@ -3,8 +3,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: block;
-  src: local("Material Icons"), local("MaterialIcons-Regular"),
-    url(/fonts/material_icons/MaterialIcons-Regular.woff2) format("woff2"),
+  src: url(/fonts/material_icons/MaterialIcons-Regular.woff2) format("woff2"),
     url(/fonts/material_icons/MaterialIcons-Regular.ttf) format("truetype");
 }
 


### PR DESCRIPTION
Fixes FE-408.

The issue appears to be that we were loading the local Material Icons, which in Lenz's case (for some reason), did not have the symbols that we were using.

This changes it so that we always import the material icon fonts.