### PR TITLE
Expose the custom test run title

### DIFF
--- a/src/graphql/GetConnection.ts
+++ b/src/graphql/GetConnection.ts
@@ -13,7 +13,7 @@ export interface GetConnection_auth {
 }
 
 export interface GetConnection {
-  auth: GetConnection_auth | null;
+  auth: GetConnection_auth;
 }
 
 export interface GetConnectionVariables {

--- a/src/graphql/GetTestsRun.ts
+++ b/src/graphql/GetTestsRun.ts
@@ -49,6 +49,7 @@ export interface GetTestsRun_node_Workspace_testRuns_recordings {
 export interface GetTestsRun_node_Workspace_testRuns {
   __typename: "TestRun";
   id: string | null;
+  title: string | null;
   branch: string | null;
   commitId: string | null;
   commitTitle: string | null;

--- a/src/graphql/GetTestsRunsForWorkspace.ts
+++ b/src/graphql/GetTestsRunsForWorkspace.ts
@@ -20,6 +20,7 @@ export interface GetTestsRunsForWorkspace_node_Workspace_testRuns_stats {
 export interface GetTestsRunsForWorkspace_node_Workspace_testRuns {
   __typename: "TestRun";
   id: string | null;
+  title: string | null;
   branch: string | null;
   commitId: string | null;
   commitTitle: string | null;

--- a/src/ui/components/Library/Team/View/TestRuns/Overview/RunSummary.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/Overview/RunSummary.tsx
@@ -73,6 +73,9 @@ export function RunSummary() {
         <Attributes testRun={testRun} />
         <RunnerLink testRun={testRun} />
       </div>
+      {testRun.title ? (
+        <div className="flex flex-row items-center justify-between text-xs">{testRun.title}</div>
+      ) : null}
     </div>
   );
 }

--- a/src/ui/components/Library/Team/View/TestRuns/TestRunListItem.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunListItem.tsx
@@ -75,6 +75,11 @@ export function TestRunListItem({ testRun, onClick }: { testRun: TestRun; onClic
             <RunStats testRun={testRun} />
           </div>
           <Attributes testRun={testRun} />
+          {testRun.title ? (
+            <div className="flex flex-row items-center justify-between text-xs">
+              {testRun.title}
+            </div>
+          ) : null}
         </div>
       </a>
     </Link>

--- a/src/ui/hooks/tests.ts
+++ b/src/ui/hooks/tests.ts
@@ -35,6 +35,7 @@ export interface TestRunStats {
 }
 export interface TestRun {
   id: string | null;
+  title: string | null;
   commitTitle: string | null;
   commitId: string | null;
   mergeTitle: string | null;
@@ -78,6 +79,7 @@ const GET_TEST_RUNS_FOR_WORKSPACE = gql`
         id
         testRuns {
           id
+          title
           branch
           commitId
           commitTitle
@@ -126,7 +128,7 @@ const GET_TEST_RUN = gql`
         id
         testRuns(id: $id) {
           id
-          id
+          title
           branch
           commitId
           commitTitle


### PR DESCRIPTION
This [backend PR](https://github.com/replayio/backend/pull/6281) allowed the user to insert some custom string into the test run. This way, users can differentiate between different matrix configurations for the same test run by composing that string.

This PR displays that (optional) test run title.