### PR TITLE
Cypress test names with `

### DIFF
--- a/src/ui/hooks/useFetchCypressSpec.tsx
+++ b/src/ui/hooks/useFetchCypressSpec.tsx
@@ -44,7 +44,7 @@ export function useFetchCypressSpec() {
       );
 
       const matches: CypressResult[] = results.map(r => {
-        const match = r.context.match(/(\"|\')(.*)(\"|\')/);
+        const match = r.context.match(/(\"|\'|\`)(.*)(\"|\'|`)/);
         return { test: match?.[2] || "", location: r.location };
       });
 


### PR DESCRIPTION
See this replay https://app.replay.io/recording/replay-of-localhost8000--4fcf77d8-f936-45a0-8729-36b72e9f46b2?point=19471113222964368120809902162575360&time=11658&hasFrames=false

<img width="503" alt="Screen Shot 2022-08-05 at 10 14 41 AM" src="https://user-images.githubusercontent.com/254562/183127882-8ccd11c9-b884-4f3c-935b-7158a50bc4a0.png">
