### PR TITLE
use css for panel width

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.css
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.css
@@ -2,10 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-.breakpoint-panel-wrapper {
-  min-width: 300px;
-}
-
 .breakpoint-panel {
   margin: 4px 0;
   background: var(--theme-toolbar-background);

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.tsx
@@ -25,14 +25,6 @@ import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { UnsafeFocusRegion } from "ui/state/timeline";
 import { getHitPointsForLocation } from "bvaughn-architecture-demo/src/suspense/PointsCache";
 
-function getPanelWidth({ editor }: { editor: $FixTypeLater }) {
-  // The indent value is an adjustment for the distance from the gutter's left edge
-  // to the panel's left edge, which is approximately ~60.
-  const panelIndent = 60;
-
-  return editor.getScrollInfo().clientWidth - panelIndent;
-}
-
 const connector = connect(
   (state: UIState) => ({
     currentTime: selectors.getCurrentTime(state),

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.tsx
@@ -68,7 +68,6 @@ function Panel({
 }: PanelProps) {
   const [editing, setEditing] = useState(false);
   const [showCondition, setShowCondition] = useState(Boolean(breakpoint!.options.condition)); // nosemgrep
-  const [width, setWidth] = useState(getPanelWidth(editor)); // nosemgrep
   const [inputToFocus, setInputToFocus] = useState<"condition" | "logValue">("logValue");
   const dismissNag = hooks.useDismissNag();
 
@@ -125,15 +124,6 @@ function Panel({
     (hitPoints?.length || 0) > MAX_POINTS_FOR_FULL_ANALYSIS;
 
   useEffect(() => {
-    const updateWidth = () => setWidth(getPanelWidth(editor));
-
-    editor.editor.on("refresh", updateWidth);
-    return () => {
-      editor.editor.off("refresh", updateWidth);
-    };
-  }, [editor]);
-
-  useEffect(() => {
     dismissNag(Nag.FIRST_BREAKPOINT_ADD);
   }, [dismissNag]);
 
@@ -165,12 +155,7 @@ function Panel({
 
   return (
     <Widget location={breakpoint!.location} editor={editor} insertAt={insertAt}>
-      <div
-        className="breakpoint-panel-wrapper"
-        style={{ width: `${width}px` }}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
-      >
+      <div onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
         <FirstEditNag editing={editing} />
         <div className={classnames("breakpoint-panel", { editing })}>
           <div className="flex space-x-0.5 pt-2 pl-1 pr-4">


### PR DESCRIPTION
Since we are now using a full width panel this moves from a JavaScript solution to a CSS-only solution.

## Future Considerations

I'm prototyping an approach [here](https://codesandbox.io/s/min-fill-panels-7ebbmw) to better shrink the Print Statement Panel so the controls are always visible.