### PR TITLE
Re-enable new console as default again

### DIFF
--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -23,8 +23,7 @@ pref("devtools.hitCounts", "hide-counts");
 // app features
 pref("devtools.features.columnBreakpoints", false);
 pref("devtools.features.commentAttachments", false);
-// TODO - remove this ternary once the new console is default again
-pref("devtools.features.disableNewComponentArchitecture", isTest() ? false : true);
+pref("devtools.features.disableNewComponentArchitecture", false);
 pref("devtools.features.disableUnHitLines", false);
 pref("devtools.features.enableLargeText", false);
 pref("devtools.features.enableQueryCache", false);

--- a/test/manifest.js
+++ b/test/manifest.js
@@ -144,9 +144,6 @@ module.exports = [
     example: "cra/dist/index.html",
     script: "sourcemap_stacktrace.js",
     targets: ["gecko", "chromium"],
-
-    // Disabled because this test only works with the new console
-    disabled: true,
   },
   {
     example: "node/basic.js",
@@ -209,9 +206,6 @@ module.exports = [
     example: "doc_rr_objects.html",
     script: "object_preview-01.js",
     targets: ["gecko", "chromium"],
-
-    // Disabled because this test only works with the new console
-    disabled: true,
   },
   {
     example: "doc_rr_objects.html",
@@ -234,9 +228,6 @@ module.exports = [
     example: "node/objects.js",
     script: "node_object_preview-01.js",
     targets: ["node"],
-
-    // Disabled because this test only works with the new console
-    disabled: true,
   },
 
   //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Re-enables the new console as default now that we've landed several fixes.

Putting this up now so it's here when we're ready to turn this back on.

See #7674 for the commit that turned it off.