### PR TITLE
Switch default hit counts setting to "show-counts"

### DIFF
--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -18,7 +18,7 @@ pref("devtools.sidePanelSize", "240px");
 pref("devtools.theme", "system");
 pref("devtools.toolbox-size", "50%");
 pref("devtools.consoleFilterDrawerExpanded", true);
-pref("devtools.hitCounts", "hide-counts");
+pref("devtools.hitCounts", "show-counts");
 
 // app features
 pref("devtools.features.basicProcessingLoadingBar", false);


### PR DESCRIPTION
Per request in SCS-129  , this changes the pref for hit counts to "show numbers" by default.  

(If users have actually selected a setting themselves, that setting will be preserved.)