### PR TITLE
Treat empty results array as valid when running analysis

### DIFF
--- a/packages/bvaughn-architecture-demo/src/suspense/AnalysisCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/AnalysisCache.ts
@@ -100,10 +100,6 @@ async function runAnalysisHelper(
       range: focusRange || undefined,
     });
 
-    if (results.length === 0) {
-      throw new Error("No results returned from analysis");
-    }
-
     const resultsMap = new Map();
     results.forEach(result => {
       const objects = result.data.objects;

--- a/packages/shared/client/ReplayClient.ts
+++ b/packages/shared/client/ReplayClient.ts
@@ -600,7 +600,6 @@ export class ReplayClient implements ReplayClientInterface {
   async runAnalysis<Result>(params: RunAnalysisParams): Promise<Result[]> {
     return new Promise<Result[]>(async (resolve, reject) => {
       const results: Result[] = [];
-      let resultReceived = false;
 
       const { location, ...rest } = params;
 
@@ -620,18 +619,11 @@ export class ReplayClient implements ReplayClientInterface {
             reject(errorMessage);
           },
           onAnalysisResult: analysisEntries => {
-            resultReceived = true;
             results.push(...analysisEntries.map(entry => entry.value));
           },
         });
 
-        if (resultReceived) {
-          resolve(results);
-        } else {
-          // No result was returned.
-          // This might happen when e.g. exceptions are being queried for a recording with no exceptions.
-          resolve([]);
-        }
+        resolve(results);
       } catch (error) {
         reject(error);
       }


### PR DESCRIPTION
We're throwing currently when we don't need to