### PR TITLE
New Object Inspector tweaks

### DIFF
--- a/packages/bvaughn-architecture-demo/src/utils/protocol.ts
+++ b/packages/bvaughn-architecture-demo/src/utils/protocol.ts
@@ -176,7 +176,7 @@ export function protocolValueToClientValue(
     // Meaning they won't have "value", "bigint", "symbol", or "unserializableNumber" keys.
     // This is pretty awkward to work with and I wish the protocol would change.
     const keys = Object.keys(protocolValue).filter(
-      key => key !== "name" && key !== "name" && key !== "isSymbol"
+      key => key !== "flags" && key !== "name" && key !== "isSymbol"
     );
     if (keys.length === 0) {
       return { name, preview: "undefined", type: "undefined" };

--- a/src/devtools/client/debugger/src/components/Editor/Preview/NewObjectInspector.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Preview/NewObjectInspector.tsx
@@ -1,3 +1,4 @@
+import ErrorBoundary from "@bvaughn/components/ErrorBoundary";
 import Inspector from "@bvaughn/components/inspector";
 import Loader from "@bvaughn/components/Loader";
 import "@bvaughn/pages/variables.css";
@@ -34,9 +35,11 @@ export default function NewObjectInspector() {
 
   return (
     <div className={`${styles.Popup} preview-popup`}>
-      <Suspense fallback={<Loader />}>
-        <Inspector pauseId={pause.pauseId!} protocolValue={protocolValue} />{" "}
-      </Suspense>
+      <ErrorBoundary>
+        <Suspense fallback={<Loader />}>
+          <Inspector pauseId={pause.pauseId!} protocolValue={protocolValue} />{" "}
+        </Suspense>
+      </ErrorBoundary>
     </div>
   );
 }

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/NewObjectInspector.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/NewObjectInspector.tsx
@@ -1,4 +1,5 @@
 import Inspector from "@bvaughn/components/inspector";
+import ErrorBoundary from "@bvaughn/components/ErrorBoundary";
 import Expandable from "@bvaughn/components/Expandable";
 import Loader from "@bvaughn/components/Loader";
 import "@bvaughn/pages/variables.css";
@@ -56,7 +57,9 @@ export default function NewObjectInspector({ roots }: { roots: Array<ContainerIt
 
   return (
     <div className={`${styles.Popup} preview-popup`}>
-      <Suspense fallback={<Loader />}>{children}</Suspense>
+      <ErrorBoundary>
+        <Suspense fallback={<Loader />}>{children}</Suspense>
+      </ErrorBoundary>
     </div>
   );
 }


### PR DESCRIPTION
- [x] 5973d5d5f01572cb6e215f93abd58f5d3112452c fixes an edge case problem with handling `undefined` values that slipped in accidentally in #7458.
- [x] Add `ErrorBoundary` wrappers around Inspector instances in the legacy app.