### PR TITLE
Fix off-by-one error in hitCounts

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
@@ -183,7 +183,7 @@ function LineHitCounts({ sourceEditor }: Props) {
 
         updatedLineNumbers?.add(lineNumber);
 
-        const hitCount = hitCountMap?.get(lineNumber) || 0;
+        const hitCount = hitCountMap?.get(lineNumber + 1) || 0;
 
         // We use a gradient to indicate the "heat" (the number of hits).
         // This absolute hit count values are relative, per file.


### PR DESCRIPTION
I don't completely understand this. I thought I could do `let lineNumber = lower + 1` and everything would be fine, but that is not in fact true. This was the only solution that worked.

Fixes https://linear.app/replay/issue/FE-735/gutter-hit-count-disagrees-with-pill-count