### PR TITLE
Better error message for outdated Replays

### DIFF
--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -116,7 +116,7 @@ const SessionErrorMessages: Record<number, Partial<UnexpectedError>> = {
   },
   [SessionError.OldBuild]: {
     content:
-      "This error has been fixed in an updated version of Replay. Please try upgrading Replay and trying a new recording.",
+      "This recording is no longer available because we have updated Replay. We apologise for the inconvenience.",
   },
   [SessionError.LongRecording]: {
     content: "You’ve hit an error that happens with long recordings. Can you try a shorter one?",

--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -116,7 +116,7 @@ const SessionErrorMessages: Record<number, Partial<UnexpectedError>> = {
   },
   [SessionError.OldBuild]: {
     content:
-      "This recording is no longer available because we have updated Replay. We apologise for the inconvenience.",
+      "This recording is no longer available because we have updated Replay. Please try recording a new replay.",
   },
   [SessionError.LongRecording]: {
     content: "You’ve hit an error that happens with long recordings. Can you try a shorter one?",


### PR DESCRIPTION
Was:
"This error has been fixed in an updated version of Replay. Please try upgrading Replay and trying a new recording."

Now:
"This recording is no longer available because we have updated Replay. Please try recording a new replay."

To an end user, this isn't an "error" that is fixed by "upgrading Replay." It's more like a 404, where it's just not going to work, and if you didn't record the original replay, there's nothing you can do. So this makes the error more clear for this case.

