### PR TITLE
Add session auth to session creation so they happen in the right order

### DIFF
--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -19,7 +19,7 @@ import { getRecordingId } from "ui/utils/recording";
 import { prefs } from "devtools/client/debugger/src/utils/prefs";
 import { shallowEqual } from "devtools/client/debugger/src/utils/compare";
 import { ThreadFront as ThreadFrontType } from "protocol/thread";
-import { isTest, getTest } from "ui/utils/environment";
+import { getTest } from "ui/utils/environment";
 import { getTheme } from "ui/reducers/app";
 import { getShowVideoPanel } from "ui/reducers/layout";
 

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -58,15 +58,6 @@ export async function setupApp(
   ThreadFront: typeof ThreadFrontType,
   replayClient: ReplayClientInterface
 ) {
-  if (!isTest()) {
-    tokenManager.addListener(({ token }) => {
-      if (token) {
-        ThreadFront.setAccessToken(token);
-      }
-    });
-    await tokenManager.getToken();
-  }
-
   ThreadFront.waitForSession().then(sessionId => {
     store.dispatch(setSessionId(sessionId));
 

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -4,7 +4,6 @@ import * as selectors from "ui/reducers/app";
 import { Canvas, ReplayEvent, ReplayNavigationEvent, EventKind } from "ui/state/app";
 import groupBy from "lodash/groupBy";
 import { compareBigInt } from "ui/utils/helpers";
-import tokenManager from "ui/utils/tokenManager";
 import {
   hideCommandPalette,
   setSelectedPanel,

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -33,6 +33,7 @@ import { getPaneCollapse } from "devtools/client/debugger/src/selectors";
 import { getViewMode } from "ui/reducers/layout";
 import { useTrackLoadingIdleTime } from "ui/hooks/tracking";
 import tokenManager, { TokenState } from "ui/utils/tokenManager";
+import { isTest } from "ui/utils/environment";
 
 const Viewer = React.lazy(() => import("./Viewer"));
 
@@ -141,7 +142,7 @@ function _DevTools({
 
   useEffect(() => {
     let token: Promise<TokenState | void> = Promise.resolve();
-    if (isAuthenticated) {
+    if (isAuthenticated && !isTest()) {
       token = tokenManager.getToken();
     }
 

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -32,6 +32,7 @@ import { prefs } from "ui/utils/prefs";
 import { getPaneCollapse } from "devtools/client/debugger/src/selectors";
 import { getViewMode } from "ui/reducers/layout";
 import { useTrackLoadingIdleTime } from "ui/hooks/tracking";
+import tokenManager, { TokenState } from "ui/utils/tokenManager";
 
 const Viewer = React.lazy(() => import("./Viewer"));
 
@@ -53,7 +54,7 @@ function ViewLoader() {
   }
 
   return (
-    <div className="absolute flex items-center justify-center w-full h-full bg-chrome">
+    <div className="absolute flex h-full w-full items-center justify-center bg-chrome">
       <ReplayLogo size="md" color="gray" />
     </div>
   );
@@ -64,8 +65,8 @@ function Body() {
   const viewMode = useAppSelector(getViewMode);
 
   return (
-    <div className="pr-2 vertical-panels">
-      <div className="flex flex-row h-full overflow-hidden bg-chrome">
+    <div className="vertical-panels pr-2">
+      <div className="flex h-full flex-row overflow-hidden bg-chrome">
         <Toolbar />
         <ReduxAnnotationsProvider>
           <SplitBox
@@ -139,12 +140,27 @@ function _DevTools({
   });
 
   useEffect(() => {
-    createSocket(recordingId, ThreadFront);
+    let token: Promise<TokenState | void> = Promise.resolve();
+    if (isAuthenticated) {
+      token = tokenManager.getToken();
+    }
+
+    token
+      .then(async ts => {
+        if (ts?.token) {
+          await ThreadFront.setAccessToken(ts.token);
+        }
+
+        createSocket(recordingId, ThreadFront);
+      })
+      .catch(() => {
+        console.error("Failed to create session");
+      });
 
     return () => {
       clearTrialExpired();
     };
-  }, [clearTrialExpired, createSocket, recordingId]);
+  }, [isAuthenticated, clearTrialExpired, createSocket, recordingId]);
 
   useEffect(() => {
     if (uploadComplete && loadingFinished) {


### PR DESCRIPTION
## Issue

Sometimes ... for reasons we haven't quite figured out ... we would try to authenticate the session (via `setAccessToken`) after the session was created (via `createSession`) which results in a runtime error

Fixes SCS-17

## Resolution

Couple authenticated the socket with creating the session so we know that happen in order