### PR TITLE
Refine the focus window as we receive points

### DIFF
--- a/packages/bvaughn-architecture-demo/components/console/LoggablesContext.tsx
+++ b/packages/bvaughn-architecture-demo/components/console/LoggablesContext.tsx
@@ -11,7 +11,6 @@ import { isInNodeModules } from "@bvaughn/src/utils/messages";
 import { suspendInParallel } from "@bvaughn/src/utils/suspense";
 import { isExecutionPointsWithinRange } from "@bvaughn/src/utils/time";
 import { EventHandlerType } from "@replayio/protocol";
-import { MAX_POINTS_FOR_FULL_ANALYSIS } from "protocol/thread/analysis";
 import {
   createContext,
   MutableRefObject,

--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -27,7 +27,7 @@ import reactDevTools from "ui/reducers/reactDevTools";
 import timeline, {
   allPaintsReceived,
   paintsReceived,
-  pointsReceived,
+  pointsReceivedThunk,
   setPlaybackStalled,
 } from "ui/reducers/timeline";
 import type { ThunkExtraArgs } from "ui/utils/thunk";
@@ -39,6 +39,7 @@ import {
   setRefreshGraphicsCallback,
   setVideoUrlCallback,
 } from "protocol/graphics";
+import { setPointsReceivedCallback as setAnalysisPointsReceivedCallback } from "protocol/analysisManager";
 
 import { extendStore, AppStore } from "../store";
 import { startAppListening } from "../listenerMiddleware";
@@ -257,12 +258,17 @@ export default async function setupDevtools(store: AppStore, replayClient: Repla
   let points: TimeStampedPoint[] = [];
 
   const onPointsReceived = debounce(() => {
-    store.dispatch(pointsReceived(points));
+    store.dispatch(pointsReceivedThunk(points));
     store.dispatch(paintsReceived(points.filter(p => "screenShots" in p)));
     points = [];
   }, 1_000);
 
   setPointsReceivedCallback(newPoints => {
+    points.push(...newPoints);
+    onPointsReceived();
+  });
+
+  setAnalysisPointsReceivedCallback(newPoints => {
     points.push(...newPoints);
     onPointsReceived();
   });


### PR DESCRIPTION
I'm not sure how this particular feature never got in. I remember
thinking last time I was working on focus stuff that we should do it,
but I guess I never actually got around to doing it. The idea is
relatively simple:

Sometimes the user asks for a focus region in which our known timeline
is sparse. We do our best to get them an accurate window, but it's tough
because points are few and far between. But there is *good* news there,
which is that we can't display anything incorrectly, because we don't
know about anything in the sparse ranges (that's why they are sparse).

But, then the trouble starts. The user has chosen a window, and they
start doing things like settings breakpoints. We are filling in our
sparse timeline! But sometimes those points actually fall *between* the
displayed end of the focus region and real end of the window for which
we are currently making requests. When this happens, you get
funny-looking results, like analysis points hanging out in regions that
look unloaded. The solution is actually relatively simple. When we are
focused and we discover new points, we check to see if any of those
points could be used to make a more refined focus window. If so, we just
update our focus window. No additional interactions with the backend are
required, and if we have a really dense analysis, that's fine, because
it just means we will get even *more* accurate information about the
point <-> time relationship in that region.