### PR TITLE
Adjust loading number based on paints seen

### DIFF
--- a/packages/protocol/graphics.ts
+++ b/packages/protocol/graphics.ts
@@ -194,6 +194,8 @@ export function setupGraphics() {
     const { client } = await import("./socket");
     client.Graphics.findPaints({}, sessionId).then(async () => {
       hasAllPaintPoints = true;
+      onAllPaintsReceived(true);
+
       await Promise.all(gPaintPromises);
       maybePaintGraphics();
       videoReady.resolve();
@@ -622,6 +624,11 @@ export function setPlaybackStatusCallback(callback: typeof onPlaybackStatus): vo
 let onPointsReceived: (points: TimeStampedPoint[]) => void;
 export function setPointsReceivedCallback(callback: typeof onPointsReceived): void {
   onPointsReceived = callback;
+}
+
+let onAllPaintsReceived: (received: boolean) => void;
+export function setAllPaintsReceivedCallback(callback: typeof onAllPaintsReceived): void {
+  onAllPaintsReceived = callback;
 }
 
 let onRefreshGraphics: (canvas: Canvas) => void;

--- a/packages/protocol/socket.ts
+++ b/packages/protocol/socket.ts
@@ -89,6 +89,7 @@ if (typeof window !== "undefined") {
 }
 
 export type ExperimentalSettings = {
+  controllerKey?: string;
   listenForMetrics: boolean;
   disableCache?: boolean;
   disableQueryCache?: boolean;

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -1,4 +1,3 @@
-import { createEntityAdapter } from "@reduxjs/toolkit";
 import { UIStore, UIThunkAction } from ".";
 import { unprocessedRegions, KeyboardEvent } from "@replayio/protocol";
 import * as selectors from "ui/reducers/app";

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -163,6 +163,8 @@ export function createSocket(
       }
 
       const experimentalSettings: ExperimentalSettings = {
+        // Uncomment this to get a new session every time you refresh
+        // controllerKey: String(Math.floor(Math.random() * 10e8)),
         listenForMetrics: !!prefs.listenForMetrics,
         disableCache: !!prefs.disableCache || !!features.profileWorkerThreads,
         disableQueryCache: !features.enableQueryCache,

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -1,4 +1,4 @@
-import { ExecutionPoint, PauseId, TimeStampedPointRange } from "@replayio/protocol";
+import { ExecutionPoint, PauseId } from "@replayio/protocol";
 import { setBreakpointOptions } from "devtools/client/debugger/src/actions/breakpoints/modify";
 import { Breakpoint, getThreadContext } from "devtools/client/debugger/src/selectors";
 import sortedIndexBy from "lodash/sortedIndexBy";

--- a/src/ui/components/Timeline/Capsule.tsx
+++ b/src/ui/components/Timeline/Capsule.tsx
@@ -5,13 +5,14 @@ import { useAppSelector } from "ui/setup/hooks";
 import { getLoadedAndIndexedProgress, getLoadingStatusSlow } from "ui/actions/app";
 import ExternalLink from "ui/components/shared/ExternalLink";
 import useModalDismissSignal from "ui/hooks/useModalDismissSignal";
-import { getShowFocusModeControls } from "ui/reducers/timeline";
+import { getBasicProcessingProgress, getShowFocusModeControls } from "ui/reducers/timeline";
 
 import Icon from "../shared/Icon";
 
 import styles from "./Capsule.module.css";
 import { EditFocusButton } from "./EditFocusButton";
 import FocusInputs from "./FocusInputs";
+import { useFeature } from "ui/hooks/settings";
 
 const SHOW_SLOW_LOADING_POP_OUT_AFTER_DELAY = 1000;
 
@@ -20,7 +21,14 @@ export default function Capsule({
 }: {
   setShowLoadingProgress: React.Dispatch<React.SetStateAction<boolean>>;
 }) {
-  const progress = Math.round(useAppSelector(getLoadedAndIndexedProgress) * 100);
+  const indexingProgress = Math.round(useAppSelector(getLoadedAndIndexedProgress) * 100);
+  const basicProcessingProgress = Math.round(useAppSelector(getBasicProcessingProgress) * 100);
+  let progress = indexingProgress;
+  const { value: basicProcessingLoadingBar } = useFeature("basicProcessingLoadingBar");
+
+  if (basicProcessingLoadingBar) {
+    progress = Math.round((basicProcessingProgress + indexingProgress) / 2);
+  }
   const loadingStatusSlow = useAppSelector(getLoadingStatusSlow);
   const showFocusModeControls = useAppSelector(getShowFocusModeControls);
 

--- a/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
+++ b/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
@@ -40,6 +40,12 @@ const EXPERIMENTAL_SETTINGS: ExperimentalSetting[] = [
       "Allow the backend to return previously generated responses without re-running the request",
     key: "enableQueryCache",
   },
+  {
+    label: "Detailed loading bar",
+    description:
+      "Split the loading bar's progress between gathering static resources from the recording and indexing runtime information",
+    key: "basicProcessingLoadingBar",
+  },
 ];
 
 const RISKY_EXPERIMENTAL_SETTINGS: ExperimentalSetting[] = [];
@@ -80,6 +86,9 @@ export default function ExperimentalSettings({}) {
     useFeature("profileWorkerThreads");
   const { value: enableQueryCache, update: updateEnableQueryCache } =
     useFeature("enableQueryCache");
+  const { value: basicProcessingLoadingBar, update: updateBasicProcessingLoadingBar } = useFeature(
+    "basicProcessingLoadingBar"
+  );
 
   const onChange = (key: ExperimentalKey, value: any) => {
     if (key == "enableColumnBreakpoints") {
@@ -92,10 +101,13 @@ export default function ExperimentalSettings({}) {
       updateProfileWorkerThreads(!profileWorkerThreads);
     } else if (key === "enableQueryCache") {
       updateEnableQueryCache(!enableQueryCache);
+    } else if (key === "basicProcessingLoadingBar") {
+      updateBasicProcessingLoadingBar(!basicProcessingLoadingBar);
     }
   };
 
   const localSettings = {
+    basicProcessingLoadingBar,
     enableColumnBreakpoints,
     enableResolveRecording,
     enableQueryCache,

--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -10,7 +10,7 @@ import { bootstrapWorkers } from "devtools/client/debugger/src/utils/bootstrap";
 import { setupDebuggerHelper } from "devtools/client/debugger/src/utils/dbg";
 import { setupNetwork } from "devtools/client/webconsole/actions/network";
 import { initOutputSyntaxHighlighting } from "devtools/client/webconsole/utils/syntax-highlighted";
-import { Canvas, setupGraphics } from "protocol/graphics";
+import { Canvas, setAllPaintsReceivedCallback, setupGraphics } from "protocol/graphics";
 // eslint-disable-next-line no-restricted-imports
 import { initSocket, addEventListener, client as protocolClient } from "protocol/socket";
 import { ThreadFront } from "protocol/thread";
@@ -24,7 +24,12 @@ import contextMenus from "ui/reducers/contextMenus";
 import network from "ui/reducers/network";
 import protocolMessages from "ui/reducers/protocolMessages";
 import reactDevTools from "ui/reducers/reactDevTools";
-import timeline, { pointsReceived, setPlaybackStalled } from "ui/reducers/timeline";
+import timeline, {
+  allPaintsReceived,
+  paintsReceived,
+  pointsReceived,
+  setPlaybackStalled,
+} from "ui/reducers/timeline";
 import type { ThunkExtraArgs } from "ui/utils/thunk";
 import {
   setMouseDownEventsCallback,
@@ -253,6 +258,7 @@ export default async function setupDevtools(store: AppStore, replayClient: Repla
 
   const onPointsReceived = debounce(() => {
     store.dispatch(pointsReceived(points));
+    store.dispatch(paintsReceived(points.filter(p => "screenShots" in p)));
     points = [];
   }, 1_000);
 
@@ -261,9 +267,14 @@ export default async function setupDevtools(store: AppStore, replayClient: Repla
     onPointsReceived();
   });
 
+  setAllPaintsReceivedCallback((received: boolean) => {
+    store.dispatch(allPaintsReceived(received));
+  });
+
   setRefreshGraphicsCallback((canvas: Canvas) => {
     store.dispatch(setCanvas(canvas));
   });
+
   setVideoUrlCallback((url: string) => {
     store.dispatch(setVideoUrl(url));
   });
@@ -300,9 +311,7 @@ export function bindSelectors(store: UIStore, selectors: Partial<ObjectOfJustSel
   // Additionally, the "binding" of passing in `state` automatically messes up the TS types here.
   // I've attempted to get TS to accept that this is valid.
   return Object.entries(selectors).reduce((bound, [key, originalSelector]) => {
-    // @ts-expect-error
     bound[key as keyof BoundSelectors] = (...args: any[]) =>
-      // @ts-expect-error
       originalSelector(store.getState(), ...args);
     return bound;
   }, {} as BoundSelectors);

--- a/src/ui/state/timeline.ts
+++ b/src/ui/state/timeline.ts
@@ -22,6 +22,7 @@ export interface UnsafeFocusRegion {
 }
 
 export interface TimelineState {
+  allPaintsReceived: boolean;
   currentTime: number;
   hoveredItem: HoveredItem | null;
   hoverTime: number | null;
@@ -33,6 +34,7 @@ export interface TimelineState {
     time: number;
   } | null;
   playbackPrecachedTime: number;
+  paints: TimeStampedPoint[];
   points: TimeStampedPoint[];
   recordingDuration: number | null;
   shouldAnimate: boolean;

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -14,6 +14,7 @@ export type ExperimentalUserSettings = {
 };
 
 export type LocalExperimentalUserSettings = {
+  basicProcessingLoadingBar: boolean;
   enableQueryCache: boolean;
   enableColumnBreakpoints: boolean;
   enableLargeText: boolean;

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -21,6 +21,7 @@ pref("devtools.consoleFilterDrawerExpanded", true);
 pref("devtools.hitCounts", "hide-counts");
 
 // app features
+pref("devtools.features.basicProcessingLoadingBar", false);
 pref("devtools.features.columnBreakpoints", false);
 pref("devtools.features.commentAttachments", false);
 pref("devtools.features.disableUnHitLines", false);
@@ -54,6 +55,7 @@ export const prefs = new PrefsHelper("devtools", {
 });
 
 export const features = new PrefsHelper("devtools.features", {
+  basicProcessingLoadingBar: ["Bool", "basicProcessingLoadingBar"],
   columnBreakpoints: ["Bool", "columnBreakpoints"],
   commentAttachments: ["Bool", "commentAttachments"],
   enableQueryCache: ["Bool", "enableQueryCache"],

--- a/src/ui/utils/timeline.test.ts
+++ b/src/ui/utils/timeline.test.ts
@@ -7,6 +7,7 @@ import {
   getTimeFromPosition,
   isFocusRegionSubset,
   isValidTimeString,
+  mergeSortedPointLists,
   overlap,
 } from "./timeline";
 
@@ -229,5 +230,34 @@ describe("filterToFocusRegion", () => {
       point(15),
       point(20),
     ]);
+  });
+});
+
+describe("mergeSortedPointLists", () => {
+  fit("will correctly interleave overlapping ranges", () => {
+    expect(mergeSortedPointLists([point(5), point(10)], [point(7), point(12)])).toEqual([
+      point(5),
+      point(7),
+      point(10),
+      point(12),
+    ]);
+  });
+
+  fit("will correctly concat non-overlapping ranges", () => {
+    expect(mergeSortedPointLists([point(5), point(7)], [point(10), point(12)])).toEqual([
+      point(5),
+      point(7),
+      point(10),
+      point(12),
+    ]);
+  });
+
+  fit("will raise an error if things are not sorted", () => {
+    expect(() =>
+      mergeSortedPointLists([point(7), point(5)], [point(10), point(12)])
+    ).toThrowError();
+    expect(() =>
+      mergeSortedPointLists([point(5), point(7)], [point(12), point(10)])
+    ).toThrowError();
   });
 });


### PR DESCRIPTION
This is kind of a crappy solution to the problem discussed in https://linear.app/replay/issue/DES-82/sometimes-loading-appears-stuck-at-0percent

But... also maybe it's better than what we have right now?


https://user-images.githubusercontent.com/5903784/189777158-3f11e7dc-d0fd-4853-80c6-79a56b539c7a.mp4

