### PR TITLE
Filter timestamped points by point, not time

### DIFF
--- a/src/ui/utils/timeline.test.ts
+++ b/src/ui/utils/timeline.test.ts
@@ -10,7 +10,7 @@ import {
   overlap,
 } from "./timeline";
 
-const point = (time: number) => ({ time, point: "" });
+const point = (time: number) => ({ time, point: `${time}` });
 const focusRegion = (from: number, to: number): FocusRegion => ({
   begin: point(from),
   beginTime: from,

--- a/src/ui/utils/timeline.ts
+++ b/src/ui/utils/timeline.ts
@@ -302,11 +302,10 @@ export function filterToFocusRegion<T extends TimeStampedPoint>(
     return sortedPoints;
   }
 
-  const beginTime = displayedBeginForFocusRegion(focusRegion);
-  const endTime = displayedEndForFocusRegion(focusRegion);
+  const { begin: beginPoint, end: endPoint } = rangeForFocusRegion(focusRegion);
 
-  const beginIndex = sortedIndexBy(sortedPoints, { time: beginTime, point: "" }, p => p.time);
-  const endIndex = sortedLastIndexBy(sortedPoints, { time: endTime, point: "" }, p => p.time);
+  const beginIndex = sortedIndexBy(sortedPoints, beginPoint, ({ point }) => BigInt(point));
+  const endIndex = sortedLastIndexBy(sortedPoints, endPoint, ({ point }) => BigInt(point));
 
   return sortedPoints.slice(beginIndex, endIndex);
 }


### PR DESCRIPTION
We were filtering analysis points by displayed begin and end times. That
does not work. The displayed begin and end times for a focus region
don't necessarily reflect the true begin and end times for that region.
Since we pass a point range for hitCounts, sometimes analysis and hitCounts
disagree. Now, we might have another class of bug: it's theoretically
possible (though hopefully pretty unlikely!) to have "hits" that are
outside of the displayed timeline of a breakpoint. If we see that
happening, we can rethink some of this, but I think it will not happen
*nearly* as often as us miscounting hits because of edge pieces.