### PR TITLE
Rewrite hit counts logic to improve perf and correctness

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/EmptyLines.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/EmptyLines.tsx
@@ -33,7 +33,7 @@ interface ELProps {
 type FinalELProps = PropsFromRedux & ELProps;
 
 class EmptyLines extends Component<FinalELProps> {
-  _idCallbackId: number | null = null;
+  _rafId: number | null = null;
 
   componentDidMount() {
     this.disableEmptyLinesRaf();
@@ -44,8 +44,8 @@ class EmptyLines extends Component<FinalELProps> {
   }
 
   componentWillUnmount() {
-    if (this._idCallbackId) {
-      cancelIdleCallback(this._idCallbackId);
+    if (this._rafId) {
+      cancelAnimationFrame(this._rafId);
     }
 
     const { editor, lower, upper } = this.props;
@@ -58,12 +58,12 @@ class EmptyLines extends Component<FinalELProps> {
   }
 
   disableEmptyLinesRaf = () => {
-    if (this._idCallbackId) {
-      clearTimeout(this._idCallbackId);
+    if (this._rafId) {
+      cancelAnimationFrame(this._rafId);
     }
 
-    this._idCallbackId = requestIdleCallback(() => {
-      this._idCallbackId = null;
+    this._rafId = requestAnimationFrame(() => {
+      this._rafId = null;
       this.disableEmptyLines();
     });
   };

--- a/src/devtools/client/debugger/src/components/Editor/EmptyLines.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/EmptyLines.tsx
@@ -33,7 +33,7 @@ interface ELProps {
 type FinalELProps = PropsFromRedux & ELProps;
 
 class EmptyLines extends Component<FinalELProps> {
-  _rafId: number | null = null;
+  _idCallbackId: number | null = null;
 
   componentDidMount() {
     this.disableEmptyLinesRaf();
@@ -44,8 +44,8 @@ class EmptyLines extends Component<FinalELProps> {
   }
 
   componentWillUnmount() {
-    if (this._rafId) {
-      cancelAnimationFrame(this._rafId);
+    if (this._idCallbackId) {
+      cancelIdleCallback(this._idCallbackId);
     }
 
     const { editor, lower, upper } = this.props;
@@ -58,12 +58,12 @@ class EmptyLines extends Component<FinalELProps> {
   }
 
   disableEmptyLinesRaf = () => {
-    if (this._rafId) {
-      cancelAnimationFrame(this._rafId);
+    if (this._idCallbackId) {
+      clearTimeout(this._idCallbackId);
     }
 
-    this._rafId = requestAnimationFrame(() => {
-      this._rafId = null;
+    this._idCallbackId = requestIdleCallback(() => {
+      this._idCallbackId = null;
       this.disableEmptyLines();
     });
   };

--- a/src/devtools/client/debugger/src/components/Editor/EmptyLines.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/EmptyLines.tsx
@@ -33,15 +33,21 @@ interface ELProps {
 type FinalELProps = PropsFromRedux & ELProps;
 
 class EmptyLines extends Component<FinalELProps> {
+  _rafId: number | null = null;
+
   componentDidMount() {
-    this.disableEmptyLines();
+    this.disableEmptyLinesRaf();
   }
 
   componentDidUpdate() {
-    this.disableEmptyLines();
+    this.disableEmptyLinesRaf();
   }
 
   componentWillUnmount() {
+    if (this._rafId) {
+      cancelAnimationFrame(this._rafId);
+    }
+
     const { editor, lower, upper } = this.props;
 
     editor.codeMirror.operation(() => {
@@ -50,6 +56,17 @@ class EmptyLines extends Component<FinalELProps> {
       });
     });
   }
+
+  disableEmptyLinesRaf = () => {
+    if (this._rafId) {
+      cancelAnimationFrame(this._rafId);
+    }
+
+    this._rafId = requestAnimationFrame(() => {
+      this._rafId = null;
+      this.disableEmptyLines();
+    });
+  };
 
   disableEmptyLines() {
     const { breakableLines, editor, lower, upper } = this.props;

--- a/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
@@ -239,16 +239,23 @@ function LineHitCounts({ sourceEditor }: Props) {
       });
     };
 
-    editor.on("change", drawLines);
-    editor.on("swapDoc", drawLines);
+    let idCallbackId: number | null = null;
+    const drawLinesRaf = () => {
+      idCallbackId = requestIdleCallback(drawLines);
+    };
 
-    const rafId = requestAnimationFrame(drawLines);
+    editor.on("change", drawLinesRaf);
+    editor.on("swapDoc", drawLinesRaf);
+
+    drawLinesRaf();
 
     return () => {
-      cancelAnimationFrame(rafId);
+      if (idCallbackId !== null) {
+        cancelIdleCallback(idCallbackId);
+      }
 
-      editor.off("change", drawLines);
-      editor.off("swapDoc", drawLines);
+      editor.off("change", drawLinesRaf);
+      editor.off("swapDoc", drawLinesRaf);
     };
   }, [
     sourceEditor,

--- a/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
@@ -19,6 +19,7 @@ import { UIState } from "ui/state";
 import type { SourceEditor } from "../../utils/editor/source-editor";
 import { getFocusRegion } from "ui/reducers/timeline";
 import { FocusRegion } from "ui/state/timeline";
+import { calculateHitCountChunksForVisibleLines } from "devtools/client/debugger/src/utils/editor/lineHitCounts";
 
 type Props = {
   sourceEditor: SourceEditor;
@@ -154,114 +155,97 @@ function LineHitCounts({ sourceEditor }: Props) {
     const { editor } = sourceEditor;
 
     const drawLines = () => {
-      const focusRegionChanged = focusRegion !== previousFocusRegion.current;
-      const hitCountMapChanged = hitCountMap !== previousHitCounts.current;
+      const uniqueChunks = calculateHitCountChunksForVisibleLines(sourceEditor);
 
-      // `drawLines` will run reasonably often. However, we will often
-      // want to bail out early and _not_ apply updates to the gutter markers.
-      // The main reason to bail out is if there is no current line number,
-      // which happens any time the mouse is over an "inactive" line in the editor,
-      // or outside the editor entirely.
-      // However, there are a couple situations when we _do_ still want to redraw
-      // even if the mouse isn't over a valid line:
-      // - The focus region just changed
-      // - We refetched hit counts due to the user closing the focus bar
-      if (!focusRegionChanged && !hitCountMapChanged) {
-        return;
-      }
-
-      // Attempt to update just the markers for just the 100-line blocks  surrounding
-      // the current line number
       editor.operation(() => {
-        editor.eachLine(lower, upper, lineHandle => {
-          const currentCMLineNumber = editor.getLineNumber(lineHandle);
-          if (currentCMLineNumber === null) {
-            return;
-          }
-
-          // CM uses 0-based indexing. Our hit counts are 1-indexed.
-          let oneIndexedLineNumber = currentCMLineNumber + 1;
-          const hitCount = hitCountMap?.get(oneIndexedLineNumber) || 0;
-
-          // Skip this line if we've updated it with its current hit count already
-          if (updatedLineNumbers?.has(oneIndexedLineNumber)) {
-            return;
-          }
-
-          updatedLineNumbers?.add(oneIndexedLineNumber);
-
-          // We use a gradient to indicate the "heat" (the number of hits).
-          // This absolute hit count values are relative, per file.
-          // Cubed root prevents high hit counts from lumping all other values together.
-          const NUM_GRADIENT_COLORS = 3;
-          let className = styles.HitsBadge0;
-          let index = NUM_GRADIENT_COLORS - 1;
-          if (hitCount > 0) {
-            if (minHitCount !== maxHitCount) {
-              index = Math.min(
-                NUM_GRADIENT_COLORS - 1,
-                Math.round(
-                  ((hitCount - minHitCount) / (maxHitCount - minHitCount)) * NUM_GRADIENT_COLORS
-                )
-              );
+        for (let hitCountChunk of uniqueChunks) {
+          // Attempt to update just the markers for just the 100-line blocks
+          // overlapping the visible display area
+          const { lower, upper } = hitCountChunk;
+          editor.eachLine(lower, upper, lineHandle => {
+            const currentCMLineNumber = editor.getLineNumber(lineHandle);
+            if (currentCMLineNumber === null) {
+              return;
             }
-            className = styles[`HitsBadge${index + 1}`];
-          }
 
-          if (features.disableUnHitLines) {
+            // CM uses 0-based indexing. Our hit counts are 1-indexed.
+            let oneIndexedLineNumber = currentCMLineNumber + 1;
+            const hitCount = hitCountMap?.get(oneIndexedLineNumber) || 0;
+
+            // We use a gradient to indicate the "heat" (the number of hits).
+            // This absolute hit count values are relative, per file.
+            // Cubed root prevents high hit counts from lumping all other values together.
+            const NUM_GRADIENT_COLORS = 3;
+            let className = styles.HitsBadge0;
+            let index = NUM_GRADIENT_COLORS - 1;
             if (hitCount > 0) {
-              sourceEditor.codeMirror.removeLineClass(lineHandle, "line", "empty-line");
+              if (minHitCount !== maxHitCount) {
+                index = Math.min(
+                  NUM_GRADIENT_COLORS - 1,
+                  Math.round(
+                    ((hitCount - minHitCount) / (maxHitCount - minHitCount)) * NUM_GRADIENT_COLORS
+                  )
+                );
+              }
+              className = styles[`HitsBadge${index + 1}`];
+            }
+
+            if (features.disableUnHitLines) {
+              if (hitCount > 0) {
+                sourceEditor.codeMirror.removeLineClass(lineHandle, "line", "empty-line");
+              } else {
+                // If this line wasn't hit any, dim the line number,
+                // even if it's a line that's technically reachable.
+                sourceEditor.codeMirror.addLineClass(lineHandle, "line", "empty-line");
+              }
+            }
+
+            const info = editor.lineInfo(lineHandle);
+
+            let markerNode: HTMLDivElement;
+            if (info?.gutterMarkers?.["hit-markers"]) {
+              // Retrieve the marker DOM node we already created
+              markerNode = info.gutterMarkers["hit-markers"];
             } else {
-              // If this line wasn't hit any, dim the line number,
-              // even if it's a line that's technically reachable.
-              sourceEditor.codeMirror.addLineClass(lineHandle, "line", "empty-line");
+              markerNode = document.createElement("div");
+              markerNode.onclick = () =>
+                updateHitCountsMode(isCollapsedRef.current ? "show-counts" : "hide-counts");
+
+              editor.setGutterMarker(lineHandle, "hit-markers", markerNode);
             }
-          }
 
-          const info = editor.lineInfo(lineHandle);
-
-          let markerNode: HTMLDivElement;
-          if (info?.gutterMarkers?.["hit-markers"]) {
-            // Retrieve the marker DOM node we already created
-            markerNode = info.gutterMarkers["hit-markers"];
-          } else {
-            markerNode = document.createElement("div");
-            markerNode.onclick = () =>
-              updateHitCountsMode(isCollapsedRef.current ? "show-counts" : "hide-counts");
-
-            editor.setGutterMarker(lineHandle, "hit-markers", markerNode);
-          }
-
-          markerNode.className = className;
-          if (!isCollapsed) {
-            let hitsLabel = "";
-            if (hitCount > 0) {
-              hitsLabel = hitCount < 1000 ? `${hitCount}` : `${(hitCount / 1000).toFixed(1)}k`;
+            markerNode.className = className;
+            if (!isCollapsed) {
+              let hitsLabel = "";
+              if (hitCount > 0) {
+                hitsLabel = hitCount < 1000 ? `${hitCount}` : `${(hitCount / 1000).toFixed(1)}k`;
+              }
+              markerNode.textContent = hitsLabel;
             }
-            markerNode.textContent = hitsLabel;
-          }
-          markerNode.title = `${hitCount} hits`;
-        });
+            markerNode.title = `${hitCount} hits`;
+          });
+        }
       });
     };
 
-    let rafId: number | null = 0;
-    // let idCallbackId: number | null = null;
+    let animationFrameId: number | null = 0;
     const drawLinesRaf = () => {
-      rafId = requestAnimationFrame(drawLines);
+      animationFrameId = requestAnimationFrame(drawLines);
     };
 
     editor.on("change", drawLinesRaf);
     editor.on("swapDoc", drawLinesRaf);
+    editor.on("scroll", drawLinesRaf);
 
     drawLines();
 
     return () => {
-      if (rafId !== null) {
-        cancelAnimationFrame(rafId);
+      if (animationFrameId !== null) {
+        cancelAnimationFrame(animationFrameId);
       }
       editor.off("change", drawLinesRaf);
       editor.off("swapDoc", drawLinesRaf);
+      editor.off("scroll", drawLinesRaf);
     };
   }, [
     sourceEditor,

--- a/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
@@ -242,9 +242,11 @@ function LineHitCounts({ sourceEditor }: Props) {
     editor.on("change", drawLines);
     editor.on("swapDoc", drawLines);
 
-    drawLines();
+    const rafId = requestAnimationFrame(drawLines);
 
     return () => {
+      cancelAnimationFrame(rafId);
+
       editor.off("change", drawLines);
       editor.off("swapDoc", drawLines);
     };

--- a/src/devtools/client/debugger/src/components/SourceOutline/getOutlineSymbols.tsx
+++ b/src/devtools/client/debugger/src/components/SourceOutline/getOutlineSymbols.tsx
@@ -35,7 +35,10 @@ function getClosestHitCount(
     }
   } else {
     const hitCounts = hitCountsByLine[start.line];
-    const hitCount = hitCounts?.find(hitCount => hitCount.location.column! >= start.column);
+    if (!hitCounts) {
+      return undefined;
+    }
+    const hitCount = hitCounts.find(hitCount => hitCount.location.column! >= start.column);
     return hitCount;
   }
 }
@@ -50,7 +53,7 @@ function addHitCountsToFunctions(
 
   return functions.map(functionSymbol => {
     const hitCount = getClosestHitCount(hitCountsByLine, functionSymbol.location);
-    return { ...functionSymbol, hits: hitCount?.hits };
+    return Object.assign({}, functionSymbol, { hits: hitCount?.hits }); // { ...functionSymbol, hits: hitCount?.hits };
   });
 }
 

--- a/src/devtools/client/debugger/src/selectors/visibleColumnBreakpoints.ts
+++ b/src/devtools/client/debugger/src/selectors/visibleColumnBreakpoints.ts
@@ -16,7 +16,7 @@ import {
   SourceContent,
   getSelectedLocation,
 } from "ui/reducers/sources";
-import { getPossibleBreakpointsForSource } from "ui/reducers/possibleBreakpoints";
+import { getPossibleBreakpointsForSourceNormalized } from "ui/reducers/possibleBreakpoints";
 import type { Breakpoint, Range, SourceLocation } from "../reducers/types";
 import { getViewport } from "../reducers/ui";
 import { sortSelectedLocations } from "../utils/location";
@@ -154,25 +154,25 @@ export const getVisibleColumnBreakpoints = createSelector(
 );
 
 export function getFirstBreakpointPosition(state: UIState, { line, sourceId }: SourceLocation) {
-  const positions = getPossibleBreakpointsForSource(state, sourceId);
+  const positions = getPossibleBreakpointsForSourceNormalized(state, sourceId);
   const source = getSourceDetails(state, sourceId);
 
   if (!source || !positions) {
     return;
   }
 
-  const possibleBreakpointsForLine = positions.filter(position => {
-    return position.line === line;
-  });
+  let locationColumn = 0;
+  const possibleBreakpointsForLine = positions[line];
+  if (possibleBreakpointsForLine) {
+    const sortedColumns = possibleBreakpointsForLine.sort((a, b) => a - b);
 
-  const sortedLocations = sortSelectedLocations(possibleBreakpointsForLine);
-
-  // There _should_ be at least one location here, but handle safely
-  const [firstLocation] = sortedLocations;
+    // There _should_ be at least one location here, but handle safely
+    locationColumn = sortedColumns[0];
+  }
 
   return {
-    line: firstLocation?.line,
-    column: firstLocation?.column,
+    line: line,
+    column: locationColumn,
     sourceId,
     sourceUrl: source.url,
   };

--- a/src/devtools/client/debugger/src/utils/editor/lineHitCounts.ts
+++ b/src/devtools/client/debugger/src/utils/editor/lineHitCounts.ts
@@ -1,0 +1,26 @@
+import { getUniqueHitCountsChunksForLines } from "ui/reducers/hitCounts";
+
+import { SourceEditor } from "./source-editor";
+
+export function calculateHitCountChunksForVisibleLines(editor: SourceEditor) {
+  var rect = editor.codeMirror.getWrapperElement().getBoundingClientRect();
+  var topVisibleLine = editor.codeMirror.lineAtHeight(rect.top, "window");
+  var bottomVisibleLine = editor.codeMirror.lineAtHeight(rect.bottom, "window");
+
+  const viewport = editor.editor.getViewport();
+  const { from: topViewportLine, to: bottomViewportLine } = viewport;
+  const centerLine = ((bottomViewportLine - topViewportLine) / 2) | 0;
+
+  // We want to try to ensure we have hit counts above and below the viewport
+  // Can't go less than line index 0, though
+  const bufferAboveLine = Math.max(topVisibleLine - 10, 0);
+  const bufferBelowLine = bottomVisibleLine + 10;
+
+  // But, some of these lines could belong to the same 100-line chunk
+  const uniqueChunks = getUniqueHitCountsChunksForLines(
+    centerLine,
+    bufferAboveLine,
+    bufferBelowLine
+  );
+  return uniqueChunks;
+}

--- a/src/ui/reducers/hitCounts.ts
+++ b/src/ui/reducers/hitCounts.ts
@@ -9,6 +9,7 @@ import { fetchProtocolHitCounts, firstColumnForLocations } from "protocol/thread
 import { listenForCondition } from "ui/setup/listenerMiddleware";
 import { LoadingStatus } from "ui/utils/LoadingStatus";
 import { createSelector } from "reselect";
+import uniqBy from "lodash/uniqBy";
 
 export interface HitCount {
   location: Location;
@@ -211,5 +212,11 @@ export const getHitCountsForSourceByLine = createSelector(getHitCountsForSource,
   }
   return hitCountsByLine;
 });
+
+export const getUniqueHitCountsChunksForLines = (...lines: number[]) => {
+  const lineChunks = lines.map(line => getBoundsForLineNumber(line));
+  const uniqueChunks = uniqBy(lineChunks, chunk => chunk.lower);
+  return uniqueChunks;
+};
 
 export default hitCountsSlice.reducer;

--- a/src/ui/reducers/possibleBreakpoints.ts
+++ b/src/ui/reducers/possibleBreakpoints.ts
@@ -115,13 +115,30 @@ export const getPossibleBreakpointsForSource = (state: UIState, sourceId: string
   return adapterSelectors.selectById(state, sourceId)?.possibleBreakpoints;
 };
 
+export const EMPTY_LOCATIONS: Location[] = [];
+
 export const getPossibleBreakpointsForSelectedSource = (state: UIState): Location[] => {
   const sourceId = getSelectedLocation(state)?.sourceId;
   if (!sourceId) {
-    return [];
+    return EMPTY_LOCATIONS;
   }
-  return getPossibleBreakpointsForSource(state, sourceId) || [];
+  return getPossibleBreakpointsForSource(state, sourceId) || EMPTY_LOCATIONS;
 };
+
+export const getPossibleBreakpointsForSourceNormalized = createSelector(
+  getPossibleBreakpointsForSource,
+  (possibleBreakpoints = []) => {
+    const linesToColumns: Record<number, number[]> = {};
+    for (let location of possibleBreakpoints) {
+      if (!linesToColumns[location.line]) {
+        linesToColumns[location.line] = [];
+      }
+      linesToColumns[location.line].push(location.column);
+    }
+
+    return linesToColumns;
+  }
+);
 
 export const getBreakableLinesForSource = (state: UIState, sourceId: string) => {
   return adapterSelectors.selectById(state, sourceId)?.breakableLines;


### PR DESCRIPTION
This PR:

- Starts with Brian's attempt to batch some hit counts updates using `requestIdleCallback`, and switches it back to his previous attempt to use `requestAnimationFrame` (which I found to be smoother)
- Makes some major updates to the hit counts rendering logic to improve perf:
  - Wrapped the `add/removeClass` lines in `cm.operation()`, which delays all CM-internal reflow calculations until after all of those individual operations are complete
  - **Reworked the line index handling to fix an off-by-one issue caused by calling `cm.getLineInfo(lineNumber)` (FE-748)**. CM uses 0-based indexing, but our `lineNumber` at that point was 1-indexed.  So, I think we were getting the right hit counts out of the map, but attaching the marker DOM node on the wrong line.
  - Improved behavior around when we bail out of updating the markers
- Improved perf around fetching hit counts for a hovered line:
  - Debounced the `fetchHitCountsForVisibleLines` method so we don't keep running it as you mouse around
  - Fixed the logic for calculating top/bottom lines so we don't go out of bounds and try to fetch lines `-100..0`
  - Deduplicated lines that could be in the same 100-line chunk, to minimize thunk dispatches
- Adds the correct `editor: SourceEditor` type across our editor UI components
- Updates "get breakable columns for a line" selection logic to use a normalized lookup table, which fixes a small hotspot I consistently saw in `useGetHitPointsForHoveredLine` and `getFirstBreakpoint`