### PR TITLE
Socket.removeEventListener() supports (optional) explicit handler param

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@redux-devtools/app": "^2.1.4",
     "@redux-devtools/extension": "^3.2.2",
     "@reduxjs/toolkit": "^1.8.1",
-    "@replayio/protocol": "^0.31.0",
+    "@replayio/protocol": "^0.31.1",
     "@sentry/react": "^7.9.0",
     "@sentry/tracing": "^7.9.0",
     "@stripe/react-stripe-js": "^1.7.0",

--- a/packages/protocol/socket.ts
+++ b/packages/protocol/socket.ts
@@ -290,13 +290,38 @@ export function addEventListener<M extends EventMethods>(
   }
 }
 
-// TODO This method should have the same signature as addEventListener.
-// It should only remove a specific event handler.
-export function removeEventListener<M extends EventMethods>(event: M) {
-  gEventListeners.delete(event);
+export function removeEventListener<M extends EventMethods>(
+  event: M,
+  handler?: (params: EventParams<M>) => void
+) {
+  switch (event) {
+    case "Analysis.analysisPoints":
+    case "Analysis.analysisResult": {
+      gEventListeners.delete(event);
+      break;
+    }
+    default: {
+      if (handler != null) {
+        const handlers = gEventToCallbacksMap.get(event);
+        if (handlers != null) {
+          const index = handlers.indexOf(handler);
+          if (index >= 0) {
+            handlers.splice(index, 1);
+          }
+        }
 
-  if (gEventToCallbacksMap.has(event)) {
-    gEventToCallbacksMap.delete(event);
+        if (handlers == null || handlers.length === 0) {
+          gEventListeners.delete(event);
+        }
+      } else {
+        gEventListeners.delete(event);
+
+        if (gEventToCallbacksMap.has(event)) {
+          gEventToCallbacksMap.delete(event);
+        }
+      }
+      break;
+    }
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3809,6 +3809,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@replayio/protocol@npm:^0.31.1":
+  version: 0.31.1
+  resolution: "@replayio/protocol@npm:0.31.1"
+  checksum: 37b581feaccb678281a198a4d0ca11cffc7bd4c5f648b96dc06cc058f67a2b899a61ba876b371df60876f5ca6a17262df0eca2ff796cb60dbce42d3b9ca5eed0
+  languageName: node
+  linkType: hard
+
 "@replayio/replay@npm:^0.4.2":
   version: 0.4.2
   resolution: "@replayio/replay@npm:0.4.2"
@@ -20529,7 +20536,7 @@ __metadata:
     "@redux-devtools/extension": ^3.2.2
     "@reduxjs/toolkit": ^1.8.1
     "@replayio/playwright": ^0.2.1
-    "@replayio/protocol": ^0.31.0
+    "@replayio/protocol": ^0.31.1
     "@replayio/replay": ^0.4.2
     "@sentry/react": ^7.9.0
     "@sentry/tracing": ^7.9.0


### PR DESCRIPTION
The generated `@replayio/protocol` client will soon pass a callback param to both `addEventListener` and `removeEventListener` params to enable multiple listeners to be attached per event type. The `Socket` class in the frontend should take advantage of this then and only remove all listeners for a type in the event that no callback param is included.

Depending on the timing of this PR (and BAC-2052) we might be able to update the `@replayio/protocol` dependency to `0.31.1` and remove the undefined param check.