### PR TITLE
Fix ThreadFront for the architecture demo

### DIFF
--- a/packages/protocol/thread/thread.ts
+++ b/packages/protocol/thread/thread.ts
@@ -1130,7 +1130,7 @@ class _ThreadFront {
 
   getCorrespondingSourceIds(sourceId: SourceId) {
     assert(this.hasAllSources, "not all sources have been loaded yet");
-    return this.sourcesSelectors!.getSourceDetails(sourceId)?.correspondingSourceIds || [sourceId];
+    return this.sourcesSelectors?.getSourceDetails(sourceId)?.correspondingSourceIds || [sourceId];
   }
 
   // Replace the sourceId in a location with the first corresponding sourceId


### PR DESCRIPTION
The architecture demo doesn't set `ThreadFront.sourcesSelectors` but it uses the `AnalysisManager` which asks for corresponding sourceIds. So we need to ensure that `ThreadFront.getCorrespondingSourceIds()` can work without `ThreadFront.sourcesSelectors`.