### PR TITLE
fix frames not spanning full grid

### DIFF
--- a/packages/bvaughn-architecture-demo/components/console/StackRenderer.module.css
+++ b/packages/bvaughn-architecture-demo/components/console/StackRenderer.module.css
@@ -5,6 +5,7 @@
 }
 
 .Frame {
+  grid-column: 1 / -1;
   padding-left: 1rem;
   display: flex;
   width: 100%;


### PR DESCRIPTION
Fixes FE-595 where the frame wasn't spanning the full width of the grid. I ran the snapshot tests and nothing changed 🎉 