### PR TITLE
Disable pure eval for Chromium

### DIFF
--- a/packages/protocol/thread/thread.ts
+++ b/packages/protocol/thread/thread.ts
@@ -245,7 +245,7 @@ class _ThreadFront {
           supportsEventTypes: false,
           supportsNetworkRequests: false,
           supportsRepaintingGraphics: false,
-          supportsPureEvaluation: true,
+          supportsPureEvaluation: false,
         };
 
         break;


### PR DESCRIPTION
Confirmed that chromium does not support this right now.