### PR TITLE
Disable Redux DevTools integration

### DIFF
--- a/src/ui/components/SecondaryToolbox/ReduxDevTools.tsx
+++ b/src/ui/components/SecondaryToolbox/ReduxDevTools.tsx
@@ -40,6 +40,10 @@ export const ReduxDevToolsPanel = () => {
   }, []);
 
   useLayoutEffect(() => {
+    // TODO Re-enable Redux DevTools annotations handling
+    return;
+
+    /*
     if (!rootRef.current) {
       return;
     }
@@ -66,16 +70,21 @@ export const ReduxDevToolsPanel = () => {
         setCurrentRDTTheme(updatedRDTTheme);
       }
     });
+    */
   }, [ReduxDevToolsAppRoot, appTheme, currentRDTTheme]);
 
   useLayoutEffect(() => {
+    // TODO Re-enable Redux DevTools annotations handling
+    return;
+
+    /*
     if (!rootRef.current) {
       return;
     }
 
     const rootComponent = rootRef.current;
     const store = rootComponent.store!;
-
+*/
     /*
 
      The Redux DevTools UI has its own Redux store with its own reducers.
@@ -95,6 +104,7 @@ export const ReduxDevToolsPanel = () => {
 
     */
 
+    /*
     const allInstanceIds: string[] = ["default"];
 
     reduxAnnotations.forEach(annotation => {
@@ -137,6 +147,7 @@ export const ReduxDevToolsPanel = () => {
         store.dispatch(annotation.action);
       });
     });
+    */
   }, [ReduxDevToolsAppRoot, reduxAnnotations]);
 
   if (!ReduxDevToolsAppRoot) {

--- a/src/ui/components/SecondaryToolbox/redux-devtools/ReduxAnnotationsProvider.tsx
+++ b/src/ui/components/SecondaryToolbox/redux-devtools/ReduxAnnotationsProvider.tsx
@@ -16,6 +16,8 @@ export const ReduxAnnotationsProvider = ({ children }: RAPProps) => {
   const isStrictEffectsSecondRenderRef = useRef(false);
 
   useEffect(() => {
+    // TODO Re-enable Redux DevTools annotations handling
+    /*
     // React will double-run effects in dev. Avoid trying to subscribe twice,
     // as `socket.ts` throws errors if you call `getAnnotations()` more than once.
     if (isStrictEffectsSecondRenderRef.current) {
@@ -33,6 +35,7 @@ export const ReduxAnnotationsProvider = ({ children }: RAPProps) => {
         );
       }
     }, "redux-devtools-bridge");
+    */
   }, [dispatch]);
 
   return (


### PR DESCRIPTION
This PR:

- Comments out all the logic for fetching Redux DevTools annotations and loading them into the UI

We've observed that both the backend browser recording integration and the frontend display logic are hogging resources.  This appears to be due to how I (hackily!) integrated the Redux DevTools into the browser side.  The _intent_ was that it would only capture and save the actual application actions that were dispatched.  Instead, it appears to be capturing the entire internal state of the Redux DevTools extension logic, including hundreds of "computed state" values.  This has resulted in individual annotation entries being dozens or even _hundreds_ of MB.

That drastically slows down recording performance, and also UI loading time.  In both cases we're sending these hundred-MB strings over the wire.  In the case of the UI, those are coming over the same websocket connection as everything else we request (source entries, source contents, messages, etc).

I tried logging out some of the annotation JSON string sizes in https://app.replay.io/recording/tab-switching-to-pretty-printed-source--0d4246b0-0ac5-4ac6-b56d-3dccc43bdd09 , and saw:

```
65
2650
20871
27672
13384
57174
878120
40649857
1319511
75571249
1415950
12814110
2905554
1446488
1446523
2892482
5784398
8676376
4338508
14704598
8823624
2918566
1456668
8746862
5831488
1456844
23366748
1466390
7336696
1466211
23542106
```

Yes, that's _hundreds_ of megabytes :(

when I tried logging and expanding some of the parsed JSON, the 40MB entry looked like:

![image](https://user-images.githubusercontent.com/1128784/183974440-feea2178-8a00-40be-83cf-cd10aad38d7b.png)

which is clearly the guts of the Redux DevTools Extension's internal Redux store _state_, rather than a given application action.

So, we're going to turn this off until I have time to revisit this and come up with a better implementation.  That should hopefully be in a couple months, after we wrap up the frontend architecture work.