### PR TITLE
Remove unnecessary async from Mixpanel functions

### DIFF
--- a/src/ui/utils/mixpanel.ts
+++ b/src/ui/utils/mixpanel.ts
@@ -200,7 +200,7 @@ const namespaceFromEventName = (event: string): string => {
   return namespace.length ? namespace : NULL_NAMESPACE;
 };
 
-export async function trackMixpanelEvent(...[event, properties]: [...MixpanelEvent]) {
+export function trackMixpanelEvent(...[event, properties]: [...MixpanelEvent]) {
   if (prefs.logTelemetryEvent) {
     console.log("🔴", event, properties);
   }
@@ -209,7 +209,7 @@ export async function trackMixpanelEvent(...[event, properties]: [...MixpanelEve
     mixpanel.track(event, { ...properties, namespace: namespaceFromEventName(event) });
   }
 }
-export async function timeMixpanelEvent(event: MixpanelEvent[0]) {
+export function timeMixpanelEvent(event: MixpanelEvent[0]) {
   if (!mixpanelDisabled) {
     mixpanel.time_event(event);
   }
@@ -217,7 +217,7 @@ export async function timeMixpanelEvent(event: MixpanelEvent[0]) {
 
 const eventsBeingOnlyTrackedOnce = new Set();
 
-export async function trackEventOnce(...[event, properties]: [...MixpanelEvent]) {
+export function trackEventOnce(...[event, properties]: [...MixpanelEvent]) {
   if (eventsBeingOnlyTrackedOnce.has(event)) {
     return;
   }

--- a/src/ui/utils/telemetry.ts
+++ b/src/ui/utils/telemetry.ts
@@ -100,7 +100,7 @@ export function setTelemetryContext({ id, email, internal }: TelemetryUser) {
   }
 }
 
-export async function sendTelemetryEvent(event: string, tags: any = {}) {
+export function sendTelemetryEvent(event: string, tags: any = {}) {
   if (prefs.logTelemetryEvent) {
     console.log("telemetry event", { event, tags });
   }


### PR DESCRIPTION
We recently enabled the `@typescript-eslint/no-floating-promises` lint rule (#7714) which flagged a bunch of false-positives with `trackEvent` calls. Events are fire-and-forget, so we could just ignore those lint rule violations– except that the Mixpanel functions were unnecessarily flagged as async in the first place. This PR fixes that.