### PR TITLE
Don't do an `immer` update for every array change

### DIFF
--- a/src/ui/reducers/timeline.ts
+++ b/src/ui/reducers/timeline.ts
@@ -54,14 +54,16 @@ const timelineSlice = createSlice({
       state.focusRegion = action.payload;
     },
     pointsReceived(state, action: PayloadAction<TimeStampedPoint[]>) {
+      const mutablePoints = [...state.points];
       state.points = mergeSortedPointLists(
-        state.points,
+        mutablePoints,
         sortBy(action.payload, p => BigInt(p.point))
       );
     },
     paintsReceived(state, action: PayloadAction<TimeStampedPoint[]>) {
+      const mutablePaints = [...state.paints];
       state.paints = mergeSortedPointLists(
-        state.paints,
+        mutablePaints,
         sortBy(action.payload, p => BigInt(p.point))
       );
     },


### PR DESCRIPTION
We want all of these updates to count as *one* update.

Before: https://share.firefox.dev/3BNZhei
After: https://share.firefox.dev/3S73Cyw