### PR TITLE
Simplify the setFramePositions thunk (FE-618)

### DIFF
--- a/src/devtools/client/debugger/src/actions/pause/setFramePositions.ts
+++ b/src/devtools/client/debugger/src/actions/pause/setFramePositions.ts
@@ -22,24 +22,9 @@ export function setFramePositions(): UIThunkAction<Promise<void>> {
     }
     await ThreadFront.ensureAllSources();
     const state = getState();
-    const { sourceId } = getPreferredLocation(
-      state,
-      positions[0].frame!,
-      ThreadFront.preferredGeneratedSources
+    const locations = positions.map(({ frame }) =>
+      getPreferredLocation(state, frame!, ThreadFront.preferredGeneratedSources)
     );
-
-    if (!sourceId) {
-      return;
-    }
-
-    const locations = positions.map(({ frame }) => {
-      const { line, column } = getPreferredLocation(
-        state,
-        frame!,
-        ThreadFront.preferredGeneratedSources
-      );
-      return { line, column, sourceId };
-    });
 
     const combinedPositions = zip(positions, locations).map(([position, location]) => {
       const { point, time } = position!;


### PR DESCRIPTION
This thunk takes the FrameSteps received from the backend and transforms them, replacing the MappedLocations with preferred Locations. For some reason it also set the `sourceId` for all locations to that of the first location. Usually this should be unnecessary (because all FrameSteps should be in the same file) and make no difference at all. But with [BAC-2128](https://linear.app/replay/issue/BAC-2128/inconsistent-framesteps) it makes a difference and it only makes the problem worse. So I decided to remove that logic.