### PR TITLE
Update ESlint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,10 +15,13 @@
       "jsx": true
     },
     "ecmaVersion": 2018,
+    "project": ["tsconfig.json"],
     "sourceType": "module"
   },
   "plugins": ["import", "react", "prettier", "@typescript-eslint"],
   "rules": {
+    "@typescript-eslint/no-base-to-string": "warn",
+    "@typescript-eslint/no-unnecessary-condition": "warn",
     "curly": "error",
     "import/order": [
       "off",


### PR DESCRIPTION
A couple of recent bug fixes (#7701, #7697) could have been better detected by TypeScript if we leveraged some of the TypeScript-specific ESLint rules. This PR enables them (and verifies that they would have caught the original bugs)!

Bug from #7697
<img width="636" alt="Screen Shot 2022-09-09 at 7 52 30 AM" src="https://user-images.githubusercontent.com/29597/189344292-6b95e189-b9d5-4fcc-a71b-502d4ea269c0.png">
ESLint error message:
![Screen Shot 2022-09-09 at 7 51 25 AM](https://user-images.githubusercontent.com/29597/189344287-fbe9b031-a8b3-4139-b22f-f1d298247c05.png)

Bug from #7701
<img width="666" alt="Screen Shot 2022-09-09 at 7 51 56 AM" src="https://user-images.githubusercontent.com/29597/189344288-96d410bf-8814-4d1f-a1fe-d063708ca425.png">
ESLint error message:
![Screen Shot 2022-09-09 at 7 52 12 AM](https://user-images.githubusercontent.com/29597/189344290-7de5f52b-84c8-43cf-92e1-3e1a3b45350a.png)
