### PR TITLE
Fix "Ready when you are" text color contrast

### DIFF
--- a/src/ui/components/shared/Dialog.tsx
+++ b/src/ui/components/shared/Dialog.tsx
@@ -39,7 +39,7 @@ export const DialogDescription = ({
   ...props
 }: HTMLProps<HTMLParagraphElement>) => {
   return (
-    <p {...props} className="mb-2 whitespace-pre-wrap text-center text-sm text-gray-500">
+    <p {...props} className="mb-2 text-sm text-center whitespace-pre-wrap text-themeBase-70">
       {children}
     </p>
   );

--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -116,7 +116,7 @@ const SessionErrorMessages: Record<number, Partial<UnexpectedError>> = {
     content: "You’ve hit an error that happens with long recordings. Can you try a shorter one?",
   },
   [SessionError.InactivityTimeout]: {
-    content: "Replays disconnect after 15 minutes to reduce server load.",
+    content: "This replay timed out to reduce server load.",
     message: "Ready when you are!",
   },
 };


### PR DESCRIPTION
We had hard-coded text-gray-500 which we don't use because it doesn't work between dark theme and light theme. I moved to a dynamic variable we use in situations like this.

I also changed the text so it doesn't have an orphan.