### PR TITLE
Cleanup how the add print statement button works

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Breakpoints.css
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Breakpoints.css
@@ -43,8 +43,8 @@
 .empty-line .toggle-widget {
   background: #8abfd8 !important;
 }
-rgb(44, 161, 214)rgb(108, 208, 255)rgb(94, 191, 236)rgb(150, 214, 244)
-  .editor-wrapper
+
+.editor-wrapper
   :not(.empty-line):not(.new-breakpoint)
   > .CodeMirror-gutter-wrapper
   > .CodeMirror-linenumber:hover::after {

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Breakpoints.css
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Breakpoints.css
@@ -36,7 +36,15 @@
   pointer-events: all;
 }
 
-.editor-wrapper
+.empty-line .line-action-button {
+  pointer-events: none !important;
+}
+
+.empty-line .toggle-widget {
+  background: #8abfd8 !important;
+}
+rgb(44, 161, 214)rgb(108, 208, 255)rgb(94, 191, 236)rgb(150, 214, 244)
+  .editor-wrapper
   :not(.empty-line):not(.new-breakpoint)
   > .CodeMirror-gutter-wrapper
   > .CodeMirror-linenumber:hover::after {

--- a/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
@@ -131,10 +131,19 @@ function LineHitCounts({ sourceEditor }: Props) {
     // HACK
     // When hit counts are shown, the hover button (to add a log point) should not overlap with the gutter.
     // That component doesn't know about hit counts though, so we can inform its position via a CSS variable.
-    const gutterElement = sourceEditor.codeMirror.getGutterElement();
-    (gutterElement as HTMLElement).parentElement!.style.setProperty(
-      "--hit-count-gutter-width",
-      `-${gutterWidth}`
+    const gutterElement = sourceEditor.codeMirror.getGutterElement() as HTMLElement;
+
+    gutterElement.parentElement!.style.setProperty("--hit-count-gutter-width", `-${gutterWidth}`);
+
+    // If hit counts are shown, the button should not overlap with the gutter.
+    // The gutter size changes though based on the number of hits, so we use a CSS variable.
+    gutterElement.parentElement!.style.setProperty(
+      "--print-statement-button-right-offset",
+      hitCountsMode === "show-counts"
+        ? "calc(var(--hit-count-gutter-width) - 6px)"
+        : hitCountsMode === "hide-counts"
+        ? "-10px"
+        : "0px"
     );
 
     return () => {
@@ -145,7 +154,7 @@ function LineHitCounts({ sourceEditor }: Props) {
       }
       resizeBreakpointGutter(editor);
     };
-  }, [gutterWidth, sourceEditor, isCollapsed]);
+  }, [gutterWidth, sourceEditor, isCollapsed, hitCountsMode]);
 
   useLayoutEffect(() => {
     if (!sourceEditor) {

--- a/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
@@ -138,7 +138,7 @@ function LineHitCounts({ sourceEditor }: Props) {
     // If hit counts are shown, the button should not overlap with the gutter.
     // The gutter size changes though based on the number of hits, so we use a CSS variable.
     gutterElement.parentElement!.style.setProperty(
-      "--print-statement-button-right-offset",
+      "--print-statement-right-offset",
       hitCountsMode === "show-counts"
         ? "calc(var(--hit-count-gutter-width) - 6px)"
         : hitCountsMode === "hide-counts"

--- a/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
@@ -17,11 +17,9 @@ import { getSelectedSource } from "ui/reducers/sources";
 
 import StaticTooltip from "./StaticTooltip";
 import {
-  getBoundsForLineNumber,
   fetchHitCounts,
   getHitCountsForSource,
   getHitCountsStatusForSourceByLine,
-  getUniqueHitCountsChunksForLines,
 } from "ui/reducers/hitCounts";
 import { LoadingStatus } from "ui/utils/LoadingStatus";
 import { calculateRangeChunksForVisibleLines } from "devtools/client/debugger/src/utils/editor/lineHitCounts";

--- a/src/devtools/client/debugger/src/components/Editor/StaticTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/StaticTooltip.tsx
@@ -1,7 +1,7 @@
 import classNames from "classnames";
 import React from "react";
 import ReactDOM from "react-dom";
-import { useFeature } from "ui/hooks/settings";
+import { useFeature, useStringPref } from "ui/hooks/settings";
 
 type StaticTooltipProps = {
   targetNode: HTMLElement;
@@ -11,15 +11,23 @@ type StaticTooltipProps = {
 
 export default function StaticTooltip({ targetNode, children }: StaticTooltipProps) {
   const { value: enableLargeText } = useFeature("enableLargeText");
-  const { value: hitCounts } = useFeature("hitCounts");
+  const { value: hitCountsMode } = useStringPref("hitCounts");
 
   return ReactDOM.createPortal(
     <div
       className={classNames(
         "pointer-events-none absolute bottom-4 z-50 mb-0.5 flex translate-x-full transform flex-row space-x-px",
         enableLargeText && "bottom-6",
-        hitCounts ? "-right-[20px]" : "-right-1"
+        hitCountsMode === "show-counts" ? "-right-[20px]" : "-right-[10px]"
       )}
+      style={{
+        right:
+          hitCountsMode === "show-counts"
+            ? "calc(var(--hit-count-gutter-width) - 6px)"
+            : hitCountsMode === "hide-counts"
+            ? "-10px"
+            : "0px",
+      }}
     >
       {children}
     </div>,

--- a/src/devtools/client/debugger/src/components/Editor/StaticTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/StaticTooltip.tsx
@@ -18,7 +18,7 @@ export default function StaticTooltip({ targetNode, children }: StaticTooltipPro
         "pointer-events-none absolute bottom-4 z-50 mb-0.5 flex translate-x-full transform flex-row space-x-px",
         enableLargeText && "bottom-6"
       )}
-      style={{ right: "var(--print-statement-button-right-offset)" }}
+      style={{ right: "var(--print-statement-right-offset)" }}
     >
       {children}
     </div>,

--- a/src/devtools/client/debugger/src/components/Editor/StaticTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/StaticTooltip.tsx
@@ -20,14 +20,7 @@ export default function StaticTooltip({ targetNode, children }: StaticTooltipPro
         enableLargeText && "bottom-6",
         hitCountsMode === "show-counts" ? "-right-[20px]" : "-right-[10px]"
       )}
-      style={{
-        right:
-          hitCountsMode === "show-counts"
-            ? "calc(var(--hit-count-gutter-width) - 6px)"
-            : hitCountsMode === "hide-counts"
-            ? "-10px"
-            : "0px",
-      }}
+      style={{ right: "var(--print-statement-button-right-offset)" }}
     >
       {children}
     </div>,

--- a/src/devtools/client/debugger/src/components/Editor/StaticTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/StaticTooltip.tsx
@@ -1,7 +1,7 @@
 import classNames from "classnames";
 import React from "react";
 import ReactDOM from "react-dom";
-import { useFeature, useStringPref } from "ui/hooks/settings";
+import { useFeature } from "ui/hooks/settings";
 
 type StaticTooltipProps = {
   targetNode: HTMLElement;
@@ -11,14 +11,12 @@ type StaticTooltipProps = {
 
 export default function StaticTooltip({ targetNode, children }: StaticTooltipProps) {
   const { value: enableLargeText } = useFeature("enableLargeText");
-  const { value: hitCountsMode } = useStringPref("hitCounts");
 
   return ReactDOM.createPortal(
     <div
       className={classNames(
         "pointer-events-none absolute bottom-4 z-50 mb-0.5 flex translate-x-full transform flex-row space-x-px",
-        enableLargeText && "bottom-6",
-        hitCountsMode === "show-counts" ? "-right-[20px]" : "-right-[10px]"
+        enableLargeText && "bottom-6"
       )}
       style={{ right: "var(--print-statement-button-right-offset)" }}
     >

--- a/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
@@ -97,7 +97,6 @@ function QuickActions({
   const showNag = shouldShowNag(nags, Nag.FIRST_BREAKPOINT_ADD);
   const { height } = targetNode.getBoundingClientRect();
   const { value: enableLargeText } = useFeature("enableLargeText");
-  const { value: hitCountsMode } = useStringPref("hitCounts");
 
   const [hitPoints, hitPointStatus] = useHitPointsForHoveredLocation();
 
@@ -147,16 +146,7 @@ function QuickActions({
       onMouseDown={onMouseDown}
       style={{
         top: `-${(1 / 2) * (18 - height)}px`,
-
-        // If hit counts are shown, the button should not overlap with the gutter.
-        // The gutter size changes though based on the number of hits, so we use a CSS variable.
-        right:
-          // we should move this util to a shared function
-          hitCountsMode === "show-counts"
-            ? "calc(var(--hit-count-gutter-width) - 6px)"
-            : hitCountsMode === "hide-counts"
-            ? "-10px"
-            : "0px",
+        right: "var(--print-statement-button-right-offset)",
       }}
     >
       {button}

--- a/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
@@ -146,7 +146,7 @@ function QuickActions({
       onMouseDown={onMouseDown}
       style={{
         top: `-${(1 / 2) * (18 - height)}px`,
-        right: "var(--print-statement-button-right-offset)",
+        right: "var(--print-statement-right-offset)",
       }}
     >
       {button}

--- a/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
@@ -75,7 +75,6 @@ const AddLogpoint: FC<{ showNag: boolean; onClick: () => void; breakpoint?: Brea
 };
 
 function QuickActions({
-  isLineHitCountsCollapsed,
   hoveredLineNumber,
   onMouseDown,
   keyModifiers,
@@ -83,7 +82,6 @@ function QuickActions({
   breakpoint,
   cx,
 }: {
-  isLineHitCountsCollapsed: boolean;
   hoveredLineNumber: number;
   onMouseDown: MouseEventHandler;
   keyModifiers: KeyModifiers;
@@ -99,7 +97,7 @@ function QuickActions({
   const showNag = shouldShowNag(nags, Nag.FIRST_BREAKPOINT_ADD);
   const { height } = targetNode.getBoundingClientRect();
   const { value: enableLargeText } = useFeature("enableLargeText");
-  const { value: hitCounts } = useFeature("hitCounts");
+  const { value: hitCountsMode } = useStringPref("hitCounts");
 
   const [hitPoints, hitPointStatus] = useHitPointsForHoveredLocation();
 
@@ -143,8 +141,7 @@ function QuickActions({
     <div
       className={classNames(
         "line-action-button absolute z-50 flex translate-x-full transform flex-row space-x-px",
-        enableLargeText && "bottom-0.5",
-        hitCounts ? (isLineHitCountsCollapsed ? "-right-2" : "-right-5") : "-right-1"
+        enableLargeText && "bottom-0.5"
       )}
       // This is necessary so that we don't move the CodeMirror cursor while clicking.
       onMouseDown={onMouseDown}
@@ -153,7 +150,13 @@ function QuickActions({
 
         // If hit counts are shown, the button should not overlap with the gutter.
         // The gutter size changes though based on the number of hits, so we use a CSS variable.
-        right: hitCounts ? "var(--hit-count-gutter-width)" : undefined,
+        right:
+          // we should move this util to a shared function
+          hitCountsMode === "show-counts"
+            ? "calc(var(--hit-count-gutter-width) - 6px)"
+            : hitCountsMode === "hide-counts"
+            ? "-10px"
+            : "0px",
       }}
     >
       {button}
@@ -167,9 +170,7 @@ type ToggleWidgetButtonProps = PropsFromRedux & ExternalProps;
 function ToggleWidgetButton({ editor, cx, breakpoints }: ToggleWidgetButtonProps) {
   const [targetNode, setTargetNode] = useState<HTMLElement | null>(null);
   const [hoveredLineNumber, setHoveredLineNumber] = useState<number | null>(null);
-  const { value: hitCountsMode } = useStringPref("hitCounts");
 
-  const isLineHitCountsCollapsed = hitCountsMode === "hide-counts";
   const bp = breakpoints.find((b: any) => b.location.line === hoveredLineNumber);
   const onMouseDown = (e: React.MouseEvent) => {
     // This keeps the cursor in CodeMirror from moving after clicking on the button.
@@ -208,7 +209,6 @@ function ToggleWidgetButton({ editor, cx, breakpoints }: ToggleWidgetButtonProps
     <KeyModifiersContext.Consumer>
       {keyModifiers => (
         <QuickActions
-          isLineHitCountsCollapsed={isLineHitCountsCollapsed}
           hoveredLineNumber={hoveredLineNumber}
           onMouseDown={onMouseDown}
           targetNode={targetNode}

--- a/src/devtools/client/debugger/src/utils/editor/line-events.ts
+++ b/src/devtools/client/debugger/src/utils/editor/line-events.ts
@@ -30,12 +30,9 @@ const getLineNodeFromGutterTarget = (target: HTMLElement) =>
   target.closest(".CodeMirror-gutter-wrapper")!.parentElement!.querySelector(".CodeMirror-line");
 
 function isValidTarget(target: HTMLElement) {
-  const isNonBreakableLineNode = target.closest(".empty-line");
   const isTooltip = target.closest(".static-tooltip");
 
-  return (
-    (isHoveredOnLine(target) || isHoveredOnGutter(target)) && !isNonBreakableLineNode && !isTooltip
-  );
+  return (isHoveredOnLine(target) || isHoveredOnGutter(target)) && !isTooltip;
 }
 
 function emitLineMouseEnter(codeMirror: $FixTypeLater, target: HTMLElement) {


### PR DESCRIPTION
We have a bunch of inconsistencies
* where the print statement buttons are shown 
* when we show the print statement button vs the line number tooltip

Some tasks
- [x] standardize the positioning logic
- [x] always show the print statement / line number tooltip button, but with clearer states


---
* [replay](https://app.replay.io/recording/tootltip-is-not-shown-for-empty-lines--098307a8-5d48-4447-993d-c9f06d249873?point=66850822074994001409865378804278314&time=38175&hasFrames=true&focusRegion=eyJiZWdpbiI6eyJwb2ludCI6IjE3NTI0MDAxODk4NTczODgyMjg1NzU0NTA0OTk3NTA2NTEwIiwidGltZSI6ODg2NSwic2NyZWVuU2hvdHMiOlt7Im1pbWVUeXBlIjoiaW1hZ2UvanBlZyIsImhhc2giOiI5MDI1ODcxODYifV19LCJlbmQiOnsicG9pbnQiOiI2ODc5NzkzMzM5ODczNjcwMjE1NjY1NjM1NDUwMDAyODE3MyIsInRpbWUiOjM4OTI4LCJraW5kIjoibW91c2Vtb3ZlIiwiY2xpZW50WCI6Nzc3LCJjbGllbnRZIjoxOTc3fX0%253D)