### PR TITLE
Ignore mysterious CodeMirror exception (FE-693)

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
@@ -158,7 +158,11 @@ function LineHitCounts({ editor }: Props) {
     drawLines();
 
     return () => {
-      editor.editor.setOption("gutters", ["breakpoints", "CodeMirror-linenumbers"]);
+      try {
+        editor.editor.setOption("gutters", ["breakpoints", "CodeMirror-linenumbers"]);
+      } catch (e) {
+        console.warn(e);
+      }
       resizeBreakpointGutter(editor.editor);
 
       doc.off("change", drawLines);


### PR DESCRIPTION
https://app.replay.io/recording/codemirror-crashes-replay--b023afaa-228c-4baa-9082-5fbc912a332a

I couldn't figure out why CodeMirror throws an exception here but catching and ignoring it doesn't seem to have any negative side-effects.