### PR TITLE
Fix syntax highlighting

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/index.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/index.tsx
@@ -393,13 +393,13 @@ class Editor extends PureComponent<PropsFromRedux, EditorState> {
   }
 
   setText(props: PropsFromRedux, editor: SourceEditor) {
-    const { selectedSourceContent, symbols } = props;
+    const { selectedSource, selectedSourceContent, symbols } = props;
     if (!editor) {
       return;
     }
 
     // check if we previously had a selected source
-    if (!selectedSourceContent) {
+    if (!selectedSource || !selectedSourceContent) {
       return this.clearEditor();
     }
 
@@ -416,12 +416,7 @@ class Editor extends PureComponent<PropsFromRedux, EditorState> {
       return this.showErrorMessage(value);
     }
 
-    return showSourceText(
-      editor,
-      selectedSourceContent,
-      selectedSourceContent.value,
-      symbols as any
-    );
+    return showSourceText(editor, selectedSource, selectedSourceContent.value, symbols as any);
   }
 
   clearEditor() {

--- a/src/devtools/client/debugger/src/utils/editor/source-documents.ts
+++ b/src/devtools/client/debugger/src/utils/editor/source-documents.ts
@@ -86,7 +86,7 @@ function setEditorText(editor: SourceEditor, sourceId: string, content: SourceCo
 
 function setMode(
   editor: SourceEditor,
-  source: SourceContent,
+  source: SourceDetails,
   content: SourceContentValue,
   symbols: SymbolDeclarations
 ) {
@@ -109,7 +109,7 @@ function setMode(
  */
 export function showSourceText(
   editor: SourceEditor,
-  source: SourceContent,
+  source: SourceDetails,
   content: SourceContentValue,
   symbols: SymbolDeclarations
 ) {


### PR DESCRIPTION
Fixes FE-491

This fixes the source that were passing into showSourceText.


Shows the bug in the old code
https://app.replay.io/recording/template-string-breaks-syntax-highlighting--09a63fbd-adb9-420c-96c2-d92dac0a240e?point=143437200791717435347476203339514079&time=55510.94331002976&hasFrames=true#