### PR TITLE
Add wrapper functions for pre-fetching Object preview suspense data

### DIFF
--- a/packages/bvaughn-architecture-demo/components/inspector/ValueRenderer.tsx
+++ b/packages/bvaughn-architecture-demo/components/inspector/ValueRenderer.tsx
@@ -1,5 +1,5 @@
 import { PauseId, Value as ProtocolValue } from "@replayio/protocol";
-import { getObject, getObjectWithPreview } from "@bvaughn/src/suspense/ObjectPreviews";
+import { getCachedObject, getObjectWithPreview } from "@bvaughn/src/suspense/ObjectPreviews";
 import { FC, memo, useContext } from "react";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
@@ -78,7 +78,7 @@ export default memo(function ValueRenderer({
     // The downside is that value renderers won't be able to display as much information (e.g. "Array" rather than "Array(3)")
     // but this is how the old console works and each value renderer should be able to downgrade like this.
     const object =
-      getObject(pauseId, clientValue.objectId!) ||
+      getCachedObject(pauseId, clientValue.objectId!) ||
       getObjectWithPreview(client, pauseId, clientValue.objectId!, noOverflow);
 
     if (object == null) {

--- a/packages/bvaughn-architecture-demo/components/inspector/useClientValue.ts
+++ b/packages/bvaughn-architecture-demo/components/inspector/useClientValue.ts
@@ -1,4 +1,4 @@
-import { getObject, getObjectWithPreview } from "@bvaughn/src/suspense/ObjectPreviews";
+import { getCachedObject, getObjectWithPreview } from "@bvaughn/src/suspense/ObjectPreviews";
 import { protocolValueToClientValue, Value as ClientValue } from "@bvaughn/src/utils/protocol";
 import { PauseId, Value as ProtocolValue } from "@replayio/protocol";
 import { useContext, useMemo } from "react";
@@ -11,7 +11,7 @@ export default function useClientValue(
   const client = useContext(ReplayClientContext);
 
   const objectId = protocolValue.object;
-  if (objectId != null && getObject(pauseId, objectId) === null) {
+  if (objectId != null && getCachedObject(pauseId, objectId) === null) {
     // If we are converting an object value, protocolValueToClientValue() will require preview data.
     // Typically we will have already cached this data from a previous request.
     // There may be edge cases where this is not true though (see BAC-2095).


### PR DESCRIPTION
Adds two new methods (`getObjectWithPreviewHelper` and `getObjectPropertyHelper`) which act as convenience wrappers around the Object preview Suspense API– allowing imperative code to (pre)load the data. Synchronous methods (`getCachedObject` and `getCachedObjectProperty`) can later be used to read the cached data.

Example usage with Suspense:
```jsx
function ReactComponent({ pauseId, objectId }) {
  const client = useContext(ReplayClientContext);

  // Suspends to load data the first time it's called
  const preview = getObjectWithPreview(client, pauseId, objectId);

  // ...
}
```
Example usage with ValueFront:
```js
const preview = await getObjectWithPreviewHelper(client, pauseId, objectId);
```
Alternate ValueFront usage example:
```js
// One part of code loads the data
await getObjectWithPreviewHelper(client, pauseId, objectId);

// Another part of code reads it
const preview = getCachedObject(pauseId, object);
```

All of the examples above populate a shared cache, so we'll never need to fetch redundant data regardless of which is called first.