### PR TITLE
Consolidate redundant "sources received" actions

### DIFF
--- a/src/devtools/client/debugger/src/client/index.ts
+++ b/src/devtools/client/debugger/src/client/index.ts
@@ -5,7 +5,7 @@
 import { newSource, Frame } from "@replayio/protocol";
 import type { ThreadFront as TF } from "protocol/thread";
 import type { UIStore } from "ui/actions";
-import { addSources, allSourcesReceived } from "ui/reducers/sources";
+import { allSourcesReceived } from "ui/reducers/sources";
 
 import { initialBreakpointsState } from "../reducers/breakpoints";
 import { asyncStore, verifyPrefSchema } from "../utils/prefs";
@@ -49,9 +49,7 @@ async function setupDebugger(ThreadFront: typeof TF) {
     }
   });
 
-  store.dispatch(addSources(sources));
-
-  store.dispatch(allSourcesReceived());
+  store.dispatch(allSourcesReceived(sources));
 }
 
 export function bootstrap(_store: UIStore, ThreadFront: typeof TF) {

--- a/src/ui/reducers/sources.ts
+++ b/src/ui/reducers/sources.ts
@@ -54,10 +54,7 @@ export interface SourceContent {
 }
 
 const sourceDetailsAdapter = createEntityAdapter<SourceDetails>();
-const sourcesAdapter = createEntityAdapter<newSource>({ selectId: source => source.sourceId });
 const contentsAdapter = createEntityAdapter<SourceContent>();
-
-export const sourceSelectors = sourcesAdapter.getSelectors();
 
 export const { selectById: getSourceContentsEntry } = contentsAdapter.getSelectors(
   (state: UIState) => state.sources.contents
@@ -73,7 +70,6 @@ export const {
 export interface SourcesState {
   allSourcesReceived: boolean;
   sourceDetails: EntityState<SourceDetails>;
-  sources: EntityState<newSource>;
   contents: EntityState<SourceContent>;
   selectedLocation: PartialLocation | null;
   selectedLocationHistory: PartialLocation[];
@@ -85,7 +81,6 @@ export interface SourcesState {
 const initialState: SourcesState = {
   allSourcesReceived: false,
   sourceDetails: sourceDetailsAdapter.getInitialState(),
-  sources: sourcesAdapter.getInitialState(),
   contents: contentsAdapter.getInitialState(),
   selectedLocation: null,
   selectedLocationHistory: [],
@@ -99,14 +94,9 @@ const sourcesSlice = createSlice({
   name: "sources",
   initialState,
   reducers: {
-    addSources: (state, action: PayloadAction<newSource[]>) => {
-      // Store the raw protocol information. Once we have recieved all sources
-      // we will iterate over this and build it into the shape we want.
-      sourcesAdapter.addMany(state.sources, action.payload);
-    },
-    allSourcesReceived: state => {
+    allSourcesReceived: (state, action: PayloadAction<newSource[]>) => {
+      const sources = action.payload;
       state.allSourcesReceived = true;
-      const sources = state.sources.ids.map(id => state.sources.entities[id]!);
 
       sourceDetailsAdapter.addMany(state.sourceDetails, newSourcesToCompleteSourceDetails(sources));
 
@@ -180,7 +170,6 @@ const sourcesSlice = createSlice({
 });
 
 export const {
-  addSources,
   allSourcesReceived,
   clearSelectedLocation,
   locationSelected,


### PR DESCRIPTION
This PR:

- _Actually_ removes the now-redundant `addSources` action, stops storing the original data, and consolidates the sources processing logic, like I _thought_ I did in #7514