### PR TITLE
Consolidate uses of `Highlighter.highlight()` and node picker logic

### DIFF
--- a/src/devtools/client/inspector/boxmodel/components/BoxModel.tsx
+++ b/src/devtools/client/inspector/boxmodel/components/BoxModel.tsx
@@ -5,7 +5,7 @@
 "use strict";
 
 import React from "react";
-import { BoxModelMain } from "./BoxModelMain";
+import BoxModelMain from "./BoxModelMain";
 import { BoxModelProperties } from "./BoxModelProperties";
 
 import type { Layout } from "../reducers/box-model";

--- a/src/devtools/client/inspector/markup/actions/markup.ts
+++ b/src/devtools/client/inspector/markup/actions/markup.ts
@@ -269,7 +269,7 @@ export function selectNode(nodeId: string, reason?: SelectionReason): UIThunkAct
   return async (dispatch, getState, { ThreadFront }) => {
     const nodeFront = ThreadFront.currentPause?.getNodeFront(nodeId);
     if (nodeFront) {
-      Highlighter.highlight(nodeFront, 1000);
+      dispatch(highlightNode(nodeId, 1000));
       const { selection } = await import("devtools/client/framework/selection");
       selection.setNodeFront(nodeFront, { reason });
     }
@@ -450,21 +450,19 @@ export function onPageDownKey(): UIThunkAction {
 // This doesn't even need to be in Redux
 let hoveredNodeId: string | null = null;
 
-export function highlightNode(nodeId: string): UIThunkAction {
+export function highlightNode(nodeId: string, duration?: number): UIThunkAction {
   return async (dispatch, getState, { ThreadFront }) => {
     if (hoveredNodeId !== nodeId) {
       hoveredNodeId = nodeId;
-      Highlighter.highlight(ThreadFront.currentPause!.getNodeFront(nodeId));
+      Highlighter.highlight(ThreadFront.currentPause!.getNodeFront(nodeId), duration);
     }
   };
 }
 
-export function unhighlightNode(nodeId: string): UIThunkAction {
+export function unhighlightNode(): UIThunkAction {
   return async (dispatch, getState) => {
-    if (hoveredNodeId && nodeId === hoveredNodeId) {
-      hoveredNodeId = null;
-      Highlighter.unhighlight();
-    }
+    hoveredNodeId = null;
+    Highlighter.unhighlight();
   };
 }
 

--- a/src/devtools/client/inspector/markup/actions/markup.ts
+++ b/src/devtools/client/inspector/markup/actions/markup.ts
@@ -454,7 +454,10 @@ export function highlightNode(nodeId: string, duration?: number): UIThunkAction 
   return async (dispatch, getState, { ThreadFront }) => {
     if (hoveredNodeId !== nodeId) {
       hoveredNodeId = nodeId;
-      Highlighter.highlight(ThreadFront.currentPause!.getNodeFront(nodeId), duration);
+      const node = await ThreadFront.ensureNodeLoaded(nodeId);
+      if (node) {
+        Highlighter.highlight(node, duration);
+      }
     }
   };
 }

--- a/src/devtools/client/inspector/markup/components/HTMLBreadcrumbs.tsx
+++ b/src/devtools/client/inspector/markup/components/HTMLBreadcrumbs.tsx
@@ -62,7 +62,7 @@ export function HTMLBreadcrumbs() {
       };
 
       const handleMouseLeave = () => {
-        dispatch(unhighlightNode(node.id));
+        dispatch(unhighlightNode());
       };
 
       return (
@@ -89,7 +89,7 @@ export function HTMLBreadcrumbs() {
     }
 
     // Find the last button DOM node
-    const buttons = [...containerRef.current!.querySelectorAll(".breadcrumbs-widget-item")];
+    const buttons = [...(containerRef.current?.querySelectorAll(".breadcrumbs-widget-item") || [])];
     const [lastButton] = buttons.slice(-1);
 
     if (lastButton) {

--- a/src/devtools/client/inspector/markup/components/Node.tsx
+++ b/src/devtools/client/inspector/markup/components/Node.tsx
@@ -57,7 +57,7 @@ class _Node extends PureComponent<FinalNodeProps> {
   };
 
   onMouseLeave = () => {
-    this.props.unhighlightNode(this.props.node.id);
+    this.props.unhighlightNode();
   };
 
   scrollIntoView = (el: HTMLElement | null) => {

--- a/src/devtools/client/webconsole/actions/toolbox.ts
+++ b/src/devtools/client/webconsole/actions/toolbox.ts
@@ -23,10 +23,11 @@ export function highlightDomElement(grip: $FixTypeLater): UIThunkAction {
       return;
     }
 
-    const { highlighter } = await import("highlighter/highlighter");
+    const { highlightNode } = await import("devtools/client/inspector/markup/actions/markup");
+
     const nodeFront = grip.getNodeFront();
-    if (highlighter && nodeFront) {
-      highlighter.highlight(nodeFront);
+    if (nodeFront) {
+      dispatch(highlightNode(nodeFront.id));
     }
   };
 }

--- a/src/ui/components/NodePicker.tsx
+++ b/src/ui/components/NodePicker.tsx
@@ -1,11 +1,11 @@
 import classnames from "classnames";
-import Highlighter from "highlighter/highlighter";
 import { getDevicePixelRatio } from "protocol/graphics";
 import { ThreadFront } from "protocol/thread";
 import { EventEmitter } from "protocol/utils";
 import React from "react";
 import { connect, ConnectedProps } from "react-redux";
 import { actions } from "ui/actions";
+import { highlightNode, unhighlightNode } from "devtools/client/inspector/markup/actions/markup";
 
 export const nodePicker: any = {};
 
@@ -104,9 +104,9 @@ class NodePicker extends React.Component<PropsFromRedux, NodePickerState> {
     this.lastPickerPosition = pos;
     const nodeBounds = pos && (await ThreadFront.getMouseTarget(pos.x, pos.y));
     if (this.lastPickerPosition == pos && nodeBounds) {
-      Highlighter.highlight(nodeBounds);
+      this.props.highlightNode(nodeBounds.nodeId);
     } else {
-      Highlighter.unhighlight();
+      this.props.unhighlightNode();
     }
   };
 
@@ -124,14 +124,14 @@ class NodePicker extends React.Component<PropsFromRedux, NodePickerState> {
 
     const nodeBounds = pos && (await ThreadFront.getMouseTarget(pos.x, pos.y));
     if (nodeBounds) {
-      Highlighter.highlight(nodeBounds);
+      this.props.highlightNode(nodeBounds.nodeId);
       const node = await ThreadFront.ensureNodeLoaded(nodeBounds.nodeId);
-      if (node && Highlighter.currentNode == nodeBounds) {
+      if (node) {
         const { selection } = await import("devtools/client/framework/selection");
         selection.setNodeFront(node);
       }
     } else {
-      Highlighter.unhighlight();
+      this.props.unhighlightNode();
     }
   }
 
@@ -156,6 +156,8 @@ const connector = connect(null, {
   setIsNodePickerActive: actions.setIsNodePickerActive,
   setMouseTargetsLoading: actions.setMouseTargetsLoading,
   setSelectedPanel: actions.setSelectedPanel,
+  highlightNode,
+  unhighlightNode,
 });
 type PropsFromRedux = ConnectedProps<typeof connector>;
 

--- a/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
+++ b/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
@@ -13,7 +13,7 @@ import {
 } from "ui/reducers/reactDevTools";
 import { setIsNodePickerActive, setIsNodePickerInitializing } from "ui/reducers/app";
 import { setHasReactComponents, setProtocolCheckFailed } from "ui/actions/reactDevTools";
-import NodePicker, { NodePickerOpts } from "ui/utils/nodePicker";
+import { NodePicker as NodePickerClass, NodePickerOpts } from "ui/utils/nodePicker";
 import { sendTelemetryEvent, trackEvent } from "ui/utils/telemetry";
 import { highlightNode, unhighlightNode } from "devtools/client/inspector/markup/actions/markup";
 
@@ -277,6 +277,8 @@ async function loadReactDevToolsInlineModuleFromProtocol(stateUpdaterCallback: F
   }
 }
 
+const nodePickerInstance = new NodePickerClass();
+
 export default function ReactDevtoolsPanel() {
   const annotations = useAppSelector(getAnnotations);
   const currentPoint = useAppSelector(getCurrentPoint);
@@ -307,14 +309,14 @@ export default function ReactDevtoolsPanel() {
   function enablePicker(opts: NodePickerOpts) {
     dispatch(setIsNodePickerActive(true));
     dispatch(setIsNodePickerInitializing(false));
-    NodePicker.enable(opts);
+    nodePickerInstance.enable(opts);
   }
   function initializePicker() {
     dispatch(setIsNodePickerActive(false));
     dispatch(setIsNodePickerInitializing(true));
   }
   function disablePicker() {
-    NodePicker.disable();
+    nodePickerInstance.disable();
     dispatch(setIsNodePickerActive(false));
     dispatch(setIsNodePickerInitializing(false));
   }

--- a/src/ui/components/SecondaryToolbox/index.tsx
+++ b/src/ui/components/SecondaryToolbox/index.tsx
@@ -4,7 +4,7 @@ import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import classnames from "classnames";
 import WebConsoleApp from "devtools/client/webconsole/components/App";
 
-import NodePicker from "../NodePicker";
+import { NodePicker } from "../NodePicker";
 import { selectors } from "../../reducers";
 import ReactDevtoolsPanel from "./ReactDevTools";
 import { ReduxDevToolsPanel } from "./ReduxDevTools";

--- a/src/ui/utils/nodePicker.ts
+++ b/src/ui/utils/nodePicker.ts
@@ -14,7 +14,7 @@ interface Position {
   y: number;
 }
 
-class NodePicker {
+export class NodePicker {
   private opts: NodePickerOpts | undefined;
   private pickerPosition: Position | undefined;
   private hoveredNodeId: string | undefined;
@@ -37,9 +37,6 @@ class NodePicker {
     const pos = this.mouseEventCanvasPosition(e);
     this.pickerPosition = pos;
     const nodeBounds = await this.nodeBounds(pos, this.opts?.enabledNodeIds);
-    if (this.pickerPosition !== pos) {
-      return;
-    }
     if (nodeBounds) {
       this.opts?.onHighlightNode(nodeBounds.nodeId);
       if (nodeBounds.nodeId !== this.hoveredNodeId) {
@@ -92,5 +89,3 @@ class NodePicker {
     return pos ? await ThreadFront.getMouseTarget(pos.x, pos.y, enabledNodeIds) : undefined;
   }
 }
-
-export default new NodePicker();

--- a/src/ui/utils/nodePicker.ts
+++ b/src/ui/utils/nodePicker.ts
@@ -1,10 +1,11 @@
 import { ThreadFront } from "protocol/thread";
 import { getDevicePixelRatio } from "protocol/graphics";
-import Highlighter from "highlighter/highlighter";
 
 export interface NodePickerOpts {
   onHovering?: (nodeId: string | null) => void;
   onPicked: (nodeId: string | null) => void;
+  onHighlightNode: (nodeId: string) => void;
+  onUnhighlightNode: () => void;
   enabledNodeIds?: string[];
 }
 
@@ -40,13 +41,13 @@ class NodePicker {
       return;
     }
     if (nodeBounds) {
-      Highlighter.highlight(nodeBounds);
+      this.opts?.onHighlightNode(nodeBounds.nodeId);
       if (nodeBounds.nodeId !== this.hoveredNodeId) {
         this.hoveredNodeId = nodeBounds.nodeId;
         this.opts?.onHovering?.(nodeBounds.nodeId);
       }
     } else {
-      Highlighter.unhighlight();
+      this.opts?.onUnhighlightNode();
     }
   };
 


### PR DESCRIPTION
This PR:

- Consolidates all previous outstanding uses of `Highlighter.highlight/unhighlight()`, so that there's only _one_ file that calls those: `actions/markup.ts`. All other uses now call `dispatch(highlightNode(nodeId))`.
- Rewrites the `<NodePicker>` component to consolidate implementation logic, as it had exactly duplicate behavior with the `ui/utils/nodePicker` vanilla JS class version:
  - Rewrote it to be a function component with hooks instead of a connected class component
  - It now instantiates an instance of the `NodePicker` JS class to do all of the `mousemove` event listeners and "which node is underneath the mouse?" logic, instead of duplicating that
  - It still exposes a `window.gNodePicker` global variable for use in `test/harness.ts` (which we should get rid of), but that's now an object with two methods instead of the React class component `this` instance


These are prep steps towards rewriting the highlighting implementation entirely to no longer be a singleton that relies on `NodeFront`s.