### PR TITLE
Work around editor freezing when sources tab is in console panel

### DIFF
--- a/src/ui/components/SecondaryToolbox/index.tsx
+++ b/src/ui/components/SecondaryToolbox/index.tsx
@@ -177,9 +177,15 @@ function SecondaryToolbox() {
         <Panel isActive={selectedPanel === "redux-devtools"}>
           <ReduxDevToolsPanel />
         </Panel>
-        <Panel isActive={toolboxLayout !== "ide" && selectedPanel === "debugger"}>
-          <EditorPane />
-        </Panel>
+        {/* _
+          Don't_ render an `<Offscreen>` around the editor.
+          It appears that this causes React to unmount and remount
+          the class components, and we end up with a duplicate
+          CodeMirror instance or similar, and the entire editor freezes
+          and becomes non-interactive. If we skip that, toggling the "Sources" 
+          tab works just fine as expected.
+        */}
+        {toolboxLayout !== "ide" && selectedPanel === "debugger" && <EditorPane />}
       </Redacted>
     </div>
   );


### PR DESCRIPTION
This PR:

- Works around the issue of the "Sources" tab freezing the editor in a specific use case

When you have the entire console panel docked to the "bottom" of the screen, the "Sources" section, which is normally its own split panel, becomes a separate tab in the row with "Console/React/Network"/etc.  

Currently, if you have the "Sources" tab, switch to any other tab, and then back to "Sources", we end up with the CodeMirror editor losing its left margin and becoming entirely unresponsive.

I've been digging through [this replay of FE-548](https://app.replay.io/recording/editor-freeze-regression-broken-main--9e0df40b-6211-4fb7-b79d-9198a566889d?point=29531188392002848564827460248535165&time=15147.404848484848&hasFrames=true&focusRegion=eyJiZWdpbiI6eyJwb2ludCI6IjI4NTU3NjMyNzMwOTg4MjMwNzAyNzQwOTc0MDcxNzE0MDIxIiwidGltZSI6MTM2OTQsImtpbmQiOiJtb3VzZW1vdmUiLCJjbGllbnRYIjozNjEsImNsaWVudFkiOjQ1NX0sImVuZCI6eyJwb2ludCI6IjM1Njk3MDQwOTEyMTAxMDAyODM0MjEwODA5ODM2NDc1MDc0IiwidGltZSI6MTc1MjQsImtpbmQiOiJtb3VzZW1vdmUiLCJjbGllbnRYIjo1MzUsImNsaWVudFkiOjQ1Nn19) trying to figure out what's going on. As far as I can tell, the `<LazyOffscreen>` wrapper is correctly returning its `props.children` of `<EditorPane>`.  That part's fine.  

But sometime later in that same render pass, React decides to unmount the existing `<Editor>` instance, and then later mount a new one.  That ends up causing some kind of a duplicate CodeMirror instance problem.

The workaround is to _not_ render a `<LazyOffscreen>` around `<EditorPane>`, at which point switching tabs works fine.

I dug all the way down into React's rendering loop before I gave up on trying to figure out _why_ it's unmounting `<Editor>`.  My vague guess is that it's either due to something about class components (even though Brian _said_ they're supposed to be preserved), or maybe losing `<EditorProps>` returned children somehow?  I dunno.