### PR TITLE
Button standardization

### DIFF
--- a/pages/browser/auth.tsx
+++ b/pages/browser/auth.tsx
@@ -11,7 +11,7 @@ const BrowserAuth = () => {
         <p>You have successfully logged into the Replay Browser. You may close this window.</p>
         <p className="text-center">
           <a
-            className="inline-flex h-12 items-center rounded-md bg-primaryAccent px-4 text-white"
+            className="inline-flex items-center h-12 px-4 rounded-md bg-primaryAccent text-buttontextColor"
             href={library}
           >
             Open Replay

--- a/pages/browser/launch.tsx
+++ b/pages/browser/launch.tsx
@@ -10,10 +10,10 @@ const BrowserLaunch = () => {
       <LaunchBrowser path={library}>
         <p className="text-center">
           <a
-            className="inline-flex h-12 items-center rounded-md bg-primaryAccent px-4 text-white"
+            className="inline-flex items-center h-12 px-4 rounded-md bg-primaryAccent text-buttontextColor"
             href={library}
           >
-            Open Replay
+            Open Replay!
           </a>
         </p>
       </LaunchBrowser>

--- a/pages/browser/launch.tsx
+++ b/pages/browser/launch.tsx
@@ -12,8 +12,8 @@ const BrowserLaunch = () => {
           <a
             className="inline-flex items-center h-12 px-4 rounded-md bg-primaryAccent text-buttontextColor"
             href={library}
-          >ˇ
-            Open Replay!
+          >
+            ˇ Open Replay!
           </a>
         </p>
       </LaunchBrowser>

--- a/pages/browser/launch.tsx
+++ b/pages/browser/launch.tsx
@@ -12,7 +12,7 @@ const BrowserLaunch = () => {
           <a
             className="inline-flex items-center h-12 px-4 rounded-md bg-primaryAccent text-buttontextColor"
             href={library}
-          >
+          >ˇ
             Open Replay!
           </a>
         </p>

--- a/pages/browser/launch.tsx
+++ b/pages/browser/launch.tsx
@@ -13,7 +13,7 @@ const BrowserLaunch = () => {
             className="inline-flex items-center h-12 px-4 rounded-md bg-primaryAccent text-buttontextColor"
             href={library}
           >
-            ˇ Open Replay!
+            Open Replay
           </a>
         </p>
       </LaunchBrowser>

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/CommentButton.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/CommentButton.tsx
@@ -18,7 +18,9 @@ export default function CommentButton({ addComment, pausedOnHit }: CommentButton
           "inline-flex items-center rounded-md border border-transparent px-1 text-xs font-medium leading-4 text-buttontextColor shadow-sm focus:outline-none focus:ring-2 focus:ring-primaryAccent focus:ring-offset-2"
         )}
       >
-        <div className="text-base material-icons add-comment-icon text-buttontextColor">add_comment</div>
+        <div className="text-base material-icons add-comment-icon text-buttontextColor">
+          add_comment
+        </div>
       </button>
     );
   }

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/CommentButton.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/CommentButton.tsx
@@ -15,10 +15,10 @@ export default function CommentButton({ addComment, pausedOnHit }: CommentButton
         title="Add Comment"
         className={classNames(
           pausedOnHit ? "paused-add-comment" : "bg-primaryAccent hover:bg-primaryAccentHover",
-          "inline-flex items-center rounded-md border border-transparent px-1 text-xs font-medium leading-4 text-white shadow-sm focus:outline-none focus:ring-2 focus:ring-primaryAccent focus:ring-offset-2"
+          "inline-flex items-center rounded-md border border-transparent px-1 text-xs font-medium leading-4 text-buttontextColor shadow-sm focus:outline-none focus:ring-2 focus:ring-primaryAccent focus:ring-offset-2"
         )}
       >
-        <div className="material-icons add-comment-icon text-base text-white">add_comment</div>
+        <div className="text-base material-icons add-comment-icon text-buttontextColor">add_comment</div>
       </button>
     );
   }

--- a/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
@@ -31,7 +31,7 @@ const QuickActionButton: FC<{
     <button
       className={classNames(
         "toggle-widget",
-        "flex rounded-md p-px leading-3 text-white shadow-lg transition hover:scale-125",
+        "flex rounded-md p-px leading-3 text-buttontextColor shadow-lg transition hover:scale-125",
         `${disabled ? "bg-gray-600" : "bg-primaryAccent"}`
       )}
       onClick={disabled ? () => {} : onClick}

--- a/src/devtools/client/themes/variables.css
+++ b/src/devtools/client/themes/variables.css
@@ -144,6 +144,7 @@
   /* Core classes (Light) */
   --chrome: var(--theme-base-95); /* bg app */
   --body-color: #38383d;
+  --buttontext-color: pink;
   --checkbox-border: var(--theme-base-80);
   --checkbox: #fff;
   --modal-bgcolor: rgba(255, 255, 255, 0.98);
@@ -412,6 +413,7 @@
   /* Core classes (Dark) */
   --chrome: #081120; /* bg app */
   --body-color: var(--grey-30);
+  --buttontext-color: pink;
   --checkbox-border: var(--theme-base-90);
   --checkbox: var(--theme-base-80);
   --modal-bgcolor: var(--theme-base-90);

--- a/src/devtools/client/themes/variables.css
+++ b/src/devtools/client/themes/variables.css
@@ -144,7 +144,7 @@
   /* Core classes (Light) */
   --chrome: var(--theme-base-95); /* bg app */
   --body-color: #38383d;
-  --buttontext-color: #F4F8FA;
+  --buttontext-color: #f4f8fa;
   --checkbox-border: var(--theme-base-80);
   --checkbox: #fff;
   --modal-bgcolor: rgba(255, 255, 255, 0.98);
@@ -414,7 +414,7 @@
   /* Core classes (Dark) */
   --chrome: #081120; /* bg app */
   --body-color: var(--grey-30);
-  --buttontext-color: #F4F8FA;
+  --buttontext-color: #f4f8fa;
   --checkbox-border: var(--theme-base-90);
   --checkbox: var(--theme-base-80);
   --modal-bgcolor: var(--theme-base-90);

--- a/src/devtools/client/themes/variables.css
+++ b/src/devtools/client/themes/variables.css
@@ -144,7 +144,7 @@
   /* Core classes (Light) */
   --chrome: var(--theme-base-95); /* bg app */
   --body-color: #38383d;
-  --buttontext-color: pink;
+  --buttontext-color: #F4F8FA;
   --checkbox-border: var(--theme-base-80);
   --checkbox: #fff;
   --modal-bgcolor: rgba(255, 255, 255, 0.98);
@@ -216,6 +216,7 @@
 
   /* To organise (Light) */
   --jellyfish-bgcolor: rgba(255, 255, 255, 0.8);
+  --timejump-text: var(--buttontext-color);
   --theme-console-input-bgcolor: var(--body-bgcolor);
   --theme-toggle-handle-bgcolor: var(--theme-base-100);
   --theme-toggle-handle-bgcolor-hover: #b5eaff;
@@ -413,7 +414,7 @@
   /* Core classes (Dark) */
   --chrome: #081120; /* bg app */
   --body-color: var(--grey-30);
-  --buttontext-color: pink;
+  --buttontext-color: #F4F8FA;
   --checkbox-border: var(--theme-base-90);
   --checkbox: var(--theme-base-80);
   --modal-bgcolor: var(--theme-base-90);
@@ -484,6 +485,7 @@
 
   /* To organise (Dark) */
   --jellyfish-bgcolor: rgba(40, 40, 40, 0.8);
+  --timejump-text: var(--buttontext-color);
   --theme-console-input-bgcolor: var(--theme-base-95);
   --theme-toggle-handle-bgcolor: var(--theme-base-100);
   --theme-toggle-handle-bgcolor-hover: #005f92;

--- a/src/ui/components/Header/ShareButton.tsx
+++ b/src/ui/components/Header/ShareButton.tsx
@@ -16,7 +16,7 @@ function ShareButton({ setModal }: PropsFromRedux) {
     <button
       type="button"
       onClick={onClick}
-      className="mr-0 flex items-center space-x-1.5 rounded-lg bg-primaryAccent text-white hover:bg-primaryAccentHover focus:outline-none focus:ring-2 focus:ring-primaryAccent focus:ring-offset-2"
+      className="mr-0 flex items-center space-x-1.5 rounded-lg bg-primaryAccent text-buttontextColor hover:bg-primaryAccentHover focus:outline-none focus:ring-2 focus:ring-primaryAccent focus:ring-offset-2"
       style={{ padding: "5px 12px" }}
     >
       <MaterialIcon style={{ fontSize: "16px" }}>ios_share</MaterialIcon>

--- a/src/ui/components/Library/Navigation/NewTeamButton.tsx
+++ b/src/ui/components/Library/Navigation/NewTeamButton.tsx
@@ -13,7 +13,7 @@ export function NewTeamButton() {
   return (
     <a
       className={classNames(
-        `${styles.teamRow} group flex flex-row justify-between space-x-2 px-4 py-2 text-left transition duration-200 hover:text-white focus:outline-none underline`
+        `${styles.teamRow} group flex flex-row justify-between space-x-2 px-4 py-2 text-left transition duration-200 hover:cursor-pointer focus:outline-none underline`
       )}
       onClick={onClick}
     >

--- a/src/ui/components/Library/Navigation/TeamButton.tsx
+++ b/src/ui/components/Library/Navigation/TeamButton.tsx
@@ -56,8 +56,8 @@ export function TeamButton({
           </div>
         </span>
         {isNew ? (
-          <div className={"rounded-lg bg-primaryAccent px-3 py-0.5 text-xs text-white"}>New</div>
-        ) : null}
+          <div className={"rounded-md bg-primaryAccent px-3 py-0.5 text-xs text-white"}>New</div>
+          ) : null}
         {showSettingsButton ? <SettingsButton /> : null}
       </a>
     </Link>

--- a/src/ui/components/Library/Navigation/TeamButton.tsx
+++ b/src/ui/components/Library/Navigation/TeamButton.tsx
@@ -57,7 +57,7 @@ export function TeamButton({
         </span>
         {isNew ? (
           <div className={"rounded-md bg-primaryAccent px-3 py-0.5 text-xs text-white"}>New</div>
-          ) : null}
+        ) : null}
         {showSettingsButton ? <SettingsButton /> : null}
       </a>
     </Link>

--- a/src/ui/components/LoginButton.tsx
+++ b/src/ui/components/LoginButton.tsx
@@ -19,7 +19,7 @@ const LoginButton = () => {
 
   return (
     <button
-      className="inline-flex items-center rounded-md border border-transparent bg-primaryAccent px-3 py-1.5 text-sm font-medium leading-4 text-white hover:bg-primaryAccentHover focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+      className="inline-flex items-center rounded-md border border-transparent bg-primaryAccent px-3 py-1.5 text-sm font-medium leading-4 text-buttontextColor hover:bg-primaryAccentHover focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
       onClick={() => loginAndReturn()}
       color="blue"
     >

--- a/src/ui/components/NetworkMonitor/RequestRow.tsx
+++ b/src/ui/components/NetworkMonitor/RequestRow.tsx
@@ -76,7 +76,7 @@ export const RequestRow = ({
                 [styles.rewind]: row.original.triggerPoint.time < currentTime,
               })}
             />
-            <span className={classNames("px-2 text-white", styles.verbose)}>
+            <span className={classNames("px-2 text-timejumpText", styles.verbose)}>
               {row.original.triggerPoint.time > currentTime ? "Fast-forward" : "Rewind"}
             </span>
           </button>

--- a/src/ui/components/UploadScreen/UploadScreen.tsx
+++ b/src/ui/components/UploadScreen/UploadScreen.tsx
@@ -34,15 +34,15 @@ function DeletedScreen({ url }: { url: string }) {
   });
 
   return (
-    <div className="h-full w-full">
+    <div className="w-full h-full">
       <Modal>
         <div
-          className="relative flex flex-col items-center justify-between space-y-4 overflow-y-auto rounded-md bg-modalBgcolor p-9 text-base shadow-lg"
+          className="relative flex flex-col items-center justify-between space-y-4 overflow-y-auto text-base rounded-md shadow-lg bg-modalBgcolor p-9"
           style={{ width: "400px" }}
         >
           <ReplayLogo size="sm" />
           <h2 className="text-2xl font-bold ">{`Replay discarded`}</h2>
-          <div className="text-md space-y-2">
+          <div className="space-y-2 text-md">
             <div>{`Hang tight while we load your library...`}</div>
           </div>
         </div>
@@ -76,7 +76,7 @@ function Actions({ onDiscard, status }: { onDiscard: () => void; status: Status 
         disabled={shouldDisableActions}
         value={isSaving ? `Uploading…` : `Save`}
         ref={saveButtonRef}
-        className="mb-8 cursor-pointer rounded-xl bg-primaryAccent py-3.5 px-16 font-bold text-white shadow-sm hover:bg-primaryAccentHover focus:border-primaryAccentHover focus:outline-none focus:ring focus:ring-primaryAccentHover"
+        className="mb-8 cursor-pointer rounded-xl bg-primaryAccent py-3.5 px-16 font-bold text-buttontextColor shadow-sm hover:bg-primaryAccentHover focus:border-primaryAccentHover focus:outline-none focus:ring focus:ring-primaryAccentHover"
       />
     </div>
   );
@@ -84,7 +84,7 @@ function Actions({ onDiscard, status }: { onDiscard: () => void; status: Status 
 
 function LimitWarning() {
   return (
-    <div className="absolute bottom-2 right-2 flex place-content-center rounded-md bg-gray-500 p-2 text-xs text-white shadow-lg">
+    <div className="absolute flex p-2 text-xs text-white bg-gray-500 rounded-md shadow-lg bottom-2 right-2 place-content-center">
       <Icon filename="warning" size="small" className="bg-white" />
       <span className="px-1">Replays work best under 2 minutes</span>
     </div>
@@ -99,9 +99,9 @@ function ReplayScreenshot({
   showLimitWarning: boolean;
 }) {
   return (
-    <div className="relative h-64 rounded-lg bg-jellyfishBgcolor px-6 pt-6 shadow-lg short:hidden">
+    <div className="relative h-64 px-6 pt-6 rounded-lg shadow-lg bg-jellyfishBgcolor short:hidden">
       {showLimitWarning ? <LimitWarning /> : null}
-      <img src={screenData} className="m-auto h-full" />
+      <img src={screenData} className="h-full m-auto" />
     </div>
   );
 }
@@ -177,20 +177,20 @@ export default function UploadScreen({ recording, userSettings, onUpload }: Uplo
       <div className="flex flex-col items-center">
         <UploadRecordingTrialEnd {...{ selectedWorkspaceId, workspaces }} />
         <form className="relative flex flex-col items-center overflow-auto" onSubmit={onSubmit}>
-          <div className="mb-10 flex flex-row space-x-4 short:h-auto">
+          <div className="flex flex-row mb-10 space-x-4 short:h-auto">
             <div
-              className="relative flex flex-col overflow-hidden rounded-xl text-lg font-medium shadow-lg"
+              className="relative flex flex-col overflow-hidden text-lg font-medium shadow-lg rounded-xl"
               style={{ width: "620px" }}
             >
-              <div className="absolute h-full w-full bg-jellyfishBgcolor" />
-              <div className="relative space-y-6 px-8 py-9">
+              <div className="absolute w-full h-full bg-jellyfishBgcolor" />
+              <div className="relative px-8 space-y-6 py-9">
                 <ReplayTitle inputValue={inputValue} setInputValue={setInputValue} />
                 <ReplayScreenshot
                   screenData={screenData!}
                   showLimitWarning={showDurationWarning(recording)}
                 />
               </div>
-              <div className="relative space-y-6 border-t border-themeBorder px-8 py-9">
+              <div className="relative px-8 space-y-6 border-t border-themeBorder py-9">
                 <Sharing
                   workspaces={workspaces}
                   selectedWorkspaceId={selectedWorkspaceId}

--- a/src/ui/components/shared/APIKeys.tsx
+++ b/src/ui/components/shared/APIKeys.tsx
@@ -22,7 +22,7 @@ function NewApiKey({ keyValue, onDone }: { keyValue: string; onDone: () => void 
   return (
     <>
       <div className="flex items-center justify-between space-x-3">
-        <div className="w-0 flex-auto">
+        <div className="flex-auto w-0">
           <div className="flex h-9 w-full items-center rounded-md border border-textFieldBorder bg-themeTextFieldBgcolor px-2.5 text-themeTextFieldColor text-primaryAccent">
             <input
               readOnly
@@ -34,7 +34,7 @@ function NewApiKey({ keyValue, onDone }: { keyValue: string; onDone: () => void 
               <div className="text-primaryAccent">Copied</div>
             ) : (
               <MaterialIcon
-                className="material-icons w-5 cursor-pointer text-primaryAccent hover:text-primaryAccentHover"
+                className="w-5 cursor-pointer material-icons text-primaryAccent hover:text-primaryAccentHover"
                 iconSize="lg"
                 onClick={() => navigator.clipboard.writeText(keyValue!).then(() => setCopied(true))}
               >
@@ -44,7 +44,7 @@ function NewApiKey({ keyValue, onDone }: { keyValue: string; onDone: () => void 
           </div>
         </div>
         <button
-          className="inline-flex h-9 items-center rounded-md border border-transparent bg-primaryAccent px-2.5 py-1.5 font-medium leading-4 text-white shadow-sm hover:bg-primaryAccentHover focus:bg-primaryAccentHover focus:outline-none"
+          className="inline-flex h-9 items-center rounded-md border border-transparent bg-primaryAccent px-2.5 py-1.5 font-medium leading-4 text-buttontextColor shadow-sm hover:bg-primaryAccentHover focus:bg-primaryAccentHover focus:outline-none"
           onClick={onDone}
         >
           Done
@@ -64,9 +64,9 @@ function ApiKeyList({ apiKeys, onDelete }: { apiKeys: ApiKey[]; onDelete: (id: s
   }
 
   return (
-    <section className="flex flex-auto flex-col">
+    <section className="flex flex-col flex-auto">
       <h3 className="text-base font-semibold uppercase">API Keys</h3>
-      <div className="h-0 flex-auto overflow-auto">
+      <div className="flex-auto h-0 overflow-auto">
         {apiKeys.map(apiKey => {
           const usage =
             typeof apiKey.maxRecordings === "number"
@@ -140,7 +140,7 @@ export default function APIKeys({
   }, [keyValue]);
 
   return (
-    <div className="flex h-0 flex-auto flex-col space-y-8">
+    <div className="flex flex-col flex-auto h-0 space-y-8">
       <label className="setting-item">
         <div className="description">{description}</div>
       </label>
@@ -176,7 +176,7 @@ export default function APIKeys({
                 <button
                   type="submit"
                   disabled={!canSubmit}
-                  className={`inline-flex items-center rounded-md border border-transparent bg-primaryAccent px-2.5 py-1.5 font-medium leading-4 text-white shadow-sm focus:outline-none ${
+                  className={`inline-flex items-center rounded-md border border-transparent bg-primaryAccent px-2.5 py-1.5 font-medium leading-4 text-buttontextColor shadow-sm focus:outline-none ${
                     canSubmit
                       ? "hover:bg-primaryAccentHover focus:bg-primaryAccentHover"
                       : "opacity-60"

--- a/src/ui/components/shared/Button.tsx
+++ b/src/ui/components/shared/Button.tsx
@@ -40,7 +40,7 @@ function getColorCode(color: Colors, num: ColorScale) {
 
 function getTextClass(color: Colors) {
   if (color === "white") {
-    return "text-white";
+    return "text-buttontextColor";
   }
 
   return `text-${getColorCode(color, 700)}`;

--- a/src/ui/components/shared/Forms/SelectMenu.tsx
+++ b/src/ui/components/shared/Forms/SelectMenu.tsx
@@ -14,7 +14,7 @@ function Option({ name, id }: { name: string; id: string | null }) {
       key={id}
       className={({ active }) =>
         classnames(
-          active ? "bg-primaryAccent text-white" : "",
+          active ? "bg-primaryAccent text-buttontextColor" : "",
           "relative cursor-default select-none py-1.5 pl-2.5 pr-7"
         )
       }
@@ -30,7 +30,7 @@ function Option({ name, id }: { name: string; id: string | null }) {
           {selected ? (
             <span
               className={classnames(
-                active ? "text-white" : "text-primaryAccent",
+                active ? "text-buttontextColor" : "text-primaryAccent",
                 "absolute inset-y-0 right-0 flex items-center pr-3"
               )}
             >

--- a/src/ui/components/shared/SharingModal/EmailForm.tsx
+++ b/src/ui/components/shared/SharingModal/EmailForm.tsx
@@ -18,30 +18,30 @@ function AutocompleteAction({
   if (status === "loading") {
     return (
       <button
-        className="inline-flex items-center space-x-1.5 rounded-md border border-transparent bg-primaryAccent px-2.5 py-1.5 font-medium text-white focus:outline-none"
+        className="inline-flex items-center space-x-1.5 rounded-md border border-transparent bg-primaryAccent px-2.5 py-1.5 font-medium text-buttontextColor focus:outline-none"
         disabled
       >
-        <Spinner className="h-4 w-4 animate-spin text-white" />
+        <Spinner className="w-4 h-4 animate-spin text-buttontextColor" />
         <span>Inviting</span>
       </button>
     );
   } else if (status === "completed") {
     return (
       <button
-        className="inline-flex items-center space-x-1 rounded-md border border-transparent bg-green-600 px-2.5 py-1.5 font-medium text-white focus:outline-none"
+        className="inline-flex items-center space-x-1 rounded-md border border-transparent bg-green-600 px-2.5 py-1.5 font-medium text-buttontextColor focus:outline-none"
         disabled
       >
-        <CheckCircleIcon className="h-4 w-4 text-white" />
+        <CheckCircleIcon className="w-4 h-4 text-buttontextColor" />
         <span>Invited</span>
       </button>
     );
   } else if (status === "error") {
     return (
       <button
-        className="inline-flex items-center space-x-1 rounded-md border border-transparent bg-red-600 px-2.5 py-1.5 font-medium text-white focus:outline-none"
+        className="inline-flex items-center space-x-1 rounded-md border border-transparent bg-red-600 px-2.5 py-1.5 font-medium text-buttontextColor focus:outline-none"
         disabled
       >
-        <ExclamationCircleIcon className="h-4 w-4 text-white" />
+        <ExclamationCircleIcon className="w-4 h-4 text-buttontextColor" />
         <span>Unknown User</span>
       </button>
     );
@@ -49,10 +49,10 @@ function AutocompleteAction({
 
   return (
     <button
-      className="inline-flex items-center space-x-1 rounded-md border border-transparent bg-primaryAccent px-2.5 py-1.5 font-medium text-white hover:bg-primaryAccentHover focus:outline-none"
+      className="inline-flex items-center space-x-1 rounded-md border border-transparent bg-primaryAccent px-2.5 py-1.5 font-medium text-buttontextColor hover:bg-primaryAccentHover focus:outline-none"
       onClick={handleSubmit}
     >
-      <PaperAirplaneIcon className="h-4 w-4 rotate-90 transform text-white" />
+      <PaperAirplaneIcon className="w-4 h-4 transform rotate-90 text-buttontextColor" />
       <span>Add</span>
     </button>
   );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,7 +16,7 @@ module.exports = {
           60: "var(--theme-base-60)",
         },
         bodyColor: "var(--body-color)",
-        buttontextColor: "var(--buttontext-color)",        
+        buttontextColor: "var(--buttontext-color)",
         breakpointEditfieldActive: "var(--breakpoint-editfield-active)",
         breakpointEditfieldHover: "var(--breakpoint-editfield-hover)",
         breakpointStatus: "var(--breakpoint-status)",
@@ -59,6 +59,7 @@ module.exports = {
         themeToggleBgcolor: "var(--theme-toggle-bgcolor)",
         themeToggleColor: "var(--theme-toggle-color)",
         themeToolbarPanelIconColor: "var(--theme-toolbar-panel-icon-color)",
+        timejumpText: "var(--timejump-text)",
         toolbarBackground: "var(--theme-toolbar-background)",
         toolbarBackgroundAlt: "var(--theme-toolbar-background-alt)",
         lightGrey: "var(--light-grey)",
@@ -73,8 +74,8 @@ module.exports = {
         "ew-resize": "ew-resize",
       },
       borderWidth: {
-        '3': '2.5px',
-      }
+        3: "2.5px",
+      },
     },
   },
   plugins: [require("@tailwindcss/forms")],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,7 @@ module.exports = {
           60: "var(--theme-base-60)",
         },
         bodyColor: "var(--body-color)",
+        buttontextColor: "var(--buttontext-color)",        
         breakpointEditfieldActive: "var(--breakpoint-editfield-active)",
         breakpointEditfieldHover: "var(--breakpoint-editfield-hover)",
         breakpointStatus: "var(--breakpoint-status)",


### PR DESCRIPTION
Part of the [Design Standardization project](https://linear.app/replay/project/design-system-icons-css-variables-e676bad5ebf7). Also see our [raw notes in Notion](https://www.notion.so/replayio/Removing-black-and-white-styles-5bff4b7438c341ff972b16468b9ab348) where I'm tracking a bunch of different components.

- [x] Stop hard-coding "black" and "white" because that can cause dark/light theme visual bugs
- [x] Start documenting all the different places we use buttons so we can standardise them in fewer components
- [x] Audit other components (our add comment circle, fast-forward/rewind buttons, "URL copied to clipboard" notifications, trial badges, etc) so we can standardize them further

ROI notes: the app has a lot of rough edges because we often reinvent components per-view. These are the first steps towards us having a unified visual language. 
