### PR TITLE
Rewrite hit counts rendering to use a virtualized list for scroll perf

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Editor.css
+++ b/src/devtools/client/debugger/src/components/Editor/Editor.css
@@ -230,4 +230,5 @@ separately stack the pause line visuals and the code. */
 
 .editor-wrapper.showLineHits .CodeMirror-gutters .hit-markers {
   width: 30px;
+  position: relative;
 }

--- a/src/devtools/client/debugger/src/components/Editor/LineHitCounts.module.css
+++ b/src/devtools/client/debugger/src/components/Editor/LineHitCounts.module.css
@@ -6,10 +6,8 @@
   align-items: center;
   justify-content: center;
 
+  /* Height will be managed by the virtualized list renderer */
   width: 100%;
-  /* height: 15px;
-  height: calc(var(--theme-code-font-size) * 1.4); */
-
   font-size: 8px;
   border-left: 5px solid var(--gutter-hit-count-background);
 

--- a/src/devtools/client/debugger/src/components/Editor/LineHitCounts.module.css
+++ b/src/devtools/client/debugger/src/components/Editor/LineHitCounts.module.css
@@ -7,7 +7,8 @@
   justify-content: center;
 
   width: 100%;
-  height: calc(var(--theme-code-font-size) * 1.4);
+  height: 15px;
+  /* height: calc(var(--theme-code-font-size) * 1.4); */
 
   font-size: 8px;
   border-left: 5px solid var(--gutter-hit-count-background);

--- a/src/devtools/client/debugger/src/components/Editor/LineHitCounts.module.css
+++ b/src/devtools/client/debugger/src/components/Editor/LineHitCounts.module.css
@@ -7,8 +7,8 @@
   justify-content: center;
 
   width: 100%;
-  height: 15px;
-  /* height: calc(var(--theme-code-font-size) * 1.4); */
+  /* height: 15px;
+  height: calc(var(--theme-code-font-size) * 1.4); */
 
   font-size: 8px;
   border-left: 5px solid var(--gutter-hit-count-background);

--- a/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useLayoutEffect, useRef, useEffect } from "react";
+import { createPortal } from "react-dom";
 import { useFeature } from "ui/hooks/settings";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 
@@ -269,7 +270,27 @@ function LineHitCounts({ sourceEditor }: Props) {
   }, [focusRegion, hitCountMap]);
 
   // We're just here for the hooks!
-  return null;
+  // return null;
+  const scroller = sourceEditor.editor.getScrollerElement();
+  const hitsGutter = scroller.querySelector(".CodeMirror-gutter.hit-markers") as HTMLElement;
+  if (!hitsGutter) {
+    return;
+  }
+  console.log("Hits gutter: ", hitsGutter);
+  return createPortal(
+    <div
+      className="hitCountsOverlay"
+      style={{
+        position: "absolute",
+        width: "100%",
+        background: "linear-gradient(#e66465, #9198e5)",
+        top: 0,
+        left: 0,
+        height: "100%",
+      }}
+    ></div>,
+    hitsGutter
+  );
 }
 
 function hitCountsToMap(hitCounts: HitCount[]): Map<number, number> {

--- a/src/devtools/client/debugger/src/utils/editor/line-events.ts
+++ b/src/devtools/client/debugger/src/utils/editor/line-events.ts
@@ -29,7 +29,10 @@ const isHoveredOnGutter = (target: HTMLElement) => !!target.closest(".CodeMirror
 const getLineNodeFromGutterTarget = (target: HTMLElement) =>
   target.closest(".CodeMirror-gutter-wrapper")!.parentElement!.querySelector(".CodeMirror-line");
 
-function isValidTarget(target: HTMLElement) {
+function isValidTarget(target?: HTMLElement) {
+  if (!target) {
+    return false;
+  }
   const isNonBreakableLineNode = target.closest(".empty-line");
   const isTooltip = target.closest(".static-tooltip");
 
@@ -38,7 +41,10 @@ function isValidTarget(target: HTMLElement) {
   );
 }
 
-function emitLineMouseEnter(codeMirror: $FixTypeLater, target: HTMLElement) {
+function emitLineMouseEnter(codeMirror: $FixTypeLater, target?: HTMLElement) {
+  if (!target) {
+    return;
+  }
   trackEventOnce("editor.mouse_over");
   const lineNode = isHoveredOnLine(target)
     ? target.closest(".CodeMirror-line")


### PR DESCRIPTION
This PR:

- Entirely replaces the existing hit counts rendering logic to use a `react-window` virtualized list instead of manually inserting and updating DOM nodes in CodeMirror's gutter
- Adds null checks to a couple of line mouse event handlers (which I think only had issues because I was changing zoom levels, but doesn't hurt to check)

Up until now, we've shown hit counts by adding a "gutter" in CodeMirror. This adds an extra column on the left side, next to the line numbers gutter.  We then watched for incoming hit counts, and used `doc.eachLine(lower, upper)` to iterate over lines and manually insert/update DOM nodes with the right classnames and hit count text content.

This led to laggy scroll perf, as the process of updating those DOM nodes would cause CodeMirror to block the main thread, in prod builds, for around 200ms:

![image](https://user-images.githubusercontent.com/1128784/190523057-66772d0f-63bf-40a0-92cd-d5f3f73a6b0d.png)

I've completely rewritten the implementation.  Now, we still create that gutter (so that CodeMirror adjusts the line start location),  but we no longer insert/update DOM nodes manually.  Instead, we render a `react-window` virtualized list positioned absolutely on top of the CM gutter, pull list item heights from CodeMirror's own line metadata, and update the list scroll position to match any scroll events in the editor overall.

This improves perf in several ways:

- We no longer do as much work to ask CM to iterate over lines
- A chunk of the time in that perf screenshot was DOM reflow. Since the list is absolutely positioned, it shouldn't be affecting other layout as much
- Since the list is virtualized, there aren't nearly as many DOM nodes being added and updated
- Even though there's work done to re-render and keep the list in sync any time you scroll in the editor, it should be fairly minimal most of the time (especially with the generous amount of "overscroll" items rendered above and below)

I've confirmed this works in Chrome and FF on Windows, with both normal and "large" editor font text sizes.

The main issue I ran into was fractional list item sizes (like 16.36667px) causing drift as the file got very large.  The current logic appears to have fixed those.  I also had issues with print statements early in a file causing misalignment when you scrolled far past them, because `react-window` couldn't take those abnormal list item sizes into account.  I've hacked around this by manually forcing it to scroll to those lines synchronously in a `useLayoutEffect` whenever the list of print statements changes, render those rows and cache their sizes, then jump back to the actual scroll position.  This does actually work :)

The net result: I can smoothly scroll the entire 271K lines of `built/local/run.js` in Andarist's recording https://app.replay.io/recording/if-thingisbeautiful-andand-thingisbiggerthanbreadbox-oror-thingisyellow--6ea8b10b-3e04-4475-be94-e29820424d7e?point=13954297841544188978501389905821696&time=11491&hasFrames=false , smoothly, with no hiccups, _in a local dev build_.