### PR TITLE
Rewrite CSS rule fetching/parsing logic to remove fronts

### DIFF
--- a/packages/protocol/thread/pause.ts
+++ b/packages/protocol/thread/pause.ts
@@ -481,11 +481,11 @@ export class Pause {
     if (data.preview.node) {
       front = new NodeFront(this, data);
     } else if (data.preview.rule) {
-      front = new RuleFront(this, data);
+      front = new RuleFront(this.pauseId!, data);
     } else if (data.preview.style) {
-      front = new StyleFront(this, data);
+      front = new StyleFront(data);
     } else if (data.preview.styleSheet) {
-      front = new StyleSheetFront(this, data);
+      front = new StyleSheetFront(data);
     } else {
       throw new Error("Unexpected DOM front");
     }

--- a/packages/protocol/thread/style.ts
+++ b/packages/protocol/thread/style.ts
@@ -1,9 +1,9 @@
-import { StyleDeclaration } from "@replayio/protocol";
+// TODO Move this into `inspector/rules/models` as cleanup
+
+import { StyleDeclaration, Object as ProtocolObject } from "@replayio/protocol";
 import { ELEMENT_STYLE } from "shared/constants";
 
-import { assert, DisallowEverythingProxyHandler } from "../utils";
-
-import { Pause, WiredObject } from "./pause";
+import { assert } from "../utils";
 
 // Manages interaction with a CSSStyleDeclaration.
 // StyleFront represents an inline element style.
@@ -15,13 +15,10 @@ export class StyleFront {
   selectors = undefined;
   href = undefined;
   isSystem = false;
-  private _pause: Pause;
-  private _object: WiredObject;
+  private _object: ProtocolObject;
   private _style: StyleDeclaration;
 
-  constructor(pause: Pause, data: WiredObject) {
-    this._pause = pause;
-
+  constructor(data: ProtocolObject) {
     assert(data && data.preview && data.preview.style, "no style preview");
     this._object = data;
     this._style = data.preview.style;
@@ -52,5 +49,3 @@ export class StyleFront {
     return this._style.cssText;
   }
 }
-
-Object.setPrototypeOf(StyleFront.prototype, new Proxy({}, DisallowEverythingProxyHandler));

--- a/packages/protocol/thread/styleSheet.ts
+++ b/packages/protocol/thread/styleSheet.ts
@@ -1,20 +1,15 @@
-import { StyleSheet } from "@replayio/protocol";
+// TODO Move this into `inspector/rules/models` as cleanup
 
-import { assert, DisallowEverythingProxyHandler } from "../utils";
+import { StyleSheet, Object as ProtocolObject } from "@replayio/protocol";
 
-import { Pause, WiredObject } from "./pause";
+import { assert } from "../utils";
 
 // Manages interaction with a StyleSheet.
 export class StyleSheetFront {
-  private _pause: Pause;
-  private _object: WiredObject;
   private _styleSheet: StyleSheet;
 
-  constructor(pause: Pause, data: WiredObject) {
-    this._pause = pause;
-
+  constructor(data: ProtocolObject) {
     assert(data && data.preview && data.preview.styleSheet, "no styleSheet preview");
-    this._object = data;
     this._styleSheet = data.preview.styleSheet;
   }
 
@@ -30,5 +25,3 @@ export class StyleSheetFront {
     return this._styleSheet.isSystem;
   }
 }
-
-Object.setPrototypeOf(StyleSheetFront.prototype, new Proxy({}, DisallowEverythingProxyHandler));

--- a/src/devtools/client/inspector/rules/actions/rules.ts
+++ b/src/devtools/client/inspector/rules/actions/rules.ts
@@ -21,15 +21,25 @@ export function setupRules(store: UIStore) {
 }
 
 function updateRulesEntries(): UIThunkAction {
-  return async (dispatch, getState) => {
-    if (!selection.isConnected() || !selection.isElementNode()) {
+  return async (dispatch, getState, { protocolClient, replayClient, ThreadFront }) => {
+    if (
+      !selection.isConnected() ||
+      !selection.isElementNode() ||
+      !ThreadFront.currentPause?.pauseId
+    ) {
       return;
     }
 
     const { nodeFront } = selection;
 
     if (nodeFront) {
-      const elementStyle = new ElementStyle(nodeFront);
+      const elementStyle = new ElementStyle(
+        nodeFront.objectId(),
+        ThreadFront.currentPause.pauseId,
+        ThreadFront.sessionId!,
+        replayClient,
+        protocolClient
+      );
       // The legacy rule style code used a timeout to keep the rules
       // panel update from blocking the UI
       // This is probably not necessary right now, but \o/

--- a/src/devtools/client/inspector/rules/models/text-property.ts
+++ b/src/devtools/client/inspector/rules/models/text-property.ts
@@ -5,7 +5,7 @@
 const { generateUUID } = require("devtools/shared/generate-uuid");
 const { hasCSSVariable } = require("devtools/client/inspector/rules/utils/utils");
 const { escapeCSSComment } = require("third-party/css/parsing-utils");
-import Rule from "./rule";
+import RuleModel from "./rule";
 import ElementStyle from "./element-style";
 import CSSProperties from "third-party/css/css-properties";
 const { OutputParser } = require("third-party/css/output-parser");
@@ -66,7 +66,7 @@ function getOutputParser() {
  */
 export default class TextProperty {
   id: string;
-  rule: Rule;
+  rule: RuleModel;
   name: string;
   value: string;
   priority: Priority;
@@ -77,7 +77,7 @@ export default class TextProperty {
   overridden?: boolean;
 
   /**
-   * @param {Rule} rule
+   * @param {RuleModel} rule
    *        The rule this TextProperty came from.
    * @param {String} name
    *        The text property name (such as "background" or "border-top").
@@ -95,7 +95,7 @@ export default class TextProperty {
    *        coming from parseDeclarations.
    */
   constructor(
-    rule: Rule,
+    rule: RuleModel,
     name: string,
     value: string,
     priority: Priority,

--- a/src/devtools/client/inspector/rules/reducers/rules.ts
+++ b/src/devtools/client/inspector/rules/reducers/rules.ts
@@ -4,7 +4,7 @@
 
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import type { RuleInheritance, RuleSelector, SourceLink } from "../models/rule";
-import type Rule from "../models/rule";
+import type RuleModel from "../models/rule";
 import type TextProperty from "../models/text-property";
 import { ComputedPropertyInfo, Priority } from "../models/text-property";
 
@@ -78,7 +78,7 @@ const rulesSlice = createSlice({
   initialState,
   reducers: {
     rulesUpdated: {
-      prepare(rules: Rule[] | null) {
+      prepare(rules: RuleModel[] | null) {
         return {
           payload: rules?.map(rule => getRuleState(rule)) ?? [],
         };
@@ -129,7 +129,7 @@ function getDeclarationState(declaration: TextProperty, ruleId: string): Declara
   };
 }
 
-function getRuleState(rule: Rule): RuleState {
+function getRuleState(rule: RuleModel): RuleState {
   return {
     // Array of CSS declarations.
     declarations: rule.declarations.map(declaration =>

--- a/src/ui/suspense/styleCaches.ts
+++ b/src/ui/suspense/styleCaches.ts
@@ -1,0 +1,135 @@
+import { Frame, PauseId, ProtocolClient, Object as ProtocolObject } from "@replayio/protocol";
+import uniqBy from "lodash/uniqBy";
+
+import { createGenericCache } from "@bvaughn/src/suspense/createGenericCache";
+import {
+  getObjectWithPreviewHelper,
+  preCacheObjects,
+} from "bvaughn-architecture-demo/src/suspense/ObjectPreviews";
+
+import { RuleFront } from "protocol/thread/rule";
+import { ReplayClientInterface } from "shared/client/types";
+
+export interface WiredAppliedRule {
+  rule: RuleFront;
+  pseudoElement?: string;
+}
+
+export const {
+  getValueSuspense: getAppliedRulesSuspense,
+  getValueAsync: getAppliedRulesAsync,
+  getValueIfCached: getAppliedRulesIfCached,
+} = createGenericCache<
+  [
+    client: ProtocolClient,
+    replayClient: ReplayClientInterface,
+    sessionId: string,
+    pauseId: PauseId,
+    nodeId: string
+  ],
+  WiredAppliedRule[]
+>(
+  async (client, replayClient, sessionId, pauseId, nodeId) => {
+    const { rules, data } = await client.CSS.getAppliedRules({ node: nodeId }, sessionId, pauseId);
+
+    const uniqueRules = uniqBy(rules, rule => `${rule.rule}|${rule.pseudoElement}`);
+
+    preCacheObjects(pauseId, data.objects ?? []);
+
+    const stylePromises: Promise<ProtocolObject>[] = [];
+
+    const rulePreviews = await Promise.all(
+      uniqueRules.map(async appliedRule => {
+        return getObjectWithPreviewHelper(replayClient, pauseId, appliedRule.rule);
+      })
+    );
+
+    for (let ruleObject of rulePreviews) {
+      if (ruleObject.preview?.rule?.style) {
+        stylePromises.push(
+          getObjectWithPreviewHelper(replayClient, pauseId, ruleObject.preview.rule.style)
+        );
+      }
+
+      if (ruleObject.preview?.rule?.parentStyleSheet) {
+        stylePromises.push(
+          getObjectWithPreviewHelper(
+            replayClient,
+            pauseId,
+            ruleObject.preview?.rule?.parentStyleSheet
+          )
+        );
+      }
+    }
+
+    if (stylePromises.length) {
+      await Promise.all(stylePromises);
+    }
+
+    const wiredRules: WiredAppliedRule[] = uniqueRules.map((appliedRule, i) => {
+      return {
+        rule: new RuleFront(pauseId, rulePreviews[i]),
+        pseudoElement: appliedRule.pseudoElement,
+      };
+    });
+    return wiredRules;
+  },
+  (client, replayClient, sessionId, pauseId, nodeId) => `${pauseId}|${nodeId}`
+);
+
+export const {
+  getValueSuspense: getComputedStyleSuspense,
+  getValueAsync: getComputedStyleAsync,
+  getValueIfCached: getComputedStyleIfCached,
+} = createGenericCache<
+  [client: ProtocolClient, sessionId: string, pauseId: PauseId, nodeId: string],
+  Map<string, string> | undefined
+>(
+  async (client, sessionId, pauseId, nodeId) => {
+    try {
+      const { computedStyle } = await client.CSS.getComputedStyle(
+        {
+          node: nodeId,
+        },
+        sessionId,
+        pauseId
+      );
+
+      const computedStyleMap = new Map();
+      for (const { name, value } of computedStyle) {
+        computedStyleMap.set(name, value);
+      }
+
+      return computedStyleMap;
+    } catch (err) {
+      return;
+    }
+  },
+  (client, sessionId, pauseId, nodeId) => `${pauseId}|${nodeId}`
+);
+
+export const {
+  getValueSuspense: getBoundingRectSuspense,
+  getValueAsync: getBoundingRectAsync,
+  getValueIfCached: getBoundingRectIfCached,
+} = createGenericCache<
+  [client: ProtocolClient, sessionId: string, pauseId: PauseId, nodeId: string],
+  DOMRect | undefined
+>(
+  async (client, sessionId, pauseId, nodeId) => {
+    try {
+      const { rect } = await client.DOM.getBoundingClientRect(
+        {
+          node: nodeId,
+        },
+        sessionId,
+        pauseId
+      );
+      const [left, top, right, bottom] = rect;
+      return new DOMRect(left, top, right - left, bottom - top);
+    } catch (err) {
+      return;
+    }
+  },
+  (client, sessionId, pauseId, nodeId) => `${pauseId}|${nodeId}`
+);


### PR DESCRIPTION
- Added caches for AppliedRules, ComputedStyles, and BoundingRects
  - Updated existing logic to use these caches
- Rewrote `Rule/Style/StyleSheetFront` to remove `Pause` fields
- Rewrote `ElementStyle` to read style and node data from caches

Note that this leaves the `Rule/Style/StyleSheetFront` classes in existence, because the existing parsing logic relies on those heavily.  However, they are now only used from within `ElementStyle` and the other classes in `inspector/rules/models`.

I opted not to move them in this PR, but in a follow-up cleanup task I'll move those three files over to that `rules/models` folder.