### PR TITLE
Move the error boundary up a level

### DIFF
--- a/packages/bvaughn-architecture-demo/components/ErrorBoundary.module.css
+++ b/packages/bvaughn-architecture-demo/components/ErrorBoundary.module.css
@@ -3,6 +3,7 @@
   text-align: center;
   background-color: var(--background-color-error);
   color: var(--color-default);
+  grid-column: 2;
 }
 
 .Logo {

--- a/packages/bvaughn-architecture-demo/components/ErrorBoundary.tsx
+++ b/packages/bvaughn-architecture-demo/components/ErrorBoundary.tsx
@@ -27,7 +27,8 @@ export default class ErrorBoundary extends Component<PropsWithChildren<{}>, Erro
           <ReplayLogo />
           <div className={styles.Header}>Our apologies!</div>
           <div className={styles.Message}>
-            Something went wrong while replaying, we'll look into it as soon as possible.
+            <p>Something went wrong while replaying.</p>
+            <p>We'll look into it as soon as possible.</p>
           </div>
         </div>
       );

--- a/packages/bvaughn-architecture-demo/components/console/ConsoleRoot.tsx
+++ b/packages/bvaughn-architecture-demo/components/console/ConsoleRoot.tsx
@@ -86,22 +86,22 @@ export default function ConsoleRoot({
               </div>
             }
           >
-            <LoggablesContextRoot messageListRef={messageListRef}>
-              <SearchContextRoot
-                messageListRef={messageListRef}
-                showSearchInputByDefault={showSearchInputByDefault}
-              >
-                <div className={styles.MessageColumn}>
-                  <ErrorBoundary>
+            <ErrorBoundary>
+              <LoggablesContextRoot messageListRef={messageListRef}>
+                <SearchContextRoot
+                  messageListRef={messageListRef}
+                  showSearchInputByDefault={showSearchInputByDefault}
+                >
+                  <div className={styles.MessageColumn}>
                     <MessagesList ref={messageListRef} />
-                  </ErrorBoundary>
 
-                  {terminalInput}
+                    {terminalInput}
 
-                  <Search className={styles.Row} hideOnEscape={terminalInput !== null} />
-                </div>
-              </SearchContextRoot>
-            </LoggablesContextRoot>
+                    <Search className={styles.Row} hideOnEscape={terminalInput !== null} />
+                  </div>
+                </SearchContextRoot>
+              </LoggablesContextRoot>
+            </ErrorBoundary>
           </Suspense>
 
           <ContextMenu />


### PR DESCRIPTION
Tested this by adding this error

```diff
diff --git a/packages/shared/client/ReplayClient.ts b/packages/shared/client/ReplayClient.ts
index 99b46ee11..8eefeba16 100644
--- a/packages/shared/client/ReplayClient.ts
+++ b/packages/shared/client/ReplayClient.ts
@@ -415,6 +415,7 @@ export class ReplayClient implements ReplayClientInterface {
       }
     }

+    throw new Error("oops");
     return [collectedHitPoints, status];
   }
```

<img width="888" alt="Screen Shot 2022-09-04 at 11 19 24 AM" src="https://user-images.githubusercontent.com/254562/188327942-ab2065b2-7bb5-43ff-9230-3794edb9dc80.png">
