### PR TITLE
Go forward / backward in the pause history

### DIFF
--- a/src/devtools/client/debugger/src/actions/pause/history.ts
+++ b/src/devtools/client/debugger/src/actions/pause/history.ts
@@ -1,0 +1,30 @@
+import { pauseHistoryDecremented, pauseHistoryIncremented } from "../../reducers/pause";
+import { getPauseHistory, getPauseHistoryIndex } from "../../selectors";
+import { seek } from "ui/actions/timeline";
+import { UIThunkAction } from "ui/actions";
+
+export function seekToPreviousPause(): UIThunkAction {
+  return function (dispatch, getState) {
+    const pauseHistory = getPauseHistory(getState());
+    const pauseHistoryIndex = getPauseHistoryIndex(getState());
+
+    const pause = pauseHistory[pauseHistoryIndex - 2];
+    if (pause) {
+      dispatch(pauseHistoryDecremented());
+      dispatch(seek(pause.executionPoint, pause.time, pause.hasFrames, pause.pauseId));
+    }
+  };
+}
+
+export function seekToNextPause(): UIThunkAction {
+  return function (dispatch, getState) {
+    const pauseHistory = getPauseHistory(getState());
+    const pauseHistoryIndex = getPauseHistoryIndex(getState());
+
+    const pause = pauseHistory[pauseHistoryIndex + 1];
+    if (pause) {
+      dispatch(pauseHistoryIncremented());
+      dispatch(seek(pause.executionPoint, pause.time, pause.hasFrames, pause.pauseId));
+    }
+  };
+}

--- a/src/devtools/client/debugger/src/actions/pause/index.ts
+++ b/src/devtools/client/debugger/src/actions/pause/index.ts
@@ -2,16 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-//
-
-/**
- * Redux actions for the pause state
- * @module actions/pause
- */
-
 export { stepIn, stepOver, stepOut, resume, rewind, reverseStepOver } from "./commands";
 export { fetchScopes, resumed } from "../../reducers/pause";
 export { paused } from "./paused";
 export { selectFrame } from "./selectFrame";
 export * from "./previewPausedLocation";
+export * from "./history";
 export { setFramePositions } from "./setFramePositions";

--- a/src/devtools/client/debugger/src/actions/pause/previewPausedLocation.ts
+++ b/src/devtools/client/debugger/src/actions/pause/previewPausedLocation.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 import type { UIThunkAction } from "ui/actions";
-import type { Context } from "devtools/client/debugger/src/reducers/pause";
 import { Location } from "@replayio/protocol";
 import { previewLocationUpdated } from "../../reducers/pause";
 

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -42,6 +42,7 @@ import {
 
 import { toggleFocusMode } from "./timeline";
 import { ReplayClientInterface } from "shared/client/types";
+import { seekToPreviousPause, seekToNextPause } from "devtools/client/debugger/src/actions/pause";
 
 const supportsPerformanceNow =
   typeof performance !== "undefined" && typeof performance.now === "function";
@@ -277,6 +278,10 @@ export function executeCommand(key: CommandKey): UIThunkAction {
       dispatch(setToolboxLayout("left"));
     } else if (key === "pin_to_bottom_right") {
       dispatch(setToolboxLayout("ide"));
+    } else if (key === "seek_to_previous_pause") {
+      dispatch(seekToPreviousPause());
+    } else if (key === "seek_to_next_pause") {
+      dispatch(seekToNextPause());
     }
 
     dispatch(hideCommandPalette());

--- a/src/ui/components/CommandPalette/CommandPalette.tsx
+++ b/src/ui/components/CommandPalette/CommandPalette.tsx
@@ -2,10 +2,7 @@ import clamp from "lodash/clamp";
 import React, { ChangeEvent, useState } from "react";
 import { connect, ConnectedProps } from "react-redux";
 import { actions } from "ui/actions";
-import hooks from "ui/hooks";
-import { selectors } from "ui/reducers";
-import { UIState } from "ui/state";
-import { ExperimentalUserSettings } from "ui/types";
+
 import CommandButton from "./CommandButton";
 import SearchInput from "./SearchInput";
 import { filter } from "fuzzaldrin-plus";
@@ -40,7 +37,9 @@ export type CommandKey =
   | "show_sharing"
   | "toggle_dark_mode"
   | "toggle_edit_focus"
-  | "toggle_video";
+  | "toggle_video"
+  | "seek_to_previous_pause"
+  | "seek_to_next_pause";
 
 const COMMANDS: readonly Command[] = [
   { key: "open_console", label: "Open Console" },
@@ -70,6 +69,8 @@ const COMMANDS: readonly Command[] = [
   { key: "pin_to_bottom", label: "Pin Toolbox To Bottom" },
   { key: "pin_to_left", label: "Pin Toolbox To Left" },
   { key: "pin_to_bottom_right", label: "Pin Toolbox To Bottom Right" },
+  { key: "seek_to_previous_pause", label: "Jump To Previous Pause", shortcut: "Cmd+Z" },
+  { key: "seek_to_next_pause", label: "Jump To Next Pause", shortcut: "Cmd+Shift+Z" },
 ] as const;
 
 const DEFAULT_COMMANDS: readonly CommandKey[] = [

--- a/src/ui/components/KeyboardShortcuts.tsx
+++ b/src/ui/components/KeyboardShortcuts.tsx
@@ -44,6 +44,8 @@ function KeyboardShortcuts({
   setViewMode,
   toggleCommandPalette,
   toggleFocusMode,
+  seekToPreviousPause,
+  seekToNextPause,
   togglePaneCollapse,
   viewMode,
   toggleThemeAction,
@@ -154,6 +156,8 @@ function KeyboardShortcuts({
       "CmdOrCtrl+Shift+O": toggleFunctionQuickOpenModal,
       "CmdOrCtrl+O": toggleProjectFunctionQuickOpenModal,
       "CmdOrCtrl+G": toggleLineQuickOpenModal,
+      "CmdOrCtrl+Z": seekToPreviousPause,
+      "Shift+CmdOrCtrl+Z": seekToNextPause,
 
       "~": toggleProtocolTimeline,
 
@@ -176,6 +180,8 @@ function KeyboardShortcuts({
     toggleQuickOpen,
     closeOpenModalsOnEscape,
     createFrameComment,
+    seekToNextPause,
+    seekToPreviousPause,
     recordingId,
   ]);
 
@@ -208,6 +214,8 @@ const connector = connect(
     toggleCommandPalette: actions.toggleCommandPalette,
     toggleFocusMode: actions.toggleFocusMode,
     toggleThemeAction: actions.toggleTheme,
+    seekToPreviousPause: actions.seekToPreviousPause,
+    seekToNextPause: actions.seekToNextPause,
     toggleQuickOpen,
     closeOpenModalsOnEscape,
   }


### PR DESCRIPTION
The ability to pop the stack and go back to a prior pause has been requested for a long time. I think we can bind these actions to cmd+z, cmd+shift+z, and surface them in the command palette