### PR TITLE
Rewrite preview logic to remove `TF.evaluate()` usage and migrate to RTK

### DIFF
--- a/src/devtools/client/debugger/src/actions/preview.ts
+++ b/src/devtools/client/debugger/src/actions/preview.ts
@@ -85,7 +85,6 @@ export function setPreview(
         cursorPos,
         expression,
         location,
-        target,
         tokenPos,
       },
     });

--- a/src/devtools/client/debugger/src/components/Editor/Preview/NewObjectInspector.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Preview/NewObjectInspector.tsx
@@ -2,34 +2,21 @@ import ErrorBoundary from "bvaughn-architecture-demo/components/ErrorBoundary";
 import Inspector from "bvaughn-architecture-demo/components/inspector";
 import Loader from "bvaughn-architecture-demo/components/Loader";
 import "bvaughn-architecture-demo/pages/variables.css";
-import { clientValueToProtocolValue } from "bvaughn-architecture-demo/src/utils/protocol";
 import { Value as ProtocolValue } from "@replayio/protocol";
 import InspectorContextReduxAdapter from "devtools/client/debugger/src/components/shared/InspectorContextReduxAdapter";
-import { ThreadFront } from "protocol/thread";
-import { Suspense, useMemo } from "react";
+import { Suspense } from "react";
 import { useAppSelector } from "ui/setup/hooks";
-
-import { getPreview } from "../../../selectors";
 
 import styles from "./NewObjectInspector.module.css";
 
