### PR TITLE
Update NUX copy to be more clear

### DIFF
--- a/packages/bvaughn-architecture-demo/components/console/MessageHoverButton.module.css
+++ b/packages/bvaughn-architecture-demo/components/console/MessageHoverButton.module.css
@@ -39,7 +39,7 @@
 .LabelHovered {
   line-height: 1rem;
   transition: padding 100ms ease-in-out;
-  transition: all 250ms ease-in-out;
+  transition: all 140ms ease-in-out;
   overflow: hidden;
 }
 .Label {

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/FirstEditNag.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/FirstEditNag.tsx
@@ -6,10 +6,12 @@ import { shouldShowNag } from "ui/utils/user";
 
 const TEXT = {
   editPrompt: "Click below to edit your first print statement",
-  savePrompt: "You can add variables here too",
+  savePrompt: "Click save and the console will time travel!",
   success: (
     <>
-      <span className="flex">Now check the console!</span>
+      <span className="flex">
+        Check the console for your print statements. You just time traveled! 🎉
+      </span>
 
       <span className="flex grow justify-end">
         <a

--- a/src/ui/components/shared/Nags/Nags.tsx
+++ b/src/ui/components/shared/Nags/Nags.tsx
@@ -56,7 +56,7 @@ export function EditorNag() {
     return null;
   }
 
-  return <NagHat subText="Now hover on a line number" nagType={Nag.FIRST_BREAKPOINT_ADD} />;
+  return <NagHat subText="Next, hover on a line number" nagType={Nag.FIRST_BREAKPOINT_ADD} />;
 }
 
 export function ConsoleNag() {
@@ -70,8 +70,8 @@ export function ConsoleNag() {
 
   return (
     <NagHat
-      mainText="Want to see something cool?"
-      subText="Try fast-forwarding or rewinding to a console log"
+      mainText="How to time travel, step one:"
+      subText="Fast-forward or rewind by hovering on a line in the console"
       nagType={Nag.FIRST_CONSOLE_NAVIGATE}
     />
   );


### PR DESCRIPTION
**Problem we're trying to solve**

* We're seeing a 50% drop-off between setting a print statement and editing it
* The text currently says "You can add a variable too" which isn't actionable

**Adjustments**

* Made the text more actionable
* Sped up the animation in the console to feel less sluggish

**Other tickets that are related to this**

* This addresses [#DES-16](https://linear.app/replay/issue/DES-116/remove-you-can-also-set-variables-step-from-nux)
* It looks like the new console has a NUX regression. [Filed here](https://linear.app/replay/issue/DES-119/nux-nag-regression-in-console).
* We should consider not showing the console drawer by default. [Filed here](https://linear.app/replay/issue/DES-118/console-drawer-shouldnt-be-deployed-during-nux).
