### PR TITLE
Fix react_devtools e2e test

### DIFF
--- a/public/test/scripts/react_devtools.js
+++ b/public/test/scripts/react_devtools.js
@@ -24,8 +24,6 @@ Test.describe(`Test React DevTools.`, async () => {
   await Test.warpToMessage("Added an entry");
 
   await Test.selectReactDevTools();
-  // TODO (466) Clicking a second time flushes the pending update; this should be unnecessary.
-  await Test.selectReactDevTools();
   await Test.waitUntil(() => getComponents().length === 4, {
     waitingFor: "There to be 4 components in ReactDevTools",
   });
@@ -49,8 +47,6 @@ Test.describe(`Test React DevTools.`, async () => {
   await Test.selectConsole();
   await Test.warpToMessage("Removed an entry");
 
-  await Test.selectReactDevTools();
-  // TODO (466) Clicking a second time flushes the pending update; this should be unnecessary.
   await Test.selectReactDevTools();
   await Test.waitUntil(() => getComponents().length === 3, {
     waitingFor: "There to be 3 components in ReactDevTools",

--- a/public/test/scripts/react_devtools.js
+++ b/public/test/scripts/react_devtools.js
@@ -24,6 +24,8 @@ Test.describe(`Test React DevTools.`, async () => {
   await Test.warpToMessage("Added an entry");
 
   await Test.selectReactDevTools();
+  // TODO (466) Clicking a second time flushes the pending update; this should be unnecessary.
+  await Test.selectReactDevTools();
   await Test.waitUntil(() => getComponents().length === 4, {
     waitingFor: "There to be 4 components in ReactDevTools",
   });
@@ -47,6 +49,8 @@ Test.describe(`Test React DevTools.`, async () => {
   await Test.selectConsole();
   await Test.warpToMessage("Removed an entry");
 
+  await Test.selectReactDevTools();
+  // TODO (466) Clicking a second time flushes the pending update; this should be unnecessary.
   await Test.selectReactDevTools();
   await Test.waitUntil(() => getComponents().length === 3, {
     waitingFor: "There to be 3 components in ReactDevTools",

--- a/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
+++ b/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
@@ -1,11 +1,9 @@
 import { ExecutionPoint, ObjectId } from "@replayio/protocol";
 import React from "react";
 import { useEffect, useState } from "react";
-import { connect, ConnectedProps } from "react-redux";
-import { useAppSelector } from "ui/setup/hooks";
+import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { ThreadFront } from "protocol/thread";
 import { compareNumericStrings } from "protocol/utils";
-import { UIState } from "ui/state";
 import { Annotation } from "ui/state/reactDevTools";
 import { getCurrentPoint, getTheme } from "ui/reducers/app";
 import {
@@ -266,15 +264,14 @@ async function loadReactDevToolsInlineModuleFromProtocol(stateUpdaterCallback: F
   }
 }
 
-function ReactDevtoolsPanel({
-  annotations,
-  currentPoint,
-  setIsNodePickerActive,
-  setIsNodePickerInitializing,
-  setHasReactComponents,
-  protocolCheckFailed,
-  reactInitPoint,
-}: PropsFromRedux) {
+export default function ReactDevtoolsPanel() {
+  const annotations = useAppSelector(getAnnotations);
+  const currentPoint = useAppSelector(getCurrentPoint);
+  const protocolCheckFailed = useAppSelector(getProtocolCheckFailed);
+  const reactInitPoint = useAppSelector(getReactInitPoint);
+
+  const dispatch = useAppDispatch();
+
   const theme = useAppSelector(getTheme);
 
   // Once we've obtained the protocol version, we'll dynamically load the correct module/version.
@@ -295,23 +292,23 @@ function ReactDevtoolsPanel({
   }
 
   function enablePicker(opts: NodePickerOpts) {
-    setIsNodePickerActive(true);
-    setIsNodePickerInitializing(false);
+    dispatch(setIsNodePickerActive(true));
+    dispatch(setIsNodePickerInitializing(false));
     NodePicker.enable(opts);
   }
   function initializePicker() {
-    setIsNodePickerActive(false);
-    setIsNodePickerInitializing(true);
+    dispatch(setIsNodePickerActive(false));
+    dispatch(setIsNodePickerInitializing(true));
   }
   function disablePicker() {
     NodePicker.disable();
-    setIsNodePickerActive(false);
-    setIsNodePickerInitializing(false);
+    dispatch(setIsNodePickerActive(false));
+    dispatch(setIsNodePickerInitializing(false));
   }
 
   function onShutdown() {
     sendTelemetryEvent("react-devtools-shutdown");
-    setHasReactComponents(false);
+    dispatch(setHasReactComponents(false));
   }
 
   if (protocolCheckFailed) {
@@ -374,15 +371,3 @@ function ReactDevtoolsPanel({
     />
   );
 }
-
-const connector = connect(
-  (state: UIState) => ({
-    annotations: getAnnotations(state),
-    currentPoint: getCurrentPoint(state),
-    protocolCheckFailed: getProtocolCheckFailed(state),
-    reactInitPoint: getReactInitPoint(state),
-  }),
-  { setIsNodePickerActive, setIsNodePickerInitializing, setHasReactComponents }
-);
-type PropsFromRedux = ConnectedProps<typeof connector>;
-export default connector(ReactDevtoolsPanel);


### PR DESCRIPTION
The core of this fix was replacing the Redux `connect()` HOC component with newer Redux selector hooks.

I think what was happening with the older HOC essentially boils down to how React Redux and the new `Offscreen` API interact:
1. When React _hides_ an offscreen tree, it runs effect cleanup functions.
1. Redux `connect()` HOC unsubscribes from Store updates when hidden (effect cleanup functions).
1. Redux `connect()` HOC doesn't correctly handle checking for missed updates when shown (effects remounted).

I talk through why this is in this lengthy Loom: https://www.loom.com/share/3d60c14466184b03acc9af7b80e9eff8