### PR TITLE
Fixed a `Maximum call stack exceeded` err in `getAlternateSourceIdForPosition`

### DIFF
--- a/src/devtools/client/debugger/src/utils/sourceVisualizations.ts
+++ b/src/devtools/client/debugger/src/utils/sourceVisualizations.ts
@@ -153,6 +153,19 @@ function getUniqueAlternateSourceId(
   return { sourceId: alternateSourceId };
 }
 
+function min(arr: number[]) {
+  if (arr.length === 0) {
+    return Infinity;
+  }
+  let lowest = arr[0];
+  for (let i = 1; i < arr.length; i++) {
+    if (arr[i] < lowest) {
+      lowest = arr[i];
+    }
+  }
+  return lowest;
+}
+
 function getAlternateSourceIdForPosition(
   client: ReplayClientInterface,
   source: SourceDetails,
@@ -160,8 +173,8 @@ function getAlternateSourceIdForPosition(
   sourcesById: Dictionary<SourceDetails>
 ) {
   const lineLocations = getBreakpointPositionsSuspense(client, source.id);
-  const breakableLine = Math.min(
-    ...lineLocations.filter(ll => ll.line >= position.line).map(ll => ll.line)
+  const breakableLine = min(
+    lineLocations.filter(ll => ll.line >= position.line).map(ll => ll.line)
   );
 
   const breakableLineLocations = lineLocations.find(ll => ll.line === breakableLine);


### PR DESCRIPTION
I noticed this error in the console and reported it a couple of days ago on Discord:
<img width="537" alt="Screenshot 2022-09-20 at 23 34 08" src="https://user-images.githubusercontent.com/9800850/191368918-f9877c2a-4c90-430c-83af-12845c83968a.png">

I couldn't repro it in Replay (it only happens for me in Chrome) - I'm not sure what **exactly** leads to it. However, when asked by @bvaughn for some more details about this I started to dig deeper. I was able to confirm that this happens for a minified code line that looks like this:
```js
, i = Math.min(...o.filter((e=>e.line >= n.line)).map((e=>e.line)))
```
and I was able to trace it back to this in the source code:
https://github.com/replayio/devtools/blob/8772827d70e442035de769681c7a191fa62cabf4/src/devtools/client/debugger/src/utils/sourceVisualizations.ts#L163-L165

The problem with `fn(...arr)` is that it pushes all array elements onto the stack and that can blow up the stack. Usually, this is not an issue but it turns out that `o` is quite huge here:
<img width="1602" alt="Screenshot 2022-09-20 at 23 41 30" src="https://user-images.githubusercontent.com/9800850/191369948-a00f93b3-a13d-458f-9c2d-0aa5f7cb70b5.png">

Note that on this screenshot we see both the original `o` and the result of the `filter`+`map` - we can notice that their lengths are the same. This might indicate a bug - but I don't know what exactly those code lines are meant to do so I'm not sure.

In case this isn't a bug on its own... I've prepared this simple fix that just doesn't rely on the spread.

You can also test the "issue" with spread by evaluating this in the Chrome's console:
```ts
var huge = Array.from({ length: 150000 }, (_, i) => i)
console.log(Math.min(...huge)) // throws Maximum call stack exceeded
```

Note that FF has a bigger allowed stack and it might be the reason why it doesn't happen in Replay. I've recorded the situation in Replay and added a comment to the call site receiving this huge array, you might find it helpful: https://app.replay.io/recording/max-call-stack-exceeded-in-replay-just-in-chrome--018c0ea7-1ffe-446e-8020-e7e45f14d228