### PR TITLE
Don't render empty Console row

### DIFF
--- a/packages/bvaughn-architecture-demo/components/inspector/values/ClientValueValueRenderer.tsx
+++ b/packages/bvaughn-architecture-demo/components/inspector/values/ClientValueValueRenderer.tsx
@@ -48,5 +48,5 @@ export default function ClientValueValueRenderer({
       break;
   }
 
-  return <span className={className}>{preview}</span>;
+  return <span className={className}>{preview || " "}</span>;
 }


### PR DESCRIPTION
I noticed this while testing FE-722

### Before
![Screen Shot 2022-09-20 at 2 55 57 PM](https://user-images.githubusercontent.com/29597/191341427-53bec286-ff7d-4571-a677-f7dd1f932115.png)

### After
![Screen Shot 2022-09-20 at 2 55 36 PM](https://user-images.githubusercontent.com/29597/191341444-d900865e-51a0-40a8-a7c0-75f875106ad9.png)
