### PR TITLE
Handle hit count load failures and display error in the UI

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
@@ -13,7 +13,12 @@ import { shouldShowNag } from "ui/utils/user";
 import { getSelectedSource } from "ui/reducers/sources";
 
 import StaticTooltip from "./StaticTooltip";
-import { fetchHitCounts, getHitCountsForSource } from "ui/reducers/hitCounts";
+import {
+  fetchHitCounts,
+  getHitCountsForSource,
+  getHitCountsStatusForSourceByLine,
+} from "ui/reducers/hitCounts";
+import { LoadingStatus } from "ui/utils/LoadingStatus";
 
 export const AWESOME_BACKGROUND = `linear-gradient(116.71deg, #FF2F86 21.74%, #EC275D 83.58%), linear-gradient(133.71deg, #01ACFD 3.31%, #F155FF 106.39%, #F477F8 157.93%, #F33685 212.38%), #007AFF`;
 
@@ -68,6 +73,9 @@ function LineNumberTooltip({ editor, keyModifiers }: Props) {
   const source = useAppSelector(getSelectedSource);
 
   const hitCounts = useAppSelector(state => getHitCountsForSource(state, source!.id));
+  const hitCountStatus = useAppSelector(state =>
+    getHitCountsStatusForSourceByLine(state, source!.id, lastHoveredLineNumber.current || 0)
+  );
 
   let hits: number | undefined;
 
@@ -116,6 +124,14 @@ function LineNumberTooltip({ editor, keyModifiers }: Props) {
 
   if (!targetNode || isMetaActive) {
     return null;
+  }
+
+  if (hitCountStatus === LoadingStatus.ERRORED) {
+    return (
+      <StaticTooltip targetNode={targetNode}>
+        <Wrapper showWarning={true}>Failed to load hit counts for this section</Wrapper>
+      </StaticTooltip>
+    );
   }
 
   if (!hitCounts) {

--- a/src/ui/reducers/hitCounts.ts
+++ b/src/ui/reducers/hitCounts.ts
@@ -175,7 +175,6 @@ export const fetchHitCounts = (sourceId: string, lineNumber: number): UIThunkAct
       dispatch(hitCountsReceived({ id: cacheKey, hitCounts }));
     } catch (e) {
       dispatch(hitCountsFailed({ id: cacheKey, error: String(e) }));
-      throw e;
     }
   };
 };
@@ -184,7 +183,18 @@ export const { hitCountsRequested, hitCountsReceived, hitCountsFailed } = hitCou
 
 export const getHitCountsForSource = (state: UIState, sourceId: string) => {
   const cacheKey = removeLineNumbersFromCacheKey(getCacheKeyForSourceHitCounts(state, sourceId, 0));
-  return aggregateHitCountsSelectors.selectById(state, cacheKey)?.hitCounts || null;
+  const aggregatedEntry = aggregateHitCountsSelectors.selectById(state, cacheKey);
+  return aggregatedEntry?.hitCounts || null;
+};
+
+export const getHitCountsStatusForSourceByLine = (
+  state: UIState,
+  sourceId: string,
+  line: number
+) => {
+  const cacheKey = getCacheKeyForSourceHitCounts(state, sourceId, line);
+  const statusEntry = hitCountsSelectors.selectById(state, cacheKey);
+  return statusEntry?.status || null;
 };
 
 export const getHitCountsForSourceByLine = createSelector(getHitCountsForSource, hitCounts => {


### PR DESCRIPTION
This PR:

- Updates `<LineNumberTooltip>` to check for hit count loading errors, and displays an error tooltip instead of staying stuck on "Loading..."

![image](https://user-images.githubusercontent.com/1128784/186473734-3fbe2040-840f-4405-8b2b-dde1b95cf2b8.png)


Fixes FE-508