### PR TITLE
Rewrite EventListeners logic to remove `Node/ValueFront` and fix pause behavior

### DIFF
--- a/src/devtools/client/debugger/src/actions/pause/paused.ts
+++ b/src/devtools/client/debugger/src/actions/pause/paused.ts
@@ -49,6 +49,8 @@ export function paused({
     // @ts-expect-error optional time mismatch
     const pause = ThreadFront.ensurePause(executionPoint, time);
 
+    await pause.createWaiter;
+
     dispatch(pausedAction({ executionPoint, time, id: pause.pauseId!, frame }));
 
     const cx = getThreadContext(getState());

--- a/src/devtools/client/inspector/event-listeners/EventListenersApp.tsx
+++ b/src/devtools/client/inspector/event-listeners/EventListenersApp.tsx
@@ -71,71 +71,92 @@ export const EventListenersApp = () => {
       {listeners.length === 0 ? (
         <div className="devtools-sidepanel-no-result">No event listeners</div>
       ) : (
-        groupedSortedListeners.map(([eventType, listeners]) => (
-          <div key={eventType} className="devtools-monospace">
-            <ExpandableItem header={eventType}>
-              {listeners.map(
-                ({ functionName, functionParameterNames, locationUrl, location, capture }, i) => {
-                  return (
-                    <ExpandableItem
-                      key={i}
-                      header={
-                        <div className="flex gap-2">
-                          <XHTMLNode node={nodeWithPreview} />
-                          <span>
-                            {location && locationUrl ? (
-                              <span
-                                className="cursor-pointer underline hover:text-gray-500"
-                                title="Open in Debugger"
-                                onClick={() => {
-                                  dispatch(
-                                    onViewSourceInDebugger(
-                                      {
-                                        ...location,
-                                        url: locationUrl,
-                                      },
-                                      true
-                                    )
-                                  );
-                                }}
-                              >
-                                {locationUrl.substring(locationUrl.lastIndexOf("/") + 1)}:
-                                {location.line}
-                              </span>
-                            ) : (
-                              "[native code]"
-                            )}
-                          </span>
+        groupedSortedListeners.map(([eventType, listeners]) => {
+          const framework = listeners.find(l => !!l.framework)?.framework;
+          // Add either a "Framework" icon (like the React logo) or a "JS" icon
+          // to the event name expanders in the treeview
+          const header = (
+            <div className="flex items-center text-sm">
+              {eventType}
+              <span className={`img ml-1 ${framework ?? "javascript"}`}></span>
+            </div>
+          );
+          return (
+            <div key={eventType} className="devtools-monospace">
+              <ExpandableItem header={header}>
+                {listeners.map(
+                  (
+                    {
+                      functionName,
+                      functionParameterNames,
+                      locationUrl,
+                      location,
+                      capture,
+                      framework,
+                    },
+                    i
+                  ) => {
+                    return (
+                      <ExpandableItem
+                        key={i}
+                        header={
+                          <div className="flex gap-2">
+                            <XHTMLNode node={nodeWithPreview} />
+                            <span>
+                              {location && locationUrl ? (
+                                <span
+                                  className="cursor-pointer underline hover:text-gray-500"
+                                  title="Open in Debugger"
+                                  onClick={() => {
+                                    dispatch(
+                                      onViewSourceInDebugger(
+                                        {
+                                          ...location,
+                                          url: locationUrl,
+                                        },
+                                        true
+                                      )
+                                    );
+                                  }}
+                                >
+                                  {locationUrl.substring(locationUrl.lastIndexOf("/") + 1)}:
+                                  {location.line}
+                                </span>
+                              ) : (
+                                "[native code]"
+                              )}
+                            </span>
+                          </div>
+                        }
+                      >
+                        <div className="pl-4">
+                          <div className="theme-fg-color3">
+                            useCapture:{" "}
+                            <span className="theme-fg-color1">{capture ? "true" : "false"}</span>
+                          </div>
+                          <div>
+                            <span className="theme-fg-color3">handler: </span>
+                            <span
+                              className="italic"
+                              style={{
+                                color: "var(--theme-highlight-lightorange)",
+                              }}
+                            >
+                              f
+                            </span>{" "}
+                            <span className="italic">
+                              {functionName}({functionParameterNames.join(", ")})
+                            </span>
+                          </div>
                         </div>
-                      }
-                    >
-                      <div className="pl-4">
-                        <div className="theme-fg-color3">
-                          useCapture:{" "}
-                          <span className="theme-fg-color1">{capture ? "true" : "false"}</span>
-                        </div>
-                        <div>
-                          <span className="theme-fg-color3">handler: </span>
-                          <span
-                            className="italic"
-                            style={{
-                              color: "var(--theme-highlight-lightorange)",
-                            }}
-                          >
-                            f
-                          </span>{" "}
-                          <span className="italic">
-                            {functionName}({functionParameterNames.join(", ")})
-                          </span>
-                        </div>
-                      </div>
-                    </ExpandableItem>
-                  );
-                }
-              )}
-            </ExpandableItem>
-          </div>
-        ))
+                      </ExpandableItem>
+                    );
+                  }
+                )}
+              </ExpandableItem>
+            </div>
+          );
+        })
       )}
     </div>
   );

--- a/src/devtools/client/inspector/event-listeners/XHTMLNode.tsx
+++ b/src/devtools/client/inspector/event-listeners/XHTMLNode.tsx
@@ -1,19 +1,29 @@
-import { NodeFront } from "protocol/thread/node";
 import React, { FC } from "react";
-import { SHADOW_ROOT_TAGNAME } from "../breadcrumbs";
+
+import { NodeWithPreview } from "ui/actions/event-listeners";
 
 type XHTMLNodeProps = {
-  node: NodeFront;
+  node: NodeWithPreview;
 };
 
+const getAttribute = (node: NodeWithPreview, name: string) => {
+  const attr = node.preview.node.attributes?.find(a => a.name == name);
+  return attr?.value;
+};
+
+// Show a stringified DOM node representation, like:
+// button#someId.class1.class2
 export const XHTMLNode: FC<XHTMLNodeProps> = ({ node }) => {
-  const tagText = `${node.isShadowRoot ? SHADOW_ROOT_TAGNAME : node.displayName}${
-    node.pseudoType ? "::" + node.pseudoType : ""
-  }`;
+  const { nodeName, pseudoType, attributes } = node.preview.node;
 
-  const idText = node.id ? `#${node.id}` : "";
+  const id = getAttribute(node, "id");
+  const className = getAttribute(node, "class") || "";
+  const classList = className.split(" ").filter(Boolean);
 
-  const classesText = node.classList.length > 0 ? "." + node.classList.join(".") : "";
+  const tagText = `${nodeName.toLowerCase()}${pseudoType ? "::" + pseudoType : ""}`;
+  const idText = id ? `#${id}` : "";
+  // Add a preceding `.` if there are any classes, plus in-between each
+  const classesText = [""].concat(classList).join(".");
 
   return (
     <span>

--- a/src/devtools/client/inspector/markup/reducers/markup.ts
+++ b/src/devtools/client/inspector/markup/reducers/markup.ts
@@ -8,6 +8,7 @@ const ATTR_COLLAPSE_LENGTH_PREF = "devtools.markup.collapseAttributeLength";
 
 import { Attr } from "@replayio/protocol";
 import { NodeFront } from "protocol/thread/node";
+import { UIState } from "ui/state";
 
 export interface NodeInfo {
   // A list of the node's attributes.
@@ -131,3 +132,5 @@ export const {
 } = markupSlice.actions;
 
 export default markupSlice.reducer;
+
+export const getSelectedDomNodeId = (state: UIState) => state.markup.selectedNode;

--- a/src/ui/actions/event-listeners.ts
+++ b/src/ui/actions/event-listeners.ts
@@ -1,7 +1,11 @@
 // Routines for finding framework-specific event listeners within a pause.
 
-import { ValueFront } from "protocol/thread";
-import { NodeFront } from "protocol/thread/node";
+import type { Object as ProtocolObject, ObjectPreview, Location } from "@replayio/protocol";
+import { ThreadFront, ValueFront } from "protocol/thread";
+import { UIThunkAction } from "./index";
+import { getSourceDetailsEntities, getPreferredLocation, SourceDetails } from "ui/reducers/sources";
+import { UIState } from "ui/state";
+import { Dictionary } from "@reduxjs/toolkit";
 
 export interface FrameworkEventListener {
   handler: ValueFront;
@@ -10,33 +14,205 @@ export interface FrameworkEventListener {
   tags: string;
 }
 
-const frameworkListenersCache = new WeakMap<NodeFront, FrameworkEventListener[]>();
+export type FunctionPreview = Required<
+  Pick<ObjectPreview, "functionName" | "functionLocation" | "functionParameterNames">
+>;
 
-export async function getFrameworkEventListeners(node: NodeFront) {
-  if (frameworkListenersCache.has(node)) {
-    return frameworkListenersCache.get(node)!;
-  }
+export interface EventListenerWithFunctionInfo {
+  type: string;
+  capture: boolean;
+  functionName: string;
+  locationUrl?: string;
+  location: Location;
+  functionParameterNames: string[];
+}
 
-  const obj = node.getObjectFront();
-  await obj.loadProperties();
-  const props = [...obj.previewValueMap().entries()];
-  const reactProp = props.find(([key]) => key.startsWith("__reactEventHandlers$"));
-  if (!reactProp) {
-    return [];
-  }
+export type FunctionWithPreview = Omit<ProtocolObject, "preview"> & {
+  preview: FunctionPreview;
+};
 
-  await reactProp[1].loadProperties();
-  const handlerProps = [...reactProp[1].previewValueMap().entries()];
-  const resultListeners = handlerProps
-    .filter(([, contents]) => {
-      return contents.isObject() && contents.className() == "Function";
-    })
-    .map(([name, contents]) => {
-      return { handler: contents, type: name, capture: false, tags: "React" };
+// TS magic: https://stackoverflow.com/a/57837897/62937
+type DeepRequired<T, P extends string[]> = T extends object
+  ? Omit<T, Extract<keyof T, P[0]>> &
+      Required<{
+        [K in Extract<keyof T, P[0]>]: NonNullable<DeepRequired<T[K], ShiftUnion<P>>>;
+      }>
+  : T;
+
+// Analogues to array.prototype.shift
+export type Shift<T extends any[]> = ((...t: T) => any) extends (
+  first: any,
+  ...rest: infer Rest
+) => any
+  ? Rest
+  : never;
+
+// use a distributed conditional type here
+type ShiftUnion<T> = T extends any[] ? Shift<T> : never;
+
+export type NodeWithPreview = DeepRequired<
+  ProtocolObject,
+  ["preview", "node"] | ["preview", "getterValues"]
+>;
+
+const isFunctionPreview = (obj?: ObjectPreview): obj is FunctionPreview => {
+  return (
+    !!obj && "functionName" in obj && "functionLocation" in obj && "functionParameterNames" in obj
+  );
+};
+
+const isFunctionWithPreview = (obj: ProtocolObject): obj is FunctionWithPreview => {
+  return obj.className === "Function" && isFunctionPreview(obj.preview);
+};
+
+const REACT_16_EVENT_LISTENER_PROP_KEY = "__reactEventHandlers$";
+const REACT_17_18_EVENT_LISTENER_PROP_KEY = "__reactProps$";
+
+const formatEventListener = (
+  listener: { type: string; capture: boolean },
+  fnPreview: FunctionWithPreview,
+  state: UIState,
+  sourcesById: Dictionary<SourceDetails>
+) => {
+  const { functionLocation, functionName = "", functionParameterNames = [] } = fnPreview.preview;
+  const location = getPreferredLocation(
+    state,
+    functionLocation,
+    ThreadFront.preferredGeneratedSources
+  );
+
+  const locationUrl = functionLocation ? sourcesById[location.sourceId]?.url : undefined;
+
+  return {
+    ...listener,
+    location,
+    locationUrl,
+    functionName,
+    functionParameterNames,
+  };
+};
+
+const eventListenersCacheByPause = new Map<string, Map<string, EventListenerWithFunctionInfo[]>>();
+
+export function getNodeEventListeners(
+  nodeId: string
+): UIThunkAction<Promise<EventListenerWithFunctionInfo[]>> {
+  return async (dispatch, getState, { ThreadFront, protocolClient, replayClient, objectCache }) => {
+    if (!ThreadFront.currentPause) {
+      return [];
+    }
+    const pauseId = ThreadFront.currentPause.pauseId!;
+
+    if (!eventListenersCacheByPause.has(pauseId)) {
+      eventListenersCacheByPause.set(pauseId, new Map());
+    }
+
+    // Reuse cached event listener entries if we've done this work already
+    const eventListenersCache = eventListenersCacheByPause.get(pauseId)!;
+    const cachedListeners = eventListenersCache.get(nodeId);
+
+    if (cachedListeners) {
+      return cachedListeners;
+    }
+
+    const state = getState();
+    const sourcesById = getSourceDetailsEntities(state);
+
+    // We need to fetch "basic" event listeners from the protocol API
+    const { listeners } = await ThreadFront.currentPause.sendMessage(
+      protocolClient.DOM.getEventListeners,
+      {
+        node: nodeId,
+      }
+    );
+
+    // Reformat those entries to add location/name/params data
+    const formattedListenerEntries = listeners.map(listener => {
+      // TODO These entries exist in current testing, but what's fetching them earlier?
+      const listenerHandler = objectCache.getObjectThrows(
+        pauseId,
+        listener.handler
+      ) as FunctionWithPreview;
+
+      return formatEventListener(listener, listenerHandler, state, sourcesById);
     });
 
-  frameworkListenersCache.set(node, resultListeners);
-  return resultListeners;
+    // Next, we want to find "framework listeners". As currently implemented,
+    // this is really just finding React `onThing` events.
+    // React normally points the "raw" event handlers like `"click"` to a `noop`
+    // function. It's much more useful to see an `onClick` entry that points to
+    // a real file like `Counter.tsx:27` instead.
+
+    // Start by getting "the JS object that represents this DOM node".
+    const domNodeObject = (await objectCache.getObjectWithPreviewHelper(
+      replayClient,
+      pauseId,
+      nodeId
+    )) as NodeWithPreview;
+
+    // DOM nodes can have normal JS object properties.
+    const { properties = [] } = domNodeObject.preview;
+
+    // React adds special secret expando properties to DOM nodes to store
+    // metadata about props and component args.
+    // HACK This is groveling into the guts of React and can easily break!
+    const reactEventListenerProperty = properties.find(
+      prop =>
+        prop.name.startsWith(REACT_16_EVENT_LISTENER_PROP_KEY) ||
+        prop.name.startsWith(REACT_17_18_EVENT_LISTENER_PROP_KEY)
+    );
+
+    if (reactEventListenerProperty) {
+      // Assuming we found the magic "props metadata" object name/ID,
+      // retrieve the actual object contents.
+      const listenerPropObj = await objectCache.getObjectWithPreviewHelper(
+        replayClient,
+        pauseId,
+        reactEventListenerProperty.object!
+      );
+
+      // The object might contain both primitives and objects/functions.
+      // Narrow down the props fields to just objects (including functions)
+      const objectProperties =
+        listenerPropObj.preview?.properties?.filter(prop => !!prop.object) ?? [];
+
+      if (objectProperties.length) {
+        // Then retrieve full preview data for all of those "object" fields
+        const allPropertyPreviews = await Promise.all(
+          objectProperties.map(async prop => ({
+            name: prop.name,
+            value: (await objectCache.getObjectWithPreviewHelper(
+              replayClient,
+              pauseId,
+              prop.object!
+            )) as FunctionWithPreview,
+          }))
+        );
+
+        // Finally, we can filter that down to "objects" that are actually functions.
+        // We can assume that any function this far down is a React event handler,
+        // defined in actual user code.
+        const formattedFrameworkListeners = allPropertyPreviews
+          .filter(obj => obj.value.className === "Function")
+          .map(obj => {
+            // Add an entry like `{name: "onClick", location, locationUrl}
+            return formatEventListener(
+              { type: obj.name, capture: false },
+              obj.value,
+              state,
+              sourcesById
+            );
+          });
+
+        // Merge the React event entries into the list of all event listeners
+        formattedListenerEntries.push(...formattedFrameworkListeners);
+      }
+    }
+
+    // Cache all that work for later
+    eventListenersCache.set(nodeId, formattedListenerEntries);
+    return formattedListenerEntries;
+  };
 }
 
 export function logpointGetFrameworkEventListeners(frameId: string, frameworkListeners: string) {

--- a/src/ui/actions/event-listeners.ts
+++ b/src/ui/actions/event-listeners.ts
@@ -7,13 +7,6 @@ import { getSourceDetailsEntities, getPreferredLocation, SourceDetails } from "u
 import { UIState } from "ui/state";
 import { Dictionary } from "@reduxjs/toolkit";
 
-export interface FrameworkEventListener {
-  handler: ValueFront;
-  type: string;
-  capture: boolean;
-  tags: string;
-}
-
 export type FunctionPreview = Required<
   Pick<ObjectPreview, "functionName" | "functionLocation" | "functionParameterNames">
 >;
@@ -25,6 +18,7 @@ export interface EventListenerWithFunctionInfo {
   locationUrl?: string;
   location: Location;
   functionParameterNames: string[];
+  framework?: string;
 }
 
 export type FunctionWithPreview = Omit<ProtocolObject, "preview"> & {
@@ -72,7 +66,8 @@ const formatEventListener = (
   listener: { type: string; capture: boolean },
   fnPreview: FunctionWithPreview,
   state: UIState,
-  sourcesById: Dictionary<SourceDetails>
+  sourcesById: Dictionary<SourceDetails>,
+  framework?: string
 ) => {
   const { functionLocation, functionName = "", functionParameterNames = [] } = fnPreview.preview;
   const location = getPreferredLocation(
@@ -89,6 +84,7 @@ const formatEventListener = (
     locationUrl,
     functionName,
     functionParameterNames,
+    framework,
   };
 };
 
@@ -200,7 +196,9 @@ export function getNodeEventListeners(
               { type: obj.name, capture: false },
               obj.value,
               state,
-              sourcesById
+              sourcesById,
+              // We're only finding React-specific event handlers atm
+              "react"
             );
           });
 

--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -49,6 +49,12 @@ import { setupSourcesListeners } from "devtools/client/debugger/src/actions/sour
 import { setupMarkup } from "devtools/client/inspector/markup/actions/markup";
 import { setupBoxModel } from "devtools/client/inspector/boxmodel/actions/box-model";
 import { setupRules } from "devtools/client/inspector/rules/actions/rules";
+import {
+  getCachedObject,
+  getObjectThrows,
+  getObjectWithPreviewHelper,
+  getObjectPropertyHelper,
+} from "@bvaughn/src/suspense/ObjectPreviews";
 
 import { setCanvas } from "ui/actions/app";
 import { precacheScreenshots } from "ui/actions/timeline";
@@ -179,6 +185,12 @@ export default async function setupDevtools(store: AppStore, replayClient: Repla
     ThreadFront,
     replayClient,
     protocolClient,
+    objectCache: {
+      getCachedObject,
+      getObjectThrows,
+      getObjectWithPreviewHelper,
+      getObjectPropertyHelper,
+    },
   };
 
   // Add all these new slice reducers and some related state in a single call,

--- a/src/ui/utils/thunk.ts
+++ b/src/ui/utils/thunk.ts
@@ -1,11 +1,25 @@
 import { ProtocolClient } from "@replayio/protocol";
 import type { ThreadFront } from "protocol/thread";
 import { ReplayClientInterface } from "shared/client/types";
+import type {
+  getCachedObject,
+  getObjectThrows,
+  getObjectWithPreviewHelper,
+  getObjectPropertyHelper,
+} from "@bvaughn/src/suspense/ObjectPreviews";
+
+interface SuspenseObjectCache {
+  getCachedObject: typeof getCachedObject;
+  getObjectThrows: typeof getObjectThrows;
+  getObjectWithPreviewHelper: typeof getObjectWithPreviewHelper;
+  getObjectPropertyHelper: typeof getObjectPropertyHelper;
+}
 
 export interface ThunkExtraArgs {
   ThreadFront: typeof ThreadFront;
   replayClient: ReplayClientInterface;
   protocolClient: ProtocolClient;
+  objectCache: SuspenseObjectCache;
 }
 
 export const extraThunkArgs = {} as ThunkExtraArgs;


### PR DESCRIPTION
This PR:

- Fixes a timing edge case where the `paused()` thunk would dispatch the `"pause/paused"` action before we actually received a pause ID back from the server. The thunk now waits until that pause ID is received, so that the Redux state can save a copy of the pause ID.
- Exposes several of the new Suspense Object Cache fetch methods as `thunkExtraArgs.objectCache`
- Rewrites all of the EventListeners logic to remove `Node/ValueFront` usage:
  - The `<EventListenersApp>` component now looks at the `selectedNodeId` in the Redux state to decide when to update, instead of listening to `Selection.on("new-node-front")`
  - The component now suspends to make sure we have the DOM node preview data before continuing
  - The `<XHTMLNode>` accepts that preview object for display instead of a `NodeFront`
  - The logic for fetching both plain and "framework" event listeners is now in a thunk
  - The event listener fetching logic relies on the low-level `protocolClient` API and the object cache's "fetch this item by ID" behavior, instead of `Node/ValueFront` methods
  - Fixed up the React "framework listener" detection so that it works with React 17/18, as the internal special hidden field name changed with 17.0
  - Adds either a "framework" icon (currently just the React logo) or a "JS" icon to the treeview event names, and slightly ups the font size of the event names (both for visibility and to align the icons better)


Example of a button with an `onClick` handler:

![image](https://user-images.githubusercontent.com/1128784/187294059-64e18671-7fb4-4692-a7f2-499e32e3a065.png)


