### PR TITLE
Removed grid-column style from generic ErrorBoundary styles

### DIFF
--- a/packages/bvaughn-architecture-demo/components/ErrorBoundary.module.css
+++ b/packages/bvaughn-architecture-demo/components/ErrorBoundary.module.css
@@ -3,7 +3,6 @@
   text-align: center;
   background-color: var(--background-color-error);
   color: var(--color-default);
-  grid-column: 2;
 }
 
 .Logo {

--- a/packages/bvaughn-architecture-demo/components/ErrorBoundary.tsx
+++ b/packages/bvaughn-architecture-demo/components/ErrorBoundary.tsx
@@ -5,7 +5,11 @@ import styles from "./ErrorBoundary.module.css";
 
 type ErrorBoundaryState = { error: Error | null };
 
-export default class ErrorBoundary extends Component<PropsWithChildren<{}>, ErrorBoundaryState> {
+type ErrorBoundaryProps = PropsWithChildren<{
+  fallbackClassName?: string;
+}>;
+
+export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   state: ErrorBoundaryState = { error: null };
 
   static getDerivedStateFromError(error: Error): ErrorBoundaryState {
@@ -19,11 +23,12 @@ export default class ErrorBoundary extends Component<PropsWithChildren<{}>, Erro
   }
 
   render() {
+    const { fallbackClassName } = this.props;
     const { error } = this.state;
 
     if (error !== null) {
       return (
-        <div className={styles.Error}>
+        <div className={`${styles.Error} ${fallbackClassName || ""}`}>
           <ReplayLogo />
           <div className={styles.Header}>Our apologies!</div>
           <div className={styles.Message}>

--- a/packages/bvaughn-architecture-demo/components/console/ConsoleRoot.module.css
+++ b/packages/bvaughn-architecture-demo/components/console/ConsoleRoot.module.css
@@ -82,3 +82,7 @@
   flex: 1;
   padding: 0.5rem;
 }
+
+.ErrorBoundaryFallback {
+  grid-column: 2;
+}

--- a/packages/bvaughn-architecture-demo/components/console/ConsoleRoot.tsx
+++ b/packages/bvaughn-architecture-demo/components/console/ConsoleRoot.tsx
@@ -86,7 +86,7 @@ export default function ConsoleRoot({
               </div>
             }
           >
-            <ErrorBoundary>
+            <ErrorBoundary fallbackClassName={styles.ErrorBoundaryFallback}>
               <LoggablesContextRoot messageListRef={messageListRef}>
                 <SearchContextRoot
                   messageListRef={messageListRef}


### PR DESCRIPTION
Follow up to https://github.com/replayio/devtools/pull/7671#discussion_r965870984

Based on my own testing, the `grid-column` style override is not actually needed. (Hopefully @jasonLaster can elaborate on the case where it is?) But if we do need it, we should inject it like this rather than defining it in the `ErrorBoundary.module.css`

(If we don't need it, we can just remove the change to the two `ConsoleRoot` files in this PR.)