### PR TITLE
Improve new Console Suspense boundary loading sequence

### DIFF
--- a/packages/bvaughn-architecture-demo/components/console/ConsoleRoot.module.css
+++ b/packages/bvaughn-architecture-demo/components/console/ConsoleRoot.module.css
@@ -73,3 +73,8 @@
   min-height: 2rem;
   flex: 0 0 auto;
 }
+
+.Loader {
+  flex: 1;
+  padding: 0.5rem;
+}

--- a/packages/bvaughn-architecture-demo/components/console/ConsoleRoot.tsx
+++ b/packages/bvaughn-architecture-demo/components/console/ConsoleRoot.tsx
@@ -37,59 +37,61 @@ export default function ConsoleRoot({
   return (
     <ConsoleContextMenuContextRoot>
       <ConsoleFiltersContextRoot>
-        <LoggablesContextRoot messageListRef={messageListRef}>
-          <SearchContextRoot
-            messageListRef={messageListRef}
-            showSearchInputByDefault={showSearchInputByDefault}
-          >
-            <div className={styles.ConsoleRoot} data-test-id="ConsoleRoot">
-              <div className={styles.TopRow}>
+        <SearchContextRoot
+          messageListRef={messageListRef}
+          showSearchInputByDefault={showSearchInputByDefault}
+        >
+          <div className={styles.ConsoleRoot} data-test-id="ConsoleRoot">
+            <div className={styles.TopRow}>
+              <button
+                className={styles.MenuToggleButton}
+                data-test-id="ConsoleMenuToggleButton"
+                onClick={() => setIsMenuOpen(!isMenuOpen)}
+                title={isMenuOpen ? "Close filter menu" : "Open filter menu"}
+              >
+                <Icon
+                  className={styles.MenuToggleButtonIcon}
+                  type={isMenuOpen ? "menu-open" : "menu-closed"}
+                />
+              </button>
+              <FilterText />
+              {consoleEvaluations.length > 0 && (
                 <button
-                  className={styles.MenuToggleButton}
-                  data-test-id="ConsoleMenuToggleButton"
-                  onClick={() => setIsMenuOpen(!isMenuOpen)}
-                  title={isMenuOpen ? "Close filter menu" : "Open filter menu"}
+                  className={styles.DeleteTerminalExpressionButton}
+                  data-test-id="ClearConsoleEvaluationsButton"
+                  onClick={clearConsoleEvaluations}
+                  title="Clear console evaluations"
                 >
-                  <Icon
-                    className={styles.MenuToggleButtonIcon}
-                    type={isMenuOpen ? "menu-open" : "menu-closed"}
-                  />
+                  <Icon className={styles.DeleteTerminalExpressionIcon} type="delete" />
                 </button>
-                <FilterText />
-                {consoleEvaluations.length > 0 && (
-                  <button
-                    className={styles.DeleteTerminalExpressionButton}
-                    data-test-id="ClearConsoleEvaluationsButton"
-                    onClick={clearConsoleEvaluations}
-                    title="Clear console evaluations"
-                  >
-                    <Icon className={styles.DeleteTerminalExpressionIcon} type="delete" />
-                  </button>
-                )}
-              </div>
-              <div className={styles.BottomRow}>
-                <Offscreen mode={isMenuOpen ? "visible" : "hidden"}>
-                  <div className={styles.FilterColumn}>
-                    <FilterToggles />
-                  </div>
-                </Offscreen>
-                <div className={styles.MessageColumn}>
-                  <ErrorBoundary>
-                    <Suspense fallback={<Loader />}>
-                      <MessagesList ref={messageListRef} />
-                    </Suspense>
-                  </ErrorBoundary>
-
-                  {terminalInput}
-
-                  <Search className={styles.Row} hideOnEscape={terminalInput !== null} />
-                </div>
-              </div>
-
-              <ContextMenu />
+              )}
             </div>
-          </SearchContextRoot>
-        </LoggablesContextRoot>
+            <div className={styles.BottomRow}>
+              <Offscreen mode={isMenuOpen ? "visible" : "hidden"}>
+                <div className={styles.FilterColumn}>
+                  <Suspense fallback={<Loader />}>
+                    <FilterToggles />
+                  </Suspense>
+                </div>
+              </Offscreen>
+              <div className={styles.MessageColumn}>
+                <ErrorBoundary>
+                  <Suspense fallback={<Loader />}>
+                    <LoggablesContextRoot messageListRef={messageListRef}>
+                      <MessagesList ref={messageListRef} />
+                    </LoggablesContextRoot>
+                  </Suspense>
+                </ErrorBoundary>
+
+                {terminalInput}
+
+                <Search className={styles.Row} hideOnEscape={terminalInput !== null} />
+              </div>
+            </div>
+
+            <ContextMenu />
+          </div>
+        </SearchContextRoot>
       </ConsoleFiltersContextRoot>
     </ConsoleContextMenuContextRoot>
   );

--- a/packages/bvaughn-architecture-demo/components/console/ConsoleRoot.tsx
+++ b/packages/bvaughn-architecture-demo/components/console/ConsoleRoot.tsx
@@ -76,7 +76,13 @@ export default function ConsoleRoot({
               </Offscreen>
               <div className={styles.MessageColumn}>
                 <ErrorBoundary>
-                  <Suspense fallback={<Loader />}>
+                  <Suspense
+                    fallback={
+                      <div className={styles.Loader}>
+                        <Loader />
+                      </div>
+                    }
+                  >
                     <LoggablesContextRoot messageListRef={messageListRef}>
                       <MessagesList ref={messageListRef} />
                     </LoggablesContextRoot>

--- a/packages/bvaughn-architecture-demo/components/console/ConsoleRoot.tsx
+++ b/packages/bvaughn-architecture-demo/components/console/ConsoleRoot.tsx
@@ -37,67 +37,67 @@ export default function ConsoleRoot({
   return (
     <ConsoleContextMenuContextRoot>
       <ConsoleFiltersContextRoot>
-        <SearchContextRoot
-          messageListRef={messageListRef}
-          showSearchInputByDefault={showSearchInputByDefault}
-        >
-          <div className={styles.ConsoleRoot} data-test-id="ConsoleRoot">
-            <div className={styles.TopRow}>
+        <div className={styles.ConsoleRoot} data-test-id="ConsoleRoot">
+          <div className={styles.TopRow}>
+            <button
+              className={styles.MenuToggleButton}
+              data-test-id="ConsoleMenuToggleButton"
+              onClick={() => setIsMenuOpen(!isMenuOpen)}
+              title={isMenuOpen ? "Close filter menu" : "Open filter menu"}
+            >
+              <Icon
+                className={styles.MenuToggleButtonIcon}
+                type={isMenuOpen ? "menu-open" : "menu-closed"}
+              />
+            </button>
+            <FilterText />
+            {consoleEvaluations.length > 0 && (
               <button
-                className={styles.MenuToggleButton}
-                data-test-id="ConsoleMenuToggleButton"
-                onClick={() => setIsMenuOpen(!isMenuOpen)}
-                title={isMenuOpen ? "Close filter menu" : "Open filter menu"}
+                className={styles.DeleteTerminalExpressionButton}
+                data-test-id="ClearConsoleEvaluationsButton"
+                onClick={clearConsoleEvaluations}
+                title="Clear console evaluations"
               >
-                <Icon
-                  className={styles.MenuToggleButtonIcon}
-                  type={isMenuOpen ? "menu-open" : "menu-closed"}
-                />
+                <Icon className={styles.DeleteTerminalExpressionIcon} type="delete" />
               </button>
-              <FilterText />
-              {consoleEvaluations.length > 0 && (
-                <button
-                  className={styles.DeleteTerminalExpressionButton}
-                  data-test-id="ClearConsoleEvaluationsButton"
-                  onClick={clearConsoleEvaluations}
-                  title="Clear console evaluations"
-                >
-                  <Icon className={styles.DeleteTerminalExpressionIcon} type="delete" />
-                </button>
-              )}
-            </div>
-            <div className={styles.BottomRow}>
-              <Offscreen mode={isMenuOpen ? "visible" : "hidden"}>
-                <div className={styles.FilterColumn}>
-                  <Suspense fallback={<Loader />}>
-                    <FilterToggles />
-                  </Suspense>
-                </div>
-              </Offscreen>
-              <div className={styles.MessageColumn}>
-                <ErrorBoundary>
-                  <Suspense
-                    fallback={
-                      <div className={styles.Loader}>
-                        <Loader />
-                      </div>
-                    }
-                  >
-                    <LoggablesContextRoot messageListRef={messageListRef}>
-                      <MessagesList ref={messageListRef} />
-                    </LoggablesContextRoot>
-                  </Suspense>
-                </ErrorBoundary>
-
-                {terminalInput}
-
-                <Search className={styles.Row} hideOnEscape={terminalInput !== null} />
-              </div>
-            </div>
-
-            <ContextMenu />
+            )}
           </div>
-        </SearchContextRoot>
+          <div className={styles.BottomRow}>
+            <Offscreen mode={isMenuOpen ? "visible" : "hidden"}>
+              <div className={styles.FilterColumn}>
+                <Suspense fallback={<Loader />}>
+                  <FilterToggles />
+                </Suspense>
+              </div>
+            </Offscreen>
+            <Suspense
+              fallback={
+                <div className={styles.Loader}>
+                  <Loader />
+                </div>
+              }
+            >
+              <LoggablesContextRoot messageListRef={messageListRef}>
+                <SearchContextRoot
+                  messageListRef={messageListRef}
+                  showSearchInputByDefault={showSearchInputByDefault}
+                >
+                  <div className={styles.MessageColumn}>
+                    <ErrorBoundary>
+                      <MessagesList ref={messageListRef} />
+                    </ErrorBoundary>
+
+                    {terminalInput}
+
+                    <Search className={styles.Row} hideOnEscape={terminalInput !== null} />
+                  </div>
+                </SearchContextRoot>
+              </LoggablesContextRoot>
+            </Suspense>
+          </div>
+
+          <ContextMenu />
+        </div>
       </ConsoleFiltersContextRoot>
     </ConsoleContextMenuContextRoot>
   );

--- a/packages/bvaughn-architecture-demo/components/console/filters/EventsList.tsx
+++ b/packages/bvaughn-architecture-demo/components/console/filters/EventsList.tsx
@@ -73,25 +73,23 @@ function EventsListCategories({
   return (
     <>
       <div className={styles.Header}>Common Events</div>
-      {commonEventCategories &&
-        commonEventCategories.map(eventCategory => (
-          <EventCategory
-            key={eventCategory.category}
-            disabled={isPending}
-            eventCategory={eventCategory}
-            filterByText={filterByText}
-          />
-        ))}
+      {commonEventCategories.map(eventCategory => (
+        <EventCategory
+          key={eventCategory.category}
+          disabled={isPending}
+          eventCategory={eventCategory}
+          filterByText={filterByText}
+        />
+      ))}
       <div className={styles.Header}>Other Events</div>
-      {otherEventCategories &&
-        otherEventCategories.map(eventCategory => (
-          <EventCategory
-            key={eventCategory.category}
-            disabled={isPending}
-            eventCategory={eventCategory}
-            filterByText={filterByText}
-          />
-        ))}
+      {otherEventCategories.map(eventCategory => (
+        <EventCategory
+          key={eventCategory.category}
+          disabled={isPending}
+          eventCategory={eventCategory}
+          filterByText={filterByText}
+        />
+      ))}
     </>
   );
 }

--- a/packages/bvaughn-architecture-demo/components/console/filters/EventsList.tsx
+++ b/packages/bvaughn-architecture-demo/components/console/filters/EventsList.tsx
@@ -1,14 +1,13 @@
+import Loader from "@bvaughn/components/Loader";
 import { getEventCategoryCounts } from "@bvaughn/src/suspense/EventsCache";
 import type { EventCategory as EventCategoryType } from "@bvaughn/src/suspense/EventsCache";
-import { ChangeEvent, useContext, useMemo, useState, useTransition } from "react";
+import { ChangeEvent, Suspense, useContext, useMemo, useState, useTransition } from "react";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
 import EventCategory from "./EventCategory";
 import styles from "./EventsList.module.css";
 
 export default function EventsList() {
-  const client = useContext(ReplayClientContext);
-
   const [filterByDisplayText, setFilterByDisplayText] = useState("");
   const [filterByText, setFilterByText] = useState("");
   const [isPending, startTransition] = useTransition();
@@ -20,6 +19,33 @@ export default function EventsList() {
       setFilterByText(newFilterByText);
     });
   };
+
+  return (
+    <div className={styles.EventsList}>
+      <input
+        className={styles.FilterInput}
+        data-test-id="EventTypeFilterInput"
+        onChange={onFilterTextChange}
+        placeholder="Filter by event type"
+        type="text"
+        value={filterByDisplayText}
+      />
+
+      <Suspense fallback={<Loader />}>
+        <EventsListCategories filterByText={filterByText} isPending={isPending} />
+      </Suspense>
+    </div>
+  );
+}
+
+function EventsListCategories({
+  filterByText,
+  isPending,
+}: {
+  filterByText: string;
+  isPending: boolean;
+}) {
+  const client = useContext(ReplayClientContext);
 
   const eventCategoryCounts = getEventCategoryCounts(client);
 
@@ -45,35 +71,27 @@ export default function EventsList() {
   }, [eventCategoryCounts]);
 
   return (
-    <div className={styles.EventsList}>
-      <input
-        className={styles.FilterInput}
-        data-test-id="EventTypeFilterInput"
-        onChange={onFilterTextChange}
-        placeholder="Filter by event type"
-        type="text"
-        value={filterByDisplayText}
-      />
-
+    <>
       <div className={styles.Header}>Common Events</div>
-      {commonEventCategories.map(eventCategory => (
-        <EventCategory
-          key={eventCategory.category}
-          disabled={isPending}
-          eventCategory={eventCategory}
-          filterByText={filterByText}
-        />
-      ))}
-
+      {commonEventCategories &&
+        commonEventCategories.map(eventCategory => (
+          <EventCategory
+            key={eventCategory.category}
+            disabled={isPending}
+            eventCategory={eventCategory}
+            filterByText={filterByText}
+          />
+        ))}
       <div className={styles.Header}>Other Events</div>
-      {otherEventCategories.map(eventCategory => (
-        <EventCategory
-          key={eventCategory.category}
-          disabled={isPending}
-          eventCategory={eventCategory}
-          filterByText={filterByText}
-        />
-      ))}
-    </div>
+      {otherEventCategories &&
+        otherEventCategories.map(eventCategory => (
+          <EventCategory
+            key={eventCategory.category}
+            disabled={isPending}
+            eventCategory={eventCategory}
+            filterByText={filterByText}
+          />
+        ))}
+    </>
   );
 }

--- a/packages/bvaughn-architecture-demo/components/console/filters/FilterToggles.tsx
+++ b/packages/bvaughn-architecture-demo/components/console/filters/FilterToggles.tsx
@@ -46,9 +46,7 @@ export default function FilterToggles() {
         onChange={showErrors => update({ showErrors })}
       />
       <hr className={styles.Divider} />
-      <Suspense fallback={<Loader />}>
-        <EventsList />
-      </Suspense>
+      <EventsList />
       <hr className={styles.Divider} />
       <Toggle
         checked={!showNodeModules}

--- a/packages/bvaughn-architecture-demo/components/console/filters/FilterToggles.tsx
+++ b/packages/bvaughn-architecture-demo/components/console/filters/FilterToggles.tsx
@@ -1,18 +1,15 @@
 import Loader from "@bvaughn/components/Loader";
 import { ConsoleFiltersContext } from "@bvaughn/src/contexts/ConsoleFiltersContext";
 import { FocusContext } from "@bvaughn/src/contexts/FocusContext";
-import { getMessages } from "@bvaughn/src/suspense/MessagesCache";
+import { CategoryCounts, getMessages } from "@bvaughn/src/suspense/MessagesCache";
 import camelCase from "lodash/camelCase";
-import React, { Suspense, useContext, useMemo } from "react";
+import React, { Suspense, useContext } from "react";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
-import { isFirefoxInternalMessage } from "../utils/messages";
 
 import EventsList from "./EventsList";
 import styles from "./FilterToggles.module.css";
 
 export default function FilterToggles() {
-  const { range: focusRange } = useContext(FocusContext);
-  const client = useContext(ReplayClientContext);
   const {
     showErrors,
     showExceptions,
@@ -23,66 +20,28 @@ export default function FilterToggles() {
     update,
   } = useContext(ConsoleFiltersContext);
 
-  const { messages } = getMessages(client, focusRange);
-  const counts = useMemo(() => {
-    let errors = 0;
-    let exceptions = 0;
-    let logs = 0;
-    let warnings = 0;
-
-    messages.forEach(message => {
-      if (isFirefoxInternalMessage(message)) {
-        return;
-      }
-
-      switch (message.level) {
-        case "assert":
-        case "info":
-        case "trace":
-          logs++;
-          break;
-        case "error":
-          switch (message.source) {
-            case "ConsoleAPI":
-              errors++;
-              break;
-            case "PageError":
-              exceptions++;
-              break;
-          }
-          break;
-        case "warning":
-          warnings++;
-          break;
-      }
-    });
-
-    return { errors, exceptions, logs, warnings };
-  }, [messages]);
-
   return (
     <div className={styles.Filters} data-test-id="ConsoleFilterToggles">
       <Toggle
         checked={showExceptions}
-        count={counts.exceptions}
         label="Exceptions"
         onChange={showExceptions => update({ showExceptions })}
       />
       <Toggle
+        category="logs"
         checked={showLogs}
-        count={counts.logs}
         label="Logs"
         onChange={showLogs => update({ showLogs })}
       />
       <Toggle
+        category="warnings"
         checked={showWarnings}
-        count={counts.warnings}
         label="Warnings"
         onChange={showWarnings => update({ showWarnings })}
       />
       <Toggle
+        category="errors"
         checked={showErrors}
-        count={counts.errors}
         label="Errors"
         onChange={showErrors => update({ showErrors })}
       />
@@ -107,12 +66,12 @@ export default function FilterToggles() {
 
 function Toggle({
   checked,
-  count = null,
+  category = null,
   label,
   onChange,
 }: {
   checked: boolean;
-  count?: number | null;
+  category?: keyof CategoryCounts | null;
   label: string;
   onChange: (checked: boolean) => void;
 }) {
@@ -129,7 +88,21 @@ function Toggle({
       <label className={styles.Label} data-test-id={id} htmlFor={id} title={label}>
         {label}
       </label>
-      {count !== null && count > 0 && <div className={styles.Count}>{count}</div>}
+      {category && (
+        <Suspense fallback={null}>
+          <ToggleCategoryCount category={category} />
+        </Suspense>
+      )}
     </div>
   );
+}
+
+function ToggleCategoryCount({ category }: { category: keyof CategoryCounts }) {
+  const { range: focusRange } = useContext(FocusContext);
+  const client = useContext(ReplayClientContext);
+
+  const { categoryCounts } = getMessages(client, focusRange);
+  const count = categoryCounts[category];
+
+  return count === 0 ? null : <div className={styles.Count}>{count}</div>;
 }

--- a/packages/bvaughn-architecture-demo/components/console/filters/FilterToggles.tsx
+++ b/packages/bvaughn-architecture-demo/components/console/filters/FilterToggles.tsx
@@ -23,6 +23,7 @@ export default function FilterToggles() {
   return (
     <div className={styles.Filters} data-test-id="ConsoleFilterToggles">
       <Toggle
+        category="exceptions"
         checked={showExceptions}
         label="Exceptions"
         onChange={showExceptions => update({ showExceptions })}

--- a/packages/bvaughn-architecture-demo/pages/index.tsx
+++ b/packages/bvaughn-architecture-demo/pages/index.tsx
@@ -83,11 +83,15 @@ export default function HomePage() {
                     </button>
                   </div>
                   <div className={styles.CommentsContainer}>
-                    {panel == "comments" && <CommentList />}
-                    {panel == "sources" && <SourceExplorer />}
+                    <Suspense fallback={<Loader />}>
+                      {panel == "comments" && <CommentList />}
+                      {panel == "sources" && <SourceExplorer />}
+                    </Suspense>
                   </div>
                   <div className={styles.SourcesContainer}>
-                    <Sources />
+                    <Suspense fallback={<Loader />}>
+                      <Sources />
+                    </Suspense>
                   </div>
                   <div className={styles.ConsoleContainer}>
                     <TerminalContextRoot>
@@ -103,7 +107,9 @@ export default function HomePage() {
                   </div>
                 </div>
                 <div className={styles.Row}>
-                  <Focuser />
+                  <Suspense fallback={<Loader />}>
+                    <Focuser />
+                  </Suspense>
                 </div>
               </div>
             </FocusContextRoot>

--- a/packages/bvaughn-architecture-demo/src/suspense/MessagesCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/MessagesCache.ts
@@ -19,6 +19,7 @@ export type ProtocolMessage = Message & {
 
 export type CategoryCounts = {
   errors: number;
+  exceptions: number; // TODO Remove this
   logs: number;
   warnings: number;
 };
@@ -67,6 +68,7 @@ export function getMessages(
       messages: [],
       categoryCounts: {
         errors: 0,
+        exceptions: 0,
         logs: 0,
         warnings: 0,
       },
@@ -147,6 +149,7 @@ export function getMessages(
     }
 
     let errors = 0;
+    let exceptions = 0; // TODO Remove this
     let logs = 0;
     let warnings = 0;
 
@@ -158,7 +161,17 @@ export function getMessages(
           logs++;
           break;
         case "error":
-          errors++;
+          // TODO Remove this switch
+          switch (message.source) {
+            case "ConsoleAPI": {
+              errors++;
+              break;
+            }
+            case "PageError": {
+              exceptions++;
+              break;
+            }
+          }
           break;
         case "warning":
           warnings++;
@@ -168,6 +181,7 @@ export function getMessages(
 
     lastFilteredCategoryCounts = {
       errors,
+      exceptions,
       logs,
       warnings,
     };

--- a/packages/bvaughn-architecture-demo/src/suspense/MessagesCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/MessagesCache.ts
@@ -17,6 +17,20 @@ export type ProtocolMessage = Message & {
   type: "ProtocolMessage";
 };
 
+export type CategoryCounts = {
+  errors: number;
+  logs: number;
+  warnings: number;
+};
+
+type MessageData = {
+  categoryCounts: CategoryCounts;
+  countAfter: number;
+  countBefore: number;
+  didOverflow: boolean;
+  messages: ProtocolMessage[];
+};
+
 // TODO Should I use React's Suspense cache APIs here?
 // It's tempting to think that I don't need to, because the recording session data is global,
 // but could this cause problems if React wants to render a high-priority update while a lower one is suspended?
@@ -28,26 +42,20 @@ let lastFetchDidOverflow: boolean = false;
 let lastFetchedFocusRange: TimeStampedPointRange | null = null;
 let lastFetchedMessages: ProtocolMessage[] | null = null;
 
-let lastFilteredFocusRange: TimeStampedPointRange | null = null;
-let lastFilteredMessages: ProtocolMessage[] | null = null;
+let lastFilteredCategoryCounts: CategoryCounts | null = null;
 let lastFilteredCountAfter: number = 0;
 let lastFilteredCountBefore: number = 0;
-
-type getMessagesResponse = {
-  countAfter: number;
-  countBefore: number;
-  didOverflow: boolean;
-  messages: ProtocolMessage[];
-};
+let lastFilteredFocusRange: TimeStampedPointRange | null = null;
+let lastFilteredMessages: ProtocolMessage[] | null = null;
 
 // Synchronously returns an array of filtered Messages,
 // or throws a Wakeable to be resolved once messages have been fetched.
 //
-// This method is Suspense friend; it is meant to be called from a React component during render.
+// This method is Suspense friendly; it is meant to be called from a React component during render.
 export function getMessages(
   client: ReplayClientInterface,
   focusRange: TimeStampedPointRange | null
-): getMessagesResponse {
+): MessageData {
   if (focusRange !== null && focusRange.begin.point === focusRange.end.point) {
     // Edge case scenario handling.
     // The backend throws if both points in a range are the same.
@@ -57,6 +65,11 @@ export function getMessages(
       countBefore: -1,
       didOverflow: false,
       messages: [],
+      categoryCounts: {
+        errors: 0,
+        logs: 0,
+        warnings: 0,
+      },
     };
   }
 
@@ -100,6 +113,9 @@ export function getMessages(
     throw inFlightWakeable;
   }
 
+  // TODO Filter Firefox internal messages?
+  // import { isFirefoxInternalMessage } from "../utils/messages";
+
   // At this point, messages have been fetched but we may still need to filter them.
   // For performance reasons (both in this function and on things that consume the filtered list)
   // it's best if we memoize this operation (by comparing ranges) to avoid recreating the filtered array.
@@ -129,12 +145,39 @@ export function getMessages(
         }
       });
     }
+
+    let errors = 0;
+    let logs = 0;
+    let warnings = 0;
+
+    lastFilteredMessages!.forEach(message => {
+      switch (message.level) {
+        case "assert":
+        case "info":
+        case "trace":
+          logs++;
+          break;
+        case "error":
+          errors++;
+          break;
+        case "warning":
+          warnings++;
+          break;
+      }
+    });
+
+    lastFilteredCategoryCounts = {
+      errors,
+      logs,
+      warnings,
+    };
   }
 
   // Note that the only time when it's safe for us to specify the number of trimmed messages
   // is when we are trimming from the complete set of messages (aka no focus region).
   // Otherwise even if we do trim some messages locally, the number isn't meaningful.
   return {
+    categoryCounts: lastFilteredCategoryCounts!,
     countAfter: lastFetchedFocusRange === null ? lastFilteredCountAfter : -1,
     countBefore: lastFetchedFocusRange === null ? lastFilteredCountBefore : -1,
     didOverflow: lastFetchDidOverflow,

--- a/src/ui/components/SecondaryToolbox/NewConsole.tsx
+++ b/src/ui/components/SecondaryToolbox/NewConsole.tsx
@@ -21,7 +21,6 @@ import {
 import React, {
   KeyboardEvent,
   PropsWithChildren,
-  Suspense,
   useCallback,
   useContext,
   useEffect,
@@ -85,21 +84,19 @@ export default function NewConsoleRoot() {
   );
 
   return (
-    <Suspense fallback={<Loader />}>
-      <SessionContext.Provider value={sessionContext}>
-        <TimelineContextAdapter>
-          <InspectorContextReduxAdapter>
-            <TerminalContextReduxAdapter>
-              <FocusContextReduxAdapter>
-                <PointsContextReduxAdapter>
-                  <NewConsole showSearchInputByDefault={false} terminalInput={<JSTermWrapper />} />
-                </PointsContextReduxAdapter>
-              </FocusContextReduxAdapter>
-            </TerminalContextReduxAdapter>
-          </InspectorContextReduxAdapter>
-        </TimelineContextAdapter>
-      </SessionContext.Provider>
-    </Suspense>
+    <SessionContext.Provider value={sessionContext}>
+      <TimelineContextAdapter>
+        <InspectorContextReduxAdapter>
+          <TerminalContextReduxAdapter>
+            <FocusContextReduxAdapter>
+              <PointsContextReduxAdapter>
+                <NewConsole showSearchInputByDefault={false} terminalInput={<JSTermWrapper />} />
+              </PointsContextReduxAdapter>
+            </FocusContextReduxAdapter>
+          </TerminalContextReduxAdapter>
+        </InspectorContextReduxAdapter>
+      </TimelineContextAdapter>
+    </SessionContext.Provider>
   );
 }
 


### PR DESCRIPTION
Improve the new Console loading UI by shifting some Suspense boundaries around and moving the `LoggablesContextRoot` (which Suspends) deeper into the new Console tree.

### Before
[Loading sequence before any changes](https://user-images.githubusercontent.com/29597/183974221-72963d16-a3e3-4ac4-9b46-1bb58e4072bf.webm)

### After commit eb3edc6175ba4694470c2091d18ee577ad1ca6f1

[Loading sequence after commit eb3edc6175ba4694470c2091d18ee577ad1ca6f1](https://user-images.githubusercontent.com/29597/183973564-94d20868-608b-4335-a3b7-8b07b8662d4e.webm)

### After commit ae28ab4897a1bd5d592028a888ca88d2600df105
[Loading sequence after commit ae28ab4897a1bd5d592028a888ca88d2600df105](https://user-images.githubusercontent.com/29597/183978040-be066b10-7128-4763-88ee-2e96411e16f7.webm)
