### PR TITLE
fix hit counts showing when collapsed

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
@@ -103,7 +103,7 @@ function LineHitCounts({ sourceEditor }: Props) {
     return numCharsToFit;
   }, [maxHitCount]);
 
-  const gutterWidth = isCollapsed ? "1ch" : `${numCharsToFit + 1}ch`;
+  const gutterWidth = isCollapsed ? "5px" : `${numCharsToFit + 1}ch`;
 
   // Save `isCollapsed` in a ref so we only create `marker.onClick` callbacks once
   // TODO Candidate for the eventual `useEvent` hook?


### PR DESCRIPTION
This fixes hit counts showing when collapsed by using a fixed pixel width for the collapsed state rather than the character unit.

closes FE-740