### PR TITLE
Batch Code Mirror updates into RAF

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/EmptyLines.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/EmptyLines.tsx
@@ -33,7 +33,7 @@ interface ELProps {
 type FinalELProps = PropsFromRedux & ELProps;
 
 class EmptyLines extends Component<FinalELProps> {
-  _rafId: number | null = null;
+  _idCallbackId: number | null = null;
 
   componentDidMount() {
     this.disableEmptyLinesRaf();
@@ -44,8 +44,8 @@ class EmptyLines extends Component<FinalELProps> {
   }
 
   componentWillUnmount() {
-    if (this._rafId) {
-      cancelAnimationFrame(this._rafId);
+    if (this._idCallbackId) {
+      cancelIdleCallback(this._idCallbackId);
     }
 
     const { editor, lower, upper } = this.props;
@@ -58,12 +58,12 @@ class EmptyLines extends Component<FinalELProps> {
   }
 
   disableEmptyLinesRaf = () => {
-    if (this._rafId) {
-      cancelAnimationFrame(this._rafId);
+    if (this._idCallbackId) {
+      clearTimeout(this._idCallbackId);
     }
 
-    this._rafId = requestAnimationFrame(() => {
-      this._rafId = null;
+    this._idCallbackId = requestIdleCallback(() => {
+      this._idCallbackId = null;
       this.disableEmptyLines();
     });
   };

--- a/src/devtools/client/debugger/src/components/Editor/EmptyLines.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/EmptyLines.tsx
@@ -33,15 +33,21 @@ interface ELProps {
 type FinalELProps = PropsFromRedux & ELProps;
 
 class EmptyLines extends Component<FinalELProps> {
+  _rafId: number | null = null;
+
   componentDidMount() {
-    this.disableEmptyLines();
+    this.disableEmptyLinesRaf();
   }
 
   componentDidUpdate() {
-    this.disableEmptyLines();
+    this.disableEmptyLinesRaf();
   }
 
   componentWillUnmount() {
+    if (this._rafId) {
+      cancelAnimationFrame(this._rafId);
+    }
+
     const { editor, lower, upper } = this.props;
 
     editor.codeMirror.operation(() => {
@@ -50,6 +56,17 @@ class EmptyLines extends Component<FinalELProps> {
       });
     });
   }
+
+  disableEmptyLinesRaf = () => {
+    if (this._rafId) {
+      cancelAnimationFrame(this._rafId);
+    }
+
+    this._rafId = requestAnimationFrame(() => {
+      this._rafId = null;
+      this.disableEmptyLines();
+    });
+  };
 
   disableEmptyLines() {
     const { breakableLines, editor, lower, upper } = this.props;

--- a/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
@@ -239,16 +239,23 @@ function LineHitCounts({ sourceEditor }: Props) {
       });
     };
 
-    editor.on("change", drawLines);
-    editor.on("swapDoc", drawLines);
+    let idCallbackId: number | null = null;
+    const drawLinesRaf = () => {
+      idCallbackId = requestIdleCallback(drawLines);
+    };
 
-    const rafId = requestAnimationFrame(drawLines);
+    editor.on("change", drawLinesRaf);
+    editor.on("swapDoc", drawLinesRaf);
+
+    drawLinesRaf();
 
     return () => {
-      cancelAnimationFrame(rafId);
+      if (idCallbackId !== null) {
+        cancelIdleCallback(idCallbackId);
+      }
 
-      editor.off("change", drawLines);
-      editor.off("swapDoc", drawLines);
+      editor.off("change", drawLinesRaf);
+      editor.off("swapDoc", drawLinesRaf);
     };
   }, [
     sourceEditor,

--- a/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
@@ -242,9 +242,11 @@ function LineHitCounts({ sourceEditor }: Props) {
     editor.on("change", drawLines);
     editor.on("swapDoc", drawLines);
 
-    drawLines();
+    const rafId = requestAnimationFrame(drawLines);
 
     return () => {
+      cancelAnimationFrame(rafId);
+
       editor.off("change", drawLines);
       editor.off("swapDoc", drawLines);
     };


### PR DESCRIPTION
Potential alternative to #7753 for discussion.

Basically this batches the updates we were making (in layout effects) that invalidated layout into animation frames. Seems like the impact of this change is comparable to the change in #7753 based on my anecdotal perf profiling?

Loom walk through: https://www.loom.com/share/f930fdb5c13b42acb2a0c92dd584b674