### PR TITLE
Add a flag to profile the source worker

### DIFF
--- a/packages/protocol/socket.ts
+++ b/packages/protocol/socket.ts
@@ -91,6 +91,7 @@ if (typeof window !== "undefined") {
 export type ExperimentalSettings = {
   listenForMetrics: boolean;
   disableCache?: boolean;
+  profileWorkerThreads?: boolean;
 };
 
 type SessionCallbacks = {

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -161,7 +161,8 @@ export function createSocket(
 
       const experimentalSettings: ExperimentalSettings = {
         listenForMetrics: !!prefs.listenForMetrics,
-        disableCache: !!prefs.disableCache,
+        disableCache: !!prefs.disableCache || !!features.profileWorkerThreads,
+        profileWorkerThreads: !!features.profileWorkerThreads,
       };
 
       const loadPoint = new URL(window.location.href).searchParams.get("point") || undefined;

--- a/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
+++ b/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
@@ -33,6 +33,12 @@ const EXPERIMENTAL_SETTINGS: ExperimentalSetting[] = [
     description: "Show line hit counts in the source view",
     key: "hitCounts",
   },
+  {
+    label: "Profile Source Worker",
+    description:
+      "Record a performance profile of the source worker and send it to Replay to help diagnose performance issues",
+    key: "profileWorkerThreads",
+  },
 ];
 
 const RISKY_EXPERIMENTAL_SETTINGS: ExperimentalSetting[] = [];
@@ -71,6 +77,8 @@ export default function ExperimentalSettings({}) {
     useFeature("enableNewComponentArchitecture");
 
   const { value: hitCounts, update: updateHitCounts } = useFeature("hitCounts");
+  const { value: profileWorkerThreads, update: updateProfileWorkerThreads } =
+    useFeature("profileWorkerThreads");
 
   const onChange = (key: ExperimentalKey, value: any) => {
     if (key == "enableColumnBreakpoints") {
@@ -81,14 +89,17 @@ export default function ExperimentalSettings({}) {
       updateEnableNewComponentArchitecture(!enableNewComponentArchitecture);
     } else if (key === "hitCounts") {
       updateHitCounts(!hitCounts);
+    } else if (key === "profileWorkerThreads") {
+      updateProfileWorkerThreads(!profileWorkerThreads);
     }
   };
 
   const localSettings = {
     enableColumnBreakpoints,
+    enableNewComponentArchitecture,
     enableResolveRecording,
     hitCounts,
-    enableNewComponentArchitecture,
+    profileWorkerThreads,
   };
 
   const settings = { ...userSettings, ...localSettings };

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -16,10 +16,11 @@ export type ExperimentalUserSettings = {
 
 export type LocalExperimentalUserSettings = {
   enableColumnBreakpoints: boolean;
+  enableLargeText: boolean;
   enableNewComponentArchitecture: boolean;
   enableResolveRecording: boolean;
   hitCounts: boolean;
-  enableLargeText: boolean;
+  profileWorkerThreads: boolean;
 };
 
 export type LocalUserSettings = LocalExperimentalUserSettings & {

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -32,6 +32,7 @@ pref("devtools.features.repaintEvaluations", false);
 pref("devtools.features.resolveRecording", false);
 pref("devtools.features.hitCounts", true);
 pref("devtools.features.disableUnHitLines", false);
+pref("devtools.features.profileWorkerThreads", false);
 
 export const prefs = new PrefsHelper("devtools", {
   colorScheme: ["String", "colorScheme"],
@@ -64,6 +65,7 @@ export const features = new PrefsHelper("devtools.features", {
   protocolTimeline: ["Bool", "protocolTimeline"],
   repaintEvaluations: ["Bool", "repaintEvaluations"],
   resolveRecording: ["Bool", "resolveRecording"],
+  profileWorkerThreads: ["Bool", "profileWorkerThreads"],
 });
 
 export const asyncStore = asyncStoreHelper("devtools", {


### PR DESCRIPTION
This will allow users to send us a profile of the source worker loading their recording, without having to grant us access to their recording.