### PR TITLE
Add discord, email, and documentation links to error messages

### DIFF
--- a/src/ui/components/shared/Dialog.tsx
+++ b/src/ui/components/shared/Dialog.tsx
@@ -6,14 +6,31 @@ export type DialogPropTypes = HTMLProps<HTMLDivElement>;
 
 export function Dialog({ children, className, ...props }: DialogPropTypes) {
   return (
+    <>
     <div
       {...props}
       className={classNames("dialog flex flex-col items-center", className)}
       role="dialog"
       style={{ animation: "linearFadeIn ease 200ms", width: 400 }}
     >
-      {children}
+      {children}      
     </div>
+    <div>
+      <div className="grid grid-cols-1 gap-1 pt-4 text-xs text-gray-400 place-items-center">            
+            
+            <div>
+              <div className="flex space-x-2">
+                <div><a className="hover:underline" href="http://docs.replay.io">Documentation</a></div>
+                <div className="text-gray-300">•</div>
+                <div><a className="hover:underline" href="http://replay.io/discord/">Discord</a></div>
+                <div className="text-gray-300">•</div>
+                <div><a className="hover:underline" href="mailto:support@replay.io">Email support</a></div>
+              </div>
+            </div>   
+
+      </div>
+    </div>
+    </>
   );
 }
 

--- a/src/ui/components/shared/Dialog.tsx
+++ b/src/ui/components/shared/Dialog.tsx
@@ -7,29 +7,39 @@ export type DialogPropTypes = HTMLProps<HTMLDivElement>;
 export function Dialog({ children, className, ...props }: DialogPropTypes) {
   return (
     <>
-    <div
-      {...props}
-      className={classNames("dialog flex flex-col items-center", className)}
-      role="dialog"
-      style={{ animation: "linearFadeIn ease 200ms", width: 400 }}
-    >
-      {children}      
-    </div>
-    <div>
-      <div className="grid grid-cols-1 gap-1 pt-4 text-xs text-gray-400 place-items-center">            
-            
-            <div>
-              <div className="flex space-x-2">
-                <div><a className="hover:underline" href="http://docs.replay.io">Documentation</a></div>
-                <div className="text-gray-300">•</div>
-                <div><a className="hover:underline" href="http://replay.io/discord/">Discord</a></div>
-                <div className="text-gray-300">•</div>
-                <div><a className="hover:underline" href="mailto:support@replay.io">Email support</a></div>
-              </div>
-            </div>   
-
+      <div
+        {...props}
+        className={classNames("dialog flex flex-col items-center", className)}
+        role="dialog"
+        style={{ animation: "linearFadeIn ease 200ms", width: 400 }}
+      >
+        {children}
       </div>
-    </div>
+      <div>
+        <div className="grid grid-cols-1 gap-1 pt-4 text-xs text-gray-400 place-items-center">
+          <div>
+            <div className="flex space-x-2">
+              <div>
+                <a className="hover:underline" href="http://docs.replay.io">
+                  Documentation
+                </a>
+              </div>
+              <div className="text-gray-300">•</div>
+              <div>
+                <a className="hover:underline" href="http://replay.io/discord/">
+                  Discord
+                </a>
+              </div>
+              <div className="text-gray-300">•</div>
+              <div>
+                <a className="hover:underline" href="mailto:support@replay.io">
+                  Email support
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </>
   );
 }


### PR DESCRIPTION
Addresses [DES-33](https://linear.app/replay/issue/DES-33/add-a-forward-path-issues-discord-support-to-our-error-screens)

We're adding three links underneath our error messages that can help things feel less like a dead-end.

![image](https://user-images.githubusercontent.com/9154902/190329916-cd46f74e-6d34-4eea-9858-cb661ba9b15d.png)

![image](https://user-images.githubusercontent.com/9154902/190329958-45d0b5ec-b1a9-4b2c-938e-b28c92dfdae1.png)

![image](https://user-images.githubusercontent.com/9154902/190329984-56300b81-2031-453c-a056-3fa1893a40bc.png)

