### PR TITLE
Switch disable repainting boolean flag

### DIFF
--- a/packages/protocol/graphics.ts
+++ b/packages/protocol/graphics.ts
@@ -248,7 +248,7 @@ export function setupGraphics() {
 
 export async function repaint(force = false) {
   const recordingCapabilities = await ThreadFront.getRecordingCapabilities();
-  if (recordingCapabilities.supportsRepaintingGraphics) {
+  if (!recordingCapabilities.supportsRepaintingGraphics) {
     return;
   }
 


### PR DESCRIPTION
Adding this concept was a really good idea, it will make adding checks like this a lot easier 👍 

Fixes https://linear.app/replay/issue/FE-734/do-we-still-request-pause-graphics-for-node-recordings