### PR TITLE
Rewrite React DevTools evaluations to not use `NodeFront/ValueFront`

### DIFF
--- a/packages/protocol/thread/thread.ts
+++ b/packages/protocol/thread/thread.ts
@@ -629,9 +629,9 @@ class _ThreadFront {
     }
 
     if (rv.returned) {
-      return { exception: null, returned: rv.returned as any as Value };
+      return { exception: null, returned: rv.returned as unknown as Value };
     } else if (rv.exception) {
-      return { exception: rv.exception as any as Value, returned: null };
+      return { exception: rv.exception as unknown as Value, returned: null };
     } else {
       return { exception: null, returned: null };
     }

--- a/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
+++ b/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
@@ -1,5 +1,5 @@
 import { ExecutionPoint, ObjectId } from "@replayio/protocol";
-import React from "react";
+import React, { useContext } from "react";
 import { useEffect, useState } from "react";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { ThreadFront } from "protocol/thread";
@@ -101,20 +101,17 @@ class ReplayWall implements Wall {
           }
           this.highlightedElementId = id;
 
-          const response = await ThreadFront.evaluate({
+          const response = await ThreadFront.evaluateNew({
             asyncIndex: 0,
             text: `${getDOMNodes}(${rendererID}, ${id})[0]`,
           });
-          if (!response.returned || this.highlightedElementId !== id) {
+
+          const nodeId = response.returned?.object;
+          if (!nodeId || this.highlightedElementId !== id) {
             return;
           }
 
-          const nodeFront = response.returned.getNodeFront();
-          if (!nodeFront || this.highlightedElementId !== id) {
-            return;
-          }
-
-          this.highlightNode(nodeFront.id!);
+          this.highlightNode(nodeId);
           break;
         }
 

--- a/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
+++ b/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
@@ -3,7 +3,7 @@ import React, { useContext } from "react";
 import { useEffect, useState } from "react";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 
-import { ThreadFront } from "protocol/thread";
+import { ThreadFront, Pause, ValueFront } from "protocol/thread";
 import { compareNumericStrings } from "protocol/utils";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { ReplayClientInterface } from "shared/client/types";
@@ -24,6 +24,7 @@ import { setHasReactComponents, setProtocolCheckFailed } from "ui/actions/reactD
 import { NodePicker as NodePickerClass, NodePickerOpts } from "ui/utils/nodePicker";
 import { sendTelemetryEvent, trackEvent } from "ui/utils/telemetry";
 import { highlightNode, unhighlightNode } from "devtools/client/inspector/markup/actions/markup";
+import { getJSON } from "ui/utils/objectFetching";
 
 import type { Store, Wall } from "react-devtools-inline/frontend";
 
@@ -174,7 +175,7 @@ class ReplayWall implements Wall {
 
   // send a request to the backend in the recording and the reply to the frontend
   private async sendRequest(event: string, payload: any) {
-    const response = await ThreadFront.evaluate({
+    const response = await ThreadFront.evaluateNew({
       asyncIndex: 0,
       text: ` __RECORD_REPLAY_REACT_DEVTOOLS_SEND_MESSAGE__("${event}", ${JSON.stringify(
         payload
@@ -182,7 +183,8 @@ class ReplayWall implements Wall {
     });
 
     if (response.returned) {
-      const result: any = await response.returned.getJSON();
+      const result: any = await getJSON(this.replayClient, this.pauseId!, response.returned);
+
       if (result) {
         this._listener?.({ event: result.event, payload: result.data });
       }

--- a/src/ui/utils/objectFetching.ts
+++ b/src/ui/utils/objectFetching.ts
@@ -1,0 +1,109 @@
+import { Value as ProtocolValue } from "@replayio/protocol";
+import { ReplayClientInterface } from "shared/client/types";
+
+import { getObjectWithPreviewHelper, getObjectThrows } from "@bvaughn/src/suspense/ObjectPreviews";
+import { protocolValueToClientValue } from "@bvaughn/src/utils/protocol";
+
+// like JSON, but including `undefined`
+export type JSONishValue =
+  | boolean
+  | string
+  | number
+  | null
+  | undefined
+  | JSONishValue[]
+  | { [key: string]: JSONishValue };
+
+/**
+ * Takes a backend `objectId`, loads its data preview, and
+ * fetches/caches data for all of its fields that are objects/arrays.
+ * Note that this does not return the object with its contents - it
+ * just makes sure all the fields exist in the cache.
+ */
+export async function loadObjectProperties(
+  replayClient: ReplayClientInterface,
+  pauseId: string,
+  objectId: string
+) {
+  const obj = await getObjectWithPreviewHelper(replayClient, pauseId, objectId);
+
+  const properties = obj.preview?.properties ?? [];
+  const objectProperties = properties.filter(entry => "object" in entry) ?? [];
+
+  const propertyPromises = objectProperties.map(prop =>
+    getObjectWithPreviewHelper(replayClient, pauseId, prop.object!)
+  );
+
+  await Promise.all(propertyPromises);
+}
+
+/**
+ * Takes a backend Replay API `ProtocolValue`, recurses over it,
+ * and returns a plain JS object/array/primitive with nested data.
+ *
+ * Ported from the original `NodeFront.getJSON()` implementation.
+ */
+export async function getJSON(
+  replayClient: ReplayClientInterface,
+  pauseId: string,
+  value: ProtocolValue,
+  visitedObjectIds = new Set<string>()
+): Promise<JSONishValue> {
+  const clientObject = protocolValueToClientValue(pauseId, value);
+
+  if (clientObject.objectId) {
+    if (visitedObjectIds.has(clientObject.objectId!)) {
+      return undefined;
+    }
+
+    visitedObjectIds = new Set(visitedObjectIds);
+    visitedObjectIds.add(clientObject.objectId!);
+
+    await loadObjectProperties(replayClient, pauseId, clientObject.objectId!);
+    const obj = getObjectThrows(pauseId, clientObject.objectId!);
+
+    const properties = obj.preview?.properties ?? [];
+
+    const actualPropValues = await Promise.all(
+      properties.map(async val => {
+        const value = await getJSON(replayClient, pauseId, val, visitedObjectIds);
+        const key = val.name;
+        return [key, value] as [string, JSONishValue];
+      })
+    );
+
+    if (clientObject.type === "array") {
+      let result: JSONishValue[] = [];
+      for (const [key, value] of actualPropValues) {
+        const index = parseInt(key);
+        if (Number.isInteger(index)) {
+          result[index] = value;
+        }
+      }
+      return result;
+    }
+
+    return Object.fromEntries(actualPropValues);
+  }
+  switch (clientObject.type) {
+    case "boolean": {
+      return clientObject.preview === "true";
+    }
+    case "string":
+    case "symbol": {
+      return clientObject.preview!;
+    }
+    case "number":
+    case "nan": {
+      return Number(clientObject.preview!);
+    }
+    case "null": {
+      return null;
+    }
+    case "undefined": {
+      return undefined;
+    }
+  }
+
+  throw new Error("Unexpected client value! " + JSON.stringify(clientObject));
+}


### PR DESCRIPTION
This PR:

- Rewrites all of the `ThreadFront.evaluate()` calls in `ReactDevTools.tsx` to call `ThreadFront.evaluateNew()` instead.  This method does not return `ValueFront` instances in the data.
- Ports `ValueFront.getJSON()`, which converts a nested protocol data description into the equivalent POJO data, to be a standalone `getJSON` util that does not need `ValueFront`s