### PR TITLE
Load hit counts in smarter 100 line chunks

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
@@ -99,8 +99,13 @@ function LineNumberTooltip({ editor, keyModifiers }: Props) {
         lastHoveredLineNumber.current = lineNumber;
       }
       dispatch(updateHoveredLineNumber(lineNumber));
-      dispatch(fetchHitCounts(source!.id, lastHoveredLineNumber.current));
       setTargetNode(lineNumberNode);
+      var rect = editor.codeMirror.getWrapperElement().getBoundingClientRect();
+      var topVisibleLine = editor.codeMirror.lineAtHeight(rect.top, "window");
+      var bottomVisibleLine = editor.codeMirror.lineAtHeight(rect.bottom, "window");
+      dispatch(fetchHitCounts(source!.id, editor.codeMirror.lineAtHeight()));
+      dispatch(fetchHitCounts(source!.id, topVisibleLine - 10));
+      dispatch(fetchHitCounts(source!.id, bottomVisibleLine + 10));
     };
     const clearHoveredLineNumber = () => {
       setTargetNode(null);

--- a/src/ui/reducers/hitCounts.ts
+++ b/src/ui/reducers/hitCounts.ts
@@ -76,9 +76,9 @@ const aggregateHitCountsSelectors = aggregateHitCountsAdapter.getSelectors<UISta
   (state: UIState) => state.hitCounts.aggregateHitCounts
 );
 
-const MAX_LINE_HITS_TO_FETCH = 1000;
+const MAX_LINE_HITS_TO_FETCH = 100;
 // This will fetch hitCounts in chunks of lines. So if line 4 is request, lines
-// 1-1000 will be fetched. If line 1001 is requested, lines 1001-2000 will be
+// 1-100 will be fetched. If line 101 is requested, lines 101-200 will be
 // fetched.
 export const getBoundsForLineNumber = (line: number) => {
   const lower = Math.floor(line / MAX_LINE_HITS_TO_FETCH) * MAX_LINE_HITS_TO_FETCH;


### PR DESCRIPTION
The core problem here is that some files are just too big for us to
fetch hitCounts for all lines at once. So, my original naive solution,
back when we were first dealing with this, was to fetch lines in chunks
of 1,000, selecting the 1,000 line window which included the line the
user was currently hovering. This works reasonably well, most of the
time, but there are a few problems with it.

1) The backend has several places where it imposes a 1,000 location
   limit. The first one is the number of locations initially passed to
   it. That limit is totally fine. Because we only ask for the first
   column, and we ask in increments of 1,000 lines, we will only ever
   ask for a maximum of 1,000 lines (and in practice we almost never ask
   for that many, because we exclude lines which are not breakable).
   However, things get a little trickier. The front-end can ask for
   hitCounts for original locations (in fact, most of the time, we are
   asking about original locations). But it makes no sense to ask "how
   many times was a position in an original location hit?" because
   original locations are never actually run. Instead, we have to ask,
   how many times were the generated location(s) which map to this
   original location hit? The sum of those is the best answer to "how
   many times was this original location hit?". So, upon first running
   the `getHitCounts` protocol method the backend will first translate
   from original to generated locations. And we also limit *those*
   locations to 1,000 total. So if you ask for 501 locations, but each
   of them is associated with 2 generated locations, you are really
   asking for 1,002 generated locations, and the backend will error.
   This is relatively uncommon, but it does happen, as in this ticket:
   https://linear.app/replay/issue/BAC-2149/[glide]-via-slack-gethitcounts-ending-in-failed-to-load-hit-counts.
2) This loads a fixed range, no matter where in that range your hovered
   line is. So we will only load up to line 1,000, even if you are
   currently looking at line 999 (which makes it likely that line 1,001
   is *also* in the viewport, but is not being loaded).

I've made a couple of small adjustments to solve both of these problems:

1) Load lines in sections of 100, instead of 1,000. This makes it a
   *lot* less likely that we will end up with more than 1,000 generated
   locations for a given set of original locations (though still not
   impossible).
2) Load for the currently hovered line, plus for the ranges a little
   above and a little beyond the current viewport. This will ensure that
   the whole viewport is always loaded (I guess in the cases where
   something like 400 lines of text is visible we might end up with some
   gaps, but tbh I don't expect that situation to happen ever, since it
   would require miniscule text displayed on an incredibly tall monitor).

There are probably more elegant solutions here, but this seems like a
solid gain for just a few lines of code.