### PR TITLE
Fixed Keyboard Shortcuts (particularly for the CommandBar)

### DIFF
--- a/src/devtools/client/debugger/src/components/SecondaryPanes/CommandBar.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/CommandBar.tsx
@@ -26,25 +26,27 @@ const isMacOS = appinfo.OS === "Darwin";
 
 // NOTE: the "resume" command will call either the resume
 // depending on whether or not the debugger is paused or running
-const COMMANDS = ["resume", "stepOver", "stepIn", "stepOut"] as const;
+const COMMANDS = ["resume", "reverseStepOver", "stepOver", "stepIn", "stepOut"] as const;
 type PossibleCommands = typeof COMMANDS[number];
 
 const KEYS = {
   WINNT: {
     resume: "F8",
+    reverseStepOver: "Shift+F10",
     stepOver: "F10",
     stepIn: "F11",
     stepOut: "Shift+F11",
   },
   Darwin: {
     resume: "Cmd+\\",
+    reverseStepOver: "Cmd+Shift+'",
     stepOver: "Cmd+'",
     stepIn: "Cmd+;",
-    stepOut: "Cmd+Shift+:",
-    stepOutDisplay: "Cmd+Shift+;",
+    stepOut: "Cmd+Shift+;",
   },
   Linux: {
     resume: "F8",
+    reverseStepOver: "Shift+F10",
     stepOver: "F10",
     stepIn: "F11",
     stepOut: "Shift+F11",
@@ -73,7 +75,6 @@ function formatKey(action: string) {
 }
 
 class CommandBar extends Component<PropsFromRedux> {
-  commandBarNode = React.createRef<HTMLDivElement>();
   // @ts-expect-error it gets initialized in cDM
   shortcuts: KeyShortcuts | null;
 
@@ -86,7 +87,10 @@ class CommandBar extends Component<PropsFromRedux> {
   }
 
   componentDidMount() {
-    this.shortcuts = new KeyShortcuts({ window, target: this.commandBarNode.current });
+    this.shortcuts = new KeyShortcuts({
+      window,
+      target: document.body,
+    });
     const shortcuts = this.shortcuts;
 
     COMMANDS.forEach(action =>
@@ -239,11 +243,7 @@ class CommandBar extends Component<PropsFromRedux> {
   }
 
   render() {
-    return (
-      <div className="command-bar" ref={this.commandBarNode}>
-        {this.renderReplayButtons()}
-      </div>
-    );
+    return <div className="command-bar">{this.renderReplayButtons()}</div>;
   }
 }
 

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/NewObjectInspector.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/NewObjectInspector.tsx
@@ -15,7 +15,6 @@ import { useAppSelector } from "ui/setup/hooks";
 import styles from "./NewObjectInspector.module.css";
 
 export default function NewObjectInspector({ roots }: { roots: Item[] }) {
-  console.log("<NewObjectInspector>", roots);
   const selectedFrame = useAppSelector(getSelectedFrame);
   const pause = ThreadFront.pauseForAsyncIndex(selectedFrame?.asyncIndex);
 

--- a/src/devtools/client/shared/key-shortcuts.js
+++ b/src/devtools/client/shared/key-shortcuts.js
@@ -4,9 +4,7 @@
 
 "use strict";
 
-const Services = require("devtools/shared/services");
 const EventEmitter = require("devtools/shared/event-emitter");
-const isOSX = Services.appinfo.OS === "Darwin";
 const { KeyCodes } = require("devtools/client/shared/keycodes");
 
 // List of electron keys mapped to DOM API (DOM_VK_*) key code
@@ -106,6 +104,7 @@ KeyShortcuts.parseElectronKey = function (window, str) {
 
   const shortcut = {
     ctrl: false,
+    ctrlOrMeta: false,
     meta: false,
     alt: false,
     shift: false,
@@ -117,21 +116,18 @@ KeyShortcuts.parseElectronKey = function (window, str) {
   for (const mod of modifiers) {
     if (mod === "Alt") {
       shortcut.alt = true;
-    } else if (["Command", "Cmd"].includes(mod)) {
+    }
+    if (["CommandOrControl", "CmdOrCtrl"].includes(mod)) {
+      shortcut.ctrlOrMeta = true;
+    }
+    if (["Command", "Cmd"].includes(mod)) {
       shortcut.meta = true;
-    } else if (["CommandOrControl", "CmdOrCtrl"].includes(mod)) {
-      if (isOSX) {
-        shortcut.meta = true;
-      } else {
-        shortcut.ctrl = true;
-      }
-    } else if (["Control", "Ctrl"].includes(mod)) {
+    }
+    if (["Control", "Ctrl"].includes(mod)) {
       shortcut.ctrl = true;
-    } else if (mod === "Shift") {
+    }
+    if (mod === "Shift") {
       shortcut.shift = true;
-    } else {
-      console.error("Unsupported modifier:", mod, "from key:", str);
-      return null;
     }
   }
 
@@ -177,6 +173,9 @@ KeyShortcuts.stringify = function (shortcut) {
   if (shortcut.alt) {
     list.push("Alt");
   }
+  if (shortcut.ctrlOrMeta) {
+    list.push("CmdOrCtrl");
+  }
   if (shortcut.ctrl) {
     list.push("Ctrl");
   }
@@ -196,46 +195,30 @@ KeyShortcuts.stringify = function (shortcut) {
   return list.join("+");
 };
 
-/*
- * Parse an xul-like key string and return an electron-like string.
- */
-KeyShortcuts.parseXulKey = function (modifiers, shortcut) {
-  modifiers = modifiers
-    .split(",")
-    .map(mod => {
-      if (mod == "alt") {
-        return "Alt";
-      } else if (mod == "shift") {
-        return "Shift";
-      } else if (mod == "accel") {
-        return "CmdOrCtrl";
-      }
-      return mod;
-    })
-    .join("+");
-
-  if (shortcut.startsWith("VK_")) {
-    shortcut = shortcut.substr(3);
-  }
-
-  return modifiers + "+" + shortcut;
-};
-
 KeyShortcuts.prototype = {
   destroy() {
     this.keys.clear();
   },
 
   doesEventMatchShortcut(event, shortcut) {
-    if (shortcut.meta != event.metaKey) {
-      return false;
+    if (shortcut.ctrlOrMeta) {
+      if (!event.ctrlKey && !event.metaKey) {
+        return false;
+      }
+    } else {
+      if (shortcut.meta != event.metaKey) {
+        return false;
+      }
+
+      if (shortcut.ctrl != event.ctrlKey) {
+        return false;
+      }
     }
-    if (shortcut.ctrl != event.ctrlKey) {
-      return false;
-    }
+
     if (shortcut.alt != event.altKey) {
       return false;
     }
+
     if (shortcut.shift != event.shiftKey) {
       // Check the `keyCode` to see whether it's a character (see also Bug 1493646)
       const char = String.fromCharCode(event.keyCode);
@@ -273,6 +256,11 @@ KeyShortcuts.prototype = {
   },
 
   handleEvent(event) {
+    if (event.defaultPrevented) {
+      // Something else (e.g. React DevTools) has already claimed this event.
+      return;
+    }
+
     for (const [key, shortcut] of this.keys) {
       if (this.doesEventMatchShortcut(event, shortcut)) {
         this.eventEmitter.emit(key, event);


### PR DESCRIPTION
Re-landing #7747

This PR fixes a couple of issues I noticed while looking at our keyboard shortcuts code (as part of FE-730):
* Add "reverse step over" shortcut, which was missing before.
* Fix incorrect "step out" command for Mac OS; it should be `Cmd+Shift+;` not `Cmd+Shift+:`.
* Fix a logic bug in command parsing that incorrectly parsed strings like "CommandOrControl".
* Target `CommandBar` (aka breakpoint shortcuts) on the document rather than the command bar itself. (How often is someone going to _focus on_ the little command bar?)