### PR TITLE
Route browser auth through the standard devtools auth flow

### DIFF
--- a/pages/api/browser/auth.ts
+++ b/pages/api/browser/auth.ts
@@ -54,10 +54,9 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   }
 
   try {
-    const clientId = "4FvFnJJW4XlnUyrXQF8zOLw6vNAH1MAo";
     const redirectUri = getAppUrl("/api/browser/callback");
     const { id, challenge, serverKey } = await initAuthRequest(key);
-    const url = `https://webreplay.us.auth0.com/authorize?response_type=code&code_challenge_method=S256&code_challenge=${challenge}&client_id=${clientId}&redirect_uri=${redirectUri}&scope=openid profile offline_access&state=${id}&audience=https://api.replay.io`;
+    const url = `/login?challenge=${challenge}&returnTo=${redirectUri}&state=${id}`;
 
     res.setHeader(
       "Set-Cookie",

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -14,9 +14,20 @@ export default function LoginPage() {
     router.push(router.query.returnTo);
   }
 
+  const challenge = Array.isArray(router.query.challenge)
+    ? router.query.challenge[0]
+    : router.query.challenge;
+  const state = Array.isArray(router.query.state) ? router.query.state[0] : router.query.state;
+
   useEffect(() => {
     dispatch(clearExpectedError());
   }, [dispatch]);
 
-  return <Login returnToPath={String(router.query.returnTo || "/")} />;
+  return (
+    <Login
+      returnToPath={String(router.query.returnTo || "/")}
+      state={state}
+      challenge={challenge}
+    />
+  );
 }


### PR DESCRIPTION
The current browser auth flow directs the user through the Auth0 login UI which can mislead some users to try to use email / password to login. Instead, route them through our UI so we can have a consistent experience both in the app and from the browser.


https://user-images.githubusercontent.com/788456/191889584-25db2016-949b-4032-b559-c57d0be6d6be.mp4

