### PR TITLE
fix line flickering when loading

### DIFF
--- a/src/devtools/client/debugger/src/utils/editor/line-events.ts
+++ b/src/devtools/client/debugger/src/utils/editor/line-events.ts
@@ -30,9 +30,12 @@ const getLineNodeFromGutterTarget = (target: HTMLElement) =>
   target.closest(".CodeMirror-gutter-wrapper")!.parentElement!.querySelector(".CodeMirror-line");
 
 function isValidTarget(target: HTMLElement) {
+  const isNonBreakableLineNode = target.closest(".empty-line");
   const isTooltip = target.closest(".static-tooltip");
 
-  return (isHoveredOnLine(target) || isHoveredOnGutter(target)) && !isTooltip;
+  return (
+    (isHoveredOnLine(target) || isHoveredOnGutter(target)) && !isNonBreakableLineNode && !isTooltip
+  );
 }
 
 function emitLineMouseEnter(codeMirror: $FixTypeLater, target: HTMLElement) {


### PR DESCRIPTION
This is a temporary fix for line flickering when in a loading state. It moves back to the original implementation (#7780) until we can figure out a better path forward.