### PR TITLE
Fix broken "Elements" sub-tab styles

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -77,6 +77,7 @@ import "devtools/client/debugger/src/components/ShortcutsModal.css";
 import "devtools/client/debugger/src/utils/editor/source-editor.css";
 import "devtools/client/shared/components/Accordion.css";
 import "devtools/client/shared/components/splitter/SplitBox.css";
+import "devtools/client/shared/components/Tabs.css";
 import "devtools/client/themes/accessibility-color-contrast.css";
 import "devtools/client/themes/badge.css";
 import "devtools/client/themes/boxmodel.css";

--- a/src/devtools/client/shared/components/Tabs.css
+++ b/src/devtools/client/shared/components/Tabs.css
@@ -1,0 +1,141 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* Tabs General Styles */
+
+.tabs {
+  height: 100%;
+  background: var(--theme-sidebar-background);
+  display: flex;
+  flex-direction: column;
+}
+
+/* Hides the tab strip in the TabBar */
+div[hidetabs="true"] .tabs .tabs-navigation {
+  display: none;
+}
+
+.tabs .tabs-navigation {
+  box-sizing: border-box;
+  display: flex;
+  position: relative;
+  background: var(--tab-bgcolor);
+}
+
+.requestDetails .tabs .tabs-navigation {
+  border-bottom: none;
+}
+
+.requestDetails .tabs .tabs-menu-item a {
+  border-bottom: none;
+}
+
+.tabs .tabs-menu {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  flex-grow: 1;
+}
+
+/* The tab takes entire horizontal space and individual tabs
+  should stretch accordingly. Use flexbox for the behavior.
+  Use also `overflow: hidden` so, 'overflow' and 'underflow'
+  events are fired (it's utilized by the all-tabs-menu). */
+.tabs .tabs-navigation .tabs-menu {
+  overflow: hidden;
+  display: flex;
+}
+
+.tabs .tabs-menu-item {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  padding: 0;
+  color: var(--theme-toolbar-color);
+}
+
+.tabs .responsive-tabs-dropdown {
+  background: var(--theme-tab-toolbar-background);
+  border: 1px solid var(--theme-splitter-color);
+  border-radius: 0 0 5px 5px;
+  box-shadow: 3px 3px 3px 1px var(--popup-shadow-color);
+  z-index: 5;
+}
+
+.tabs .responsive-tabs-dropdown .tabs-menu-item {
+  display: block;
+}
+
+.tabs .tabs-menu-item.is-active {
+  color: var(--tab-selected-color);
+  background: var(--tab-selected-bgcolor);
+}
+
+.tabs .tabs-menu-item {
+  color: var(--tab-color);
+  background: var(--tab-bgcolor);
+}
+
+.tabs .tabs-menu-item:hover:not(.is-active) {
+  background-color: var(--tab-hover-bgcolor);
+  color: var(--tab-hover-color);
+}
+
+.tabs .tabs-menu-item :is(a, button) {
+  display: flex;
+  place-items: center;
+  padding: 0 10px;
+  font-size: 12px;
+  line-height: 16px;
+  text-decoration: none;
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+  text-align: center;
+  height: calc(2px + var(--theme-toolbar-height));
+}
+
+.tabs .tabs-menu-item :is(a, button):is(:focus-visible, :hover) {
+  outline: 0;
+  color: var(--tab-hover-color);
+  background-color: var(--tab-hover-bgcolor);
+}
+
+/* Remove the outline focusring from tabs-menu-item. */
+.tabs .tabs-navigation .tabs-menu-item > a:-moz-focusring {
+  outline: none;
+}
+
+.tabs .tabs-menu-item .tab-badge {
+  color: var(--theme-highlight-blue);
+  font-size: 80%;
+  font-style: italic;
+  /* Tabs have a 15px padding start/end, so we set the margins here in order to center the
+     badge after the tab title, with a 5px effective margin. */
+  margin-inline-start: 5px;
+  margin-inline-end: -10px;
+}
+
+.tabs .tabs-menu-item.is-active .tab-badge {
+  /* Use the same color as the tab-item when active */
+  color: inherit;
+}
+
+/* To avoid "select all" commands from selecting content in hidden tabs */
+.tabs .hidden,
+.tabs .hidden * {
+  user-select: none !important;
+}
+
+/* Make sure panel content takes entire vertical space. */
+.tabs .panels {
+  flex: 1;
+  overflow: hidden;
+}
+
+.tabs .tab-panel {
+  height: 100%;
+  overflow-x: hidden;
+  overflow-y: auto;
+}


### PR DESCRIPTION
This PR:

- Re-adds the `Tabs.css` file I previously nuked - turns out that while the component wasn't being used, the CSS was still necessary