### PR TITLE
Use the correct pause in the new Scopes panel (FE-699)

### DIFF
--- a/packages/protocol/thread/thread.ts
+++ b/packages/protocol/thread/thread.ts
@@ -504,14 +504,14 @@ class _ThreadFront {
     return frames.slice(1);
   }
 
-  async pauseForAsyncIndex(asyncIndex?: number) {
+  pauseForAsyncIndex(asyncIndex?: number) {
     const pause = asyncIndex ? this.asyncPauses[asyncIndex - 1] : this.getCurrentPause();
     assert(pause, "no pause for given asyncIndex");
     return pause;
   }
 
   async getScopes(asyncIndex: number, frameId: FrameId) {
-    const pause = await this.pauseForAsyncIndex(asyncIndex);
+    const pause = this.pauseForAsyncIndex(asyncIndex);
     assert(pause, "no pause for asyncIndex");
     return await pause.getScopes(frameId);
   }
@@ -531,7 +531,7 @@ class _ThreadFront {
     frameId?: FrameId;
     pure?: boolean;
   }) {
-    const pause = await this.pauseForAsyncIndex(asyncIndex);
+    const pause = this.pauseForAsyncIndex(asyncIndex);
     assert(pause, "no pause for asyncIndex");
 
     const rv = await pause.evaluate(frameId, text, pure);
@@ -764,8 +764,8 @@ class _ThreadFront {
     return pause == this.currentPause ? node : null;
   }
 
-  async getFrameSteps(asyncIndex: number, frameId: FrameId) {
-    const pause = await this.pauseForAsyncIndex(asyncIndex);
+  getFrameSteps(asyncIndex: number, frameId: FrameId) {
+    const pause = this.pauseForAsyncIndex(asyncIndex);
     return pause.getFrameSteps(frameId);
   }
 

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/NewObjectInspector.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/NewObjectInspector.tsx
@@ -9,11 +9,14 @@ import { ContainerItem, ValueItem } from "devtools/packages/devtools-reps";
 import InspectorContextReduxAdapter from "devtools/client/debugger/src/components/shared/InspectorContextReduxAdapter";
 import { ThreadFront } from "protocol/thread";
 import { ReactNode, Suspense, useMemo } from "react";
+import { useAppSelector } from "ui/setup/hooks";
+import { getSelectedFrame } from "../../selectors/pause";
 
 import styles from "./NewObjectInspector.module.css";
 
 export default function NewObjectInspector({ roots }: { roots: Array<ContainerItem | ValueItem> }) {
-  const pause = ThreadFront.currentPause;
+  const selectedFrame = useAppSelector(getSelectedFrame);
+  const pause = ThreadFront.pauseForAsyncIndex(selectedFrame?.asyncIndex);
 
   // HACK
   // The new Object Inspector does not consume ValueFronts.

--- a/src/devtools/client/webconsole/actions/input.ts
+++ b/src/devtools/client/webconsole/actions/input.ts
@@ -64,7 +64,7 @@ export function paywallExpression(expression: string, reason = "team-user"): UIT
     const selectedFrame = getSelectedFrame(getState());
     const asyncIndex = selectedFrame?.asyncIndex;
 
-    const pause = await ThreadFront.pauseForAsyncIndex(asyncIndex);
+    const pause = ThreadFront.pauseForAsyncIndex(asyncIndex);
     const evalId = await dispatchExpression(dispatch, pause!, expression);
 
     dispatch(
@@ -98,7 +98,7 @@ export function evaluateExpression(expression: string): UIThunkAction {
     const asyncIndex = selectedFrame?.asyncIndex;
     const frameId = selectedFrame?.protocolId;
 
-    const pause = await ThreadFront.pauseForAsyncIndex(asyncIndex);
+    const pause = ThreadFront.pauseForAsyncIndex(asyncIndex);
     const evalId = await dispatchExpression(dispatch, pause!, expression);
 
     dispatch(
@@ -201,7 +201,7 @@ async function evaluateJSAsync(
   if (failed || !(returned || exception)) {
     v = createPrimitiveValueFront(
       "Error: Evaluation failed",
-      await ThreadFront.pauseForAsyncIndex(asyncIndex!)
+      ThreadFront.pauseForAsyncIndex(asyncIndex!)
     );
   } else if (returned) {
     v = returned;


### PR DESCRIPTION
The new Scopes panel always used the current pause for fetching object previews but for async frames it needs to use a different pause.