### PR TITLE
Fill in graphics for points past the last paint

### DIFF
--- a/packages/protocol/graphics.ts
+++ b/packages/protocol/graphics.ts
@@ -180,13 +180,19 @@ export const timeIsBeyondKnownPaints = (time: number) =>
 
 export function setupGraphics() {
   ThreadFront.sessionWaiter.promise.then(async (sessionId: string) => {
+    let paintedGraphics = false;
+
     const { client } = await import("./socket");
     client.Graphics.findPaints({}, sessionId).then(async () => {
+      if (!paintedGraphics) {
+        paintedGraphics = true;
+        const { screen, mouse } = await getGraphicsAtTime(ThreadFront.currentTime);
+        paintGraphics(screen, mouse);
+      }
       hasAllPaintPoints = true;
       await Promise.all(gPaintPromises);
       videoReady.resolve();
     });
-    let paintedGraphics = false;
     client.Graphics.addPaintPointsListener(async ({ paints }) => {
       onPaints(paints);
       const latestPaint = maxBy(paints, p => BigInt(p.point));


### PR DESCRIPTION
The fix in 9816360b9 works if we eventually get a paint point *after*
the time we are at. But we should also use the paints if we are past the
last paint. Instead of looking for a later paint, we should look to see
if we have *all* paints.