### PR TITLE
Wait for access token during devtools setup

### DIFF
--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -54,7 +54,7 @@ function now(): number {
   return Date.now();
 }
 
-export function setupApp(
+export async function setupApp(
   store: UIStore,
   ThreadFront: typeof ThreadFrontType,
   replayClient: ReplayClientInterface
@@ -65,7 +65,7 @@ export function setupApp(
         ThreadFront.setAccessToken(token);
       }
     });
-    tokenManager.getToken();
+    await tokenManager.getToken();
   }
 
   ThreadFront.waitForSession().then(sessionId => {

--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -217,7 +217,7 @@ export default async function setupDevtools(store: AppStore, replayClient: Repla
     );
   });
 
-  setupApp(store, ThreadFront, replayClient);
+  await setupApp(store, ThreadFront, replayClient);
   setupTimeline(store);
   setupEventListeners(store);
   setupGraphics();


### PR DESCRIPTION

See this replay which shows how setAccessToken is called in the token manager logic, but could be too late if `getToken` takes awhile

Fix SCS-17