### PR TITLE
Fix 1 of 2 problems with react_devtools e2e test

### DIFF
--- a/public/test/scripts/react_devtools.js
+++ b/public/test/scripts/react_devtools.js
@@ -71,7 +71,7 @@ Test.describe(`Test React DevTools.`, async () => {
 
   await Test.app.actions.seekToTime(0);
   await Test.waitUntil(
-    () => document.querySelector(".secondary-toolbox-content").textContent === "Mounting your React application...Try picking a different point on the timeline.",
+    () => document.querySelector(".secondary-toolbox-content").textContent.includes("Try picking a different point on the timeline"),
     { waitingFor: 'ReactDevTools to say "Try picking a different point"' },
   );
 });


### PR DESCRIPTION
Looks like the e2e test was _actually working_ but the final selector was failing probably due to a minor whitespace issue (at least from what I'm seeing locally).

The page showed the text:
> Mounting your React application...
>
> Try picking a different point on the timeline.

The test selector was waiting to match:
```js
textContent === "Mounting your React application...Try picking a different point on the timeline."
```

Looking at the `textContent` though, it now contains _a lot more text_ (that's just been hidden by the Offscreen API):
```
'ExceptionsErrors1WarningsLogs4Common EventsOther EventsTimer7Hide Node ModulesShow TimestampsRewindApp.js:15 Initial listRewindApp.js:22 Added an entryCommentadd_commentApp.js:26 Removed an entryFast-forwardApp.js:28 Error: "Baz"e App.js:28c runtime.js:63_invoke runtime.js:294x runtime.js:119r asyncToGenerator.js:3u asyncToGenerator.js:25promise callback*r asyncToGenerator.js:13u asyncToGenerator.js:25promise callback*r asyncToGenerator.js:13u asyncToGenerator.js:25promise callback*r asyncToGenerator.js:13u asyncToGenerator.js:25l asyncToGenerator.js:32l asyncToGenerator.js:21e App.js:11p App.js:11p App.js:33React6Webpack12Fast-forwardApp.js:31 ExampleFinished​x ​xxxxxxxxxx ​xxxxxxxxxx ​Mounting your React application...Try picking a different point on the timeline.'
```

The fix is just to make the selector do a substring comparison.

I dug into the failure here:
https://www.loom.com/share/8fa12146d376433bbcd9ca9d554669a8?t=378