### PR TITLE
Return the generated source ID until all sources have come in

### DIFF
--- a/src/ui/reducers/sources.ts
+++ b/src/ui/reducers/sources.ts
@@ -359,6 +359,9 @@ export function getPreferredLocation(
   locations: MappedLocation,
   preferredGeneratedSources: Set<string>
 ) {
+  if (!state.sources.allSourcesReceived) {
+    return locations[0];
+  }
   const sourceId = getPreferredSourceId(
     getSourceDetailsEntities(state),
     locations.map(l => l.sourceId),


### PR DESCRIPTION
Right now it's pretty rare that console messages will come in before
sources, but it's possible, and when that happens we get bombarded with
`unknown source` errors as we try to find preferred locations without
having source details loaded yet. By returning the generated location
until we actually load sources, we avoid those errors. There might be an
even better way to solve this problem, but this one seems to work well
in my tests (I just threw a fake await in before actually processing the
sources).