### PR TITLE
Optimize sources processing perf on start

### DIFF
--- a/src/devtools/client/debugger/src/components/PrimaryPanes/SourcesTree.tsx
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/SourcesTree.tsx
@@ -24,6 +24,7 @@ import {
   getSourcesLoading,
   SourceDetails,
   getSourceDetailsEntities,
+  getSourceDetailsCount,
 } from "ui/reducers/sources";
 
 // Actions
@@ -81,7 +82,7 @@ const mapStateToProps = (state: UIState) => {
     expanded: getExpandedState(state),
     focused: getFocusedSourceItem(state),
     sources: sources,
-    sourceCount: Object.values(sources).length,
+    sourceCount: getSourceDetailsCount(state),
   };
 };
 

--- a/src/ui/utils/sources.ts
+++ b/src/ui/utils/sources.ts
@@ -3,23 +3,6 @@ import { newSource, SourceKind } from "@replayio/protocol";
 import { SourceDetails } from "ui/reducers/sources";
 import newGraph from "./graph";
 
-const fullSourceDetails = (
-  attributes: Partial<SourceDetails> & {
-    id: string;
-    kind: SourceKind;
-  }
-): SourceDetails => {
-  return Object.assign(
-    {
-      canonicalId: attributes.id,
-      correspondingSourceIds: [],
-      generated: [],
-      generatedFrom: [],
-    },
-    attributes
-  );
-};
-
 export const keyForSource = (source: newSource): string => {
   return `${source.url!}:${source.contentHash}`;
 };
@@ -121,18 +104,16 @@ export const newSourcesToCompleteSourceDetails = (
   for (let source of newSources) {
     const { sourceId, generatedSourceIds, ...remainingFields } = source;
 
-    returnValue[sourceId] = fullSourceDetails(
-      Object.assign(remainingFields, {
-        contentHash: contentHashForSource(source),
-        correspondingSourceIds: corresponding[keyForSource(source)],
-        id: sourceId,
-        prettyPrinted: prettyPrinted.from(sourceId)?.[0],
-        prettyPrintedFrom: prettyPrinted.to(source.sourceId)?.[0],
-        generated: generated.from(sourceId) || [],
-        generatedFrom: generated.to(sourceId) || [],
-        canonicalId: findCanonicalId(sourceId),
-      })
-    );
+    returnValue[sourceId] = Object.assign(remainingFields, {
+      contentHash: contentHashForSource(source),
+      correspondingSourceIds: corresponding[keyForSource(source)] || [],
+      id: sourceId,
+      prettyPrinted: prettyPrinted.from(sourceId)?.[0],
+      prettyPrintedFrom: prettyPrinted.to(source.sourceId)?.[0],
+      generated: generated.from(sourceId) || [],
+      generatedFrom: generated.to(sourceId) || [],
+      canonicalId: findCanonicalId(sourceId),
+    });
   }
 
   return returnValue;


### PR DESCRIPTION
This PR:

- Speeds up the processing in `newSourcesToCompleteSourceDetails`:
  - Used object destructuring and manual lookup tables instead of Lodash
  - Changed `.forEach` to be `for...of` loops
  - Created lookup tables in a single loop instead of multiples
  - Used some `Object.assign` instead of spreads
- Speeds up `SourcesTree`'s `mapState`, by using an RTK `selectTotal` selector instead of calling `Object.values(sources).length` every time
- Consolidates the two `addSources` and `allSourcesReceived` actions that we were dispatching back-to-back, and removes storing the original source data in Redux (which we never read or process anywhere ever again anyway)

Based on local perf profiling, what I'm seeing is that the overall time to execute `setupDebugger` dropped from about 675ms to about 210ms.  More specifically, `newSourcesToCompleteSourceDetails` dropped from about 240ms to 105ms, and `SourcesTree.mapState` dropped from 250ms to, uh... small enough I can't see it in the profiler any more :)