### PR TITLE
enable empty line hover

### DIFF
--- a/src/devtools/client/debugger/src/utils/editor/line-events.ts
+++ b/src/devtools/client/debugger/src/utils/editor/line-events.ts
@@ -30,12 +30,9 @@ const getLineNodeFromGutterTarget = (target: HTMLElement) =>
   target.closest(".CodeMirror-gutter-wrapper")!.parentElement!.querySelector(".CodeMirror-line");
 
 function isValidTarget(target: HTMLElement) {
-  const isNonBreakableLineNode = target.closest(".empty-line");
   const isTooltip = target.closest(".static-tooltip");
 
-  return (
-    (isHoveredOnLine(target) || isHoveredOnGutter(target)) && !isNonBreakableLineNode && !isTooltip
-  );
+  return (isHoveredOnLine(target) || isHoveredOnGutter(target)) && !isTooltip;
 }
 
 function emitLineMouseEnter(codeMirror: $FixTypeLater, target: HTMLElement) {


### PR DESCRIPTION
Follow-up to #7803 to reenable all lines for hovering.