### PR TITLE
Allow Inspector to scroll horizontally when in popup window

### DIFF
--- a/packages/bvaughn-architecture-demo/components/inspector/Inspector.tsx
+++ b/packages/bvaughn-architecture-demo/components/inspector/Inspector.tsx
@@ -4,10 +4,12 @@ import styles from "./Inspector.module.css";
 import KeyValueRenderer from "./KeyValueRenderer";
 
 export default function Inspector({
+  className,
   context,
   pauseId,
   protocolValue,
 }: {
+  className?: string;
   context: "console" | "default";
   pauseId: PauseId;
   protocolValue: ProtocolValue;
@@ -25,7 +27,7 @@ export default function Inspector({
     return keyValue;
   } else {
     return (
-      <div className={styles.Inspector} data-test-id="InspectorRoot">
+      <div className={`${styles.Inspector} ${className || ""}`} data-test-id="InspectorRoot">
         {keyValue}
       </div>
     );

--- a/src/devtools/client/debugger/src/components/Editor/Preview/NewObjectInspector.module.css
+++ b/src/devtools/client/debugger/src/components/Editor/Preview/NewObjectInspector.module.css
@@ -3,3 +3,7 @@
   display: flex;
   flex-direction: column;
 }
+
+.Inspector {
+  overflow-x: auto;
+}

--- a/src/devtools/client/debugger/src/components/Editor/Preview/NewObjectInspector.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Preview/NewObjectInspector.tsx
@@ -39,7 +39,12 @@ export default function NewObjectInspector() {
       <InspectorContextReduxAdapter>
         <div className={`${styles.Popup} preview-popup`}>
           <Suspense fallback={<Loader />}>
-            <Inspector context="default" pauseId={pause.pauseId!} protocolValue={protocolValue} />{" "}
+            <Inspector
+              className={styles.Inspector}
+              context="default"
+              pauseId={pause.pauseId!}
+              protocolValue={protocolValue}
+            />{" "}
           </Suspense>
         </div>
       </InspectorContextReduxAdapter>


### PR DESCRIPTION
Like Chrome, the new Object Inspector _will_ scroll horizontally within the popup preview window (if there's overflow) but it _will not_ within the Scopes side panel.

[Kapture 2022-09-02 at 10.38.06.webm](https://user-images.githubusercontent.com/29597/188173287-688f3b9a-fd8a-4af4-ab01-7a7e5cd56684.webm)
