### PR TITLE
Toggle theme shortcut now ALT+Shift+T

### DIFF
--- a/src/ui/components/KeyboardShortcuts.tsx
+++ b/src/ui/components/KeyboardShortcuts.tsx
@@ -154,7 +154,7 @@ function KeyboardShortcuts({
 
       // Should be ignored when an editable element is focused
       "Shift+C": addComment,
-      "Shift+T": toggleTheme,
+      "Alt+Shift+T": toggleTheme,
       "Shift+F": toggleEditFocusMode,
 
       // Quick Open-related toggles


### PR DESCRIPTION
Hopefully this will avoid the number of times it's accidentally toggled while focus hasn't yet changed to the comment input.