### PR TITLE
Rewrite autocompletion to remove fronts

### DIFF
--- a/packages/bvaughn-architecture-demo/src/suspense/MappedLocationCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/MappedLocationCache.ts
@@ -9,7 +9,10 @@ export const {
   getValueSuspense: getMappedLocationSuspense,
   getValueAsync: getMappedLocationAsync,
   getValueIfCached: getMappedLocationIfCached,
-} = createGenericCache<[ReplayClientInterface, ProtocolLocation], ProtocolMappedLocation>(
+} = createGenericCache<
+  [replayClient: ReplayClientInterface, location: ProtocolLocation],
+  ProtocolMappedLocation
+>(
   (client, location) => client.getMappedLocation(location),
   (client, location) => `${location.sourceId}:${location.line}:${location.column}`
 );

--- a/packages/bvaughn-architecture-demo/src/suspense/SourcesCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/SourcesCache.ts
@@ -118,7 +118,11 @@ export const {
   getValueAsync: getBreakpointPositionsAsync,
   getValueIfCached: getBreakpointPositionsIfCached,
 } = createGenericCache<
-  [ReplayClientInterface, ProtocolSourceId, SourceLocationRange?],
+  [
+    replayClient: ReplayClientInterface,
+    sourceId: ProtocolSourceId,
+    locationRange?: SourceLocationRange
+  ],
   ProtocolSameLineSourceLocations[]
 >(
   (client, sourceId, range) => client.getBreakpointPositions(sourceId, range),

--- a/packages/protocol/thread/pause.ts
+++ b/packages/protocol/thread/pause.ts
@@ -385,7 +385,7 @@ export class Pause {
           this.addData(data);
         }
         const scope = this.scopes.get(id);
-        assert(scope, "scope not found");
+        assert(scope, `scope not found (scope ID: ${id})`);
         return scope;
       })
     );
@@ -393,7 +393,7 @@ export class Pause {
 
   async getScopes(frameId: FrameId) {
     const frame = this.frames.get(frameId);
-    assert(frame, "frame not found");
+    assert(frame, `frame not found (frame ID: ${frameId})`);
 
     // Normally we use the original scope chain for the frame if there is one,
     // but when a generated source is marked as preferred we use the generated

--- a/src/ui/suspense/frameCache.ts
+++ b/src/ui/suspense/frameCache.ts
@@ -7,7 +7,7 @@ export const {
   getValueSuspense: getFramesSuspense,
   getValueAsync: getFramesAsync,
   getValueIfCached: getFramesIfCached,
-} = createGenericCache<[PauseId], Frame[] | undefined>(
+} = createGenericCache<[pauseId: PauseId], Frame[] | undefined>(
   async pauseId => {
     const pause = Pause.getById(pauseId);
     assert(pause, `no pause for ${pauseId}`);

--- a/src/ui/suspense/frameStepsCache.ts
+++ b/src/ui/suspense/frameStepsCache.ts
@@ -7,7 +7,7 @@ export const {
   getValueSuspense: getFrameStepsSuspense,
   getValueAsync: getFrameStepsAsync,
   getValueIfCached: getFrameStepsIfCached,
-} = createGenericCache<[PauseId, FrameId], PointDescription[]>(
+} = createGenericCache<[pauseId: PauseId, frameId: FrameId], PointDescription[]>(
   (pauseId, frameId) => {
     const pause = Pause.getById(pauseId);
     assert(pause, `no pause for ${pauseId}`);

--- a/src/ui/suspense/scopeCache.ts
+++ b/src/ui/suspense/scopeCache.ts
@@ -3,7 +3,7 @@ import { createGenericCache } from "@bvaughn/src/suspense/createGenericCache";
 import { Pause } from "protocol/thread/pause";
 import { assert } from "protocol/utils";
 
-interface FrameScopes {
+export interface FrameScopes {
   scopes: Scope[];
   originalScopesUnavailable: boolean;
 }
@@ -16,6 +16,12 @@ export const {
   async (pauseId, frameId) => {
     const pause = Pause.getById(pauseId);
     assert(pause, `no pause for ${pauseId}`);
+    // Wait until the pause is "created" to see if we have frames
+    await pause.createWaiter;
+    if (!pause.hasFrames) {
+      return { scopes: [], originalScopesUnavailable: true };
+    }
+
     const { scopes: wiredScopes, originalScopesUnavailable } = await pause.getScopes(frameId);
     const scopes = wiredScopes.map(f => pause!.rawScopes.get(f.scopeId)!);
     return { scopes, originalScopesUnavailable };

--- a/src/ui/suspense/scopeCache.ts
+++ b/src/ui/suspense/scopeCache.ts
@@ -12,7 +12,7 @@ export const {
   getValueSuspense: getScopesSuspense,
   getValueAsync: getScopesAsync,
   getValueIfCached: getScopesIfCached,
-} = createGenericCache<[PauseId, FrameId], FrameScopes>(
+} = createGenericCache<[pauseId: PauseId, frameId: FrameId], FrameScopes>(
   async (pauseId, frameId) => {
     const pause = Pause.getById(pauseId);
     assert(pause, `no pause for ${pauseId}`);


### PR DESCRIPTION
This PR:

- Updates all of our `createGenericCache` usages to add labels to the "parameter type" tuples, so we get meaningful variable names like `(frameId, pauseId)` instead of `(arg_0, arg_1)`
- Rewrites the autocompletion logic to replace uses of `ValueFront` and `ThreadFront.evaluate()` with corresponding object cache fetching logic and `ThreadFront.evaluateNew()`