### PR TITLE
Migrate highlighters content to TS

### DIFF
--- a/packages/third-party/css-logic/actors-inspector-css-logic.js
+++ b/packages/third-party/css-logic/actors-inspector-css-logic.js
@@ -27,7 +27,7 @@
 
 "use strict";
 
-const nodeConstants = require("devtools/shared/dom-node-constants");
+const nodeConstants = require("devtools/shared/dom-node-constants").default;
 const {
   getBindingElementAndPseudo,
   getCSSStyleRules,

--- a/src/devtools/client/inspector/markup/actions/markup.ts
+++ b/src/devtools/client/inspector/markup/actions/markup.ts
@@ -29,7 +29,7 @@ import {
 import { paused } from "devtools/client/debugger/src/reducers/pause";
 
 import Highlighter from "highlighter/highlighter";
-import { DOCUMENT_TYPE_NODE, TEXT_NODE } from "devtools/shared/dom-node-constants";
+import NodeConstants from "devtools/shared/dom-node-constants";
 import { features } from "devtools/client/inspector/prefs";
 
 let rootNodeWaiter: Deferred<void> | undefined;
@@ -145,7 +145,7 @@ export function addChildren(
   return async (dispatch, getState, { ThreadFront }) => {
     if (!features.showWhitespaceNodes) {
       childFronts = childFronts.filter(
-        node => node.nodeType !== TEXT_NODE || /[^\s]/.exec(node.getNodeValue()!)
+        node => node.nodeType !== NodeConstants.TEXT_NODE || /[^\s]/.exec(node.getNodeValue()!)
       );
     }
 
@@ -304,7 +304,7 @@ function getPreviousNodeId(state: UIState, nodeId: string) {
   }
   const parentNodeInfo = getNodeInfo(state, parentNodeId);
   assert(parentNodeInfo, "parent node not found in markup state");
-  if (parentNodeInfo.type === DOCUMENT_TYPE_NODE) {
+  if (parentNodeInfo.type === NodeConstants.DOCUMENT_TYPE_NODE) {
     return nodeId;
   }
   const index = parentNodeInfo.children.indexOf(nodeId);
@@ -357,7 +357,7 @@ export function onLeftKey(): UIThunkAction {
       const parentNodeId = getParentNodeId(state, selectedNodeId);
       if (parentNodeId != null) {
         const parentNodeInfo = getNodeInfo(state, parentNodeId);
-        if (parentNodeInfo && parentNodeInfo.type !== DOCUMENT_TYPE_NODE) {
+        if (parentNodeInfo && parentNodeInfo.type !== NodeConstants.DOCUMENT_TYPE_NODE) {
           dispatch(selectNode(parentNodeId, "keyboard"));
         }
       }
@@ -475,7 +475,8 @@ async function convertNode(node: NodeFront, { isExpanded = false } = {}): Promis
   return {
     attributes: node.attributes,
     children: [],
-    displayName: node.nodeType === DOCUMENT_TYPE_NODE ? node.doctypeString : node.displayName,
+    displayName:
+      node.nodeType === NodeConstants.DOCUMENT_TYPE_NODE ? node.doctypeString : node.displayName,
     displayType: await node.getDisplayType(),
     hasChildren: !!node.hasChildren,
     hasEventListeners: await node.hasEventListeners(),

--- a/src/devtools/client/inspector/markup/components/Node.tsx
+++ b/src/devtools/client/inspector/markup/components/Node.tsx
@@ -1,11 +1,6 @@
 import React, { PureComponent, MouseEvent, ReactElement } from "react";
 import { connect, ConnectedProps } from "react-redux";
-const {
-  COMMENT_NODE,
-  DOCUMENT_TYPE_NODE,
-  ELEMENT_NODE,
-  TEXT_NODE,
-} = require("devtools/shared/dom-node-constants");
+import NodeConstants from "devtools/shared/dom-node-constants";
 import { assert } from "protocol/utils";
 import {
   getNode,
@@ -133,15 +128,15 @@ class _Node extends PureComponent<FinalNodeProps> {
     const { node } = this.props;
 
     let component = null;
-    if (node.type === ELEMENT_NODE) {
+    if (node.type === NodeConstants.ELEMENT_NODE) {
       component = <ElementNode node={node} onToggleNodeExpanded={this.props.toggleNodeExpanded} />;
-    } else if (node.type === COMMENT_NODE || node.type === TEXT_NODE) {
+    } else if (node.type === NodeConstants.COMMENT_NODE || node.type === NodeConstants.TEXT_NODE) {
       component = <TextNode type={node.type} value={node.value} />;
     } else {
       component = (
         <ReadOnlyNode
           displayName={node.displayName}
-          isDocType={node.type === DOCUMENT_TYPE_NODE}
+          isDocType={node.type === NodeConstants.DOCUMENT_TYPE_NODE}
           pseudoType={!!node.pseudoType}
         />
       );

--- a/src/devtools/client/inspector/markup/components/TextNode.tsx
+++ b/src/devtools/client/inspector/markup/components/TextNode.tsx
@@ -1,6 +1,6 @@
 import { assert } from "protocol/utils";
 import React, { PureComponent } from "react";
-const { COMMENT_NODE } = require("devtools/shared/dom-node-constants");
+import NodeConstants from "devtools/shared/dom-node-constants";
 
 interface TextNodeProps {
   type: number;
@@ -11,7 +11,7 @@ class TextNode extends PureComponent<TextNodeProps> {
   render() {
     const { type, value } = this.props;
     assert(typeof value === "string", "value not set in TextNode props");
-    const isComment = type === COMMENT_NODE;
+    const isComment = type === NodeConstants.COMMENT_NODE;
     const isWhiteSpace = !/[^\s]/.exec(value);
 
     return (

--- a/src/devtools/packages/devtools-reps/reps/element-node.js
+++ b/src/devtools/packages/devtools-reps/reps/element-node.js
@@ -10,7 +10,7 @@ const PropTypes = require("prop-types");
 const { isGrip, wrapRender } = require("./rep-utils");
 const { rep: StringRep, isLongString } = require("./string");
 const { MODE } = require("./constants");
-const nodeConstants = require("devtools/shared/dom-node-constants");
+const nodeConstants = require("devtools/shared/dom-node-constants").default;
 const { createPrimitiveValueFront } = require("protocol/thread");
 
 const MAX_ATTRIBUTE_LENGTH = 50;

--- a/src/devtools/server/actors/highlighters/box-model.d.ts
+++ b/src/devtools/server/actors/highlighters/box-model.d.ts
@@ -1,8 +1,0 @@
-import { NodeFront } from "protocol/thread/node";
-import { NodeBoundsFront } from "protocol/thread/bounds";
-
-export class BoxModelHighlighter {
-  show(node: NodeFront | NodeBoundsFront): boolean;
-  hide(): void;
-  destroy(): void;
-}

--- a/src/devtools/server/actors/highlighters/utils/markup.ts
+++ b/src/devtools/server/actors/highlighters/utils/markup.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { getViewportDimensions } from "devtools/shared/layout/utils";
+import { NodeBoundsFront } from "protocol/thread/bounds";
 import { NodeFront } from "protocol/thread/node";
 
 const lazyContainer = {
@@ -28,7 +29,10 @@ const XUL_NS = "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul";
  * @param {Number} nodeType Optional, defaults to ELEMENT_NODE
  * @return {Boolean}
  */
-export function isNodeValid(node: NodeFront | undefined, nodeType = Node.ELEMENT_NODE) {
+export function isNodeValid(
+  node: NodeFront | NodeBoundsFront | undefined,
+  nodeType = Node.ELEMENT_NODE
+) {
   // Is it still alive?
   if (!node) {
     return false;
@@ -41,12 +45,12 @@ export function isNodeValid(node: NodeFront | undefined, nodeType = Node.ELEMENT
   }
 
   // Is it of the right type?
-  if (node.nodeType !== nodeType) {
+  if ((node as NodeFront).nodeType !== nodeType) {
     return false;
   }
 
   // Is the node connected to the document?
-  if (!node.isConnected) {
+  if (!(node as NodeFront).isConnected) {
     return false;
   }
 
@@ -75,7 +79,7 @@ export function createSVGNode(win: Window, options: NodeCreationOptions) {
 interface NodeCreationOptions {
   nodeType?: string;
   attributes: Record<string, any>;
-  parent?: HTMLElement;
+  parent?: Element;
   text?: string;
   prefix?: string;
   namespace?: string;
@@ -423,7 +427,7 @@ export class CanvasFrameAnonymousContentHelper {
  *         If set to `true`, hides the infobar if it's offscreen, instead of automatically
  *         reposition it.
  */
-function moveInfobar(
+export function moveInfobar(
   container: HTMLElement,
   bounds: DOMRect,
   win: Window,
@@ -524,4 +528,3 @@ function moveInfobar(
 
   container.setAttribute("position", positionAttribute);
 }
-module.exports.moveInfobar = moveInfobar;

--- a/src/devtools/shared/dom-node-constants.ts
+++ b/src/devtools/shared/dom-node-constants.ts
@@ -1,4 +1,4 @@
-module.exports = {
+const DOM_NODE_CONSTANTS = {
   ELEMENT_NODE: 1,
   ATTRIBUTE_NODE: 2,
   TEXT_NODE: 3,
@@ -20,3 +20,5 @@ module.exports = {
   DOCUMENT_POSITION_CONTAINED_BY: 0x10,
   DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC: 0x20,
 };
+
+export default DOM_NODE_CONSTANTS;

--- a/src/devtools/shared/layout/utils.ts
+++ b/src/devtools/shared/layout/utils.ts
@@ -30,7 +30,7 @@ import { NodeFront } from "protocol/thread/node";
  */
 export function getAdjustedQuads(
   boundaryWindow: Window,
-  node: NodeFront | null | undefined,
+  node: NodeFront | NodeBoundsFront | null | undefined,
   region: any,
   { ignoreZoom, ignoreScroll }: { ignoreZoom?: boolean; ignoreScroll?: boolean } = {}
 ) {

--- a/src/devtools/shared/layout/utils.ts
+++ b/src/devtools/shared/layout/utils.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { NodeBoundsFront } from "protocol/thread/bounds";
+import { NodeFront } from "protocol/thread/node";
 
 /**
  * Get box quads adjusted for iframes and zoom level.
@@ -29,7 +30,7 @@ import { NodeBoundsFront } from "protocol/thread/bounds";
  */
 export function getAdjustedQuads(
   boundaryWindow: Window,
-  node: NodeBoundsFront,
+  node: NodeFront | null | undefined,
   region: any,
   { ignoreZoom, ignoreScroll }: { ignoreZoom?: boolean; ignoreScroll?: boolean } = {}
 ) {

--- a/src/devtools/shared/layout/utils.ts
+++ b/src/devtools/shared/layout/utils.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-"use strict";
+import { NodeBoundsFront } from "protocol/thread/bounds";
 
 /**
  * Get box quads adjusted for iframes and zoom level.
@@ -27,7 +27,12 @@
  *        An array of objects that have the same structure as quads returned by
  *        getBoxQuads. An empty array if the node has no quads or is invalid.
  */
-function getAdjustedQuads(boundaryWindow, node, region, { ignoreZoom, ignoreScroll } = {}) {
+export function getAdjustedQuads(
+  boundaryWindow: Window,
+  node: NodeBoundsFront,
+  region: any,
+  { ignoreZoom, ignoreScroll }: { ignoreZoom?: boolean; ignoreScroll?: boolean } = {}
+) {
   if (!node || !node.getBoxQuads) {
     return [];
   }
@@ -87,7 +92,6 @@ function getAdjustedQuads(boundaryWindow, node, region, { ignoreZoom, ignoreScro
 
   return adjustedQuads;
 }
-exports.getAdjustedQuads = getAdjustedQuads;
 
 /**
  * Check if a node and its document are still alive
@@ -96,7 +100,7 @@ exports.getAdjustedQuads = getAdjustedQuads;
  * @param {DOMNode} node
  * @return {Boolean}
  */
-function isNodeConnected(node) {
+export function isNodeConnected(node: HTMLElement) {
   if (!node.ownerDocument || !node.ownerDocument.defaultView) {
     return false;
   }
@@ -111,7 +115,6 @@ function isNodeConnected(node) {
     return false;
   }
 }
-exports.isNodeConnected = isNodeConnected;
 
 /**
  * Determine whether a node is a ::marker pseudo.
@@ -119,10 +122,9 @@ exports.isNodeConnected = isNodeConnected;
  * @param {DOMNode} node
  * @return {Boolean}
  */
-function isMarkerPseudoElement(node) {
+export function isMarkerPseudoElement(node: HTMLElement) {
   return node.nodeName === "_moz_generated_content_marker";
 }
-exports.isMarkerPseudoElement = isMarkerPseudoElement;
 
 /**
  * Determine whether a node is a ::before pseudo.
@@ -130,10 +132,9 @@ exports.isMarkerPseudoElement = isMarkerPseudoElement;
  * @param {DOMNode} node
  * @return {Boolean}
  */
-function isBeforePseudoElement(node) {
+export function isBeforePseudoElement(node: HTMLElement) {
   return node.nodeName === "_moz_generated_content_before";
 }
-exports.isBeforePseudoElement = isBeforePseudoElement;
 
 /**
  * Determine whether a node is a ::after pseudo.
@@ -141,10 +142,9 @@ exports.isBeforePseudoElement = isBeforePseudoElement;
  * @param {DOMNode} node
  * @return {Boolean}
  */
-function isAfterPseudoElement(node) {
+export function isAfterPseudoElement(node: HTMLElement) {
   return node.nodeName === "_moz_generated_content_after";
 }
-exports.isAfterPseudoElement = isAfterPseudoElement;
 
 /**
  * Returns the viewport's dimensions for the `window` given.
@@ -152,8 +152,7 @@ exports.isAfterPseudoElement = isAfterPseudoElement;
  * @return {Object} An object with `width` and `height` properties, representing the
  * number of pixels for the viewport's size.
  */
-function getViewportDimensions(window) {
-  const canvas = document.getElementById("graphics");
+export function getViewportDimensions() {
+  const canvas = document.getElementById("graphics")! as HTMLCanvasElement;
   return { width: canvas.width, height: canvas.height };
 }
-exports.getViewportDimensions = getViewportDimensions;


### PR DESCRIPTION
This PR:

- Migrates the `highlighters` files to TS

These are vanilla JS / DOM manipulation logic that somehow handle the colored "current hovered node" overlays in the video preview area as you mouse over nodes in the "Elements" panel