### PR TITLE
Optimize CodeMirror hit counts gutter performance

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Gutter.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Gutter.tsx
@@ -1,11 +1,12 @@
 import LineHitCounts from "./LineHitCounts";
 import ToggleWidgetButton from "./ToggleWidgetButton";
+import type { SourceEditor } from "../../utils/editor/source-editor";
 
-export default function Gutter({ editor }: any) {
+export default function Gutter({ sourceEditor }: { sourceEditor: SourceEditor }) {
   return (
     <>
-      <ToggleWidgetButton editor={editor} />
-      <LineHitCounts editor={editor} />
+      <ToggleWidgetButton editor={sourceEditor} />
+      <LineHitCounts sourceEditor={sourceEditor} />
     </>
   );
 }

--- a/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useLayoutEffect } from "react";
+import { useMemo, useLayoutEffect, useRef, useEffect } from "react";
 import { useFeature } from "ui/hooks/settings";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 
@@ -17,6 +17,8 @@ import {
 } from "ui/reducers/hitCounts";
 import { UIState } from "ui/state";
 import type { SourceEditor } from "../../utils/editor/source-editor";
+import { getFocusRegion } from "ui/reducers/timeline";
+import { FocusRegion } from "ui/state/timeline";
 
 type Props = {
   sourceEditor: SourceEditor;
@@ -38,34 +40,50 @@ function LineHitCounts({ sourceEditor }: Props) {
   const sourceId = useAppSelector(getSelectedSourceId)!;
   const hitCounts = useAppSelector(state => getHitCountsForSource(state, sourceId));
   const { value: hitCountsMode, update: updateHitCountsMode } = useStringPref("hitCounts");
-  const isCollapsed = hitCountsMode == "hide-counts";
   const currentLineNumber = useAppSelector(
-    (state: UIState) => state.app.hoveredLineNumberLocation?.line || 0
+    (state: UIState) => state.app.hoveredLineNumberLocation?.line
   );
-  const { lower, upper } = getBoundsForLineNumber(currentLineNumber);
+  const focusRegion = useAppSelector(getFocusRegion);
 
-  const hitCountMap = useMemo(
-    () => (hitCounts !== null ? hitCountsToMap(hitCounts) : null),
-    [hitCounts]
-  );
+  const previousFocusRegion = useRef<FocusRegion | null>(null);
+  const previousHitCounts = useRef<Map<number, number> | null>(null);
+
+  const isCollapsed = hitCountsMode == "hide-counts";
+  const isCurrentLineNumberValid = currentLineNumber !== undefined;
+  const { lower, upper } = getBoundsForLineNumber(currentLineNumber || 0);
+
+  const hitCountMap = useMemo(() => {
+    if (hitCounts !== null) {
+      const hitCountsMap = hitCountsToMap(hitCounts);
+      return hitCountsMap;
+    }
+    return null;
+  }, [hitCounts]);
+
+  const updatedLineNumbers = useMemo(() => {
+    return new Set<number>();
+    // We _want_ this re-created every time these change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hitCountMap, isCollapsed]);
 
   // Min/max hit counts are used to determine heat map color.
-  const { minHitCount, maxHitCount } = useMemo(() => {
+  const [minHitCount, maxHitCount] = useMemo(() => {
     let minHitCount = Infinity;
     let maxHitCount = 0;
     if (hitCounts) {
-      hitCounts.forEach(hitCount => {
-        if (hitCount.hits > 0) {
-          if (minHitCount > hitCount.hits) {
-            minHitCount = hitCount.hits;
+      // Iterate the entire array once to find min/max as we go
+      for (let { hits } of hitCounts) {
+        if (hits > 0) {
+          if (minHitCount > hits) {
+            minHitCount = hits;
           }
-          if (maxHitCount < hitCount.hits) {
-            maxHitCount = hitCount.hits;
+          if (maxHitCount < hits) {
+            maxHitCount = hits;
           }
         }
-      });
+      }
     }
-    return { minHitCount, maxHitCount };
+    return [minHitCount, maxHitCount] as const;
   }, [hitCounts]);
 
   useLayoutEffect(() => {
@@ -75,6 +93,25 @@ function LineHitCounts({ sourceEditor }: Props) {
     }
   }, [dispatch, sourceId, hitCounts]);
 
+  // Make sure we have enough room to fit large hit count numbers in the gutter markers
+  const numCharsToFit = useMemo(() => {
+    const numCharsToFit =
+      maxHitCount < 1000
+        ? Math.max(2, maxHitCount.toString().length)
+        : `${(maxHitCount / 1000).toFixed(1)}k`.length;
+    return numCharsToFit;
+  }, [maxHitCount]);
+
+  const gutterWidth = isCollapsed ? "1ch" : `${numCharsToFit + 1}ch`;
+
+  // Save `isCollapsed` in a ref so we only create `marker.onClick` callbacks once
+  // TODO Candidate for the eventual `useEvent` hook?
+  const isCollapsedRef = useRef(isCollapsed);
+
+  useLayoutEffect(() => {
+    isCollapsedRef.current = isCollapsed;
+  }, [isCollapsed]);
+
   useLayoutEffect(() => {
     if (!sourceEditor) {
       return;
@@ -82,35 +119,69 @@ function LineHitCounts({ sourceEditor }: Props) {
 
     const { editor } = sourceEditor;
 
-    // const doc = editor.editor.getDoc();
-    const drawLines = () => {
-      // Make sure we have enough room to fit large hit count numbers.
-      const numCharsToFit =
-        maxHitCount < 1000
-          ? Math.max(2, maxHitCount.toString().length)
-          : `${(maxHitCount / 1000).toFixed(1)}k`.length;
-      const gutterWidth = isCollapsed ? "1ch" : `${numCharsToFit + 1}ch`;
+    // Tell CodeMirror to actually create a gutter column for hit counts
+    editor.setOption("gutters", [
+      "breakpoints",
+      "CodeMirror-linenumbers",
+      { className: "hit-markers", style: `width: ${gutterWidth}` },
+    ]);
+    resizeBreakpointGutter(editor);
 
-      editor.setOption("gutters", [
-        "breakpoints",
-        "CodeMirror-linenumbers",
-        { className: "hit-markers", style: `width: ${gutterWidth}` },
-      ]);
+    // HACK
+    // When hit counts are shown, the hover button (to add a log point) should not overlap with the gutter.
+    // That component doesn't know about hit counts though, so we can inform its position via a CSS variable.
+    const gutterElement = sourceEditor.codeMirror.getGutterElement();
+    (gutterElement as HTMLElement).parentElement!.style.setProperty(
+      "--hit-count-gutter-width",
+      `-${gutterWidth}`
+    );
+
+    return () => {
+      try {
+        editor.setOption("gutters", ["breakpoints", "CodeMirror-linenumbers"]);
+      } catch (e) {
+        console.warn(e);
+      }
       resizeBreakpointGutter(editor);
+    };
+  }, [gutterWidth, sourceEditor, isCollapsed]);
 
-      // HACK
-      // When hit counts are shown, the hover button (to add a log point) should not overlap with the gutter.
-      // That component doesn't know about hit counts though, so we can inform its position via a CSS variable.
-      const gutterElement = sourceEditor.codeMirror.getGutterElement();
-      (gutterElement as HTMLElement).parentElement!.style.setProperty(
-        "--hit-count-gutter-width",
-        `-${gutterWidth}`
-      );
+  useLayoutEffect(() => {
+    if (!sourceEditor) {
+      return;
+    }
 
+    const { editor } = sourceEditor;
+
+    const drawLines = () => {
       let lineNumber = lower;
+      const focusRegionChanged = focusRegion !== previousFocusRegion.current;
+      const hitCountMapChanged = hitCountMap !== previousHitCounts.current;
 
+      // `drawLines` will run reasonably often. However, we will often
+      // want to bail out early and _not_ apply updates to the gutter markers.
+      // The main reason to bail out is if there is no current line number,
+      // which happens any time the mouse is over an "inactive" line in the editor,
+      // or outside the editor entirely.
+      // However, there are a couple situations when we _do_ still want to redraw
+      // even if the mouse isn't over a valid line:
+      // - The focus region just changed
+      // - We refetched hit counts due to the user closing the focus bar
+      if (!isCurrentLineNumberValid && !focusRegionChanged && !hitCountMapChanged) {
+        return;
+      }
+
+      // Attempt to update just the markers for just the 100-line blocks  surrounding
+      // the current line number
       editor.eachLine(lower, upper, lineHandle => {
         lineNumber++;
+
+        // Skip this line if we've updated it with its current hit count already
+        if (updatedLineNumbers?.has(lineNumber)) {
+          return;
+        }
+
+        updatedLineNumbers?.add(lineNumber);
 
         const hitCount = hitCountMap?.get(lineNumber) || 0;
 
@@ -142,16 +213,29 @@ function LineHitCounts({ sourceEditor }: Props) {
           }
         }
 
-        const markerNode = document.createElement("div");
-        markerNode.onclick = () => updateHitCountsMode(isCollapsed ? "show-counts" : "hide-counts");
+        const info = editor.lineInfo(lineNumber);
+
+        let markerNode: HTMLDivElement;
+        if (info?.gutterMarkers?.["hit-markers"]) {
+          // Retrieve the marker DOM node we already created
+          markerNode = info.gutterMarkers["hit-markers"];
+        } else {
+          markerNode = document.createElement("div");
+          markerNode.onclick = () =>
+            updateHitCountsMode(isCollapsedRef.current ? "show-counts" : "hide-counts");
+
+          editor.setGutterMarker(lineHandle, "hit-markers", markerNode);
+        }
+
         markerNode.className = className;
-        if (!isCollapsed && hitCount > 0) {
-          markerNode.textContent =
-            hitCount < 1000 ? `${hitCount}` : `${(hitCount / 1000).toFixed(1)}k`;
+        if (!isCollapsed) {
+          let hitsLabel = "";
+          if (hitCount > 0) {
+            hitsLabel = hitCount < 1000 ? `${hitCount}` : `${(hitCount / 1000).toFixed(1)}k`;
+          }
+          markerNode.textContent = hitsLabel;
         }
         markerNode.title = `${hitCount} hits`;
-
-        editor.setGutterMarker(lineHandle, "hit-markers", markerNode);
       });
     };
 
@@ -161,26 +245,28 @@ function LineHitCounts({ sourceEditor }: Props) {
     drawLines();
 
     return () => {
-      try {
-        editor.setOption("gutters", ["breakpoints", "CodeMirror-linenumbers"]);
-      } catch (e) {
-        console.warn(e);
-      }
-      resizeBreakpointGutter(editor);
-
       editor.off("change", drawLines);
       editor.off("swapDoc", drawLines);
     };
   }, [
     sourceEditor,
     hitCountMap,
+    updatedLineNumbers,
     isCollapsed,
     minHitCount,
     maxHitCount,
     updateHitCountsMode,
     lower,
     upper,
+    isCurrentLineNumberValid,
+    focusRegion,
   ]);
+
+  useEffect(() => {
+    // Save the previous references for comparison in `drawLines`
+    previousFocusRegion.current = focusRegion;
+    previousHitCounts.current = hitCountMap;
+  }, [focusRegion, hitCountMap]);
 
   // We're just here for the hooks!
   return null;

--- a/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
@@ -122,15 +122,16 @@ function LineNumberTooltip({ editor, keyModifiers }: Props) {
       lineNumber: number;
       lineNumberNode: HTMLElement;
     }) => {
-      // Bail out of any pending "clear hover line" dispatch, since we're over a new line
-      clearHoveredLineNumber.cancel();
-
       if (lineNumber !== lastHoveredLineNumber.current) {
+        // Bail out of any pending "clear hover line" dispatch, since we're over a new line
+        clearHoveredLineNumber.cancel();
+
         lastHoveredLineNumber.current = lineNumber;
+
+        dispatch(updateHoveredLineNumber(lineNumber));
+        setTargetNode(lineNumberNode);
+        fetchHitCountsForVisibleLines();
       }
-      dispatch(updateHoveredLineNumber(lineNumber));
-      setTargetNode(lineNumberNode);
-      fetchHitCountsForVisibleLines();
     };
 
     editor.codeMirror.on("lineMouseEnter", setHoveredLineNumber);

--- a/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
@@ -1,12 +1,15 @@
 import { updateHoveredLineNumber } from "devtools/client/debugger/src/actions/breakpoints/index";
 import minBy from "lodash/minBy";
-import React, { useRef, useState, useEffect, ReactNode } from "react";
+import debounce from "lodash/debounce";
+import React, { useRef, useState, useEffect, ReactNode, useCallback } from "react";
+
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { KeyModifiers } from "ui/components/KeyModifiers";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
 import hooks from "ui/hooks";
 import { Nag } from "ui/hooks/users";
-import { setHoveredLineNumberLocation } from "ui/reducers/app";
+import { getLoadedRegions, setHoveredLineNumberLocation } from "ui/reducers/app";
+import { getShowFocusModeControls } from "ui/reducers/timeline";
 import { trackEvent } from "ui/utils/telemetry";
 import { shouldShowNag } from "ui/utils/user";
 
@@ -36,14 +39,14 @@ function Wrapper({
 
   if (showWarning) {
     return (
-      <div className="space-x-2 bg-red-700 static-tooltip-content">
+      <div className="static-tooltip-content space-x-2 bg-red-700">
         <MaterialIcon>warning_amber</MaterialIcon>
         <div>{children}</div>
       </div>
     );
   } else if (showNag) {
     return (
-      <div className="space-x-2 static-tooltip-content" style={{ background: AWESOME_BACKGROUND }}>
+      <div className="static-tooltip-content space-x-2" style={{ background: AWESOME_BACKGROUND }}>
         <MaterialIcon iconSize="xl">auto_awesome</MaterialIcon>
         <div className="flex flex-col items-start">
           {!loading ? <div className="font-bold">Click to add a print statement</div> : null}
@@ -53,7 +56,7 @@ function Wrapper({
     );
   }
 
-  return <div className="bg-gray-700 static-tooltip-content">{children}</div>;
+  return <div className="static-tooltip-content bg-gray-700">{children}</div>;
 }
 
 type Props = {
@@ -71,6 +74,8 @@ function LineNumberTooltip({ editor, keyModifiers }: Props) {
   const lastHoveredLineNumber = useRef<number | null>(null);
   const isMetaActive = keyModifiers.meta;
   const source = useAppSelector(getSelectedSource);
+  const loadedRegions = useAppSelector(getLoadedRegions);
+  const focusControlsActive = useAppSelector(getShowFocusModeControls);
 
   const hitCounts = useAppSelector(state => getHitCountsForSource(state, source!.id));
   const hitCountStatus = useAppSelector(state =>
@@ -87,7 +92,29 @@ function LineNumberTooltip({ editor, keyModifiers }: Props) {
     hits = lineHitCounts?.hits;
   }
 
+  const fetchHitCountsForVisibleLines = useCallback(() => {
+    var rect = editor.codeMirror.getWrapperElement().getBoundingClientRect();
+    var topVisibleLine = editor.codeMirror.lineAtHeight(rect.top, "window");
+    var bottomVisibleLine = editor.codeMirror.lineAtHeight(rect.bottom, "window");
+    dispatch(fetchHitCounts(source!.id, editor.codeMirror.lineAtHeight()));
+    dispatch(fetchHitCounts(source!.id, topVisibleLine - 10));
+    dispatch(fetchHitCounts(source!.id, bottomVisibleLine + 10));
+  }, [editor, dispatch, source]);
+
   useEffect(() => {
+    const clearHoveredLineNumber = debounce(() => {
+      // Only reset the Redux state here after a short delay.
+      // That way, if we immediately mouse from active line X to X + 1,
+      // we won't dispatch a "reset line to null" action as part of that change.
+      // This avoids causing the `{lower, upper} selector to think we're at range 0..100,
+      // which was causing many unnecessary gutter marker updates.
+      // Note that mousing over an inactive line _will_ cause us to clear this line number.
+      setTargetNode(null);
+      if (lastHoveredLineNumber.current !== null) {
+        dispatch(setHoveredLineNumberLocation(null));
+      }
+    }, 10);
+
     const setHoveredLineNumber = ({
       lineNumber,
       lineNumberNode,
@@ -95,21 +122,15 @@ function LineNumberTooltip({ editor, keyModifiers }: Props) {
       lineNumber: number;
       lineNumberNode: HTMLElement;
     }) => {
+      // Bail out of any pending "clear hover line" dispatch, since we're over a new line
+      clearHoveredLineNumber.cancel();
+
       if (lineNumber !== lastHoveredLineNumber.current) {
         lastHoveredLineNumber.current = lineNumber;
       }
       dispatch(updateHoveredLineNumber(lineNumber));
       setTargetNode(lineNumberNode);
-      var rect = editor.codeMirror.getWrapperElement().getBoundingClientRect();
-      var topVisibleLine = editor.codeMirror.lineAtHeight(rect.top, "window");
-      var bottomVisibleLine = editor.codeMirror.lineAtHeight(rect.bottom, "window");
-      dispatch(fetchHitCounts(source!.id, editor.codeMirror.lineAtHeight()));
-      dispatch(fetchHitCounts(source!.id, topVisibleLine - 10));
-      dispatch(fetchHitCounts(source!.id, bottomVisibleLine + 10));
-    };
-    const clearHoveredLineNumber = () => {
-      setTargetNode(null);
-      dispatch(setHoveredLineNumberLocation(null));
+      fetchHitCountsForVisibleLines();
     };
 
     editor.codeMirror.on("lineMouseEnter", setHoveredLineNumber);
@@ -118,7 +139,14 @@ function LineNumberTooltip({ editor, keyModifiers }: Props) {
       editor.codeMirror.off("lineMouseEnter", setHoveredLineNumber);
       editor.codeMirror.off("lineMouseLeave", clearHoveredLineNumber);
     };
-  }, [dispatch, editor.codeMirror, source]);
+  }, [dispatch, editor.codeMirror, fetchHitCountsForVisibleLines]);
+
+  useEffect(() => {
+    // TODO Could maybe be an RTK listener that watches for the "stop focus bar" action?
+    if (!focusControlsActive) {
+      fetchHitCountsForVisibleLines();
+    }
+  }, [loadedRegions, focusControlsActive, fetchHitCountsForVisibleLines]);
 
   useEffect(() => {
     if (hits) {

--- a/src/devtools/client/debugger/src/components/Editor/index.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/index.tsx
@@ -481,7 +481,7 @@ class Editor extends PureComponent<PropsFromRedux, EditorState> {
           selectedSource={selectedSource}
         />
         <ColumnBreakpoints editor={editor} />
-        <Gutter editor={editor} />
+        <Gutter sourceEditor={editor} />
       </div>
     );
   }

--- a/src/devtools/client/debugger/src/components/Editor/index.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/index.tsx
@@ -60,6 +60,7 @@ import {
   hasDocument,
   onTokenMouseOver,
   onLineMouseOver,
+  onMouseScroll,
   startOperation,
   endOperation,
   clearDocuments,
@@ -121,6 +122,8 @@ interface EditorState {
 class Editor extends PureComponent<PropsFromRedux, EditorState> {
   shortcuts = new KeyShortcuts({ window, target: document });
   $editorWrapper: any;
+  lastClientX = 0;
+  lastClientY = 0;
 
   constructor(props: PropsFromRedux) {
     super(props);
@@ -178,6 +181,7 @@ class Editor extends PureComponent<PropsFromRedux, EditorState> {
 
     const { codeMirror } = editor;
     const codeMirrorWrapper = codeMirror.getWrapperElement();
+    const scrollWrapper = codeMirror.getScrollerElement();
 
     // @ts-expect-error event doesn't exist?
     codeMirror.on("gutterClick", this.onGutterClick);
@@ -188,6 +192,13 @@ class Editor extends PureComponent<PropsFromRedux, EditorState> {
     codeMirrorWrapper.addEventListener("click", e => this.onClick(e));
     codeMirrorWrapper.addEventListener("mouseover", onTokenMouseOver(codeMirror));
     codeMirrorWrapper.addEventListener("mouseover", onLineMouseOver(codeMirror));
+
+    document.addEventListener("mousemove", e => {
+      // Store mouse coords so we can use them when checking the mouse location
+      // during a CodeMirror "scroll" event
+      this.lastClientX = e.clientX;
+      this.lastClientY = e.clientY;
+    });
 
     if (!isFirefox()) {
       codeMirror.on("gutterContextMenu", (cm, line, eventName, event) =>
@@ -238,7 +249,12 @@ class Editor extends PureComponent<PropsFromRedux, EditorState> {
     return fromEditorLine(line);
   }
 
-  onEditorScroll = debounce(this.props.updateViewport, 75);
+  onEditorScroll = debounce((...args) => {
+    this.props.updateViewport();
+    if (this.lastClientX && this.lastClientY) {
+      onMouseScroll(this.state.editor?.codeMirror, this.lastClientX, this.lastClientY);
+    }
+  }, 75);
 
   onKeyDown(e: KeyboardEvent) {
     const { codeMirror } = this.state.editor!;

--- a/src/devtools/client/debugger/src/utils/editor/index.ts
+++ b/src/devtools/client/debugger/src/utils/editor/index.ts
@@ -6,7 +6,7 @@ export * from "./source-documents";
 export * from "./source-search";
 export * from "../ui";
 export { onTokenMouseOver } from "./token-events";
-export { onLineMouseOver } from "./line-events";
+export { onLineMouseOver, onMouseScroll } from "./line-events";
 
 import { SourceLocation } from "graphql";
 import { SourceDetails } from "ui/reducers/sources";

--- a/src/devtools/client/debugger/src/utils/editor/line-events.ts
+++ b/src/devtools/client/debugger/src/utils/editor/line-events.ts
@@ -83,3 +83,19 @@ export function onLineMouseOver(codeMirror: $FixTypeLater) {
     }
   };
 }
+
+// Copied from `onLineMouseOver` above, but requires `clientX/clientY` passed  in/
+// because scroll events don't appear to contain those coords
+export function onMouseScroll(codeMirror: $FixTypeLater, clientX: number, clientY: number) {
+  let target = document.elementFromPoint(clientX, clientY) as HTMLElement;
+  // Hacky, try to fix this.
+  if (target?.closest(".CodeMirror-linewidget")) {
+    target = target
+      .closest(".CodeMirror-linewidget")!
+      .parentElement!.querySelector(".CodeMirror-line")!;
+  }
+
+  if (isValidTarget(target) && codeMirror) {
+    emitLineMouseEnter(codeMirror, target);
+  }
+}


### PR DESCRIPTION
Made multiple changes to how we update hit counts in the CodeMirror gutter:

- We precalculate `gutterWidth`, and only call `CM.setOptions()` to recreate the gutters whenever that _character_-based width changes
- `drawLines` now bails out early in many cases, and also skips updating lines that we've seen already with this hit count map
- We only create marker DOM nodes once per line
- We no longer dispatch `setHoveredLine(null)` _every_ time the mouse leaves a line. Instead, we call a debounced function, and cancel it in the "mouseenter" handler, since the most common behavior is to mouse from line X to X + 1.
- We also don't dispatch if the hovered line number is null, which is the case when the existing line is inactive / no hits
- We _do_ now refetch hit counts when the focus region changes, so that the hit counts update as soon as you close the focus bar without having to wait until you mouse over the editor again.

Also I tweaked the TS types to better refer to which `editor/sourceEditor` variables/types we're using here.

This is still _slightly_ draft-y. What's here should be a big improvement, but I want to do a couple more perf captures from this preview build to see how it behaves in comparison.