### PR TITLE
Move `searchSources` into `ReplayClient` and migrate full text search components to TS

### DIFF
--- a/packages/protocol/thread/thread.ts
+++ b/packages/protocol/thread/thread.ts
@@ -435,20 +435,6 @@ class _ThreadFront {
     }
   }
 
-  async searchSources(
-    { query, sourceIds }: { query: string; sourceIds?: string[] },
-    onMatches: (matches: SearchSourceContentsMatch[]) => void
-  ) {
-    const sessionId = await this.waitForSession();
-    const searchId = uniqueId("search-");
-    this.searchWaiters.set(searchId, onMatches);
-    try {
-      await client.Debugger.searchSourceContents({ searchId, query, sourceIds } as any, sessionId);
-    } finally {
-      this.searchWaiters.delete(searchId);
-    }
-  }
-
   async searchFunctions(
     { query, sourceIds }: { query: string; sourceIds?: string[] },
     onMatches: (matches: FunctionMatch[]) => void

--- a/packages/shared/client/types.ts
+++ b/packages/shared/client/types.ts
@@ -89,8 +89,8 @@ export interface ReplayClientInterface {
   loadRegion(range: TimeRange, duration: number): Promise<void>;
   removeEventListener(type: ReplayClientEvents, handler: Function): void;
   runAnalysis<Result>(analysisParams: AnalysisParams): Promise<Result[]>;
-  searchSources(
-    opts: { query: string; sourceIds?: string[] },
-    onMatches: (matches: SearchSourceContentsMatch[]) => void
-  ): Promise<void>;
+  searchSources(opts: {
+    query: string;
+    sourceIds?: string[];
+  }): Promise<SearchSourceContentsMatch[]>;
 }

--- a/packages/shared/client/types.ts
+++ b/packages/shared/client/types.ts
@@ -89,8 +89,11 @@ export interface ReplayClientInterface {
   loadRegion(range: TimeRange, duration: number): Promise<void>;
   removeEventListener(type: ReplayClientEvents, handler: Function): void;
   runAnalysis<Result>(analysisParams: AnalysisParams): Promise<Result[]>;
-  searchSources(opts: {
-    query: string;
-    sourceIds?: string[];
-  }): Promise<SearchSourceContentsMatch[]>;
+  searchSources(
+    opts: {
+      query: string;
+      sourceIds?: string[];
+    },
+    onMatches: (matches: SearchSourceContentsMatch[]) => void
+  ): Promise<void>;
 }

--- a/src/devtools/client/debugger/src/components/FullTextSearch/FullTextFilter.tsx
+++ b/src/devtools/client/debugger/src/components/FullTextSearch/FullTextFilter.tsx
@@ -2,6 +2,17 @@ import React, { useState, useRef, useEffect } from "react";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
 import Spinner from "ui/components/shared/Spinner";
 
+import type { FTSState } from "./index";
+
+interface FTFProps {
+  value: string;
+  setValue: (value: string) => void;
+  focused: boolean;
+  results: FTSState["results"];
+  onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  focusFullTextInput: (shouldFocus: boolean) => void;
+}
+
 export function FullTextFilter({
   value,
   setValue,
@@ -9,40 +20,10 @@ export function FullTextFilter({
   results,
   onKeyDown,
   focusFullTextInput,
-}) {
-  const [history, setHistory] = useState([]);
-  const [historyIndex, setHistoryIndex] = useState(0);
-  const inputRef = useRef();
+}: FTFProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => inputRef.current?.focus(), []);
   useEffect(() => inputRef.current?.focus(), [focused]);
-
-  function inputOnKeyDown(e) {
-    if (e.key === "Escape") {
-      return;
-    }
-
-    if (e.key === "ArrowUp") {
-      e.preventDefault();
-      const newIndex = (historyIndex + 1) % history.length;
-      setHistoryIndex(newIndex);
-      return setValue(history[newIndex]);
-    }
-
-    if (e.key === "ArrowDown" && historyIndex !== 0) {
-      e.preventDefault();
-      const newIndex = historyIndex - 1;
-      setHistoryIndex(newIndex);
-      return setValue(history[newIndex]);
-    }
-
-    // Don't add the same query to the history
-    const searchQuery = onKeyDown(e);
-    if (searchQuery && !history.includes(searchQuery)) {
-      setHistory([searchQuery, ...history]);
-      setHistoryIndex(0);
-    }
-  }
 
   return (
     <div className="p-2">
@@ -55,7 +36,7 @@ export function FullTextFilter({
           type="text"
           value={value}
           onChange={e => setValue(e.target.value)}
-          onKeyDown={inputOnKeyDown}
+          onKeyDown={onKeyDown}
           onFocus={() => focusFullTextInput(false)}
           ref={inputRef}
           autoFocus

--- a/src/devtools/client/debugger/src/components/FullTextSearch/FullTextItem.tsx
+++ b/src/devtools/client/debugger/src/components/FullTextSearch/FullTextItem.tsx
@@ -5,7 +5,16 @@ import { getRelativePathWithoutFile, getURL } from "../../utils/sources-tree";
 import AccessibleImage from "../shared/AccessibleImage";
 import { RedactedSpan, Redacted } from "ui/components/Redacted";
 
-export function FullTextItem({ item, focused, expanded, onSelect }) {
+import { SourceResultEntry, SourceMatchEntry } from "./search";
+
+interface FTIProps {
+  item: SourceResultEntry | SourceMatchEntry;
+  focused: boolean;
+  expanded: boolean;
+  onSelect: (item: SourceMatchEntry) => void;
+}
+
+export function FullTextItem({ item, focused, expanded, onSelect }: FTIProps) {
   if (item.type === "RESULT") {
     const matchesLength = item.matches.length;
     const matches = ` (${matchesLength} match${matchesLength > 1 ? "es" : ""})`;

--- a/src/devtools/client/debugger/src/components/FullTextSearch/FullTextSummary.tsx
+++ b/src/devtools/client/debugger/src/components/FullTextSearch/FullTextSummary.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 
-export function FullTextSummary({ results }) {
+import type { FTSState } from "./index";
+
+const numberFormat = new Intl.NumberFormat();
+
+export function FullTextSummary({ results }: { results: FTSState["results"] }) {
   const { status, matchesBySource } = results;
 
   if (status !== "DONE") {
@@ -14,7 +18,7 @@ export function FullTextSummary({ results }) {
 
   return (
     <div className="whitespace-pre pl-2">
-      {new Intl.NumberFormat().format(totalMatches)} result{totalMatches === 1 ? "" : "s"}
+      {numberFormat.format(totalMatches)} result{totalMatches === 1 ? "" : "s"}
     </div>
   );
 }

--- a/src/devtools/client/debugger/src/components/FullTextSearch/index.tsx
+++ b/src/devtools/client/debugger/src/components/FullTextSearch/index.tsx
@@ -2,92 +2,124 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-import React, { Component, createRef } from "react";
-import { connect, ConnectedProps } from "react-redux";
-import { SearchSourceContentsMatch } from "@replayio/protocol";
+import React, { useRef, useReducer, useContext } from "react";
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
 import Checkbox from "ui/components/shared/Forms/Checkbox";
 import { trackEvent } from "ui/utils/telemetry";
-import { UIState } from "ui/state";
+
+import { useAppSelector, useAppDispatch } from "ui/setup/hooks";
 
 import { getSourceDetailsEntities, SourceDetails } from "ui/reducers/sources";
-import actions from "../../actions";
-import { getContext, getFullTextSearchQuery, getFullTextSearchFocus } from "../../selectors";
+import { selectSpecificLocation } from "devtools/client/debugger/src/actions/sources";
+import { doSearchForHighlight } from "devtools/client/debugger/src/actions/file-search";
+import { focusFullTextInput } from "devtools/client/debugger/src/reducers/ui";
+import { ReplayClientContext } from "shared/client/ReplayClientContext";
+import { getContext, getFullTextSearchFocus } from "../../selectors";
 
 import { getEditor } from "../../utils/editor";
 
 import { FullTextFilter } from "./FullTextFilter";
 import { FullTextResults } from "./FullTextResults";
-import { search } from "./search";
-
-type $FixTypeLater = any;
+import { search, SourceResultEntry, SourceMatchEntry } from "./search";
 
 function sanitizeQuery(query: string) {
   // no '\' at end of query
   return query.replace(/\\$/, "");
 }
 
-const mapStateToProps = (state: UIState) => ({
-  cx: getContext(state),
-  sourcesById: getSourceDetailsEntities(state),
-  query: getFullTextSearchQuery(state),
-  focused: getFullTextSearchFocus(state),
-});
-
-const connector = connect(mapStateToProps, {
-  focusFullTextInput: actions.focusFullTextInput,
-  setFullTextQuery: actions.setFullTextQuery,
-  selectSpecificLocation: actions.selectSpecificLocation,
-  doSearchForHighlight: actions.doSearchForHighlight,
-});
-
-type PropsFromRedux = ConnectedProps<typeof connector>;
-
-interface FTSState {
-  focusedItem: SearchSourceContentsMatch | null;
+export interface FTSState {
+  focusedItem: SourceResultEntry | SourceMatchEntry | null;
   query: string;
   results: {
-    status: "DONE";
-    matchesBySource: $FixTypeLater[];
+    status: "DONE" | "LOADING";
+    matchesBySource: SourceResultEntry[];
   };
   includeNodeModules: boolean;
 }
 
-export class FullTextSearch extends Component<PropsFromRedux, FTSState> {
-  searchRef = createRef<HTMLDivElement>();
-  state = {
-    focusedItem: null,
-    query: "",
-    results: {
-      status: "DONE" as const,
-      matchesBySource: [],
-    },
-    includeNodeModules: true,
-  };
+const initialState: FTSState = {
+  focusedItem: null,
+  query: "",
+  results: {
+    status: "DONE" as const,
+    matchesBySource: [],
+  },
+  includeNodeModules: true,
+};
 
-  selectMatchItem = (matchItem: $FixTypeLater) => {
-    const { query, cx, doSearchForHighlight, selectSpecificLocation } = this.props;
+// Reducer for use in the `<FullTextSearch>` component,
+// mostly to avoid having to pass around existing matches
+// in order to concatenate them together
+const ftsSlice = createSlice({
+  name: "fts",
+  initialState,
+  reducers: {
+    itemFocused(state, action: PayloadAction<SourceResultEntry | SourceMatchEntry | null>) {
+      state.focusedItem = action.payload;
+    },
+    queryUpdated(state, action: PayloadAction<string>) {
+      state.query = action.payload;
+    },
+    searchStarted(state) {
+      state.results.status = "LOADING";
+      state.results.matchesBySource = [];
+    },
+    searchResultsReceived(state, action: PayloadAction<SourceResultEntry[]>) {
+      state.results.matchesBySource.push(...action.payload);
+    },
+    searchCompleted(state) {
+      state.results.status = "DONE";
+    },
+    nodeModulesToggled(state) {
+      state.includeNodeModules = !state.includeNodeModules;
+    },
+  },
+});
+
+const {
+  itemFocused,
+  nodeModulesToggled,
+  searchStarted,
+  searchResultsReceived,
+  searchCompleted,
+  queryUpdated,
+} = ftsSlice.actions;
+
+function FullTextSearch() {
+  const [state, localDispatch] = useReducer(ftsSlice.reducer, initialState);
+  const replayClient = useContext(ReplayClientContext);
+  const { includeNodeModules, query, results, focusedItem } = state;
+
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  const dispatch = useAppDispatch();
+
+  const cx = useAppSelector(getContext);
+  const sourcesById = useAppSelector(getSourceDetailsEntities);
+  const focused = useAppSelector(getFullTextSearchFocus);
+
+  const selectMatchItem = (matchItem: SourceMatchEntry) => {
     trackEvent("project_search.select");
 
-    selectSpecificLocation(cx, {
-      sourceId: matchItem.sourceId,
-      line: matchItem.line,
-      column: matchItem.column,
-    });
+    dispatch(
+      selectSpecificLocation(cx, {
+        sourceId: matchItem.sourceId,
+        line: matchItem.line,
+        column: matchItem.column,
+      })
+    );
 
     setTimeout(
-      () => doSearchForHighlight(query, getEditor(), matchItem.line, matchItem.column),
+      () => dispatch(doSearchForHighlight(query, getEditor(), matchItem.line, matchItem.column)),
       20
     );
   };
 
-  onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    const { sourcesById, setFullTextQuery, query } = this.props;
-    const { includeNodeModules } = this.state;
-
+  const onKeyDown = async (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "ArrowDown") {
       trackEvent("project_search.go_to_first_result");
-      this.searchRef.current!.querySelector<HTMLElement>(".file-result:first-child")!.focus();
+      searchRef.current!.querySelector<HTMLElement>(".file-result:first-child")!.focus();
       e.preventDefault();
       return;
     }
@@ -98,74 +130,69 @@ export class FullTextSearch extends Component<PropsFromRedux, FTSState> {
 
     // @ts-expect-error e.target.value doesn't exist
     const sanitizedQuery = sanitizeQuery(e.target.value);
-    const updateResults = (getNextResults: (someResults: $FixTypeLater) => $FixTypeLater[]) => {
-      this.setState(prevState => ({
-        results: {
-          ...prevState.results,
-          ...getNextResults(prevState.results),
-        },
-      }));
-    };
 
-    setFullTextQuery(sanitizedQuery);
-    this.setState({ focusedItem: null });
-    if (sanitizedQuery && query !== this.state.query && sanitizedQuery.length >= 3) {
-      search(
-        sanitizedQuery,
-        sourcesById as Record<string, SourceDetails>,
-        updateResults,
-        includeNodeModules
-      );
-      return sanitizedQuery;
+    localDispatch(itemFocused(null));
+
+    if (sanitizedQuery && sanitizedQuery.length >= 3) {
+      localDispatch(searchStarted());
+      try {
+        const loadResults = (newResults: SourceResultEntry[]) => {
+          localDispatch(searchResultsReceived(newResults));
+        };
+        await search(
+          sanitizedQuery,
+          sourcesById as Record<string, SourceDetails>,
+          loadResults,
+          includeNodeModules,
+          replayClient
+        );
+      } finally {
+        localDispatch(searchCompleted);
+      }
     }
-
-    return null;
   };
 
-  onFocus = (item: $FixTypeLater) => {
-    if (this.state.focusedItem !== item) {
-      this.setState({ focusedItem: item });
+  const onFocus = (item: SourceResultEntry | SourceMatchEntry) => {
+    if (focusedItem !== item) {
+      localDispatch(itemFocused(item));
     }
 
     if (item?.type === "MATCH") {
-      this.selectMatchItem(item);
+      selectMatchItem(item);
     }
   };
 
-  render() {
-    const { query, setFullTextQuery, focused, focusFullTextInput } = this.props;
-    const { results, focusedItem, includeNodeModules } = this.state;
-    return (
-      <div ref={this.searchRef} className="search-container">
-        <div className="project-text-search">
-          <div className="header">
-            <FullTextFilter
-              value={query}
-              focused={focused}
-              setValue={setFullTextQuery}
-              results={this.state.results}
-              onKeyDown={this.onKeyDown}
-              focusFullTextInput={focusFullTextInput}
-            />
-          </div>
-          <label className="select-none space-x-2 p-2" htmlFor="node-modules">
-            <Checkbox
-              id="node-modules"
-              checked={includeNodeModules}
-              onChange={e => this.setState({ includeNodeModules: !includeNodeModules })}
-            />
-            <span>Include node modules</span>
-          </label>
-          <FullTextResults
-            onItemSelect={(item: $FixTypeLater) => this.selectMatchItem(item)}
-            focusedItem={focusedItem}
-            onFocus={this.onFocus}
+  return (
+    <div ref={searchRef} className="search-container">
+      <div className="project-text-search">
+        <div className="header">
+          <FullTextFilter
+            value={query}
+            focused={focused}
+            setValue={(value: string) => localDispatch(queryUpdated(value))}
             results={results}
+            onKeyDown={onKeyDown}
+            focusFullTextInput={focusFullTextInput}
           />
         </div>
+        <label className="select-none space-x-2 p-2" htmlFor="node-modules">
+          <Checkbox
+            id="node-modules"
+            checked={includeNodeModules}
+            onChange={() => localDispatch(nodeModulesToggled())}
+          />
+          <span>Include node modules</span>
+        </label>
+        <FullTextResults
+          onItemSelect={selectMatchItem}
+          focusedItem={focusedItem}
+          onFocus={onFocus}
+          results={results}
+          query={query}
+        />
       </div>
-    );
-  }
+    </div>
+  );
 }
 
-export default connector(FullTextSearch);
+export default FullTextSearch;

--- a/src/devtools/client/debugger/src/utils/sources-tree/getURL.ts
+++ b/src/devtools/client/debugger/src/utils/sources-tree/getURL.ts
@@ -37,7 +37,7 @@ export interface ParsedUrl {
 
 const def: ParsedUrl = { path: "", group: "", filename: "" };
 
-export function getURL(source: MiniSource, defaultDomain = "") {
+export function getURL(source: { url?: string }, defaultDomain = "") {
   const { url } = source;
   if (!url) {
     return def;


### PR DESCRIPTION
This PR:

- Moves `ThreadFront.searchSources` over into the new `ReplayClient` class
  - Simplified the handling of `onMatches` callbacks to remove a couple levels of indirection
- Rewrites `<FullTextSearch>` as a function component, so it can get access to `ReplayClient` via `useContext`
  - Rewrote its state logic as a `useReducer` + `createSlice`
  - Simplified the keydown handling - the child component _was_ looking for a return value in order to update its internal "history" logic, but that logic was dead and not used at all
- Migrates all the full text search child components to TS
  - Filled out TS types for items in more detail
  - Deleted that dead "history" logic in `<FullTextFilter>`