### PR TITLE
Reduce UI jump when adding a print statement

### DIFF
--- a/src/devtools/client/debugger/images/rewind-rounded.svg
+++ b/src/devtools/client/debugger/images/rewind-rounded.svg
@@ -4,7 +4,7 @@
 </g>
 <defs>
 <clipPath id="clip0_11452_96270">
-<rect width="16" height="16" fill="white" transform="translate(0.0163879)"/>
+<rect width="16" height="16" fill="white"/>
 </clipPath>
 </defs>
 </svg>

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/SummaryExpression.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/SummaryExpression.tsx
@@ -38,7 +38,7 @@ export function SummaryExpression({ isEditable, value }: SummaryExpressionProps 
   const { isTeamDeveloper } = hooks.useIsTeamDeveloper();
 
   return isEditable ? (
-    <div className="group flex space-x-1 px-1 hover:text-primaryAccent">
+    <div className="group flex space-x-1 px-2 hover:text-primaryAccent">
       <Expression value={value} isEditable={true} />
       <MaterialIcon className="pencil opacity-0" iconSize="xs">
         edit

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.css
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.css
@@ -17,7 +17,8 @@
 }
 
 .breakpoint-navigation-commands > * {
-  padding: 4px;
+  padding: 0 4px;
+  height: 20px;
 }
 
 .breakpoint-navigation-commands > *:hover:not(.disabled) {
@@ -37,6 +38,8 @@
 }
 
 .breakpoint-navigation-status-container {
+  margin-top: 1px;
+  height: 19px;
   min-width: 50px;
   display: flex;
   justify-content: flex-end;


### PR DESCRIPTION
This is just a handful of things I noticed about the print statement panel:
- The arrows were not aligned properly in their boxes or with the rest of the timeline/pill.
- When the buttons on the left came in they bumped the size of the box by a pixel, causing a tiny UI jump
- The editor had *slightly* different X padding depending on whether it was editable, also causing a tiny UI jump

### Before

https://user-images.githubusercontent.com/5903784/188300236-e71f56b9-350a-4491-9ce9-e6bc3ec5be9d.mp4



### After


https://user-images.githubusercontent.com/5903784/188300232-81f35cc0-d584-41f1-b35e-63eb18a249a3.mp4

