### PR TITLE
Add support for OSS and internal team plans

### DIFF
--- a/src/ui/components/shared/WorkspaceSettingsModal/Details.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/Details.tsx
@@ -72,7 +72,7 @@ function SubscriptionDetails({
       <PlanDetails subscription={subscription} />
       {isSubscriptionCancelled(subscription) ||
       subscription.billingSchedule === "contract" ||
-      subscription.plan?.key === "beta-v1" ? null : (
+      subscription.seatPrice === 0 ? null : (
         <div className="flex flex-row items-center justify-between border-b border-themeBase-85 py-2">
           <span>Payment Method</span>
           <span className="flex flex-col items-end">

--- a/src/ui/components/shared/WorkspaceSettingsModal/utils.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/utils.tsx
@@ -54,6 +54,22 @@ export const pricingDetailsForSubscription = (subscription: Subscription): PlanP
         discount: 0,
         trial: isTrial(subscription),
       };
+    case "team-oss-v1":
+      return {
+        billingSchedule: "monthly",
+        displayName: "OSS Team",
+        seatPrice: 0,
+        discount: 0,
+        trial: false,
+      };
+    case "team-internal-v1":
+      return {
+        billingSchedule: "monthly",
+        displayName: "Replay Team",
+        seatPrice: 0,
+        discount: 0,
+        trial: false,
+      };
     case "team-v1":
     case "test-team-v1":
       return {

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -75,7 +75,9 @@ type PlanKey =
   | "test-beta-v1"
   | "ent-v1"
   | "team-annual-v1"
-  | "org-annual-v1";
+  | "org-annual-v1"
+  | "team-oss-v1"
+  | "team-internal-v1";
 
 export interface Subscription {
   id?: string;


### PR DESCRIPTION
We've added a couple admin-only pricing plans for internal teams and OSS projects so this PR adds those details into the pricing details lookup. It also suppresses the "Add Payment Method" link for plans that don't require payment.