### PR TITLE
Make sure points are sorted before we insert them

### DIFF
--- a/src/ui/reducers/timeline.ts
+++ b/src/ui/reducers/timeline.ts
@@ -3,6 +3,7 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { UIState } from "ui/state";
 import { FocusRegion, HoveredItem, TimelineState, ZoomRegion } from "ui/state/timeline";
 import { displayedEndForFocusRegion, displayedBeginForFocusRegion } from "ui/utils/timeline";
+import sortBy from "lodash/sortBy";
 
 function initialTimelineState(): TimelineState {
   return {
@@ -49,8 +50,10 @@ const timelineSlice = createSlice({
       let actionIndex = 0;
       let stateIndex = 0;
 
-      while (actionIndex < action.payload.length) {
-        const actionPoint = action.payload[actionIndex];
+      const received = sortBy(action.payload, x => BigInt(x.point));
+
+      while (actionIndex < received.length) {
+        const actionPoint = received[actionIndex];
 
         let stateIndexPoint = state.points[stateIndex];
 


### PR DESCRIPTION
https://app.replay.io/recording/replay-hit-counts-are-squirly--eb04dd6b-d936-477c-8b6a-38cfa94dce3a?point=19795631773575772037790641728520309&time=13727.36557020868&hasFrames=true&focusRegion=eyJiZWdpbiI6eyJ0aW1lIjowLCJwb2ludCI6IjAifSwiZW5kIjp7InBvaW50IjoiMjAzNDczMTMzMjA0MjgxMjY2NzY3MjIwOTUwMDU4NDIwODc2IiwidGltZSI6ODExOTcsImtpbmQiOiJtb3VzZW1vdmUiLCJjbGllbnRYIjo1NiwiY2xpZW50WSI6NDQwfX0%253D really confused the crap out of me for the longest time, but then I realized that our focus window was all messed up. We were using somewhat random time values for our endpoints, when there were perfectly *good* time values nearby. It turns out, sometimes we pass unsorted time points in to the point store, which is what we use to try and find appropriate points for focus regions.