### PR TITLE
Fixed Keyboard Shortcuts issues

### DIFF
--- a/src/devtools/client/debugger/src/components/SecondaryPanes/CommandBar.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/CommandBar.tsx
@@ -26,25 +26,27 @@ const isMacOS = appinfo.OS === "Darwin";
 
 // NOTE: the "resume" command will call either the resume
 // depending on whether or not the debugger is paused or running
-const COMMANDS = ["resume", "stepOver", "stepIn", "stepOut"] as const;
+const COMMANDS = ["resume", "reverseStepOver", "stepOver", "stepIn", "stepOut"] as const;
 type PossibleCommands = typeof COMMANDS[number];
 
 const KEYS = {
   WINNT: {
     resume: "F8",
+    reverseStepOver: "Shift+F10",
     stepOver: "F10",
     stepIn: "F11",
     stepOut: "Shift+F11",
   },
   Darwin: {
     resume: "Cmd+\\",
+    reverseStepOver: "Cmd+Shift+'",
     stepOver: "Cmd+'",
     stepIn: "Cmd+;",
-    stepOut: "Cmd+Shift+:",
-    stepOutDisplay: "Cmd+Shift+;",
+    stepOut: "Cmd+Shift+;",
   },
   Linux: {
     resume: "F8",
+    reverseStepOver: "Shift+F10",
     stepOver: "F10",
     stepIn: "F11",
     stepOut: "Shift+F11",
@@ -73,7 +75,6 @@ function formatKey(action: string) {
 }
 
 class CommandBar extends Component<PropsFromRedux> {
-  commandBarNode = React.createRef<HTMLDivElement>();
   // @ts-expect-error it gets initialized in cDM
   shortcuts: KeyShortcuts | null;
 
@@ -86,7 +87,10 @@ class CommandBar extends Component<PropsFromRedux> {
   }
 
   componentDidMount() {
-    this.shortcuts = new KeyShortcuts({ window, target: this.commandBarNode.current });
+    this.shortcuts = new KeyShortcuts({
+      window,
+      target: document.body,
+    });
     const shortcuts = this.shortcuts;
 
     COMMANDS.forEach(action =>
@@ -239,11 +243,7 @@ class CommandBar extends Component<PropsFromRedux> {
   }
 
   render() {
-    return (
-      <div className="command-bar" ref={this.commandBarNode}>
-        {this.renderReplayButtons()}
-      </div>
-    );
+    return <div className="command-bar">{this.renderReplayButtons()}</div>;
   }
 }
 

--- a/src/devtools/client/shared/key-shortcuts.js
+++ b/src/devtools/client/shared/key-shortcuts.js
@@ -117,21 +117,15 @@ KeyShortcuts.parseElectronKey = function (window, str) {
   for (const mod of modifiers) {
     if (mod === "Alt") {
       shortcut.alt = true;
-    } else if (["Command", "Cmd"].includes(mod)) {
+    }
+    if (["Command", "Cmd"].includes(mod)) {
       shortcut.meta = true;
-    } else if (["CommandOrControl", "CmdOrCtrl"].includes(mod)) {
-      if (isOSX) {
-        shortcut.meta = true;
-      } else {
-        shortcut.ctrl = true;
-      }
-    } else if (["Control", "Ctrl"].includes(mod)) {
+    }
+    if (["Control", "Ctrl"].includes(mod)) {
       shortcut.ctrl = true;
-    } else if (mod === "Shift") {
+    }
+    if (mod === "Shift") {
       shortcut.shift = true;
-    } else {
-      console.error("Unsupported modifier:", mod, "from key:", str);
-      return null;
     }
   }
 
@@ -205,9 +199,11 @@ KeyShortcuts.parseXulKey = function (modifiers, shortcut) {
     .map(mod => {
       if (mod == "alt") {
         return "Alt";
-      } else if (mod == "shift") {
+      }
+      if (mod == "shift") {
         return "Shift";
-      } else if (mod == "accel") {
+      }
+      if (mod == "accel") {
         return "CmdOrCtrl";
       }
       return mod;


### PR DESCRIPTION
This PR fixes a couple of issues I noticed while looking at our keyboard shortcuts code (as part of FE-730):
* Add "reverse step over" shortcut, which was missing before.
* Fix incorrect "step out" command for Mac OS; it should be `Cmd+Shift+;` not `Cmd+Shift+:`.
* Fix a logic bug in command parsing that incorrectly parsed strings like "CommandOrControl".
* Target `CommandBar` (aka breakpoint shortcuts) on the document rather than the command bar itself. (How often is someone going to _focus on_ the little command bar?)

@markerikson Could you give this a test drive on Windows?