### PR TITLE
Don't show the team settings icon when you're on My Library

### DIFF
--- a/src/ui/components/Library/Navigation/TeamButton.tsx
+++ b/src/ui/components/Library/Navigation/TeamButton.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { MouseEvent } from "react";
 import { setModal } from "ui/actions/app";
+import { MY_LIBRARY } from "ui/components/UploadScreen/libraryConstants";
 import { useUpdateDefaultWorkspace } from "ui/hooks/settings";
 import { useAppDispatch } from "ui/setup/hooks";
 import { trackEvent } from "ui/utils/telemetry";
@@ -24,7 +25,7 @@ export function TeamButton({
   const basePath = `/team/${id}`;
   const url = `${basePath}/${isTest ? "runs" : "recordings"}`;
   const isSelected = router.asPath.includes(basePath);
-  const showSettingsButton = id && isSelected && !isNew;
+  const showSettingsButton = isSelected && id && id !== MY_LIBRARY_TEAM.id && !isNew;
   const updateDefaultWorkspace = useUpdateDefaultWorkspace();
 
   const onClick = () => {
@@ -47,7 +48,7 @@ export function TeamButton({
         )}
         onClick={onClick}
       >
-        <span className="overflow-hidden overflow-ellipsis whitespace-pre">
+        <span className="overflow-hidden whitespace-pre overflow-ellipsis">
           {label} {isTest && "(test)"}
         </span>
         {isNew ? (
@@ -71,7 +72,7 @@ export function SettingsButton() {
   return (
     <button
       onClick={onClick}
-      className="material-icons w-5 text-sm text-gray-200 transition duration-200"
+      className="w-5 text-sm text-gray-200 transition duration-200 material-icons"
     >
       settings
     </button>


### PR DESCRIPTION
There's no settings applicable to a user's Library (My Library), so having the settings icon show up beside it doesn't make any sense.

This makes it so that the settings icon doesn't show up beside My Library.

Before | After
-- | --
<img width="382" alt="image" src="https://user-images.githubusercontent.com/15959269/182968978-2a925e93-b039-433b-9850-8c7acb364cc9.png"> | <img width="319" alt="image" src="https://user-images.githubusercontent.com/15959269/182969000-b6b845a8-7fa6-4992-be1d-fe808921dd49.png">
