### PR TITLE
Turn query cache off by default

### DIFF
--- a/packages/protocol/socket.ts
+++ b/packages/protocol/socket.ts
@@ -91,6 +91,7 @@ if (typeof window !== "undefined") {
 export type ExperimentalSettings = {
   listenForMetrics: boolean;
   disableCache?: boolean;
+  disableQueryCache?: boolean;
   profileWorkerThreads?: boolean;
 };
 

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -165,6 +165,7 @@ export function createSocket(
       const experimentalSettings: ExperimentalSettings = {
         listenForMetrics: !!prefs.listenForMetrics,
         disableCache: !!prefs.disableCache || !!features.profileWorkerThreads,
+        disableQueryCache: !features.enableQueryCache,
         profileWorkerThreads: !!features.profileWorkerThreads,
       };
 

--- a/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
+++ b/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
@@ -39,6 +39,12 @@ const EXPERIMENTAL_SETTINGS: ExperimentalSetting[] = [
       "Record a performance profile of the source worker and send it to Replay to help diagnose performance issues",
     key: "profileWorkerThreads",
   },
+  {
+    label: "Enable query-level caching",
+    description:
+      "Allow the backend to return previously generated responses without re-running the request",
+    key: "enableQueryCache",
+  },
 ];
 
 const RISKY_EXPERIMENTAL_SETTINGS: ExperimentalSetting[] = [];
@@ -79,6 +85,8 @@ export default function ExperimentalSettings({}) {
   const { value: hitCounts, update: updateHitCounts } = useFeature("hitCounts");
   const { value: profileWorkerThreads, update: updateProfileWorkerThreads } =
     useFeature("profileWorkerThreads");
+  const { value: enableQueryCache, update: updateEnableQueryCache } =
+    useFeature("enableQueryCache");
 
   const onChange = (key: ExperimentalKey, value: any) => {
     if (key == "enableColumnBreakpoints") {
@@ -91,11 +99,14 @@ export default function ExperimentalSettings({}) {
       updateHitCounts(!hitCounts);
     } else if (key === "profileWorkerThreads") {
       updateProfileWorkerThreads(!profileWorkerThreads);
+    } else if (key === "enableQueryCache") {
+      updateEnableQueryCache(!enableQueryCache);
     }
   };
 
   const localSettings = {
     disableNewComponentArchitecture,
+    enableQueryCache,
     enableColumnBreakpoints,
     enableResolveRecording,
     hitCounts,

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -15,9 +15,10 @@ export type ExperimentalUserSettings = {
 };
 
 export type LocalExperimentalUserSettings = {
+  disableNewComponentArchitecture: boolean;
+  enableQueryCache: boolean;
   enableColumnBreakpoints: boolean;
   enableLargeText: boolean;
-  disableNewComponentArchitecture: boolean;
   enableResolveRecording: boolean;
   hitCounts: boolean;
   profileWorkerThreads: boolean;

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -1,5 +1,6 @@
 import { PrefsHelper } from "devtools/client/shared/prefs";
 import { pref } from "devtools/shared/services";
+import { isTest } from "./environment";
 
 const { asyncStoreHelper } = require("devtools/shared/async-store-helper");
 
@@ -22,17 +23,19 @@ pref("devtools.hitCounts", "hide-counts");
 // app features
 pref("devtools.features.columnBreakpoints", false);
 pref("devtools.features.commentAttachments", false);
+// TODO - remove this ternary once the new console is default again
+pref("devtools.features.disableNewComponentArchitecture", isTest() ? false : true);
+pref("devtools.features.disableUnHitLines", false);
 pref("devtools.features.enableLargeText", false);
-pref("devtools.features.disableNewComponentArchitecture", true);
+pref("devtools.features.enableQueryCache", false);
+pref("devtools.features.hitCounts", true);
 pref("devtools.features.logProtocol", false);
 pref("devtools.features.logProtocolEvents", false);
 pref("devtools.features.originalClassNames", false);
+pref("devtools.features.profileWorkerThreads", false);
 pref("devtools.features.protocolTimeline", false);
 pref("devtools.features.repaintEvaluations", false);
 pref("devtools.features.resolveRecording", false);
-pref("devtools.features.hitCounts", true);
-pref("devtools.features.disableUnHitLines", false);
-pref("devtools.features.profileWorkerThreads", false);
 
 export const prefs = new PrefsHelper("devtools", {
   colorScheme: ["String", "colorScheme"],
@@ -55,17 +58,18 @@ export const prefs = new PrefsHelper("devtools", {
 export const features = new PrefsHelper("devtools.features", {
   columnBreakpoints: ["Bool", "columnBreakpoints"],
   commentAttachments: ["Bool", "commentAttachments"],
+  disableNewComponentArchitecture: ["Bool", "disableNewComponentArchitecture"],
+  enableQueryCache: ["Bool", "enableQueryCache"],
   disableUnHitLines: ["Bool", "disableUnHitLines"],
   enableLargeText: ["Bool", "enableLargeText"],
-  disableNewComponentArchitecture: ["Bool", "disableNewComponentArchitecture"],
   hitCounts: ["Bool", "hitCounts"],
   logProtocol: ["Bool", "logProtocol"],
   logProtocolEvents: ["Bool", "logProtocolEvents"],
   originalClassNames: ["Bool", "originalClassNames"],
+  profileWorkerThreads: ["Bool", "profileWorkerThreads"],
   protocolTimeline: ["Bool", "protocolTimeline"],
   repaintEvaluations: ["Bool", "repaintEvaluations"],
   resolveRecording: ["Bool", "resolveRecording"],
-  profileWorkerThreads: ["Bool", "profileWorkerThreads"],
 });
 
 export const asyncStore = asyncStoreHelper("devtools", {


### PR DESCRIPTION
See conversation here: https://github.com/replayio/backend/pull/6299

Also: keep the new architecture on by default *in tests*, because some of them permafail when it's turned off.