### PR TITLE
Enable @typescript-eslint/no-floating-promises

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,6 +21,7 @@
   "plugins": ["import", "react", "prettier", "@typescript-eslint"],
   "rules": {
     "@typescript-eslint/no-base-to-string": "warn",
+    "@typescript-eslint/no-floating-promises": "error",
     "curly": "error",
     "import/order": [
       "off",


### PR DESCRIPTION
Enable [`@typescript-eslint/no-floating-promises`](https://typescript-eslint.io/rules/no-floating-promises/) so that we don't accidentally forget to catch and handle Promise errors. I ran `npx trunk check --force` to verify that we don't seem to have any existing failures in the codebase here, but it seems like a good guard for us.