### PR TITLE
New Console handles too many exception points

### DIFF
--- a/packages/bvaughn-architecture-demo/components/Icon.tsx
+++ b/packages/bvaughn-architecture-demo/components/Icon.tsx
@@ -33,6 +33,7 @@ export default function Icon({
     | "search"
     | "share"
     | "source-explorer"
+    | "spinner"
     | "up"
     | "view-function-source"
     | "view-html-element"
@@ -144,6 +145,10 @@ export default function Icon({
     case "source-explorer":
       path =
         "M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z";
+      break;
+    case "spinner":
+      path =
+        "M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z";
       break;
     case "up":
       path = "M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z";

--- a/packages/bvaughn-architecture-demo/components/console/LoggablesContext.tsx
+++ b/packages/bvaughn-architecture-demo/components/console/LoggablesContext.tsx
@@ -2,8 +2,8 @@ import { ConsoleFiltersContext } from "@bvaughn/src/contexts/ConsoleFiltersConte
 import { FocusContext } from "@bvaughn/src/contexts/FocusContext";
 import { PointInstance, PointsContext } from "@bvaughn/src/contexts/PointsContext";
 import { TerminalContext, TerminalExpression } from "@bvaughn/src/contexts/TerminalContext";
-import { getExceptions, UncaughtException } from "@bvaughn/src/suspense/AnalysisCache";
 import { EventLog, getEventTypeEntryPoints } from "@bvaughn/src/suspense/EventsCache";
+import { getExceptions, UncaughtException } from "@bvaughn/src/suspense/ExceptionsCache";
 import { getMessages, ProtocolMessage } from "@bvaughn/src/suspense/MessagesCache";
 import { getHitPointsForLocation } from "@bvaughn/src/suspense/PointsCache";
 import { loggableSort } from "@bvaughn/src/utils/loggables";
@@ -118,7 +118,7 @@ export function LoggablesContextRoot({
   // We may suspend based on this value, so let's this value changes at sync priority,
   let exceptions: UncaughtException[] = EMPTY_ARRAY;
   if (showExceptions) {
-    exceptions = getExceptions(client);
+    exceptions = getExceptions(client, focusRange);
   }
 
   // Trim eventLogs and logPoints by focusRange.

--- a/packages/bvaughn-architecture-demo/components/console/filters/FilterToggles.module.css
+++ b/packages/bvaughn-architecture-demo/components/console/filters/FilterToggles.module.css
@@ -20,3 +20,9 @@
   border: none;
   background-color: var(--background-color-default);
 }
+
+.ExceptionsErrorIcon {
+  color: var(--color-error);
+  height: 1rem;
+  width: 1rem;
+}

--- a/packages/bvaughn-architecture-demo/components/console/filters/FilterToggles.module.css
+++ b/packages/bvaughn-architecture-demo/components/console/filters/FilterToggles.module.css
@@ -26,3 +26,19 @@
   height: 1rem;
   width: 1rem;
 }
+
+.SpinnerIcon {
+  color: var(--color-dim);
+  width: 1rem;
+  height: 1rem;
+  animation: 1s spin linear infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0);
+  }
+  100% {
+    transform: rotate(359deg);
+  }
+}

--- a/packages/bvaughn-architecture-demo/components/console/filters/FilterToggles.tsx
+++ b/packages/bvaughn-architecture-demo/components/console/filters/FilterToggles.tsx
@@ -1,14 +1,19 @@
+import Icon from "@bvaughn/components/Icon";
 import { ConsoleFiltersContext } from "@bvaughn/src/contexts/ConsoleFiltersContext";
 import { FocusContext } from "@bvaughn/src/contexts/FocusContext";
+import {
+  addTooManyPointsListeners,
+  didExceptionsFailTooManyPoints,
+} from "@bvaughn/src/suspense/ExceptionsCache";
+import { isInNodeModules } from "@bvaughn/src/utils/messages";
 import { CategoryCounts, getMessages } from "@bvaughn/src/suspense/MessagesCache";
 import camelCase from "lodash/camelCase";
-import React, { ReactNode, Suspense, useContext, useMemo } from "react";
+import React, { ReactNode, Suspense, useContext, useMemo, useSyncExternalStore } from "react";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { Badge, Checkbox } from "design";
 
 import EventsList from "./EventsList";
 import styles from "./FilterToggles.module.css";
-import { isInNodeModules } from "@bvaughn/src/utils/messages";
 
 export default function FilterToggles() {
   const {
@@ -21,40 +26,54 @@ export default function FilterToggles() {
     update,
   } = useContext(ConsoleFiltersContext);
 
+  const tooManyPoints = useSyncExternalStore(
+    (callback: () => void) => addTooManyPointsListeners(callback),
+    didExceptionsFailTooManyPoints,
+    didExceptionsFailTooManyPoints
+  );
+  const showExceptionsErrorBadge = showExceptions && tooManyPoints;
+
   return (
     <div className={styles.Filters} data-test-id="ConsoleFilterToggles">
       <Toggle
+        afterContent={
+          showExceptionsErrorBadge ? (
+            <span title="There are too many exceptions. Please focus to a smaller time range and try again.">
+              <Icon className={styles.ExceptionsErrorIcon} type="warning" />
+            </span>
+          ) : null
+        }
         checked={showExceptions}
         label="Exceptions"
         onChange={showExceptions => update({ showExceptions })}
       />
       <Toggle
-        checked={showLogs}
-        count={
+        afterContent={
           <Suspense fallback={null}>
             <ToggleCategoryCount category="logs" />
           </Suspense>
         }
+        checked={showLogs}
         label="Logs"
         onChange={showLogs => update({ showLogs })}
       />
       <Toggle
-        checked={showWarnings}
-        count={
+        afterContent={
           <Suspense fallback={null}>
             <ToggleCategoryCount category="warnings" />
           </Suspense>
         }
+        checked={showWarnings}
         label="Warnings"
         onChange={showWarnings => update({ showWarnings })}
       />
       <Toggle
-        checked={showErrors}
-        count={
+        afterContent={
           <Suspense fallback={null}>
             <ToggleCategoryCount category="errors" />
           </Suspense>
         }
+        checked={showErrors}
         label="Errors"
         onChange={showErrors => update({ showErrors })}
       />
@@ -62,8 +81,8 @@ export default function FilterToggles() {
       <EventsList />
       <hr className={styles.Divider} />
       <Toggle
+        afterContent={<NodeModulesCount />}
         checked={showNodeModules}
-        count={<NodeModulesCount />}
         label="Node modules"
         onChange={showNodeModules => update({ showNodeModules })}
       />
@@ -77,13 +96,13 @@ export default function FilterToggles() {
 }
 
 function Toggle({
+  afterContent = null,
   checked,
-  count = null,
   label,
   onChange,
 }: {
+  afterContent?: ReactNode | null;
   checked: boolean;
-  count?: ReactNode | null;
   label: string;
   onChange: (checked: boolean) => void;
 }) {
@@ -97,7 +116,7 @@ function Toggle({
         id={id}
         onChange={(event: React.ChangeEvent<HTMLInputElement>) => onChange(event.target.checked)}
       />
-      {count}
+      {afterContent}
     </div>
   );
 }

--- a/packages/bvaughn-architecture-demo/components/console/renderers/UncaughtExceptionRenderer.tsx
+++ b/packages/bvaughn-architecture-demo/components/console/renderers/UncaughtExceptionRenderer.tsx
@@ -3,7 +3,7 @@ import Inspector from "@bvaughn/components/inspector";
 import Loader from "@bvaughn/components/Loader";
 import { ConsoleFiltersContext } from "@bvaughn/src/contexts/ConsoleFiltersContext";
 import Expandable from "@bvaughn/components/Expandable";
-import { UncaughtException } from "@bvaughn/src/suspense/AnalysisCache";
+import { UncaughtException } from "@bvaughn/src/suspense/ExceptionsCache";
 import { formatTimestamp } from "@bvaughn/src/utils/time";
 import { Value as ProtocolValue } from "@replayio/protocol";
 import { Fragment, MouseEvent, useRef, useState } from "react";

--- a/packages/bvaughn-architecture-demo/src/suspense/AnalysisCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/AnalysisCache.ts
@@ -25,9 +25,9 @@ type AnalysisResult = {
   values: Value[];
 };
 
-type AnalysisResults = (timeStampedPoint: TimeStampedPoint) => AnalysisResult | null;
+export type AnalysisResults = (timeStampedPoint: TimeStampedPoint) => AnalysisResult | null;
 
-type RemoteAnalysisResult = {
+export type RemoteAnalysisResult = {
   data: { frames: Frame[]; objects: Object[]; scopes: Scope[] };
   location: Location | Location[];
   pauseId: PauseId;
@@ -36,12 +36,10 @@ type RemoteAnalysisResult = {
   values: Array<{ value?: any; object?: string }>;
 };
 
-export type UncaughtException = RemoteAnalysisResult & {
-  type: "UncaughtException";
-};
-
-let inProgressSourcesWakeable: Wakeable<RemoteAnalysisResult[]> | null = null;
-let exceptions: UncaughtException[] | null = null;
+function getKey(focusRange: PointRange | null, location: Location, code: string): string {
+  const rangeString = focusRange ? `${focusRange.begin}-${focusRange.end}` : "-";
+  return `${rangeString}:${location.sourceId}:${location.line}:${location.column}:${code}`;
+}
 
 const locationAndTimeToValueMap: Map<string, Record<AnalysisResults>> = new Map();
 
@@ -49,47 +47,6 @@ const locationAndTimeToValueMap: Map<string, Record<AnalysisResults>> = new Map(
 // Currently we re-run the analysis which seems wasteful.
 
 // TODO (FE-469) Add focus region awareness to analysis.
-
-function getKey(focusRange: PointRange | null, location: Location, code: string): string {
-  const rangeString = focusRange ? `${focusRange.begin}-${focusRange.end}` : "-";
-  return `${rangeString}:${location.sourceId}:${location.line}:${location.column}:${code}`;
-}
-
-export function getExceptions(client: ReplayClientInterface): UncaughtException[] {
-  if (exceptions !== null) {
-    return exceptions;
-  }
-
-  if (inProgressSourcesWakeable === null) {
-    inProgressSourcesWakeable = createWakeable();
-    fetchExceptions(client);
-  }
-
-  throw inProgressSourcesWakeable;
-}
-
-async function fetchExceptions(client: ReplayClientInterface) {
-  const results = await client.runAnalysis<RemoteAnalysisResult>({
-    effectful: false,
-    exceptionPoints: true,
-    mapper: EXCEPTIONS_MAPPER,
-  });
-
-  // This will avoid us having to turn around and request them again when rendering the logs.
-  results.forEach(result => {
-    if (result.data.objects) {
-      preCacheObjects(result.pauseId, result.data.objects);
-    }
-  });
-
-  exceptions = results.map(result => ({
-    ...result,
-    type: "UncaughtException",
-  }));
-
-  inProgressSourcesWakeable!.resolve(exceptions!);
-  inProgressSourcesWakeable = null;
-}
 
 export function runAnalysis(
   client: ReplayClientInterface,
@@ -287,45 +244,3 @@ function createMapperForAnalysis(code: string): string {
     ];
   `;
 }
-
-const EXCEPTIONS_MAPPER = `
-  const finalData = { frames: [], scopes: [], objects: [] };
-
-  function addPauseData({ frames, scopes, objects }) {
-    finalData.frames.push(...(frames || []));
-    finalData.scopes.push(...(scopes || []));
-    finalData.objects.push(...(objects || []));
-  }
-
-  function getTopFrame() {
-    const { data, frame: frameId } = sendCommand("Pause.getTopFrame");
-
-    return (data.frames || []).find((f) => f.frameId == frameId);
-  }
-
-  const { pauseId, point, time } = input;
-  const { frameId, location } = getTopFrame();
-  const {
-    data: { objects, scopes },
-    exception,
-  } = sendCommand("Pause.getExceptionValue");
-  const {
-    data: { frames },
-  } = sendCommand("Pause.getAllFrames");
-
-  addPauseData({ frames, objects, scopes });
-
-  return [
-    {
-      key: time,
-      value: {
-        data: finalData,
-        location,
-        pauseId,
-        point,
-        time,
-        values: [exception],
-      },
-    },
-  ];
-`;

--- a/packages/bvaughn-architecture-demo/src/suspense/ExceptionsCache.test.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/ExceptionsCache.test.ts
@@ -1,0 +1,271 @@
+import { TimeStampedPoint, TimeStampedPointRange } from "@replayio/protocol";
+import { ReplayClientInterface } from "shared/client/types";
+
+import { createMockReplayClient } from "../utils/testing";
+
+import { UncaughtException } from "./ExceptionsCache";
+
+describe("ExceptionsCache", () => {
+  function createCE() {
+    const error = new Error("There are too many points to complete this operation");
+    error.name = "CommandError";
+    return error;
+  }
+
+  function createUE(time: number = 0) {
+    return {
+      data: { frames: [], objects: [], scopes: [] },
+      location: [],
+      pauseId: "pause",
+      point: `${time * 1000}`,
+      time,
+      values: [],
+      type: "UncaughtException",
+    };
+  }
+
+  function toTSP(time: number): TimeStampedPoint {
+    return { time, point: `${time * 1000}` };
+  }
+
+  function toTSPR(beginTime: number, endTime: number): TimeStampedPointRange {
+    return { begin: toTSP(beginTime), end: toTSP(endTime) };
+  }
+
+  async function getExceptionsHelper(
+    range: TimeStampedPointRange | null
+  ): Promise<UncaughtException[]> {
+    try {
+      return getExceptions(client as any as ReplayClientInterface, range);
+    } catch (promise) {
+      await promise;
+
+      return getExceptions(client as any as ReplayClientInterface, range);
+    }
+  }
+
+  let client: { [key: string]: jest.Mock };
+  let didExceptionsFailTooManyPoints: () => boolean;
+  let getExceptions: (
+    client: ReplayClientInterface,
+    range: TimeStampedPointRange | null
+  ) => Promise<UncaughtException[]>;
+
+  beforeEach(() => {
+    client = createMockReplayClient() as any;
+
+    // Clear and recreate cached data between tests.
+    const module = require("./ExceptionsCache");
+    didExceptionsFailTooManyPoints = module.didExceptionsFailTooManyPoints;
+    getExceptions = module.getExceptions;
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it("should handle empty range", async () => {
+    const exceptions = await getExceptionsHelper(toTSPR(1, 1));
+
+    expect(exceptions).toEqual([]);
+    expect(exceptions).toBe(await getExceptionsHelper(toTSPR(1, 1)));
+
+    expect(client.runAnalysis).not.toHaveBeenCalled();
+  });
+
+  it("should handle an empty array of exceptions", async () => {
+    client.runAnalysis.mockImplementation(() => Promise.resolve([]));
+
+    const exceptions = await getExceptionsHelper(toTSPR(1, 2));
+    expect(exceptions).toEqual([]);
+    expect(exceptions).toBe(await getExceptionsHelper(toTSPR(1, 2)));
+
+    expect(client.runAnalysis).toHaveBeenCalledTimes(1);
+
+    expect(didExceptionsFailTooManyPoints()).toBe(false);
+  });
+
+  it("should reuse cached exceptions when there is no focus range", async () => {
+    client.runAnalysis.mockImplementation(() =>
+      Promise.resolve([createUE(0), createUE(1), createUE(2), createUE(3)])
+    );
+
+    const exceptions = await getExceptionsHelper(null);
+    expect(exceptions.map(({ time }) => time)).toEqual([0, 1, 2, 3]);
+    expect(exceptions).toBe(await getExceptionsHelper(null));
+
+    expect(client.runAnalysis).toHaveBeenCalledTimes(1);
+
+    expect(didExceptionsFailTooManyPoints()).toBe(false);
+  });
+
+  it("should reuse cached exceptions for the same focus range", async () => {
+    client.runAnalysis.mockImplementation(() =>
+      Promise.resolve([createUE(0), createUE(1), createUE(2), createUE(3)])
+    );
+
+    const exceptions = await getExceptionsHelper(toTSPR(1, 2));
+    expect(exceptions.map(({ time }) => time)).toEqual([1, 2]);
+    expect(exceptions).toBe(await getExceptionsHelper(toTSPR(1, 2)));
+
+    expect(client.runAnalysis).toHaveBeenCalledTimes(1);
+
+    expect(didExceptionsFailTooManyPoints()).toBe(false);
+  });
+
+  it("should handle a too many exception points", async () => {
+    client.runAnalysis.mockImplementation(() => Promise.reject(createCE()));
+
+    const exceptions = await getExceptionsHelper(toTSPR(1, 2));
+    expect(exceptions).toEqual([]);
+    expect(exceptions).toBe(await getExceptionsHelper(toTSPR(1, 2)));
+
+    expect(client.runAnalysis).toHaveBeenCalledTimes(1);
+
+    expect(didExceptionsFailTooManyPoints()).toBe(true);
+  });
+
+  it("should filter within memory if focus range contracts from previously null", async () => {
+    client.runAnalysis.mockImplementation(() =>
+      Promise.resolve([createUE(0), createUE(1), createUE(2), createUE(3)])
+    );
+
+    let exceptions = await getExceptionsHelper(null);
+    expect(exceptions.map(({ time }) => time)).toEqual([0, 1, 2, 3]);
+    expect(client.runAnalysis).toHaveBeenCalledTimes(1);
+
+    exceptions = await getExceptionsHelper(toTSPR(1, 2));
+    expect(exceptions.map(({ time }) => time)).toEqual([1, 2]);
+    expect(client.runAnalysis).toHaveBeenCalledTimes(1);
+
+    expect(didExceptionsFailTooManyPoints()).toBe(false);
+  });
+
+  it("should filter within memory if focus range contracts from previously focused", async () => {
+    client.runAnalysis.mockImplementation(() =>
+      Promise.resolve([createUE(0), createUE(1), createUE(2), createUE(3)])
+    );
+
+    let exceptions = await getExceptionsHelper(toTSPR(0, 3));
+    expect(exceptions.map(({ time }) => time)).toEqual([0, 1, 2, 3]);
+    expect(client.runAnalysis).toHaveBeenCalledTimes(1);
+
+    exceptions = await getExceptionsHelper(toTSPR(1, 3));
+    expect(exceptions.map(({ time }) => time)).toEqual([1, 2, 3]);
+    expect(client.runAnalysis).toHaveBeenCalledTimes(1);
+
+    exceptions = await getExceptionsHelper(toTSPR(2, 3));
+    expect(exceptions.map(({ time }) => time)).toEqual([2, 3]);
+    expect(client.runAnalysis).toHaveBeenCalledTimes(1);
+
+    expect(didExceptionsFailTooManyPoints()).toBe(false);
+  });
+
+  it("should re-request if focus range expands", async () => {
+    client.runAnalysis.mockImplementation(() => Promise.resolve([createUE(1), createUE(2)]));
+
+    let exceptions = await getExceptionsHelper(toTSPR(1, 2));
+    expect(exceptions.map(({ time }) => time)).toEqual([1, 2]);
+    expect(client.runAnalysis).toHaveBeenCalledTimes(1);
+
+    client.runAnalysis.mockImplementation(() =>
+      Promise.resolve([createUE(1), createUE(2), createUE(3)])
+    );
+    exceptions = await getExceptionsHelper(toTSPR(1, 3));
+    expect(exceptions.map(({ time }) => time)).toEqual([1, 2, 3]);
+    expect(client.runAnalysis).toHaveBeenCalledTimes(2);
+
+    client.runAnalysis.mockImplementation(() =>
+      Promise.resolve([createUE(0), createUE(1), createUE(2), createUE(3)])
+    );
+    exceptions = await getExceptionsHelper(toTSPR(0, 3));
+    expect(exceptions.map(({ time }) => time)).toEqual([0, 1, 2, 3]);
+    expect(client.runAnalysis).toHaveBeenCalledTimes(3);
+
+    expect(didExceptionsFailTooManyPoints()).toBe(false);
+  });
+
+  it("should re-request if focus range expands to null", async () => {
+    client.runAnalysis.mockImplementation(() => Promise.resolve([createUE(1), createUE(2)]));
+
+    let exceptions = await getExceptionsHelper(toTSPR(1, 2));
+    expect(exceptions.map(({ time }) => time)).toEqual([1, 2]);
+    expect(client.runAnalysis).toHaveBeenCalledTimes(1);
+
+    client.runAnalysis.mockImplementation(() =>
+      Promise.resolve([createUE(0), createUE(1), createUE(2), createUE(3)])
+    );
+    exceptions = await getExceptionsHelper(null);
+    expect(exceptions.map(({ time }) => time)).toEqual([0, 1, 2, 3]);
+    expect(client.runAnalysis).toHaveBeenCalledTimes(2);
+
+    expect(didExceptionsFailTooManyPoints()).toBe(false);
+  });
+
+  it("should always re-request if focus region changes after too many points error", async () => {
+    client.runAnalysis.mockImplementation(() => Promise.reject(createCE()));
+
+    let exceptions = await getExceptionsHelper(toTSPR(0, 3));
+    expect(exceptions).toEqual([]);
+    expect(didExceptionsFailTooManyPoints()).toBe(true);
+    expect(client.runAnalysis).toHaveBeenCalledTimes(1);
+
+    exceptions = await getExceptionsHelper(toTSPR(1, 3));
+    expect(exceptions).toEqual([]);
+    expect(didExceptionsFailTooManyPoints()).toBe(true);
+    expect(client.runAnalysis).toHaveBeenCalledTimes(2);
+
+    exceptions = await getExceptionsHelper(toTSPR(1, 2));
+    expect(exceptions).toEqual([]);
+    expect(didExceptionsFailTooManyPoints()).toBe(true);
+    expect(client.runAnalysis).toHaveBeenCalledTimes(3);
+  });
+
+  it("should ignore a protocol response if a newer request is in-flight", async () => {
+    let resolvePromise1: any;
+    let resolvePromise2: any;
+
+    const promise1 = new Promise(resolve => {
+      resolvePromise1 = () => resolve([createUE(0), createUE(1)]);
+    });
+    const promise2 = new Promise(resolve => {
+      resolvePromise2 = () => resolve([createUE(2), createUE(3)]);
+    });
+
+    client.runAnalysis.mockImplementation(() => promise1);
+    try {
+      getExceptions(client as any as ReplayClientInterface, toTSPR(0, 1));
+    } catch (error) {}
+
+    client.runAnalysis.mockImplementation(() => promise2);
+    try {
+      getExceptions(client as any as ReplayClientInterface, toTSPR(2, 3));
+    } catch (error) {}
+
+    resolvePromise2();
+    await promise2;
+
+    resolvePromise1();
+    await promise1;
+
+    const exceptions = await getExceptionsHelper(toTSPR(2, 3));
+    expect(exceptions.map(({ time }) => time)).toEqual([2, 3]);
+    expect(didExceptionsFailTooManyPoints()).toBe(false);
+    expect(client.runAnalysis).toHaveBeenCalledTimes(2);
+  });
+
+  it("should re-use the in-flight promise if the same focus range is specified", async () => {
+    let resolvePromise: any;
+
+    const promise = new Promise(resolve => {
+      resolvePromise = () => resolve([]);
+    });
+
+    client.runAnalysis.mockImplementation(() => promise);
+    getExceptionsHelper(toTSPR(0, 1));
+    getExceptionsHelper(toTSPR(0, 1));
+    getExceptionsHelper(toTSPR(0, 1));
+
+    expect(client.runAnalysis).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/bvaughn-architecture-demo/src/suspense/ExceptionsCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/ExceptionsCache.ts
@@ -1,0 +1,192 @@
+import { isTooManyPointsError } from "@bvaughn/../shared/utils/error";
+import { TimeStampedPointRange } from "@replayio/protocol";
+import { ReplayClientInterface } from "shared/client/types";
+
+import { createWakeable } from "../utils/suspense";
+import { isRangeEqual, isRangeSubset } from "../utils/time";
+import { RemoteAnalysisResult } from "./AnalysisCache";
+import { preCacheObjects } from "./ObjectPreviews";
+
+import { Wakeable } from "./types";
+
+export type UncaughtException = RemoteAnalysisResult & {
+  type: "UncaughtException";
+};
+
+type Callback = () => void;
+
+const EMPTY_ARRAY: any[] = [];
+
+let inFlightFocusRange: TimeStampedPointRange | null = null;
+let inFlightWakeable: Wakeable<RemoteAnalysisResult[]> | null = null;
+let lastFetchDidFailTooManyPoints: boolean = false;
+let lastFetchedFocusRange: TimeStampedPointRange | null = null;
+let lastFetchedExceptions: UncaughtException[] | null = null;
+let lastFilteredExceptions: UncaughtException[] | null = null;
+let lastFilteredFocusRange: TimeStampedPointRange | null = null;
+
+const tooManyPointsListeners: Set<Callback> = new Set();
+
+export function didExceptionsFailTooManyPoints(): boolean {
+  return lastFetchDidFailTooManyPoints;
+}
+
+export function addTooManyPointsListeners(callback: Callback): Callback {
+  tooManyPointsListeners.add(callback);
+  return function unsubscribe() {
+    tooManyPointsListeners.delete(callback);
+  };
+}
+
+function setFetchDidFailTooManyPoints(value: boolean): void {
+  if (lastFetchDidFailTooManyPoints !== value) {
+    lastFetchDidFailTooManyPoints = value;
+    tooManyPointsListeners.forEach(callback => callback());
+  }
+}
+
+export function getExceptions(
+  client: ReplayClientInterface,
+  focusRange: TimeStampedPointRange | null
+): UncaughtException[] {
+  if (focusRange !== null && focusRange.begin.point === focusRange.end.point) {
+    // Edge case scenario handling.
+    return EMPTY_ARRAY;
+  }
+
+  if (inFlightWakeable !== null && isRangeEqual(inFlightFocusRange, focusRange)) {
+    // If we're already fetching this data, rethrow the same Wakeable (for Suspense reasons).
+    throw inFlightWakeable;
+  }
+
+  let shouldFetch = false;
+  if (lastFetchedExceptions === null) {
+    // This is the first time we're fetching data.
+    shouldFetch = true;
+  } else {
+    if (!isRangeSubset(lastFetchedFocusRange, focusRange)) {
+      // The new range is bigger than the old range so we need to fetch again.
+      shouldFetch = true;
+    } else if (!isRangeEqual(lastFetchedFocusRange, focusRange) && lastFetchDidFailTooManyPoints) {
+      // The last time we tried to fetch overflowed,
+      // but the new range is smaller so we should try again
+      shouldFetch = true;
+    }
+  }
+
+  if (shouldFetch) {
+    inFlightFocusRange = focusRange;
+    inFlightWakeable = createWakeable();
+
+    fetchExceptions(client);
+
+    throw inFlightWakeable;
+  }
+
+  if (focusRange === null) {
+    lastFilteredExceptions = lastFetchedExceptions;
+    lastFilteredFocusRange = focusRange;
+  } else if (!isRangeEqual(lastFilteredFocusRange, focusRange)) {
+    lastFilteredExceptions = lastFetchedExceptions!.filter(exception => {
+      return exception.point >= focusRange.begin.point && exception.point <= focusRange.end.point;
+    });
+    lastFilteredFocusRange = focusRange;
+  }
+
+  return lastFilteredExceptions!;
+}
+
+async function fetchExceptions(client: ReplayClientInterface) {
+  const wakeable = inFlightWakeable!;
+
+  try {
+    const results = await client.runAnalysis<RemoteAnalysisResult>({
+      effectful: false,
+      exceptionPoints: true,
+      mapper: EXCEPTIONS_MAPPER,
+      range: inFlightFocusRange
+        ? { begin: inFlightFocusRange.begin.point, end: inFlightFocusRange.end.point }
+        : undefined,
+    });
+
+    // Cache Object preview data since we have it.
+    // This may save us from making unnecessary requests later.
+    results.forEach(result => {
+      if (result.data.objects) {
+        preCacheObjects(result.pauseId, result.data.objects);
+      }
+    });
+
+    if (wakeable === inFlightWakeable) {
+      lastFetchedExceptions = results.map(result => ({
+        ...result,
+        type: "UncaughtException",
+      }));
+      lastFetchedFocusRange = inFlightFocusRange;
+
+      setFetchDidFailTooManyPoints(false);
+    }
+
+    // React doesn't use the resolved value.
+    wakeable.resolve(null as any);
+  } catch (error) {
+    if (isTooManyPointsError(error) && wakeable === inFlightWakeable) {
+      lastFetchedExceptions = EMPTY_ARRAY;
+      lastFetchedFocusRange = inFlightFocusRange;
+
+      setFetchDidFailTooManyPoints(true);
+    } else {
+      console.error(error);
+    }
+
+    // React doesn't use the resolved value.
+    wakeable.resolve(null as any);
+  } finally {
+    if (wakeable === inFlightWakeable) {
+      inFlightFocusRange = null;
+      inFlightWakeable = null;
+    }
+  }
+}
+
+const EXCEPTIONS_MAPPER = `
+  const finalData = { frames: [], scopes: [], objects: [] };
+
+  function addPauseData({ frames, scopes, objects }) {
+    finalData.frames.push(...(frames || []));
+    finalData.scopes.push(...(scopes || []));
+    finalData.objects.push(...(objects || []));
+  }
+
+  function getTopFrame() {
+    const { data, frame: frameId } = sendCommand("Pause.getTopFrame");
+
+    return (data.frames || []).find((f) => f.frameId == frameId);
+  }
+
+  const { pauseId, point, time } = input;
+  const { frameId, location } = getTopFrame();
+  const {
+    data: { objects, scopes },
+    exception,
+  } = sendCommand("Pause.getExceptionValue");
+  const {
+    data: { frames },
+  } = sendCommand("Pause.getAllFrames");
+
+  addPauseData({ frames, objects, scopes });
+
+  return [
+    {
+      key: time,
+      value: {
+        data: finalData,
+        location,
+        pauseId,
+        point,
+        time,
+        values: [exception],
+      },
+    },
+  ];
+`;

--- a/packages/bvaughn-architecture-demo/src/utils/loggables.ts
+++ b/packages/bvaughn-architecture-demo/src/utils/loggables.ts
@@ -1,8 +1,8 @@
 import { Loggable } from "@bvaughn/components/console/LoggablesContext";
 import { PointInstance } from "@bvaughn/src/contexts/PointsContext";
 import { TerminalExpression } from "@bvaughn/src/contexts/TerminalContext";
-import { UncaughtException } from "@bvaughn/src/suspense/AnalysisCache";
 import { EventLog } from "@bvaughn/src/suspense/EventsCache";
+import { UncaughtException } from "@bvaughn/src/suspense/ExceptionsCache";
 import { ProtocolMessage } from "@bvaughn/src/suspense/MessagesCache";
 import { ExecutionPoint } from "@replayio/protocol";
 import { compareExecutionPoints } from "./time";

--- a/packages/bvaughn-architecture-demo/src/utils/testing.tsx
+++ b/packages/bvaughn-architecture-demo/src/utils/testing.tsx
@@ -28,7 +28,7 @@ export async function render(
   sessionContext: SessionContextType;
 }> {
   const replayClient: ReplayClientInterface = {
-    ...MockReplayClient,
+    ...createMockReplayClient(),
     ...options?.replayClient,
   };
 
@@ -160,38 +160,40 @@ export function setupWindow(): void {
 
 // This mock client is mostly useless by itself,
 // but its methods can be overridden individually (or observed/inspected) by test code.
-const MockReplayClient = {
-  get loadedRegions() {
-    return null;
-  },
-  addEventListener: jest.fn(),
-  configure: jest.fn().mockImplementation(async () => {}),
-  createPause: jest.fn().mockImplementation(async () => ({
-    frames: [],
-    data: {},
-  })),
-  evaluateExpression: jest.fn().mockImplementation(async () => ({ data: {} })),
-  findMessages: jest.fn().mockImplementation(async () => ({ messages: [], overflow: false })),
-  findSources: jest.fn().mockImplementation(async () => []),
-  getAllFrames: jest.fn().mockImplementation(async () => []),
-  getEventCountForType: jest.fn().mockImplementation(async () => 0),
-  getHitPointsForLocation: jest.fn().mockImplementation(async () => []),
-  getObjectWithPreview: jest.fn().mockImplementation(async () => ({})),
-  getPointNearTime: jest.fn().mockImplementation(async () => ({ point: "0", time: 0 })),
-  getRecordingId: jest.fn().mockImplementation(async () => "fake-recording-id"),
-  getSessionEndpoint: jest.fn().mockImplementation(async () => ({
-    point: "1000",
-    time: 1000,
-  })),
-  getSessionId: jest.fn().mockImplementation(async () => "fake-session-id"),
-  getSourceContents: jest.fn().mockImplementation(async () => ({
-    contents: "fake-source-contents",
-    contentType: "text/javascript",
-  })),
-  getSourceHitCounts: jest.fn().mockImplementation(async () => new Map()),
-  initialize: jest.fn().mockImplementation(async () => {}),
-  loadRegion: jest.fn().mockImplementation(async () => {}),
-  removeEventListener: jest.fn(),
-  runAnalysis: jest.fn().mockImplementation(async () => []),
-  searchSources: jest.fn().mockImplementation(async () => []),
-};
+export function createMockReplayClient() {
+  return {
+    get loadedRegions() {
+      return null;
+    },
+    addEventListener: jest.fn(),
+    configure: jest.fn().mockImplementation(async () => {}),
+    createPause: jest.fn().mockImplementation(async () => ({
+      frames: [],
+      data: {},
+    })),
+    evaluateExpression: jest.fn().mockImplementation(async () => ({ data: {} })),
+    findMessages: jest.fn().mockImplementation(async () => ({ messages: [], overflow: false })),
+    findSources: jest.fn().mockImplementation(async () => []),
+    getAllFrames: jest.fn().mockImplementation(async () => []),
+    getEventCountForType: jest.fn().mockImplementation(async () => 0),
+    getHitPointsForLocation: jest.fn().mockImplementation(async () => []),
+    getObjectWithPreview: jest.fn().mockImplementation(async () => ({})),
+    getPointNearTime: jest.fn().mockImplementation(async () => ({ point: "0", time: 0 })),
+    getRecordingId: jest.fn().mockImplementation(async () => "fake-recording-id"),
+    getSessionEndpoint: jest.fn().mockImplementation(async () => ({
+      point: "1000",
+      time: 1000,
+    })),
+    getSessionId: jest.fn().mockImplementation(async () => "fake-session-id"),
+    getSourceContents: jest.fn().mockImplementation(async () => ({
+      contents: "fake-source-contents",
+      contentType: "text/javascript",
+    })),
+    getSourceHitCounts: jest.fn().mockImplementation(async () => new Map()),
+    initialize: jest.fn().mockImplementation(async () => {}),
+    loadRegion: jest.fn().mockImplementation(async () => {}),
+    removeEventListener: jest.fn(),
+    runAnalysis: jest.fn().mockImplementation(async () => []),
+    searchSources: jest.fn().mockImplementation(async () => []),
+  };
+}

--- a/packages/bvaughn-architecture-demo/src/utils/time.test.ts
+++ b/packages/bvaughn-architecture-demo/src/utils/time.test.ts
@@ -1,6 +1,15 @@
-import { formatDuration, formatTimestamp } from "./time";
+import { TimeStampedPoint, TimeStampedPointRange } from "@replayio/protocol";
+import { formatDuration, formatTimestamp, isRangeEqual, isRangeSubset } from "./time";
 
 describe("Time util", () => {
+  function toTSP(time: number): TimeStampedPoint {
+    return { time, point: `${time * 1000}` };
+  }
+
+  function toTSPR(beginTime: number, endTime: number): TimeStampedPointRange {
+    return { begin: toTSP(beginTime), end: toTSP(endTime) };
+  }
+
   describe("formatDuration", () => {
     it("should format values", () => {
       expect(formatDuration(0)).toEqual("0ms");
@@ -41,6 +50,42 @@ describe("Time util", () => {
     it("should round fractional values", () => {
       expect(formatTimestamp(1.3, true)).toEqual("0:00.001");
       expect(formatTimestamp(1.7, true)).toEqual("0:00.002");
+    });
+  });
+
+  describe("isRangeEqual", () => {
+    it("should properly handle combinations of null values", () => {
+      expect(isRangeEqual(null, null)).toEqual(true);
+      expect(isRangeEqual(toTSPR(1, 3), null)).toEqual(false);
+      expect(isRangeEqual(null, toTSPR(1, 3))).toEqual(false);
+    });
+
+    it("should properly handle non-null ranges", () => {
+      expect(isRangeEqual(toTSPR(1, 3), toTSPR(1, 3))).toEqual(true);
+      expect(isRangeEqual(toTSPR(1, 3), toTSPR(0, 0))).toEqual(false);
+      expect(isRangeEqual(toTSPR(1, 3), toTSPR(1, 1))).toEqual(false);
+      expect(isRangeEqual(toTSPR(1, 3), toTSPR(3, 3))).toEqual(false);
+    });
+  });
+
+  describe("isRangeSubset", () => {
+    it("should properly handle combinations of null values", () => {
+      expect(isRangeSubset(null, null)).toBe(true);
+      expect(isRangeSubset(null, toTSPR(1, 3))).toBe(true);
+      expect(isRangeSubset(toTSPR(1, 3), null)).toBe(false);
+    });
+
+    it("should properly handle non-null ranges", () => {
+      expect(isRangeSubset(toTSPR(1, 3), toTSPR(1, 3))).toBe(true);
+      expect(isRangeSubset(toTSPR(1, 3), toTSPR(2, 3))).toBe(true);
+      expect(isRangeSubset(toTSPR(1, 3), toTSPR(1, 2))).toBe(true);
+      expect(isRangeSubset(toTSPR(1, 3), toTSPR(2, 2))).toBe(true);
+
+      expect(isRangeSubset(toTSPR(1, 3), toTSPR(0, 3))).toBe(false);
+      expect(isRangeSubset(toTSPR(1, 3), toTSPR(1, 4))).toBe(false);
+      expect(isRangeSubset(toTSPR(1, 3), toTSPR(2, 4))).toBe(false);
+      expect(isRangeSubset(toTSPR(1, 3), toTSPR(0, 2))).toBe(false);
+      expect(isRangeSubset(toTSPR(1, 3), toTSPR(0, 4))).toBe(false);
     });
   });
 });

--- a/packages/bvaughn-architecture-demo/src/utils/time.ts
+++ b/packages/bvaughn-architecture-demo/src/utils/time.ts
@@ -3,7 +3,7 @@ import differenceInCalendarDays from "date-fns/differenceInCalendarDays";
 import differenceInWeeks from "date-fns/differenceInWeeks";
 import differenceInMonths from "date-fns/differenceInMonths";
 import differenceInYears from "date-fns/differenceInYears";
-import { ExecutionPoint, TimeStampedPointRange } from "@replayio/protocol";
+import { ExecutionPoint, PointRange, TimeStampedPointRange } from "@replayio/protocol";
 import padStart from "lodash/padStart";
 import prettyMilliseconds from "pretty-ms";
 
@@ -103,9 +103,9 @@ export function isRangeSubset(
     // No matter what the previous range was, the new one is not a subset.
     return false;
   } else {
-    return (
-      !isExecutionPointsLessThan(prevRange.begin.point, nextRange.begin.point) &&
-      !isExecutionPointsGreaterThan(prevRange.end.point, nextRange.end.point)
+    return !(
+      isExecutionPointsLessThan(nextRange.begin.point, prevRange.begin.point) ||
+      isExecutionPointsGreaterThan(nextRange.end.point, prevRange.end.point)
     );
   }
 }

--- a/packages/shared/client/ReplayClient.ts
+++ b/packages/shared/client/ReplayClient.ts
@@ -366,22 +366,26 @@ export class ReplayClient implements ReplayClientInterface {
       const results: Result[] = [];
       let resultReceived = false;
 
-      await analysisManager.runAnalysis(analysisParams, {
-        onAnalysisError: (errorMessage: string) => {
-          reject(errorMessage);
-        },
-        onAnalysisResult: analysisEntries => {
-          resultReceived = true;
-          results.push(...analysisEntries.map(entry => entry.value));
-        },
-      });
+      try {
+        await analysisManager.runAnalysis(analysisParams, {
+          onAnalysisError: (errorMessage: string) => {
+            reject(errorMessage);
+          },
+          onAnalysisResult: analysisEntries => {
+            resultReceived = true;
+            results.push(...analysisEntries.map(entry => entry.value));
+          },
+        });
 
-      if (resultReceived) {
-        resolve(results);
-      } else {
-        // No result was returned.
-        // This might happen when e.g. exceptions are being queried for a recording with no exceptions.
-        resolve([]);
+        if (resultReceived) {
+          resolve(results);
+        } else {
+          // No result was returned.
+          // This might happen when e.g. exceptions are being queried for a recording with no exceptions.
+          resolve([]);
+        }
+      } catch (error) {
+        reject(error);
       }
     });
   }

--- a/packages/shared/utils/error.ts
+++ b/packages/shared/utils/error.ts
@@ -1,3 +1,11 @@
+export function isTooManyPointsError(error: any) {
+  return (
+    error instanceof Error &&
+    error.name === "CommandError" &&
+    error.message.includes("too many points")
+  );
+}
+
 export function isUnloadedRegionError(error: any) {
   return (
     error instanceof Error && error.name === "CommandError" && error.message.includes("unloaded")


### PR DESCRIPTION
Migrated the exceptions handling to its own cache that knows how to work with focus range and the "too many points" error. Also added a lot of Suspense cache unit tests. (I should add these for other caches– like `MessagesCache` at least.)