### PR TITLE
Better timeout message

### DIFF
--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -110,7 +110,7 @@ export function getDisconnectionError(): UnexpectedError {
   endMixpanelSession("disconnected");
   return {
     action: "refresh",
-    content: "Replays disconnect after 15 minutes to reduce server load.",
+    content: "This replay timed out to reduce server load.",
     message: "Ready when you are!",
   };
 }


### PR DESCRIPTION
Follow-up to https://github.com/replayio/devtools/pull/7537

The old alert was just long enough to have a single word floating on the second line. This one is more succinct.