### PR TITLE
Fix linter

### DIFF
--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -311,7 +311,9 @@ export function bindSelectors(store: UIStore, selectors: Partial<ObjectOfJustSel
   // Additionally, the "binding" of passing in `state` automatically messes up the TS types here.
   // I've attempted to get TS to accept that this is valid.
   return Object.entries(selectors).reduce((bound, [key, originalSelector]) => {
+    // @ts-expect-error
     bound[key as keyof BoundSelectors] = (...args: any[]) =>
+      // @ts-expect-error
       originalSelector(store.getState(), ...args);
     return bound;
   }, {} as BoundSelectors);


### PR DESCRIPTION
My trunk has been totally busted recently. It told me that I needed to remove these @ts-expect-error lines because there were no errors. Now it says it needs them back (and apparently I broke the `main` build in the process, sorry!)