### PR TITLE
Dont create pauses for async frames that are not loaded

### DIFF
--- a/packages/protocol/thread/thread.ts
+++ b/packages/protocol/thread/thread.ts
@@ -48,6 +48,7 @@ import { defer, assert, EventEmitter } from "../utils";
 
 import { Pause } from "./pause";
 import { ValueFront } from "./value";
+import { isInLoadedRegion } from "devtools/client/debugger/src/utils/pause";
 
 export interface RecordingDescription {
   duration: TimeStamp;
@@ -482,7 +483,7 @@ class _ThreadFront {
       : this.getCurrentPause();
   }
 
-  async loadAsyncParentFrames() {
+  async loadAsyncParentFrames(loadedRegions: LoadedRegions) {
     await this.getCurrentPause().ensureLoaded();
     const basePause = this.lastAsyncPause();
     assert(basePause, "no lastAsyncPause");
@@ -494,6 +495,11 @@ class _ThreadFront {
     if (basePause != this.lastAsyncPause()) {
       return [];
     }
+
+    if (!isInLoadedRegion(steps[0].point)) {
+      return [];
+    }
+
     const entryPause = this.ensurePause(steps[0].point, steps[0].time);
     this.asyncPauses.push(entryPause);
     const frames = await entryPause.getFrames();

--- a/src/devtools/client/debugger/src/reducers/pause.ts
+++ b/src/devtools/client/debugger/src/reducers/pause.ts
@@ -208,9 +208,10 @@ export const fetchAsyncFrames = createAsyncThunk<
   { state: UIState; extra: ThunkExtraArgs }
 >(
   "pause/fetchAsyncFrames",
-  async ({ cx }, thunkApi) => {
+  async ({}, thunkApi) => {
     const { ThreadFront } = thunkApi.extra;
     let asyncFrames: PauseFrame[] = [];
+    const loadedRegions = getLoadedRegions(thunkApi.getState())!;
 
     // How many times to fetch an async set of parent frames.
     const MAX_ASYNC_FRAME_GROUPS = 5;
@@ -220,7 +221,7 @@ export const fetchAsyncFrames = createAsyncThunk<
     // so the first group of async frames is group 1.
     // These are used to generate frame IDs, such as `"2:3"` (third frame in group 2)
     for (let asyncIndex = 1; asyncIndex <= MAX_ASYNC_FRAME_GROUPS; asyncIndex++) {
-      const frames = await ThreadFront.loadAsyncParentFrames();
+      const frames = await ThreadFront.loadAsyncParentFrames(loadedRegions);
 
       if (!frames.length) {
         break;

--- a/src/devtools/client/debugger/src/utils/pause/index.js
+++ b/src/devtools/client/debugger/src/utils/pause/index.js
@@ -1,7 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
-
-//
-
-export * from "./why";

--- a/src/devtools/client/debugger/src/utils/pause/index.ts
+++ b/src/devtools/client/debugger/src/utils/pause/index.ts
@@ -1,0 +1,13 @@
+import { LoadedRegions } from "ui/state/app";
+
+export * from "./why";
+
+export function isInLoadedRegion(regions: LoadedRegions, executionPoint: string) {
+  return (
+    regions !== null &&
+    regions.loaded.some(
+      ({ begin, end }) =>
+        BigInt(executionPoint) >= BigInt(begin.point) && BigInt(executionPoint) <= BigInt(end.point)
+    )
+  );
+}

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -19,11 +19,12 @@ import {
   SettingsTabTitle,
   AppMode,
 } from "ui/state/app";
-import { PanelName } from "ui/state/layout";
 import { Workspace } from "ui/types";
 import { getNonLoadingRegionTimeRanges } from "ui/utils/app";
 import { compareBigInt } from "ui/utils/helpers";
 import { prefs } from "ui/utils/prefs";
+import { isInLoadedRegion } from "devtools/client/debugger/src/utils/pause";
+
 import {
   displayedEndForFocusRegion,
   isPointInRegions,
@@ -371,13 +372,6 @@ export const isPointInLoadingRegion = createSelector(
   getLoadedRegions,
   (_state: UIState, executionPoint: string) => executionPoint,
   (regions: LoadedRegions | null, executionPoint: string) => {
-    return (
-      regions !== null &&
-      regions.loading.some(
-        ({ begin, end }) =>
-          BigInt(executionPoint) >= BigInt(begin.point) &&
-          BigInt(executionPoint) <= BigInt(end.point)
-      )
-    );
+    return isInLoadedRegion(regions, executionPoint);
   }
 );


### PR DESCRIPTION
This is a short term fix for an issue we are seeing trying to create pauses when the point is not loaded. 

Once we do something like #7672, we'll be throwing more aggressively if we cannot pause and can do a better job of checking there as well. 