### PR TITLE
Ensure Pause data syncing is set up correctly on startup

### DIFF
--- a/src/devtools/client/debugger/src/components/SecondaryPanes/ObjectPreviewSuspenseCacheAdapter.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/ObjectPreviewSuspenseCacheAdapter.tsx
@@ -7,8 +7,9 @@ import { useFeature } from "ui/hooks/settings";
 
 // Connects legacy PauseData to the new Object Inspector Suspense cache.
 // This avoids requiring the new Object Inspector to load redundant data.
+// TODO Consider moving this logic into `bootstrapApp()` instead
 export default function ObjectPreviewSuspenseCacheAdapter() {
-  const disableNewComponentArchitecture = useFeature("disableNewComponentArchitecture");
+  const { value: disableNewComponentArchitecture } = useFeature("disableNewComponentArchitecture");
 
   // It's important to not miss pre-cached data because there's no way to access it after the fact.
   // So use a layout effect for subscription rather than a passive effect.


### PR DESCRIPTION
## Fix

This fixes FE-689, "Object inspector stuck on 'Loading...".

The `useFeature` hook returns an object, not a boolean. So, this would incorrectly bail out early even when the flag was intended to be turned on.  That led to some Pause data not being synced because there was no listener, which in turn caused other breakage.

The fix here is to destructure the object and pull out the `.value` boolean field we care about.

### Replay

The original bug and the comments from our investigation can be seen in  https://app.replay.io/recording/stuck-on-loading-in-object-preview--b7396a69-0abb-4371-8d77-086f5457aa9c?point=84050305421925862493083386620438551&time=30491.313411078718&hasFrames=false# for FE-689 .

### Background

The original issue we were investigating was a case where hovering a value while paused showed the tooltip but never finished loading the value.

After investigation, this one literally had 5 nested "root causes":

- **Bug**: the new object inspector tooltip was stuck on "Loading..."
- Behavior: the components were re-suspending hundreds of times
- Cause 1: the API call to `client.getObjectPreview("34")` was returning `{data: {}}`, ie, no preview, so it would suspend, re-try, suspend, re-try...
- Cause 2: the backend didn't send a preview because it had _already_ sent a preview for object `"34"` in another response.  (Complaint: the backend should _always_ send data if we directly ask for an item by its ID! fine to skip if it's "here's related data" attached to some other request)
- Cause 3: we've got syncing set up to mirror all `Pause`-cached objects over to the Object Preview cache. Why didn't it happen? Because there were no `pauseDataListeners` at the time we received that object
- Cause 4: why was there no pause listener set up? We have a `<ObjectPreviewSuspenseCacheAdapter>` component that should have added that listener way earlier in the app setup sequence. But, it bailed out early due to `if (disableNewComponentArchitecture) return`.
- Cause 5: wait, how can it bail out early and think the feature flag is off, and then we still use the new inspector?  Welll.... turns out that `const disableNewComponentArchitecture = useFeature("disableNewComponentArchitecture");` **returns an _object_ with a `.value` field, and not a _boolean_ value by itself!**  So, the `if` check was buggy