### PR TITLE
Show the pause line faster when stepping

### DIFF
--- a/packages/protocol/thread/thread.ts
+++ b/packages/protocol/thread/thread.ts
@@ -684,7 +684,8 @@ class _ThreadFront {
     }
 
     const epoch = this.resumeTargetEpoch;
-    const { target } = await command({ point }, this.sessionId);
+    const resp = await command({ point }, this.sessionId);
+    const { target } = resp;
     if (epoch == this.resumeTargetEpoch) {
       this.updateMappedLocation(target.frame);
       this.resumeTargets.set(key, target);
@@ -728,6 +729,7 @@ class _ThreadFront {
         time: this.currentTime,
       });
     }
+
     if (
       resumeTarget &&
       loadedRegions.loaded.every(
@@ -739,25 +741,26 @@ class _ThreadFront {
     if (resumeTarget && resumeEmitted) {
       warpToTarget();
     }
+    return resumeTarget;
   }
 
   rewind(point: ExecutionPoint, loadedRegions: LoadedRegions) {
-    this._resumeOperation(client.Debugger.findRewindTarget, point, loadedRegions);
+    return this._resumeOperation(client.Debugger.findRewindTarget, point, loadedRegions);
   }
   resume(point: ExecutionPoint, loadedRegions: LoadedRegions) {
-    this._resumeOperation(client.Debugger.findResumeTarget, point, loadedRegions);
+    return this._resumeOperation(client.Debugger.findResumeTarget, point, loadedRegions);
   }
   reverseStepOver(point: ExecutionPoint, loadedRegions: LoadedRegions) {
-    this._resumeOperation(client.Debugger.findReverseStepOverTarget, point, loadedRegions);
+    return this._resumeOperation(client.Debugger.findReverseStepOverTarget, point, loadedRegions);
   }
   stepOver(point: ExecutionPoint, loadedRegions: LoadedRegions) {
-    this._resumeOperation(client.Debugger.findStepOverTarget, point, loadedRegions);
+    return this._resumeOperation(client.Debugger.findStepOverTarget, point, loadedRegions);
   }
   stepIn(point: ExecutionPoint, loadedRegions: LoadedRegions) {
-    this._resumeOperation(client.Debugger.findStepInTarget, point, loadedRegions);
+    return this._resumeOperation(client.Debugger.findStepInTarget, point, loadedRegions);
   }
   stepOut(point: ExecutionPoint, loadedRegions: LoadedRegions) {
-    this._resumeOperation(client.Debugger.findStepOutTarget, point, loadedRegions);
+    return this._resumeOperation(client.Debugger.findStepOutTarget, point, loadedRegions);
   }
 
   async resumeTarget(point: ExecutionPoint) {

--- a/src/devtools/client/debugger/src/actions/pause/paused.ts
+++ b/src/devtools/client/debugger/src/actions/pause/paused.ts
@@ -21,13 +21,6 @@ import { isPointInLoadingRegion } from "ui/reducers/app";
 
 type $FixTypeLater = any;
 
-/**
- * Debugger has just paused
- *
- * @param {object} pauseInfo
- * @memberof actions/pause
- * @static
- */
 export function paused({
   executionPoint,
   frame,

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/FrameTimeline.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/FrameTimeline.tsx
@@ -9,7 +9,6 @@ import React, { Component } from "react";
 import { connect, ConnectedProps } from "react-redux";
 import { selectors } from "ui/reducers";
 import { actions } from "ui/actions";
-import { previewLocationCleared } from "devtools/client/debugger/src/reducers/pause";
 
 import classnames from "classnames";
 import ReactTooltip from "react-tooltip";
@@ -106,7 +105,7 @@ class FrameTimeline extends Component<PropsFromRedux, FrameTimelineState> {
   };
 
   onMouseUp = (event: MouseEvent) => {
-    const { seek, clearPreviewPausedLocation } = this.props;
+    const { seek } = this.props;
 
     const progress = this.getProgress(event.clientX);
     const position = this.getPosition(progress);
@@ -114,7 +113,6 @@ class FrameTimeline extends Component<PropsFromRedux, FrameTimelineState> {
 
     if (position) {
       seek(position.point, position.time, true);
-      clearPreviewPausedLocation();
     }
   };
 
@@ -193,7 +191,6 @@ const connector = connect(
   {
     seek: actions.seek,
     setPreviewPausedLocation: actions.setPreviewPausedLocation,
-    clearPreviewPausedLocation: previewLocationCleared,
   }
 );
 


### PR DESCRIPTION
This change starts updating our pause reducer so that we can use the returned target location as the pause preview location.

There are some other things we'll want to do here to ensure preview pause locations are set/cleared appropriately, but should be hot

https://www.loom.com/share/c4c5fceb42184e31bf9fc63081a30ae8