### PR TITLE
Change Focus Mode Learn More link

### DIFF
--- a/src/ui/components/Timeline/FocusModePopout.tsx
+++ b/src/ui/components/Timeline/FocusModePopout.tsx
@@ -81,7 +81,7 @@ export default function FocusModePopout() {
         <div className={styles.Text}>
           <strong>Focus mode</strong> lets you specify a region for your debugging.{" "}
           <a
-            href="https://docs.replay.io/docs/viewer-26591deb256c473a946d0f64abb67859#bf19baaa57004b0d9282cc0a02b281f5"
+            href="https://docs.replay.io/reference-guide/focus-mode"
             rel="noreferrer noopener"
             style={{ textDecoration: "underline" }}
             target="_blank"


### PR DESCRIPTION
While Answering a question from Glide I noticed the following:

We display a "Learn More" link when going into focus mode. When clicking on "Learn more" we're taken to a Notion page that doesn't mention region loading or focus mode: https://docs.replay.io/recording-a-web-app/viewing-and-collaborating

We should probably link to this page: https://docs.replay.io/reference-guide/focus-mode .