### PR TITLE
Fix vertical alignment for Console prefix badges

### DIFF
--- a/packages/bvaughn-architecture-demo/components/console/renderers/shared.module.css
+++ b/packages/bvaughn-architecture-demo/components/console/renderers/shared.module.css
@@ -130,21 +130,18 @@
 
 .ColorBadge,
 .UnicornBadge {
-  position: absolute;
-  left: 0.25rem;
+  position: relative;
   display: inline-block;
   width: 0.5rem;
   height: 0.5rem;
-  flex: 0 0 0.5rem;
-  margin: 0 0.25rem;
+  margin: 0 0.5rem 0 -1rem;
 }
 .ColorBadge {
-  top: 0.75rem;
   border-radius: 0.5rem;
   background-color: var(--badge-color);
 }
 .UnicornBadge {
-  top: 0.5rem;
+  top: 0.25rem;
   overflow: visible;
 }
 .Unicorn {


### PR DESCRIPTION
<img width="540" alt="Screen Shot 2022-09-16 at 2 30 50 PM" src="https://user-images.githubusercontent.com/29597/190707973-7bd81c12-4225-48a2-b02d-f86b84baa1cd.png">
