### PR TITLE
Don't try to create pauses that will error

### DIFF
--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -65,7 +65,7 @@ import {
 } from "../reducers/timeline";
 import { framePositionsCleared, resumed } from "devtools/client/debugger/src/reducers/pause";
 
-import { getLoadedRegions } from "./app";
+import { getLoadedRegions, isPointInLoadingRegion } from "./app";
 import type { UIStore, UIThunkAction } from "./index";
 import { UIState } from "ui/state";
 
@@ -124,7 +124,9 @@ export function jumpToInitialPausePoint(): UIThunkAction {
       hasFrames = initialPausePoint.hasFrames;
       time = initialPausePoint.time;
     }
-    ThreadFront.timeWarp(point, time, hasFrames);
+    if (isPointInLoadingRegion(state, point)) {
+      ThreadFront.timeWarp(point, time, hasFrames);
+    }
   };
 }
 


### PR DESCRIPTION
If the pause that we would normally go to is out of the window we are trying to load, then we should not try and create it.

This was a tiny part of https://github.com/replayio/devtools/pull/7666/ but it's taking me a long time to get that PR in because I keep getting distracted by other things, and meanwhile this keeps happening, so I figured I would pull it out into its own tiny fix.