### PR TITLE
Add default value to getCorrespondingSourceIds selector

### DIFF
--- a/src/ui/reducers/hitCounts.ts
+++ b/src/ui/reducers/hitCounts.ts
@@ -154,7 +154,7 @@ export const fetchHitCounts = (sourceId: string, lineNumber: number): UIThunkAct
       );
       const focusRegion = getFocusRegion(getState());
       const range = focusRegion ? rangeForFocusRegion(focusRegion) : undefined;
-      const correspondingSourceIds = getCorrespondingSourceIds(getState(), sourceId)!;
+      const correspondingSourceIds = getCorrespondingSourceIds(getState(), sourceId);
       // See https://linear.app/replay/issue/FE-412/two-different-responses-to-the-same-protocol-message-in-a-single
       await Promise.all(
         correspondingSourceIds.map(sourceId =>

--- a/src/ui/reducers/sources.ts
+++ b/src/ui/reducers/sources.ts
@@ -232,7 +232,9 @@ export const getSourcesById = (state: UIState, ids: string[]) => {
   return ids.map(id => getSourceDetails(state, id)!);
 };
 export const getCorrespondingSourceIds = (state: UIState, id: string) => {
-  return getSourceDetails(state, id)?.correspondingSourceIds;
+  const source = getSourceDetails(state, id);
+  assert(source, `unknown source ${id}`);
+  return source?.correspondingSourceIds || [id];
 };
 export const getSourceContent = (state: UIState, id: string) => {
   return state.sources.contents.entities[id];
@@ -363,7 +365,7 @@ export function getHasSiblingOfSameName(state: UIState, source: MiniSource) {
 }
 
 export function getSourceIdToDisplayById(state: UIState, sourceId: string) {
-  return getCorrespondingSourceIds(state, sourceId)![0];
+  return getCorrespondingSourceIds(state, sourceId)[0];
 }
 
 export const getSourceToDisplayById = (state: UIState, sourceId: string) => {
@@ -397,7 +399,7 @@ export function getSourceIdToDisplayForUrl(state: UIState, url: string) {
     return;
   }
   const preferred = getPreferredSourceId(state.sources.sourceDetails.entities, sourceIds)!;
-  return getCorrespondingSourceIds(state, preferred)![0];
+  return getCorrespondingSourceIds(state, preferred)[0];
 }
 
 export const getSourceToDisplayForUrl = (state: UIState, url: string) => {


### PR DESCRIPTION
Fixes FE-585:
apparently there was a persisted source tab with a sourceId that doesn't exist in the recording (at least that's the only explanation I could think of), so an exception was thrown when trying to get the first corresponding sourceId.
`getCorrespondingSourceIds(sourceId)` will now return `[sourceId]` if the source could not be found in the store.