### PR TITLE
Color improvements

### DIFF
--- a/pages/browser/new-tab.tsx
+++ b/pages/browser/new-tab.tsx
@@ -9,7 +9,7 @@ export default function NewTab() {
     <LoadingScreenTemplate>
       <div className="space-y-8 text-center">
         {motd ? <h2 className="text-2xl text-gray-600">{motd}</h2> : null}
-        <div className="text-base text-gray-600">
+        <div className="text-base text-bodyColor">
           Please navigate to the page you want to record, then press the blue record button.
         </div>
       </div>

--- a/src/devtools/client/themes/variables.css
+++ b/src/devtools/client/themes/variables.css
@@ -414,7 +414,7 @@
   --body-color: var(--grey-30);
   --checkbox-border: var(--theme-base-90);
   --checkbox: var(--theme-base-80);
-  --modal-bgcolor: rgba(0, 0, 0, 0.98);
+  --modal-bgcolor: var(--theme-base-90);
   --modal-border: #222;
   --tab-bgcolor-alt-subtle: var(--theme-base-95); /* info, events */
   --tab-bgcolor: var(--theme-base-100); /* bg tabs */

--- a/src/ui/components/Library/Team/View/Recordings/Header/RecordingsPageViewerHeader.tsx
+++ b/src/ui/components/Library/Team/View/Recordings/Header/RecordingsPageViewerHeader.tsx
@@ -37,9 +37,10 @@ function ViewerHeaderActions({
   }
 
   return (
-    <SecondaryButton className={styles.editButton} color="blue" onClick={() => setIsEditing(true)}>
-      Edit
-    </SecondaryButton>
+
+    <>    
+        {recordings.length != 0 ? <><SecondaryButton className={styles.editButton} color="blue" onClick={() => setIsEditing(true)}>Edit</SecondaryButton></> : <></>}
+    </>
   );
 }
 

--- a/src/ui/components/Library/Team/View/Recordings/Recordings.tsx
+++ b/src/ui/components/Library/Team/View/Recordings/Recordings.tsx
@@ -39,7 +39,7 @@ export function Recordings({
 
   return (
     <div
-      className={`recording-list flex flex-col space-y-1 overflow-y-auto rounded-md text-sm shadow-md ${styles.recordingList}`}
+      className={`recording-list flex flex-col space-y-0 overflow-y-auto rounded-md text-sm shadow-md ${styles.recordingList}`}
     >
       {shownRecordings.map((r, i) => (
         <RecordingRow

--- a/src/ui/components/Library/Team/View/Recordings/RecordingsError.tsx
+++ b/src/ui/components/Library/Team/View/Recordings/RecordingsError.tsx
@@ -11,10 +11,11 @@ export function RecordingsError() {
   if (filter) {
     msg = (
       <>
-        <div>No recordings found</div>
-        <PrimaryButton color="blue" onClick={() => setAppliedText("")}>
-          Clear filters
-        </PrimaryButton>
+        <div>No results found.  
+          <span onClick={() => setAppliedText("")} className="pl-2 underline cursor-pointer">
+            Show all replays?
+          </span>
+        </div>
       </>
     );
   } else if (isReplayBrowser()) {
@@ -25,9 +26,11 @@ export function RecordingsError() {
 
   return (
     <section
-      className={`flex flex-grow flex-col items-center justify-center space-y-1 text-lg ${styles.recordingsBackground}`}
+      className={`flex flex-grow flex-col items-center justify-center space-y-1 text-lg h-3/4 ${styles.recordingsBackground}`}
     >
+      <div className="p-6 m-24 text-bodyColor">
       {msg}
+      </div>
     </section>
   );
 }

--- a/src/ui/components/UploadScreen/Privacy.tsx
+++ b/src/ui/components/UploadScreen/Privacy.tsx
@@ -29,7 +29,7 @@ export function ToggleShowPrivacyButton({
     <button
       type="button"
       onClick={() => setShowPrivacy(!showPrivacy)}
-      className="group flex w-full flex-row items-center justify-between rounded-lg bg-jellyfishBgcolor p-3 text-left font-normal"
+      className="flex flex-row items-center justify-between w-full p-3 font-normal text-left rounded-lg group"
     >
       <div className="flex flex-row items-center space-x-2">
         <MaterialIcon iconSize="xl">storage</MaterialIcon>
@@ -49,7 +49,7 @@ function FavIcon({ url }: { url: string }) {
         <MaterialIcon>public</MaterialIcon>
       </div>
       <img
-        className="absolute top-0 left-0 h-4 w-4 bg-transparent"
+        className="absolute top-0 left-0 w-4 h-4 bg-transparent"
         src={`https://www.google.com/s2/favicons?domain=${url}`}
       />
     </div>
@@ -67,7 +67,7 @@ function Source({ url }: { url: string }) {
 
 function PrivacyData({ icon, name, urls }: { icon: string; name: string; urls: string[] }) {
   return (
-    <div className="space-y-3 rounded-lg bg-jellyfishBgcolor p-3">
+    <div className="p-3 space-y-3 rounded-lg">
       <div className="flex flex-row items-center space-x-2 font-bold">
         <MaterialIcon iconSize="xl">{icon}</MaterialIcon>
         <div>{name}</div>
@@ -86,15 +86,15 @@ export function Privacy() {
   const { operations } = recording ?? {};
 
   return (
-    <div className="relative flex h-full w-full overflow-hidden rounded-xl bg-jellyfishBgcolor p-5 shadow-xl">
-      <div className="flex flex-col space-y-7 overflow-hidden">
+    <div className="relative flex w-full h-full p-5 overflow-hidden shadow-xl rounded-xl bg-themeBase-90">
+      <div className="flex flex-col overflow-hidden space-y-7">
         <div className="flex flex-col space-y-1">
           <div className="text-lg font-bold">Privacy</div>
           <div className="">
             {`Replays include all of the data needed to replay the browser. `}
             <ExternalLink
               href="https://www.replay.io/security-privacy"
-              className="text-primaryAccent underline"
+              className="underline text-primaryAccent"
             >
               Learn more
             </ExternalLink>

--- a/src/ui/components/shared/Forms/SelectMenu.tsx
+++ b/src/ui/components/shared/Forms/SelectMenu.tsx
@@ -34,7 +34,7 @@ function Option({ name, id }: { name: string; id: string | null }) {
                 "absolute inset-y-0 right-0 flex items-center pr-3"
               )}
             >
-              <CheckIcon className="h-4 w-4" aria-hidden="true" />
+              <CheckIcon className="w-4 h-4" aria-hidden="true" />
             </span>
           ) : null}
         </>
@@ -64,10 +64,10 @@ export default function SelectMenu({
         <>
           {label ? <Listbox.Label className="block font-medium">label</Listbox.Label> : null}
           <div className={`relative ${className || ""}`}>
-            <Listbox.Button className="relative w-full cursor-default rounded-md border border-textFieldBorder bg-chrome py-1.5 pl-2.5 pr-8 text-left shadow-sm focus:border-primaryAccentHover focus:outline-none focus:ring-1 focus:ring-primaryAccent">
+            <Listbox.Button className="relative w-full cursor-default rounded-md border border-textFieldBorder bg-themeBase-95 py-1.5 pl-2.5 pr-8 text-left shadow-sm focus:border-primaryAccentHover focus:outline-none focus:ring-1 focus:ring-primaryAccent">
               <span className="block truncate">{selectedName}</span>
               <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-1.5">
-                <SelectorIcon className="h-4 w-4 text-textFieldBorder" aria-hidden="true" />
+                <SelectorIcon className="w-4 h-4 text-textFieldBorder" aria-hidden="true" />
               </span>
             </Listbox.Button>
             <Transition
@@ -79,7 +79,7 @@ export default function SelectMenu({
             >
               <Listbox.Options
                 static
-                className="absolute z-10 mt-1 max-h-48 w-full overflow-auto rounded-md bg-chrome py-1 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
+                className="absolute z-10 w-full py-1 mt-1 overflow-auto rounded-md shadow-lg max-h-48 bg-chrome ring-1 ring-black ring-opacity-5 focus:outline-none"
               >
                 {options.map(({ name, id }) => (
                   <Option name={name} id={id} key={id} />

--- a/src/ui/components/shared/SettingsModal/SettingsBody.tsx
+++ b/src/ui/components/shared/SettingsModal/SettingsBody.tsx
@@ -8,7 +8,7 @@ interface SettingsBodyProps<T extends string, P extends Record<string, unknown>>
 }
 
 function SettingsBodyWrapper({ children }: { children: (React.ReactChild | null)[] }) {
-  return <main className="flex w-full flex-col overflow-hidden p-8 text-sm">{children}</main>;
+  return <main className="flex flex-col w-full p-8 pr-2 overflow-hidden text-sm">{children}</main>;
 }
 
 export function SettingsHeader({ children }: { children: React.ReactNode }) {

--- a/src/ui/components/shared/UserSettingsModal/PreferencesSettings.tsx
+++ b/src/ui/components/shared/UserSettingsModal/PreferencesSettings.tsx
@@ -122,7 +122,7 @@ function UiPreferences() {
   };
 
   return (
-    <div className="space-y-4">
+    <div className="mr-4 space-y-4">
       <div className="text-lg">Appearance</div>
       <div className="flex flex-row justify-between">
         <div>Theme</div>


### PR DESCRIPTION
Default tab text before and after:
<img width="534" alt="image" src="https://user-images.githubusercontent.com/9154902/182740818-5c3a2d7e-1f2f-4525-86a7-ffb4e286a6a5.png">

Default tab text before and after:
<img width="811" alt="image" src="https://user-images.githubusercontent.com/9154902/182740850-75dbeb79-4ee1-4aec-9c29-d00d2eefa827.png">

Dividers before and after:
<img width="300" alt="image" src="https://user-images.githubusercontent.com/9154902/182740902-0b99b20e-284a-45ae-b239-9f6a04cc9f6e.png">

Settings before and after:
<img width="540" alt="image" src="https://user-images.githubusercontent.com/9154902/182740951-0170cfeb-15ae-4e4b-b0e3-8de591b0d7af.png">

Privacy pane before and after:
<img width="327" alt="image" src="https://user-images.githubusercontent.com/9154902/182740981-dd77c84c-4742-4efd-a418-1be5d0b6bac4.png">
