### PR TITLE
Pre-cache sources for new architecture

### DIFF
--- a/packages/bvaughn-architecture-demo/components/console/renderers/EventLogRenderer.tsx
+++ b/packages/bvaughn-architecture-demo/components/console/renderers/EventLogRenderer.tsx
@@ -61,7 +61,7 @@ function EventLogRenderer({
             {index < values.length - 1 && " "}
           </Fragment>
         ))
-      : " ";
+      : null;
 
   const showContextMenu = (event: MouseEvent) => {
     event.preventDefault();
@@ -73,7 +73,11 @@ function EventLogRenderer({
       {showTimestamps && (
         <span className={styles.TimeStamp}>{formatTimestamp(eventLog.time, true)} </span>
       )}
-      <span className={styles.LogContents}>{content}</span>
+      {content ? (
+        <span className={styles.LogContents}>{content}</span>
+      ) : (
+        <span className={styles.LogContentsEmpty}>No data to display.</span>
+      )}
     </>
   );
 

--- a/packages/bvaughn-architecture-demo/components/console/renderers/shared.module.css
+++ b/packages/bvaughn-architecture-demo/components/console/renderers/shared.module.css
@@ -78,10 +78,15 @@
   grid-template-columns: auto;
 }
 
-.LogContents {
+.LogContents,
+.LogContentsEmpty {
   flex: 1 1 100%;
   display: inline;
   vertical-align: top;
+}
+
+.LogContentsEmpty {
+  color: var(--color-dim);
 }
 
 .Source {

--- a/src/ui/reducers/sources.ts
+++ b/src/ui/reducers/sources.ts
@@ -19,7 +19,7 @@ import type { PartialLocation } from "devtools/client/debugger/src/actions/sourc
 import { prefs } from "devtools/client/debugger/src/utils/prefs";
 import { getTextAtPosition } from "devtools/client/debugger/src/utils/source";
 import { assert } from "protocol/utils";
-import { UiState } from "devtools/client/webconsole/reducers/ui";
+import { preCacheSources } from "bvaughn-architecture-demo/src/suspense/SourcesCache";
 
 export interface SourceDetails {
   isSourceMapped: boolean;
@@ -102,6 +102,12 @@ const sourcesSlice = createSlice({
       state.allSourcesReceived = true;
 
       sourceDetailsAdapter.addMany(state.sourceDetails, newSourcesToCompleteSourceDetails(sources));
+
+      // The backend doesn't send the same source twice, nor should we request them twice (since it wastes bytes).
+      // Pre-cache source data in the new Suspense cache then so that it can use it for e.g. displaying sources in the Console.
+      //
+      // TODO [bvaughn] Will the new console code need to add some step similar to newSourcesToCompleteSourceDetails() to map between generated and corresponding sources?
+      preCacheSources(sources);
 
       const sourcesByUrl: Record<string, string[]> = {};
 


### PR DESCRIPTION
Fixes completely empty rows that would sometimes show up for e.g. event types.

![Screen Shot 2022-09-02 at 9 20 02 AM](https://user-images.githubusercontent.com/29597/188154731-275b5f2c-02fb-4105-8c37-47b772fe1c06.png)

Related to https://app.replay.io/recording/c50e0967-d230-42b6-a16b-9406fa42979e

Note that there is probably follow up work that should be done here.