### PR TITLE
Always create a new Pause in ThreadFront.instantiatePause()

### DIFF
--- a/packages/protocol/thread/thread.ts
+++ b/packages/protocol/thread/thread.ts
@@ -459,11 +459,7 @@ class _ThreadFront {
     hasFrames: boolean,
     data: PauseData = {}
   ) {
-    let pause = Pause.getByPoint(point);
-    if (pause) {
-      return pause;
-    }
-    pause = new Pause(this);
+    const pause = new Pause(this);
     pause.instantiate(pauseId, point, time, hasFrames, data);
     return pause;
   }


### PR DESCRIPTION
Currently we try to not create multiple pauses for the same point, but I realized that this is unsafe if we receive a pauseId from the backend for a console message or a logpoint result: The message or logpoint result may contain objectIds from that pause, but there can be no guarantee that an objectId will reference the same object in a different pause for the same point.
This also fixes FE-679, where not creating a new pause for a console message also means that the sourceIds in its frames are not updated to the first corresponding sourceId.