### PR TITLE
Add error boundary around SourcemapVisualizerLink in case API call fails

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Footer.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Footer.tsx
@@ -1,8 +1,8 @@
 import React, { memo, Suspense, useEffect, useLayoutEffect, useRef, useState } from "react";
+import ErrorBoundary from "ui/components/ErrorBoundary";
 import { useAppSelector } from "ui/setup/hooks";
-import { localStorageGetItem, localStorageSetItem } from "ui/utils/storage";
-
 import { getSelectedSource } from "ui/reducers/sources";
+import { localStorageGetItem, localStorageSetItem } from "ui/utils/storage";
 
 import SourcemapToggle from "./SourcemapToggle";
 import SourcemapVisualizerLink from "./SourcemapVisualizerLink";
@@ -132,10 +132,12 @@ function SourceFooter() {
 
   return (
     <div className="source-footer">
-      <Suspense>
-        <SourcemapToggle cursorPosition={cursorPosition} />
-        <SourcemapVisualizerLink cursorPosition={cursorPosition} />
-      </Suspense>
+      <ErrorBoundary>
+        <Suspense>
+          <SourcemapToggle cursorPosition={cursorPosition} />
+          <SourcemapVisualizerLink cursorPosition={cursorPosition} />
+        </Suspense>
+      </ErrorBoundary>
       <div className="source-footer-end">{cursorPositionUI}</div>
     </div>
   );


### PR DESCRIPTION
Avoids crash reported in [f086a0cd-1f3f-4e9f-8dfd-af02c79e298b](https://app.replay.io/recording/if-thingisbiggerthanbreadbox-oror-thingisyellow-crash--f086a0cd-1f3f-4e9f-8dfd-af02c79e298b) by wrapping an error boundary around the `<SourcemapVisualizerLink>` component.

Note that this is a _partial_ fix. Follow up work needs to be done as part of BAC-2207 to determine _why_ the backend was throwing for this case.

# Testing
I intentionally threw an error in the Suspense cache to simulate the backend failing for this request.

## Before change
Before this change, an error thrown during this request caused the whole app to unmount.
<img width="1158" alt="Screen Shot 2022-09-14 at 11 46 05 AM" src="https://user-images.githubusercontent.com/29597/190203217-5278c525-e399-4c75-a6d6-6d4a1023143a.png">

## After change
After this change, an error thrown just unmounted the `<SourcemapVisualizerLink>` component (making the footer blank/empty).
<img width="1158" alt="Screen Shot 2022-09-14 at 11 47 03 AM" src="https://user-images.githubusercontent.com/29597/190203403-af6b641d-4ac2-4985-a798-ed57228bb660.png">

cc @Andarist 