### PR TITLE
Clean up some leftover sources implementation

### DIFF
--- a/src/devtools/client/debugger/src/actions/sources/newSources.ts
+++ b/src/devtools/client/debugger/src/actions/sources/newSources.ts
@@ -28,39 +28,10 @@ import {
 import { syncBreakpoint } from "../breakpoints";
 
 import { toggleBlackBox } from "./blackbox";
-import { experimentalLoadSourceText, getPreviousPersistedLocation } from "ui/reducers/sources";
+import { loadSourceText, getPreviousPersistedLocation } from "ui/reducers/sources";
 import { AppStartListening } from "ui/setup/listenerMiddleware";
 
 import { prefs } from "../../utils/prefs";
-
-// If a request has been made to show this source, go ahead and
-// select it.
-function checkSelectedSource(cx: Context, source: SourceDetails): UIThunkAction {
-  return async (dispatch, getState) => {
-    const state = getState();
-    const persistedLocation = getPreviousPersistedLocation(state);
-
-    const pendingUrl = persistedLocation?.sourceUrl;
-    if (!pendingUrl) {
-      return;
-    }
-
-    if (!source || !source.url) {
-      return;
-    }
-
-    if (pendingUrl === source.url) {
-      const { selectLocation } = await import("../sources");
-      await dispatch(
-        selectLocation(cx, {
-          column: persistedLocation.column,
-          line: typeof persistedLocation.line === "number" ? persistedLocation.line : 0,
-          sourceId: source.id,
-        })
-      );
-    }
-  };
-}
 
 function checkPendingBreakpoints(cx: Context, sourceId: string): UIThunkAction {
   return async (dispatch, getState, { ThreadFront }) => {
@@ -87,7 +58,7 @@ function checkPendingBreakpoints(cx: Context, sourceId: string): UIThunkAction {
     }
 
     // load the source text if there is a pending breakpoint for it
-    const textPromise = dispatch(experimentalLoadSourceText(source.id));
+    const textPromise = dispatch(loadSourceText(source.id));
     const possibleBreakpointsPromise = dispatch(fetchPossibleBreakpointsForSource(source.id));
 
     await Promise.all([textPromise, possibleBreakpointsPromise]);

--- a/src/devtools/client/debugger/src/actions/sources/select.ts
+++ b/src/devtools/client/debugger/src/actions/sources/select.ts
@@ -20,7 +20,7 @@ import { getTabExists } from "../../reducers/tabs";
 import { closeActiveSearch } from "../../reducers/ui";
 import { setShownSource } from "../../reducers/ui";
 import {
-  experimentalLoadSourceText,
+  loadSourceText,
   getSelectedSource,
   getSourceDetails,
   getSourceByUrl,
@@ -167,7 +167,7 @@ export function selectLocation(
 
     // This adds the source's text to the client-side parser, which is a necessary step
     // before we can ask the parser to return symbols in `fetchSymbolsForSource`.
-    const textPromise = dispatch(experimentalLoadSourceText(source.id));
+    const textPromise = dispatch(loadSourceText(source.id));
     const possibleBreakpointsPromise = dispatch(fetchPossibleBreakpointsForSource(source.id));
 
     await Promise.all([textPromise, possibleBreakpointsPromise]);

--- a/src/devtools/client/debugger/src/selectors/visibleBreakpoints.ts
+++ b/src/devtools/client/debugger/src/selectors/visibleBreakpoints.ts
@@ -16,7 +16,7 @@ import { getSelectedLocation } from "ui/reducers/sources";
  * Finds the breakpoints, which appear in the selected source.
  */
 export const getVisibleBreakpoints = createSelector(
-  (state: UIState) => state.experimentalSources.selectedLocation?.sourceId,
+  (state: UIState) => state.sources.selectedLocation?.sourceId,
   getBreakpointsList,
   (selectedSourceId, breakpoints) => {
     if (!selectedSourceId) {

--- a/src/ui/reducers/sources.ts
+++ b/src/ui/reducers/sources.ts
@@ -60,14 +60,14 @@ const contentsAdapter = createEntityAdapter<SourceContent>();
 export const sourceSelectors = sourcesAdapter.getSelectors();
 
 export const { selectById: getSourceContentsEntry } = contentsAdapter.getSelectors(
-  (state: UIState) => state.experimentalSources.contents
+  (state: UIState) => state.sources.contents
 );
 
 export const {
   selectAll: getAllSourceDetails,
   selectById: getSourceDetails,
   selectEntities: getSourceDetailsEntities,
-} = sourceDetailsAdapter.getSelectors((state: UIState) => state.experimentalSources.sourceDetails);
+} = sourceDetailsAdapter.getSelectors((state: UIState) => state.sources.sourceDetails);
 
 export interface SourcesState {
   allSourcesReceived: boolean;
@@ -219,9 +219,9 @@ export const experimentalLoadSourceText = (sourceId: string): UIThunkAction<Prom
   };
 };
 
-export const getSourcesLoading = (state: UIState) => !state.experimentalSources.allSourcesReceived;
+export const getSourcesLoading = (state: UIState) => !state.sources.allSourcesReceived;
 
-export const getSelectedLocation = (state: UIState) => state.experimentalSources.selectedLocation;
+export const getSelectedLocation = (state: UIState) => state.sources.selectedLocation;
 
 export const getSelectedSourceId = (state: UIState) => {
   const location = getSelectedLocation(state);
@@ -238,7 +238,7 @@ export const getCorrespondingSourceIds = (state: UIState, id: string) => {
   return getSourceDetails(state, id)?.correspondingSourceIds;
 };
 export const getSourceByUrl = (state: UIState, url: string) => {
-  const urlEntries = state.experimentalSources.sourcesByUrl[url] ?? [];
+  const urlEntries = state.sources.sourcesByUrl[url] ?? [];
   const id = urlEntries[0];
   if (!id) {
     return undefined;
@@ -246,7 +246,7 @@ export const getSourceByUrl = (state: UIState, url: string) => {
   return getSourceDetails(state, id);
 };
 export const getSourceContent = (state: UIState, id: string) => {
-  return state.experimentalSources.contents.entities[id];
+  return state.sources.contents.entities[id];
 };
 export const getSelectedSourceWithContent = (state: UIState) => {
   const selectedSourceId = getSelectedSourceId(state);
@@ -261,7 +261,7 @@ export const getTextAtLocation = (state: UIState, location: Location) => {
 };
 
 export const getSelectedLocationHasScrolled = (state: UIState) =>
-  state.experimentalSources.selectedLocationHasScrolled;
+  state.sources.selectedLocationHasScrolled;
 
 // This is useful if you are displaying a bunch of sources and want them to
 // ensure they all have unique names, even though some of them might have been
@@ -272,7 +272,7 @@ export const getUniqueUrlForSource = (state: UIState, sourceId: string) => {
   if (!sourceDetails || !sourceDetails.url) {
     return null;
   }
-  if (state.experimentalSources.sourcesByUrl[sourceDetails.url].length > 1) {
+  if (state.sources.sourcesByUrl[sourceDetails.url].length > 1) {
     // I was going to put the query string back here...
     // But I'm not sure we're actually *removing* query strings in the first
     // place yet!
@@ -318,7 +318,7 @@ export function getHasSiblingOfSameName(state: UIState, source: MiniSource) {
     return false;
   }
 
-  return state.experimentalSources.sourcesByUrl[source.url]?.length > 0;
+  return state.sources.sourcesByUrl[source.url]?.length > 0;
 }
 
 export const getCanonicalSourceFromEntities = (
@@ -333,7 +333,7 @@ export const getCanonicalSourceFromEntities = (
 };
 
 export const getCanonicalSource = (state: UIState, sd: SourceDetails) => {
-  return getCanonicalSourceFromEntities(state.experimentalSources.sourceDetails.entities, sd);
+  return getCanonicalSourceFromEntities(state.sources.sourceDetails.entities, sd);
 };
 
 export const getCanonicalSourceForUrl = (state: UIState, url: string) => {
@@ -397,7 +397,7 @@ export const getSourceToDisplayForUrl = (state: UIState, url: string) => {
 };
 
 export const getPreviousPersistedLocation = (state: UIState) =>
-  state.experimentalSources.persistedSelectedLocation;
+  state.sources.persistedSelectedLocation;
 
 /*
 export const getStableLocationForLocation = (

--- a/src/ui/reducers/sources.ts
+++ b/src/ui/reducers/sources.ts
@@ -184,7 +184,7 @@ export const {
   sourceErrored,
 } = sourcesSlice.actions;
 
-export const experimentalLoadSourceText = (sourceId: string): UIThunkAction<Promise<void>> => {
+export const loadSourceText = (sourceId: string): UIThunkAction<Promise<void>> => {
   return async (dispatch, getState, { ThreadFront }) => {
     const existing = getSourceContentsEntry(getState(), sourceId);
     if (existing?.status === LoadingStatus.LOADING) {

--- a/src/ui/setup/prefs.ts
+++ b/src/ui/setup/prefs.ts
@@ -114,7 +114,7 @@ export const updatePrefs = (state: UIState, oldState: UIState) => {
       oldState,
       "pendingSelectedLocation",
       // TS types say `null` isn't acceptable to persist, but it seems to work at runtime
-      state => state.experimentalSources.persistedSelectedLocation as any
+      state => state.sources.persistedSelectedLocation as any
     );
   }
 

--- a/src/ui/setup/store.ts
+++ b/src/ui/setup/store.ts
@@ -44,7 +44,7 @@ type ReduxDevToolsOptions = Exclude<
 // slice reducers we know will be added, to get the right state type.
 let reducers = {
   app: appReducer,
-  experimentalSources: sources,
+  sources: sources,
   hitCounts: hitCounts,
   layout: layoutReducer,
   messages: messagesReducer,
@@ -100,8 +100,8 @@ const sanitizeStateForDevtools = <S>(state: S) => {
   const sanitizedState = customImmer.produce(state, (draft: any) => {
     sanitizeContents(draft.sourceTree?.focusedItem?.contents);
 
-    if (draft.experimentalSources) {
-      Object.values(draft.experimentalSources.contents.entities).forEach((contentsItem: any) => {
+    if (draft.sources) {
+      Object.values(draft.sources.contents.entities).forEach((contentsItem: any) => {
         if (contentsItem.value) {
           contentsItem.value.value = OMITTED;
         }

--- a/src/ui/state/index.ts
+++ b/src/ui/state/index.ts
@@ -45,7 +45,7 @@ export interface UIState {
   consoleUI: WebconsoleUIState;
   contextMenus: ContextMenusState;
   eventListenerBreakpoints: EventListenersState;
-  experimentalSources: NewSourcesState;
+  sources: NewSourcesState;
   fileSearch: FileSearchState;
   hitCounts: HitCountsState;
   inspector: InspectorState;


### PR DESCRIPTION
This PR:

- Renames `state.experimentalSources` to `state.sources`
- Renames `experimentalLoadSourceText` to `loadSourceText`
- Removes a dead thunk left over in `newSources.ts`