### PR TITLE
Fix the fallback logic for inconsistent sourceIds (FE-671)

### DIFF
--- a/src/devtools/client/debugger/src/actions/sources/select.ts
+++ b/src/devtools/client/debugger/src/actions/sources/select.ts
@@ -132,9 +132,10 @@ export function selectLocation(
     if (location.sourceUrl && location.sourceUrl !== source?.url) {
       await ThreadFront.ensureAllSources();
       const state = getState();
-      const sourceId = getSourceToDisplayForUrl(state, location.sourceUrl)!.id;
-      source = getSourceDetails(state, sourceId);
-      location = { ...location, sourceId };
+      source = getSourceToDisplayForUrl(state, location.sourceUrl);
+      if (source) {
+        location = { ...location, sourceId: source.id };
+      }
     }
     if (!source) {
       // If there is no source we deselect the current selected source


### PR DESCRIPTION
This used to throw when no source to display for the given URL was found.