### PR TITLE
Test suit bvaughn

### DIFF
--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -7,13 +7,15 @@
     "test": "tests"
   },
   "scripts": {
-    "test:install": "playwright install",
-    "test": "playwright test"
+    "test": "playwright test",
+    "test:debug": "DEBUG=1 playwright test",
+    "test:install": "playwright install"
   },
   "author": "",
   "license": "ISC",
-  "dependencies": {
-    "@playwright/test": "^1.23.1",
-    "@replayio/playwright": "^0.2.24"
+  "devDependencies": {
+    "@playwright/test": "^1.25.1",
+    "@replayio/playwright": "^0.2.24",
+    "playwright": "^1.25.1"
   }
 }

--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -1,14 +1,16 @@
 import { PlaywrightTestConfig, devices } from "@playwright/test";
-import { devices as replayDevices } from "@replayio/playwright";
+
+const { DEBUG } = process.env;
 
 const config: PlaywrightTestConfig = {
   use: {
+    headless: !DEBUG,
     browserName: "chromium",
     viewport: {
       width: 1024,
       height: 600,
     },
+
   },
 };
-
 export default config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3354,6 +3354,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@playwright/test@npm:^1.25.1":
+  version: 1.26.1
+  resolution: "@playwright/test@npm:1.26.1"
+  dependencies:
+    "@types/node": "*"
+    playwright-core: 1.26.1
+  bin:
+    playwright: cli.js
+  checksum: 872bc58dfa8f8a94547b69aaf7e88178213e2201a17aced1b425ef6b13bdd2b53e7274ae8f7ca57dfc189b214be5da5e3290f80b03e5bf5bdc4f3ff0ccd38375
+  languageName: node
+  linkType: hard
+
 "@pmmmwh/react-refresh-webpack-plugin@npm:^0.5.3":
   version: 0.5.7
   resolution: "@pmmmwh/react-refresh-webpack-plugin@npm:0.5.7"
@@ -13187,8 +13199,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "functional-tests@workspace:packages/e2e-tests"
   dependencies:
-    "@playwright/test": ^1.23.1
+    "@playwright/test": ^1.25.1
     "@replayio/playwright": ^0.2.24
+    playwright: ^1.25.1
   languageName: unknown
   linkType: soft
 
@@ -19041,6 +19054,26 @@ __metadata:
   bin:
     playwright: cli.js
   checksum: 1e6a3a7a9aaee1864b22195c7fef52b6980fcafc6d667749737455360a44a182a7035f12bfd76f298f957d1b99550420a8748f6a473ceeacf2cb2db42beb9be0
+  languageName: node
+  linkType: hard
+
+"playwright-core@npm:1.26.1":
+  version: 1.26.1
+  resolution: "playwright-core@npm:1.26.1"
+  bin:
+    playwright: cli.js
+  checksum: 6347224c28c1ec21d49b659ae35452955e2d8a8ff7aa578f0a0dbb1eccfbcea97e7400446335e966c2a1cbb356381d78131ea65e4a2f19a3eccfb58d33aed0ca
+  languageName: node
+  linkType: hard
+
+"playwright@npm:^1.25.1":
+  version: 1.26.1
+  resolution: "playwright@npm:1.26.1"
+  dependencies:
+    playwright-core: 1.26.1
+  bin:
+    playwright: cli.js
+  checksum: 42af6e949af68dec3327d5cce2e7f2f0d6d175528ba983b9b76f8f21995ae223f901d672799e655446b71ec5d19223464f7c587d3f569312a452718cbf8a706a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- [x] `yarn test:debug <pattern>` now launches headless browser so you can _watch_ the e2e test run.