-export default function NewObjectInspector() {
-  const preview = useAppSelector(getPreview);
-  const pause = ThreadFront.currentPause;
+interface NIOProps {
+  protocolValue: ProtocolValue;
+}
 
-  // HACK
-  // The new Object Inspector does not consume ValueFronts.
-  // It works with the Replay protocol's Value objects directly.
-  // At the moment this means that we need to convert the ValueFront back to a protocol Value.
-  const protocolValue: ProtocolValue | null = useMemo(() => {
-    if (preview == null || !preview.hasOwnProperty("root") == null) {
-      return null;
-    }
+export default function NewObjectInspector({ protocolValue }: NIOProps) {
+  const pauseId = useAppSelector(state => state.pause.id);
 
-    return clientValueToProtocolValue(preview?.root);
-  }, [preview]);
-
-  if (pause == null || pause.pauseId == null || protocolValue === null) {
+  if (pauseId == null || protocolValue === null) {
     return null;
   }
 
@@ -41,7 +28,7 @@ export default function NewObjectInspector() {
             <Inspector
               className={styles.Inspector}
               context="default"
-              pauseId={pause.pauseId!}
+              pauseId={pauseId!}
               protocolValue={protocolValue}
             />{" "}
           </Suspense>

--- a/src/devtools/client/debugger/src/components/Editor/Preview/Popup.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Preview/Popup.tsx
@@ -8,14 +8,14 @@ import type { PreviewState } from "devtools/client/debugger/src/reducers/preview
 
 import { useAppSelector, useAppDispatch } from "ui/setup/hooks";
 
-import { clearPreview } from "devtools/client/debugger/src/actions/preview";
+import { previewCleared } from "devtools/client/debugger/src/reducers/preview";
 import { getThreadContext } from "devtools/client/debugger/src/selectors";
 import Popover from "../../shared/Popover";
 
 import NewObjectInspector from "./NewObjectInspector";
 
 interface PopupProps {
-  preview: PreviewState["preview"];
+  preview: PreviewState;
   editorRef: HTMLDivElement;
   target: HTMLElement;
 }
@@ -25,7 +25,7 @@ export function Popup({ editorRef, target, preview }: PopupProps) {
   const cx = useAppSelector(getThreadContext);
 
   const onMouseOut = () => {
-    dispatch(clearPreview(cx, preview!.previewId));
+    dispatch(previewCleared({ cx, previewId: preview!.previewId }));
   };
 
   const { cursorPos, value } = preview!;

--- a/src/devtools/client/debugger/src/components/Editor/Preview/Popup.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Preview/Popup.tsx
@@ -26,6 +26,7 @@ import NewObjectInspector from "./NewObjectInspector";
 interface PopupProps {
   preview: PreviewState["preview"];
   editorRef: HTMLDivElement;
+  target: HTMLElement;
 }
 
 type FinalPopupProps = PropsFromRedux & PopupProps;
@@ -62,7 +63,7 @@ export class Popup extends Component<FinalPopupProps> {
   };
 
   render() {
-    const { preview, editorRef } = this.props;
+    const { preview, editorRef, target } = this.props;
     const { cursorPos, resultGrip } = preview!;
 
     if (resultGrip.isUnavailable()) {
@@ -75,7 +76,7 @@ export class Popup extends Component<FinalPopupProps> {
         targetPosition={cursorPos}
         type={type}
         editorRef={editorRef}
-        target={this.props.preview!.target}
+        target={target}
         mouseout={this.onMouseOut}
       >
         <NewObjectInspector />

--- a/src/devtools/client/debugger/src/components/Editor/Preview/Popup.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Preview/Popup.tsx
@@ -3,22 +3,13 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 import React, { Component } from "react";
-import { connect, ConnectedProps } from "react-redux";
 
-import type { UIState } from "ui/state";
 import type { PreviewState } from "devtools/client/debugger/src/reducers/preview";
 
-import {
-  highlightDomElement,
-  unHighlightDomElement,
-  openLink,
-  openNodeInInspector,
-} from "devtools/client/webconsole/actions/toolbox";
-import { selectSourceURL } from "devtools/client/debugger/src/actions/sources/select";
+import { useAppSelector, useAppDispatch } from "ui/setup/hooks";
+
 import { clearPreview } from "devtools/client/debugger/src/actions/preview";
 import { getThreadContext } from "devtools/client/debugger/src/selectors";
-import { getSourceDetailsEntities } from "ui/reducers/sources";
-
 import Popover from "../../shared/Popover";
 
 import NewObjectInspector from "./NewObjectInspector";
@@ -29,77 +20,38 @@ interface PopupProps {
   target: HTMLElement;
 }
 
-type FinalPopupProps = PropsFromRedux & PopupProps;
+export function Popup({ editorRef, target, preview }: PopupProps) {
+  const dispatch = useAppDispatch();
+  const cx = useAppSelector(getThreadContext);
 
-export class Popup extends Component<FinalPopupProps> {
-  calculateMaxHeight = () => {
-    const { editorRef } = this.props;
-    if (!editorRef) {
-      return "auto";
-    }
-
-    const { height, top } = editorRef.getBoundingClientRect();
-    const maxHeight = height + top;
-    if (maxHeight < 250) {
-      return maxHeight;
-    }
-
-    return 250;
+  const onMouseOut = () => {
+    dispatch(clearPreview(cx, preview!.previewId));
   };
 
-  getPreviewType() {
-    const { preview } = this.props;
-    const { root } = preview!;
-    if (root.isPrimitive() || (root.type === "value" && root.isFunction())) {
-      return "tooltip";
-    }
+  const { cursorPos, value } = preview!;
 
-    return "popover";
+  if (value === null) {
+    return null;
   }
 
-  onMouseOut = () => {
-    const { clearPreview, cx, preview } = this.props;
-    clearPreview(cx, preview!.previewId);
-  };
+  // Primitives get rendered as a smaller "tooltip" style, above the line.
+  // Other values get rendered as a larger "popover" style, below.
 
-  render() {
-    const { preview, editorRef, target } = this.props;
-    const { cursorPos, resultGrip } = preview!;
+  // The backend returns primitive data in a field called `value`
+  const isPrimitive = typeof value === "object" && "value" in value;
+  const popoverType = isPrimitive ? "tooltip" : "popover";
 
-    if (resultGrip.isUnavailable()) {
-      return null;
-    }
-
-    const type = this.getPreviewType();
-    return (
-      <Popover
-        targetPosition={cursorPos}
-        type={type}
-        editorRef={editorRef}
-        target={target}
-        mouseout={this.onMouseOut}
-      >
-        <NewObjectInspector />
-      </Popover>
-    );
-  }
+  return (
+    <Popover
+      targetPosition={cursorPos}
+      type={popoverType}
+      editorRef={editorRef}
+      target={target}
+      mouseout={onMouseOut}
+    >
+      <NewObjectInspector protocolValue={value} />
+    </Popover>
+  );
 }
 
-const mapStateToProps = (state: UIState) => ({
-  cx: getThreadContext(state),
-  sourcesById: getSourceDetailsEntities(state),
-});
-
-const mapDispatchToProps = {
-  selectSourceURL,
-  openLink,
-  openElementInInspector: openNodeInInspector,
-  highlightDomElement,
-  unHighlightDomElement,
-  clearPreview,
-};
-
-const connector = connect(mapStateToProps, mapDispatchToProps);
-type PropsFromRedux = ConnectedProps<typeof connector>;
-
-export default connector(Popup);
+export default Popup;

--- a/src/devtools/client/debugger/src/components/Editor/Preview/index.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Preview/index.tsx
@@ -33,13 +33,23 @@ type PreviewProps = PropsFromRedux & {
   editorRef: any;
 };
 
-type PreviewState = { selecting: boolean };
+type PreviewState = {
+  selecting: boolean;
+  hoveredTarget: HTMLElement | null;
+};
 
 class Preview extends PureComponent<PreviewProps, PreviewState> {
-  state = { selecting: false };
+  state = { selecting: false, hoveredTarget: null };
 
   componentDidMount() {
     this.updateListeners();
+  }
+
+  componentDidUpdate(prevProps: PreviewProps) {
+    // Reset state on preview dismissal
+    if (!this.props.preview && prevProps.preview && this.state.hoveredTarget) {
+      this.setState({ hoveredTarget: null });
+    }
   }
 
   componentWillUnmount() {
@@ -75,6 +85,7 @@ class Preview extends PureComponent<PreviewProps, PreviewState> {
 
     // Double-check status after timer runs
     if (cx?.isPaused && !this.state.selecting) {
+      this.setState({ hoveredTarget: target });
       updatePreview(cx, target, tokenPos, editor.codeMirror);
     }
   }, 100);
@@ -106,15 +117,15 @@ class Preview extends PureComponent<PreviewProps, PreviewState> {
 
   render() {
     const { preview } = this.props;
-    const { selecting } = this.state;
+    const { selecting, hoveredTarget } = this.state;
 
     return (
       <>
-        {!selecting && preview && (
-          <PreviewHighlight expression={preview.expression} target={preview.target} />
+        {!selecting && preview && hoveredTarget && (
+          <PreviewHighlight expression={preview.expression} target={hoveredTarget!} />
         )}
-        {!selecting && preview?.resultGrip && (
-          <Popup preview={preview} editorRef={this.props.editorRef} />
+        {!selecting && preview?.resultGrip && hoveredTarget && (
+          <Popup preview={preview} editorRef={this.props.editorRef} target={hoveredTarget!} />
         )}
       </>
     );

--- a/src/devtools/client/debugger/src/components/Editor/Preview/index.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Preview/index.tsx
@@ -15,6 +15,9 @@ import { getPreview, getThreadContext } from "../../../selectors";
 import actions from "../../../actions";
 import { PreviewHighlight } from "./PreviewHighlight";
 
+import { updatePreview } from "devtools/client/debugger/src/actions/preview";
+import { previewCleared } from "devtools/client/debugger/src/reducers/preview";
+
 const mapStateToProps = (state: UIState) => {
   return {
     cx: getThreadContext(state),
@@ -23,8 +26,8 @@ const mapStateToProps = (state: UIState) => {
 };
 
 const connector = connect(mapStateToProps, {
-  clearPreview: actions.clearPreview,
-  updatePreview: actions.updatePreview,
+  previewCleared,
+  updatePreview,
 });
 
 type PropsFromRedux = ConnectedProps<typeof connector>;
@@ -109,9 +112,9 @@ class Preview extends PureComponent<PreviewProps, PreviewState> {
   };
 
   onScroll = () => {
-    const { clearPreview, cx, preview } = this.props;
+    const { previewCleared, cx, preview } = this.props;
     if (cx?.isPaused && preview) {
-      clearPreview(cx, preview.previewId);
+      previewCleared({ cx, previewId: preview.previewId });
     }
   };
 

--- a/src/devtools/client/debugger/src/components/Editor/Preview/index.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Preview/index.tsx
@@ -124,7 +124,7 @@ class Preview extends PureComponent<PreviewProps, PreviewState> {
         {!selecting && preview && hoveredTarget && (
           <PreviewHighlight expression={preview.expression} target={hoveredTarget!} />
         )}
-        {!selecting && preview?.resultGrip && hoveredTarget && (
+        {!selecting && preview?.value && hoveredTarget && (
           <Popup preview={preview} editorRef={this.props.editorRef} target={hoveredTarget!} />
         )}
       </>

--- a/src/devtools/client/debugger/src/components/shared/Popover.tsx
+++ b/src/devtools/client/debugger/src/components/shared/Popover.tsx
@@ -15,7 +15,7 @@ interface PopoverProps {
   type: "tooltip" | "popover";
   editorRef: any;
   target: HTMLElement;
-  targetPosition: any;
+  targetPosition: DOMRect;
   mouseout: () => void;
   children?: React.ReactNode;
 }

--- a/src/devtools/client/debugger/src/reducers/preview.ts
+++ b/src/devtools/client/debugger/src/reducers/preview.ts
@@ -9,15 +9,11 @@ import type { UIState } from "ui/state";
 import type { Preview } from "./types";
 import { ValueItem } from "devtools/packages/devtools-reps";
 
-// TODO Are we really putting more DOM nodes in state?
-type $FixTypeLater = any;
-
 export interface PreviewState {
   preview:
     | (Preview & {
         previewId: string;
         expression: string;
-        target: $FixTypeLater;
         cursorPos: any;
         resultGrip: any;
         root: ValueItem;

--- a/src/devtools/client/debugger/src/reducers/preview.ts
+++ b/src/devtools/client/debugger/src/reducers/preview.ts
@@ -2,70 +2,65 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-import type { Value } from "@replayio/protocol";
-import uniqueId from "lodash/uniqueId";
-import type { AnyAction } from "@reduxjs/toolkit";
+import type { Value, SourceLocation } from "@replayio/protocol";
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
 import type { UIState } from "ui/state";
 
-import type { Preview } from "./types";
-import { ValueItem } from "devtools/packages/devtools-reps";
+import { ThreadContext } from "./pause";
 
-export interface PreviewState {
-  preview:
-    | (Preview & {
-        previewId: string;
-        expression: string;
-        cursorPos: any;
-        value: Value | null;
-      })
-    | null;
+interface PreviewInitialFields {
+  expression: string;
+  // TODO DOMRects shouldn't be in Redux
+  cursorPos: DOMRect;
+  location: { start: SourceLocation; end: SourceLocation };
+  tokenPos: SourceLocation;
 }
 
-export function initialPreviewState(): PreviewState {
-  return {
-    preview: null,
-  };
+interface PreviewStartedContents extends PreviewInitialFields {
+  previewId: string;
 }
 
-function update(state = initialPreviewState(), action: AnyAction) {
-  switch (action.type) {
-    case "CLEAR_PREVIEW": {
-      if (action.previewId !== state.preview?.previewId) {
-        return state;
-      }
+interface PreviewData extends PreviewStartedContents {
+  value: Value | null;
+}
 
-      return { preview: null };
-    }
+export type PreviewState = PreviewData | null;
 
-    case "START_PREVIEW": {
+const initialState = null as PreviewState;
+
+const previewSlice = createSlice({
+  name: "preview",
+  initialState,
+  reducers: {
+    previewStarted(state, action: PayloadAction<PreviewStartedContents>) {
       return {
-        preview: {
-          ...action.value,
-          previewId: uniqueId(),
-        },
+        ...action.payload,
+        value: null,
       };
-    }
-
-    case "COMPLETE_PREVIEW": {
-      const { previewId, value } = action;
-      if (previewId !== state.preview?.previewId) {
-        return state;
+    },
+    previewCleared(state, action: PayloadAction<{ previewId: string; cx: ThreadContext }>) {
+      if (action.payload.previewId === state?.previewId) {
+        return null;
       }
+    },
+    previewLoaded(
+      state,
+      action: PayloadAction<{ cx: ThreadContext; previewId: string; value: Value | null }>
+    ) {
+      const { previewId, value } = action.payload;
 
-      return {
-        preview: {
-          ...state.preview,
-          value,
-        },
-      };
-    }
-  }
+      if (previewId === state?.previewId) {
+        state.value = value;
+      }
+    },
+  },
+});
 
-  return state;
-}
+export const { previewStarted, previewLoaded, previewCleared } = previewSlice.actions;
+
+export default previewSlice.reducer;
 
 export function getPreview(state: UIState) {
-  return state.preview.preview;
+  return state.preview;
 }
-
-export default update;

--- a/src/devtools/client/debugger/src/reducers/preview.ts
+++ b/src/devtools/client/debugger/src/reducers/preview.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
+import type { Value } from "@replayio/protocol";
 import uniqueId from "lodash/uniqueId";
 import type { AnyAction } from "@reduxjs/toolkit";
 import type { UIState } from "ui/state";
@@ -15,8 +16,7 @@ export interface PreviewState {
         previewId: string;
         expression: string;
         cursorPos: any;
-        resultGrip: any;
-        root: ValueItem;
+        value: Value | null;
       })
     | null;
 }
@@ -55,7 +55,7 @@ function update(state = initialPreviewState(), action: AnyAction) {
       return {
         preview: {
           ...state.preview,
-          ...value,
+          value,
         },
       };
     }

--- a/src/devtools/client/debugger/src/utils/preview.js
+++ b/src/devtools/client/debugger/src/utils/preview.js
@@ -1,9 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
-
-//
-
-export function isConsole(expression) {
-  return /^console/.test(expression);
-}

--- a/src/ui/setup/store.ts
+++ b/src/ui/setup/store.ts
@@ -148,6 +148,7 @@ const reduxDevToolsOptions: ReduxDevToolsOptions = {
   maxAge: 100,
   stateSanitizer: sanitizeStateForDevtools,
   actionSanitizer: sanitizeActionForDevTools,
+  trace: true,
   // @ts-ignore This field has been renamed, but RTK types haven't caught up yet
   actionsDenylist: [
     "protocolMessages/eventReceived",


### PR DESCRIPTION
This PR:

- Updates the preview component handling to keep the current hovered token DOM node in React component state instead of the Redux store
- Rewrites the hover variable preview evaluation to use raw protocol data instead of `ValueFront`s
- Migrates the `<Popup>` component to be a function component
- Migrates the `reducers/preview` file to use RTK
- Enables action stack traces in the Redux DevTools (which for some reason I had missed turning on)