### PR TITLE
Set height in requestAnimationFrame for perf

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
@@ -18,7 +18,7 @@ import findLast from "lodash/findLast";
 import { compareNumericStrings } from "protocol/utils";
 import { getExecutionPoint } from "../../reducers/pause";
 import { seek } from "ui/actions/timeline";
-import { useFeature, useStringPref } from "ui/hooks/settings";
+import { useFeature } from "ui/hooks/settings";
 import useHitPointsForHoveredLocation from "ui/hooks/useHitPointsForHoveredLocation";
 
 const QuickActionButton: FC<{
@@ -89,13 +89,21 @@ function QuickActions({
   breakpoint?: Breakpoint;
   cx: any;
 }) {
+  const [height, setHeight] = useState(18);
+  useEffect(() => {
+    const animationFrameId = requestAnimationFrame(() =>
+      setHeight(targetNode.getBoundingClientRect().height)
+    );
+
+    return () => cancelAnimationFrame(animationFrameId);
+  }, [targetNode]);
+
   const isMetaActive = keyModifiers.meta;
   const isShiftActive = keyModifiers.shift;
   const dispatch = useAppDispatch();
   const executionPoint = useAppSelector(getExecutionPoint);
   const { nags } = hooks.useGetUserInfo();
   const showNag = shouldShowNag(nags, Nag.FIRST_BREAKPOINT_ADD);
-  const { height } = targetNode.getBoundingClientRect();
   const { value: enableLargeText } = useFeature("enableLargeText");
 
   const [hitPoints, hitPointStatus] = useHitPointsForHoveredLocation();


### PR DESCRIPTION
`requestAnimationFrame` fires right after the DOM has just calculated layout anyways, so reading from dom rects is usually cheaper when done here, where no recalc is required. If we call `getBoundingClientRect` in render, we are causing style recalcs, which are expensive.

Before:
https://share.firefox.dev/3dzkSy0

![CleanShot 2022-09-21 at 14 18 33](https://user-images.githubusercontent.com/5903784/191612522-76832ca8-f9e8-4fbe-8f37-528aa849c636.png)


After:
https://share.firefox.dev/3Bxej73

I don't have a screenshot because `getBoundingClientRect` is only in 3 samples so it does not make it on to that list 🙂 