### PR TITLE
Allow analysis to fail

### DIFF
--- a/packages/protocol/analysisManager.ts
+++ b/packages/protocol/analysisManager.ts
@@ -160,6 +160,9 @@ class AnalysisManager {
         !handler.onAnalysisResult || client.Analysis.runAnalysis({ analysisId }, sessionId),
         !handler.onAnalysisPoints || client.Analysis.findAnalysisPoints({ analysisId }, sessionId),
       ]);
+    } catch (e) {
+      this.onAnalysisError({ analysisId, error: e instanceof Error ? e.message : "Unknown Error" });
+      console.error(e);
     } finally {
       this.handlers.delete(analysisId);
       await client.Analysis.releaseAnalysis({ analysisId }, sessionId);

--- a/src/devtools/client/debugger/src/actions/sources/newSources.ts
+++ b/src/devtools/client/debugger/src/actions/sources/newSources.ts
@@ -30,8 +30,6 @@ import { syncBreakpoint } from "../breakpoints";
 import { loadSourceText, getPreviousPersistedLocation } from "ui/reducers/sources";
 import { AppStartListening } from "ui/setup/listenerMiddleware";
 
-import { prefs } from "../../utils/prefs";
-
 function checkPendingBreakpoints(cx: Context, sourceId: string): UIThunkAction {
   return async (dispatch, getState, { ThreadFront }) => {
     // source may have been modified by selectLocation

--- a/src/ui/setup/helpers.ts
+++ b/src/ui/setup/helpers.ts
@@ -1,6 +1,7 @@
 import { UIStore } from "ui/actions";
 import { getRecordingId } from "ui/utils/recording";
 import { prefs, features, asyncStore } from "ui/utils/prefs";
+import { asyncStore as debuggerAsyncStore } from "devtools/client/debugger/src/utils/prefs";
 
 // eslint-disable-next-line no-restricted-imports
 import { triggerEvent, sendMessage, client } from "protocol/socket";
@@ -15,6 +16,7 @@ declare global {
     prefs: typeof prefs;
     features: typeof features;
     asyncStore: typeof asyncStore;
+    debuggerAsyncStore: typeof debuggerAsyncStore;
     dumpPrefs: () => string;
     dumpBasicProcessing: () => void;
     local: () => void;
@@ -55,6 +57,7 @@ export async function setupAppHelper(store: UIStore) {
     prefs,
     features,
     asyncStore,
+    debuggerAsyncStore,
     triggerEvent,
     replaySession,
     client,


### PR DESCRIPTION
Should fix the crash we were seeing with invalid location. Of course, we should also still have a backend command error that we want to hunt down to explain why we were sending the bad location as well