### PR TITLE
Set up Playwright Testing Library

### DIFF
--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -14,6 +14,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@playwright-testing-library/test": "^4.4.0",
     "@playwright/test": "^1.25.1",
     "@replayio/playwright": "^0.2.24",
     "playwright": "^1.25.1"

--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -10,7 +10,6 @@ const config: PlaywrightTestConfig = {
       width: 1024,
       height: 600,
     },
-
   },
 };
 export default config;

--- a/packages/e2e-tests/tests/breakpoints-01.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-01.test.ts
@@ -1,6 +1,5 @@
-import { test } from "@playwright/test";
-
 import {
+  test,
   openExample,
   rewindToLine,
   addBreakpoint,
@@ -9,28 +8,28 @@ import {
   resumeToLine,
 } from "../helpers";
 
-test(`Test basic breakpoint functionality.`, async ({ page }) => {
-  await openExample(page, "doc_rr_basic.html");
-  await clickDevTools(page);
+test(`Test basic breakpoint functionality.`, async ({ screen }) => {
+  await openExample(screen, "doc_rr_basic.html");
+  await clickDevTools(screen);
 
-  await addBreakpoint(page, "doc_rr_basic.html", 21);
+  await addBreakpoint(screen, "doc_rr_basic.html", 21);
 
-  await rewindToLine(page, 21);
-  await checkEvaluateInTopFrame(page, "number", "10");
-  await rewindToLine(page, 21);
-  await checkEvaluateInTopFrame(page, "number", "9");
-  await rewindToLine(page, 21);
-  await checkEvaluateInTopFrame(page, "number", "8");
-  await rewindToLine(page, 21);
-  await checkEvaluateInTopFrame(page, "number", "7");
-  await rewindToLine(page, 21);
-  await checkEvaluateInTopFrame(page, "number", "6");
-  await resumeToLine(page, 21);
-  await checkEvaluateInTopFrame(page, "number", "7");
-  await resumeToLine(page, 21);
-  await checkEvaluateInTopFrame(page, "number", "8");
-  await resumeToLine(page, 21);
-  await checkEvaluateInTopFrame(page, "number", "9");
-  await resumeToLine(page, 21);
-  await checkEvaluateInTopFrame(page, "number", "10");
+  await rewindToLine(screen, 21);
+  await checkEvaluateInTopFrame(screen, "number", "10");
+  await rewindToLine(screen, 21);
+  await checkEvaluateInTopFrame(screen, "number", "9");
+  await rewindToLine(screen, 21);
+  await checkEvaluateInTopFrame(screen, "number", "8");
+  await rewindToLine(screen, 21);
+  await checkEvaluateInTopFrame(screen, "number", "7");
+  await rewindToLine(screen, 21);
+  await checkEvaluateInTopFrame(screen, "number", "6");
+  await resumeToLine(screen, 21);
+  await checkEvaluateInTopFrame(screen, "number", "7");
+  await resumeToLine(screen, 21);
+  await checkEvaluateInTopFrame(screen, "number", "8");
+  await resumeToLine(screen, 21);
+  await checkEvaluateInTopFrame(screen, "number", "9");
+  await resumeToLine(screen, 21);
+  await checkEvaluateInTopFrame(screen, "number", "10");
 });

--- a/packages/e2e-tests/tests/breakpoints-02.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-02.test.ts
@@ -1,6 +1,5 @@
-import { test } from "@playwright/test";
-
 import {
+  test,
   openExample,
   rewindToLine,
   addBreakpoint,
@@ -8,17 +7,17 @@ import {
   checkEvaluateInTopFrame,
   resumeToLine,
 } from "../helpers";
-test(`Test unhandled divergence while evaluating at a breakpoint.`, async ({ page }) => {
-  await openExample(page, "doc_rr_basic.html");
-  await clickDevTools(page);
+test(`Test unhandled divergence while evaluating at a breakpoint.`, async ({ screen }) => {
+  await openExample(screen, "doc_rr_basic.html");
+  await clickDevTools(screen);
 
-  await addBreakpoint(page, "doc_rr_basic.html", 21);
-  await rewindToLine(page, 21);
+  await addBreakpoint(screen, "doc_rr_basic.html", 21);
+  await rewindToLine(screen, 21);
 
-  await checkEvaluateInTopFrame(page, "number", "10");
-  await checkEvaluateInTopFrame(page, "dump(3)", `Error: Evaluation failed`);
-  await checkEvaluateInTopFrame(page, "number", "10");
-  await checkEvaluateInTopFrame(page, "dump(3)", `Error: Evaluation failed`);
-  await checkEvaluateInTopFrame(page, "number", "10");
-  await checkEvaluateInTopFrame(page, "testStepping2()", "undefined");
+  await checkEvaluateInTopFrame(screen, "number", "10");
+  await checkEvaluateInTopFrame(screen, "dump(3)", `Error: Evaluation failed`);
+  await checkEvaluateInTopFrame(screen, "number", "10");
+  await checkEvaluateInTopFrame(screen, "dump(3)", `Error: Evaluation failed`);
+  await checkEvaluateInTopFrame(screen, "number", "10");
+  await checkEvaluateInTopFrame(screen, "testStepping2()", "undefined");
 });

--- a/packages/e2e-tests/tests/breakpoints-03.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-03.test.ts
@@ -1,6 +1,5 @@
-import { test } from "@playwright/test";
-
 import {
+  test,
   openExample,
   rewindToLine,
   addBreakpoint,
@@ -11,16 +10,16 @@ import {
 
 // Test hitting breakpoints when rewinding past the point where the breakpoint
 test(`Test hitting breakpoints when rewinding past the point where the breakpoint.`, async ({
-  page,
+  screen,
 }) => {
-  await openExample(page, "doc_rr_basic.html");
-  await clickDevTools(page);
+  await openExample(screen, "doc_rr_basic.html");
+  await clickDevTools(screen);
 
-  await rewindToLine(page);
+  await rewindToLine(screen);
 
-  await addBreakpoint(page, "doc_rr_basic.html", 21);
-  await resumeToLine(page, 21);
-  await checkEvaluateInTopFrame(page, "number", "1");
-  await resumeToLine(page, 21);
-  await checkEvaluateInTopFrame(page, "number", "2");
+  await addBreakpoint(screen, "doc_rr_basic.html", 21);
+  await resumeToLine(screen, 21);
+  await checkEvaluateInTopFrame(screen, "number", "1");
+  await resumeToLine(screen, 21);
+  await checkEvaluateInTopFrame(screen, "number", "2");
 });

--- a/packages/e2e-tests/tests/breakpoints-04.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-04.test.ts
@@ -1,41 +1,41 @@
-import { test, Page } from "@playwright/test";
-
 import {
+  test,
   openExample,
   rewindToLine,
   addBreakpoint,
   clickDevTools,
   checkEvaluateInTopFrame,
   resumeToLine,
+  Screen,
 } from "../helpers";
 
 // Test hitting breakpoints when using tricky control flow constructs:
-test(`catch, finally, generators, and async/await.`, async ({ page }) => {
-  await openExample(page, "doc_control_flow.html");
-  await clickDevTools(page);
+test(`catch, finally, generators, and async/await.`, async ({ screen }) => {
+  await openExample(screen, "doc_control_flow.html");
+  await clickDevTools(screen);
 
-  await rewindToBreakpoint(page, 10);
-  await resumeToBreakpoint(page, 12);
-  await resumeToBreakpoint(page, 18);
-  await resumeToBreakpoint(page, 20);
-  await resumeToBreakpoint(page, 32);
-  await resumeToBreakpoint(page, 27);
-  await resumeToLine(page, 32);
-  await resumeToLine(page, 27);
-  await resumeToBreakpoint(page, 42);
-  await resumeToBreakpoint(page, 44);
-  await resumeToBreakpoint(page, 50);
-  await resumeToBreakpoint(page, 54);
-  await resumeToBreakpoint(page, 65);
-  await resumeToBreakpoint(page, 72);
+  await rewindToBreakpoint(screen, 10);
+  await resumeToBreakpoint(screen, 12);
+  await resumeToBreakpoint(screen, 18);
+  await resumeToBreakpoint(screen, 20);
+  await resumeToBreakpoint(screen, 32);
+  await resumeToBreakpoint(screen, 27);
+  await resumeToLine(screen, 32);
+  await resumeToLine(screen, 27);
+  await resumeToBreakpoint(screen, 42);
+  await resumeToBreakpoint(screen, 44);
+  await resumeToBreakpoint(screen, 50);
+  await resumeToBreakpoint(screen, 54);
+  await resumeToBreakpoint(screen, 65);
+  await resumeToBreakpoint(screen, 72);
 
-  async function rewindToBreakpoint(page: Page, line: number) {
-    await addBreakpoint(page, "doc_control_flow.html", line);
-    await rewindToLine(page, line);
+  async function rewindToBreakpoint(screen: Screen, line: number) {
+    await addBreakpoint(screen, "doc_control_flow.html", line);
+    await rewindToLine(screen, line);
   }
 
-  async function resumeToBreakpoint(page: Page, line: number) {
-    await addBreakpoint(page, "doc_control_flow.html", line);
-    await resumeToLine(page, line);
+  async function resumeToBreakpoint(screen: Screen, line: number) {
+    await addBreakpoint(screen, "doc_control_flow.html", line);
+    await resumeToLine(screen, line);
   }
 });

--- a/packages/e2e-tests/tests/breakpoints-05.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-05.test.ts
@@ -1,6 +1,5 @@
-import { test, Page } from "@playwright/test";
-
 import {
+  test,
   openExample,
   clickDevTools,
   removeAllBreakpoints,
@@ -9,17 +8,17 @@ import {
   resumeToLine,
 } from "../helpers";
 
-test(`Test interaction of breakpoints with debugger statements.`, async ({ page }) => {
-  await openExample(page, "doc_debugger_statements.html");
-  await clickDevTools(page);
+test(`Test interaction of breakpoints with debugger statements.`, async ({ screen }) => {
+  await openExample(screen, "doc_debugger_statements.html");
+  await clickDevTools(screen);
 
   // TODO: remove timeout
   await new Promise(r => setTimeout(r, 1000));
-  await rewindToLine(page, 9);
-  await addBreakpoint(page, "doc_debugger_statements.html", 8);
-  await rewindToLine(page, 8);
-  await resumeToLine(page, 9);
-  await removeAllBreakpoints(page);
-  await rewindToLine(page, 7);
-  await resumeToLine(page, 9);
+  await rewindToLine(screen, 9);
+  await addBreakpoint(screen, "doc_debugger_statements.html", 8);
+  await rewindToLine(screen, 8);
+  await resumeToLine(screen, 9);
+  await removeAllBreakpoints(screen);
+  await rewindToLine(screen, 7);
+  await resumeToLine(screen, 9);
 });

--- a/packages/e2e-tests/tests/breakpoints-06.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-06.test.ts
@@ -1,8 +1,7 @@
 // TODO fix this test
 
-import { test, Page, expect } from "@playwright/test";
-
 import {
+  test,
   openExample,
   clickDevTools,
   removeAllBreakpoints,
@@ -10,28 +9,29 @@ import {
   addBreakpoint,
   resumeToLine,
   waitForConsoleMessage,
+  Screen,
 } from "../helpers";
 
-async function checkMessageLocation(page: Page, text: string, location: string) {
-  const msg = await waitForConsoleMessage(page, text);
+async function checkMessageLocation(screen: Screen, text: string, location: string) {
+  const msg = await waitForConsoleMessage(screen, text);
   expect(
     msg.querySelector(".frame-link a").innerText == location,
     `Message location should be ${location}`
   );
 }
 
-test(`Test breakpoints in a sourcemapped file.`, async ({ page }) => {
-  await openExample(page, "doc_prod_bundle.html");
-  await clickDevTools(page);
+test(`Test breakpoints in a sourcemapped file.`, async ({ screen }) => {
+  await openExample(screen, "doc_prod_bundle.html");
+  await clickDevTools(screen);
   console.log("Test that the breakpoint added to line 15 maps to line 15");
-  await addBreakpoint(page, "bundle_input.js", 15, undefined, {
+  await addBreakpoint(screen, "bundle_input.js", 15, undefined, {
     logValue: "'line 15'",
   });
-  await checkMessageLocation(page, "line 15", "bundle_input.js:15");
+  await checkMessageLocation(screen, "line 15", "bundle_input.js:15");
 
   console.log("Test that the breakpoint added to line 17 maps to line 17");
-  await addBreakpoint(page, "bundle_input.js", 17, undefined, {
+  await addBreakpoint(screen, "bundle_input.js", 17, undefined, {
     logValue: "'line 17'",
   });
-  await checkMessageLocation(page, "line 17", "bundle_input.js:17");
+  await checkMessageLocation(screen, "line 17", "bundle_input.js:17");
 });

--- a/packages/e2e-tests/tests/breakpoints-07.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-07.test.ts
@@ -1,6 +1,6 @@
 // // TODO: fix this test
 
-import test from "@playwright/test";
+import { test } from "../helpers";
 
 // (async () => {
 //   const url = new URL(location.href);
@@ -94,5 +94,4 @@ import test from "@playwright/test";
 //   );
 // }
 
-test(`TODO.`, async ({ page }) => {
-});
+test(`TODO.`, async ({ screen }) => {});

--- a/packages/e2e-tests/tests/object_preview-01-chromium.test.ts
+++ b/packages/e2e-tests/tests/object_preview-01-chromium.test.ts
@@ -1,5 +1,5 @@
 // // Test the objects produced by console.log() calls and by evaluating various
-// test(`expressions in the console after time warping.`, async ({ page }) => {
+// test(`expressions in the console after time warping.`, async ({ screen }) => {
 //   await Test.selectConsole();
 
 //   // Several objects currently show up differently in chromium.

--- a/packages/e2e-tests/tests/object_preview-01.test.ts
+++ b/packages/e2e-tests/tests/object_preview-01.test.ts
@@ -1,5 +1,5 @@
-import { test } from "@playwright/test";
 import {
+  test,
   openExample,
   clickDevTools,
   executeInConsole,
@@ -11,56 +11,56 @@ import {
 } from "../helpers";
 
 // Test the objects produced by console.log() calls and by evaluating various
-test(`expressions in the console after time warping.`, async ({ page }) => {
+test(`expressions in the console after time warping.`, async ({ screen }) => {
   let msg;
-  await openExample(page, "doc_rr_objects.html");
-  await clickDevTools(page);
-  await selectConsole(page);
+  await openExample(screen, "doc_rr_objects.html");
+  await clickDevTools(screen);
+  await selectConsole(screen);
 
-  await waitForConsoleMessage(page, "Array(20) [ 0, 1, 2, 3, 4, 5,");
-  await waitForConsoleMessage(page, "Uint8Array(20) [ 0, 1, 2, 3, 4, 5,");
-  await waitForConsoleMessage(page, "Set(22) [ {…}, {…}, 0, 1, 2, 3, 4, 5,");
+  await waitForConsoleMessage(screen, "Array(20) [ 0, 1, 2, 3, 4, 5,");
+  await waitForConsoleMessage(screen, "Uint8Array(20) [ 0, 1, 2, 3, 4, 5,");
+  await waitForConsoleMessage(screen, "Set(22) [ {…}, {…}, 0, 1, 2, 3, 4, 5,");
 
-  await waitForConsoleMessage(page, "Map(21) { {…} → {…}, 0 → 1, 1 → 2, 2 → 3, 3 → 4, 4 → 5,");
-  await waitForConsoleMessage(page, "WeakSet(20) [ {…}, {…}, {…},");
-  await waitForConsoleMessage(page, "WeakMap(20) { {…} → {…}, {…} → {…},");
-  await waitForConsoleMessage(page, "Object { a: 0, a0: 0, a1: 1, a2: 2, a3: 3, a4: 4,");
-  await waitForConsoleMessage(page, "/abc/gi");
-  await waitForConsoleMessage(page, "Date");
+  await waitForConsoleMessage(screen, "Map(21) { {…} → {…}, 0 → 1, 1 → 2, 2 → 3, 3 → 4, 4 → 5,");
+  await waitForConsoleMessage(screen, "WeakSet(20) [ {…}, {…}, {…},");
+  await waitForConsoleMessage(screen, "WeakMap(20) { {…} → {…}, {…} → {…},");
+  await waitForConsoleMessage(screen, "Object { a: 0, a0: 0, a1: 1, a2: 2, a3: 3, a4: 4,");
+  await waitForConsoleMessage(screen, "/abc/gi");
+  await waitForConsoleMessage(screen, "Date");
 
-  await waitForConsoleMessage(page, `RangeError: "foo"`);
+  await waitForConsoleMessage(screen, `RangeError: "foo"`);
   await waitForConsoleMessage(
-    page,
+    screen,
     '<div id="foo" class="bar" style="visibility: visible" blahblah="">'
   );
 
-  await waitForConsoleMessage(page, "function bar()");
-  await checkJumpIcon(page, "function bar()");
+  await waitForConsoleMessage(screen, "function bar()");
+  await checkJumpIcon(screen, "function bar()");
   // await new Promise(r => setTimeout(r, 100_000));
 
-  await waitForConsoleMessage(page, 'Array(6) [ undefined, true, 3, null, "z", 40n ]');
-  await waitForConsoleMessage(page, "Proxy {  }");
-  await waitForConsoleMessage(page, "Symbol()");
-  await waitForConsoleMessage(page, "Symbol(symbol)");
-  await waitForConsoleMessage(page, `Object { "Symbol()": 42, "Symbol(symbol)": "Symbol()" }`);
+  await waitForConsoleMessage(screen, 'Array(6) [ undefined, true, 3, null, "z", 40n ]');
+  await waitForConsoleMessage(screen, "Proxy {  }");
+  await waitForConsoleMessage(screen, "Symbol()");
+  await waitForConsoleMessage(screen, "Symbol(symbol)");
+  await waitForConsoleMessage(screen, `Object { "Symbol()": 42, "Symbol(symbol)": "Symbol()" }`);
 
-  msg = await waitForConsoleMessage(page, "Object { _foo: C }");
+  msg = await waitForConsoleMessage(screen, "Object { _foo: C }");
 
   // TODO: add support for expanding objects in the console
   await checkMessageObjectContents(
-    page,
+    screen,
     msg,
     ['foo: C { baz: "baz" }', 'bar: "bar"', 'baz: "baz"'],
     ["foo", "bar"]
   );
 
-  await warpToMessage(page, "Done");
+  await warpToMessage(screen, "Done");
 
-  await executeInConsole(page, "Error('helo')");
-  await waitForConsoleMessage(page, 'Error: "helo"');
+  await executeInConsole(screen, "Error('helo')");
+  await waitForConsoleMessage(screen, 'Error: "helo"');
 
   await executeInConsole(
-    page,
+    screen,
     `
         function f() {
           throw Error("there");
@@ -69,71 +69,71 @@ test(`expressions in the console after time warping.`, async ({ page }) => {
       `
   );
   // FIXME the first line in this stack isn't right.
-  await waitForConsoleMessage(page, 'Error: "there"');
+  await waitForConsoleMessage(screen, 'Error: "there"');
 
-  executeInConsole(page, "Array(1, 2, 3)");
-  msg = await waitForConsoleMessage(page, "Array(3) [ 1, 2, 3 ]");
-  await checkMessageObjectContents(page, msg, ["0: 1", "1: 2", "2: 3", "length: 3"]);
+  executeInConsole(screen, "Array(1, 2, 3)");
+  msg = await waitForConsoleMessage(screen, "Array(3) [ 1, 2, 3 ]");
+  await checkMessageObjectContents(screen, msg, ["0: 1", "1: 2", "2: 3", "length: 3"]);
 
-  await executeInConsole(page, "new Uint8Array([1, 2, 3, 4])");
-  msg = await waitForConsoleMessage(page, "Uint8Array(4) [ 1, 2, 3, 4 ]");
-  await checkMessageObjectContents(page, msg, ["0: 1", "1: 2", "2: 3", "3: 4", "length: 4"]);
+  await executeInConsole(screen, "new Uint8Array([1, 2, 3, 4])");
+  msg = await waitForConsoleMessage(screen, "Uint8Array(4) [ 1, 2, 3, 4 ]");
+  await checkMessageObjectContents(screen, msg, ["0: 1", "1: 2", "2: 3", "3: 4", "length: 4"]);
 
-  await executeInConsole(page, `RegExp("abd", "g")`);
-  msg = await waitForConsoleMessage(page, "/abd/g");
+  await executeInConsole(screen, `RegExp("abd", "g")`);
+  msg = await waitForConsoleMessage(screen, "/abd/g");
 
   // RegExp object properties are not currently available in chromium.
 
-  await checkMessageObjectContents(page, msg, ["global: true", `source: "abd"`]);
+  await checkMessageObjectContents(screen, msg, ["global: true", `source: "abd"`]);
 
-  await executeInConsole(page, "new Set([1, 2, 3])");
-  msg = await waitForConsoleMessage(page, "Set(3) [ 1, 2, 3 ]");
-  await checkMessageObjectContents(page, msg, ["0: 1", "1: 2", "2: 3", "size: 3"], ["<entries>"]);
+  await executeInConsole(screen, "new Set([1, 2, 3])");
+  msg = await waitForConsoleMessage(screen, "Set(3) [ 1, 2, 3 ]");
+  await checkMessageObjectContents(screen, msg, ["0: 1", "1: 2", "2: 3", "size: 3"], ["<entries>"]);
 
-  await executeInConsole(page, "new Map([[1, {a:1}], [2, {b:2}]])");
-  msg = await waitForConsoleMessage(page, "Map { 1 → {…}, 2 → {…} }");
+  await executeInConsole(screen, "new Map([[1, {a:1}], [2, {b:2}]])");
+  msg = await waitForConsoleMessage(screen, "Map { 1 → {…}, 2 → {…} }");
   await checkMessageObjectContents(
-    page,
+    screen,
     msg,
     ["0: 1 → Object { a: 1 }", "1: 2 → Object { b: 2 }", "size: 2"],
     ["<entries>"]
   );
 
-  await executeInConsole(page, "new WeakSet([{a:1}, {b:2}])");
-  msg = await waitForConsoleMessage(page, "WeakSet(2) [ {…}, {…} ]");
+  await executeInConsole(screen, "new WeakSet([{a:1}, {b:2}])");
+  msg = await waitForConsoleMessage(screen, "WeakSet(2) [ {…}, {…} ]");
   await checkMessageObjectContents(
-    page,
+    screen,
     msg,
     ["Object { a: 1 }", "Object { b: 2 }"],
     ["<entries>"]
   );
 
-  await executeInConsole(page, "new WeakMap([[{a:1},{b:1}], [{a:2},{b:2}]])");
-  msg = await waitForConsoleMessage(page, "WeakMap { {…} → {…}, {…} → {…} }");
+  await executeInConsole(screen, "new WeakMap([[{a:1},{b:1}], [{a:2},{b:2}]])");
+  msg = await waitForConsoleMessage(screen, "WeakMap { {…} → {…}, {…} → {…} }");
   await checkMessageObjectContents(
-    page,
+    screen,
     msg,
     ["Object { a: 1 } → Object { b: 1 }", "Object { a: 2 } → Object { b: 2 }"],
     ["<entries>"]
   );
 
-  await executeInConsole(page, "new Promise(() => {})");
-  msg = await waitForConsoleMessage(page, "Promise {  }");
+  await executeInConsole(screen, "new Promise(() => {})");
+  msg = await waitForConsoleMessage(screen, "Promise {  }");
 
   // Promise contents aren't currently available in chromium.
 
-  await checkMessageObjectContents(page, msg, ['"pending"'], []);
+  await checkMessageObjectContents(screen, msg, ['"pending"'], []);
 
-  await executeInConsole(page, "Promise.resolve({ a: 1 })");
-  msg = await waitForConsoleMessage(page, "Promise {  }");
+  await executeInConsole(screen, "Promise.resolve({ a: 1 })");
+  msg = await waitForConsoleMessage(screen, "Promise {  }");
 
-  await checkMessageObjectContents(page, msg, ['"fulfilled"', "a: 1"], ["<value>"]);
+  await checkMessageObjectContents(screen, msg, ['"fulfilled"', "a: 1"], ["<value>"]);
 
-  await executeInConsole(page, "Promise.reject({ a: 1 })");
-  msg = await waitForConsoleMessage(page, "Promise {  }");
+  await executeInConsole(screen, "Promise.reject({ a: 1 })");
+  msg = await waitForConsoleMessage(screen, "Promise {  }");
 
-  await executeInConsole(page, "baz");
-  msg = await waitForConsoleMessage(page, "function baz()");
+  await executeInConsole(screen, "baz");
+  msg = await waitForConsoleMessage(screen, "function baz()");
   const text = await msg.textContent();
-  checkJumpIcon(page, text!);
+  checkJumpIcon(screen, text!);
 });

--- a/packages/e2e-tests/tests/stepping-01.test.ts
+++ b/packages/e2e-tests/tests/stepping-01.test.ts
@@ -1,5 +1,5 @@
-import { test } from "@playwright/test";
 import {
+  test,
   checkEvaluateInTopFrame,
   openExample,
   rewind,
@@ -11,30 +11,30 @@ import {
   togglePausePane,
 } from "../helpers";
 
-test("Test basic step-over/back functionality.", async ({ page }) => {
-  await openExample(page, "doc_rr_basic.html");
-  await clickDevTools(page);
+test("Test basic step-over/back functionality.", async ({ screen }) => {
+  await openExample(screen, "doc_rr_basic.html");
+  await clickDevTools(screen);
 
   // Open doc_rr_basic.html
-  await clickSourceTreeNode(page, "test");
-  await clickSourceTreeNode(page, "examples");
-  await clickSourceTreeNode(page, "doc_rr_basic.html");
+  await clickSourceTreeNode(screen, "test");
+  await clickSourceTreeNode(screen, "examples");
+  await clickSourceTreeNode(screen, "doc_rr_basic.html");
 
   // Pause on line 20
-  await toggleBreakpoint(page, 20);
-  await togglePausePane(page);
-  await rewind(page);
+  await toggleBreakpoint(screen, 20);
+  await togglePausePane(screen);
+  await rewind(screen);
 
   // Should get ten when evaluating number.
-  await checkEvaluateInTopFrame(page, "number", "10");
+  await checkEvaluateInTopFrame(screen, "number", "10");
 
   // Should get nine when stepping over.
-  await reverseStepOver(page);
-  await checkEvaluateInTopFrame(page, "number", "9");
+  await reverseStepOver(screen);
+  await checkEvaluateInTopFrame(screen, "number", "9");
 
   // Should get ten when stepping over.
-  await stepOver(page);
-  await checkEvaluateInTopFrame(page, "number", "10");
+  await stepOver(screen);
+  await checkEvaluateInTopFrame(screen, "number", "10");
 
   await new Promise(r => setTimeout(r, 1_000));
 });

--- a/packages/e2e-tests/tests/stepping-02.test.ts
+++ b/packages/e2e-tests/tests/stepping-02.test.ts
@@ -1,5 +1,5 @@
-import { test } from "@playwright/test";
 import {
+  test,
   openExample,
   clickDevTools,
   rewindToLine,
@@ -12,31 +12,31 @@ import {
   waitForScopeValue,
 } from "../helpers";
 
-test("Test basic step-over/back functionality.", async ({ page }) => {
-  await openExample(page, "doc_rr_basic.html");
-  await clickDevTools(page);
+test("Test basic step-over/back functionality.", async ({ screen }) => {
+  await openExample(screen, "doc_rr_basic.html");
+  await clickDevTools(screen);
 
   // Open doc_rr_basic.html
-  await clickSourceTreeNode(page, "test");
-  await clickSourceTreeNode(page, "examples");
-  await clickSourceTreeNode(page, "doc_rr_basic.html");
+  await clickSourceTreeNode(screen, "test");
+  await clickSourceTreeNode(screen, "examples");
+  await clickSourceTreeNode(screen, "doc_rr_basic.html");
 
-  await toggleBreakpoint(page, 21);
-  await rewindToLine(page, 21);
+  await toggleBreakpoint(screen, 21);
+  await rewindToLine(screen, 21);
 
-  await stepInToLine(page, 24);
-  await stepOverToLine(page, 25);
-  await stepOverToLine(page, 26);
-  await reverseStepOverToLine(page, 25);
-  await stepInToLine(page, 29);
-  await stepOverToLine(page, 30);
-  await stepOverToLine(page, 31);
+  await stepInToLine(screen, 24);
+  await stepOverToLine(screen, 25);
+  await stepOverToLine(screen, 26);
+  await reverseStepOverToLine(screen, 25);
+  await stepInToLine(screen, 29);
+  await stepOverToLine(screen, 30);
+  await stepOverToLine(screen, 31);
 
   // Check that the scopes pane shows the value of the local variable.
-  await waitForScopeValue(page, "c", "NaN");
-  await stepOverToLine(page, 32);
-  await reverseStepOverToLine(page, 31);
-  await stepOutToLine(page, 26);
-  await reverseStepOverToLine(page, 25);
-  await reverseStepOverToLine(page, 24);
+  await waitForScopeValue(screen, "c", "NaN");
+  await stepOverToLine(screen, 32);
+  await reverseStepOverToLine(screen, 31);
+  await stepOutToLine(screen, 26);
+  await reverseStepOverToLine(screen, 25);
+  await reverseStepOverToLine(screen, 24);
 });

--- a/packages/e2e-tests/tests/stepping-03.test.ts
+++ b/packages/e2e-tests/tests/stepping-03.test.ts
@@ -1,5 +1,5 @@
-import { test } from "@playwright/test";
 import {
+  test,
   openExample,
   clickDevTools,
   rewindToLine,
@@ -11,36 +11,36 @@ import {
 } from "../helpers";
 
 test(`Stepping past the beginning or end of a frame should act like a step-out.`, async ({
-  page,
+  screen,
 }) => {
-  await openExample(page, "doc_rr_basic.html");
-  await clickDevTools(page);
+  await openExample(screen, "doc_rr_basic.html");
+  await clickDevTools(screen);
 
   // Open doc_rr_basic.html
-  await clickSourceTreeNode(page, "test");
-  await clickSourceTreeNode(page, "examples");
-  await clickSourceTreeNode(page, "doc_rr_basic.html");
+  await clickSourceTreeNode(screen, "test");
+  await clickSourceTreeNode(screen, "examples");
+  await clickSourceTreeNode(screen, "doc_rr_basic.html");
 
-  await toggleBreakpoint(page, 20);
+  await toggleBreakpoint(screen, 20);
 
-  await rewindToLine(page, 20);
-  await checkEvaluateInTopFrame(page, "number", "10");
-  await reverseStepOverToLine(page, 19);
-  await reverseStepOverToLine(page, 11);
+  await rewindToLine(screen, 20);
+  await checkEvaluateInTopFrame(screen, "number", "10");
+  await reverseStepOverToLine(screen, 19);
+  await reverseStepOverToLine(screen, 11);
 
   // After reverse-stepping out of the topmost frame we should rewind to the
   // last breakpoint hit.
-  await reverseStepOverToLine(page, 20);
-  await checkEvaluateInTopFrame(page, "number", "9");
+  await reverseStepOverToLine(screen, 20);
+  await checkEvaluateInTopFrame(screen, "number", "9");
 
-  await stepOverToLine(page, 21);
-  await stepOverToLine(page, 22);
-  await stepOverToLine(page, 12);
-  await stepOverToLine(page, 16);
-  await stepOverToLine(page, 17);
+  await stepOverToLine(screen, 21);
+  await stepOverToLine(screen, 22);
+  await stepOverToLine(screen, 12);
+  await stepOverToLine(screen, 16);
+  await stepOverToLine(screen, 17);
 
   // After forward-stepping out of the topmost frame we should run forward to
   // the next breakpoint hit.
-  await stepOverToLine(page, 20);
-  await checkEvaluateInTopFrame(page, "number", "10");
+  await stepOverToLine(screen, 20);
+  await checkEvaluateInTopFrame(screen, "number", "10");
 });

--- a/packages/e2e-tests/tests/stepping-05.test.ts
+++ b/packages/e2e-tests/tests/stepping-05.test.ts
@@ -1,5 +1,5 @@
-import { test } from "@playwright/test";
 import {
+  test,
   openExample,
   clickDevTools,
   rewindToLine,
@@ -13,27 +13,27 @@ import {
   warpToMessage,
 } from "../helpers";
 
-test(`Test stepping in pretty-printed code`, async ({ page }) => {
-  await openExample(page, "doc_minified.html");
-  await clickDevTools(page);
-  await addBreakpoint(page, "bundle_input.js", 4);
-  await rewindToLine(page, 4);
-  await stepInToLine(page, 1);
+test(`Test stepping in pretty-printed code`, async ({ screen }) => {
+  await openExample(screen, "doc_minified.html");
+  await clickDevTools(screen);
+  await addBreakpoint(screen, "bundle_input.js", 4);
+  await rewindToLine(screen, 4);
+  await stepInToLine(screen, 1);
 
   // Add a breakpoint in minified.html and resume to there
-  await addBreakpoint(page, "doc_minified.html", 8);
-  await resumeToLine(page, 8);
-  await stepOverToLine(page, 8);
-  await stepOverToLine(page, 9);
+  await addBreakpoint(screen, "doc_minified.html", 8);
+  await resumeToLine(screen, 8);
+  await stepOverToLine(screen, 8);
+  await stepOverToLine(screen, 9);
 
-  await selectConsole(page);
-  await addEventListenerLogpoints(page, ["event.mouse.click"]);
-  await warpToMessage(page, "click", 14);
+  await selectConsole(screen);
+  await addEventListenerLogpoints(screen, ["event.mouse.click"]);
+  await warpToMessage(screen, "click", 14);
 
-  await stepInToLine(page, 2);
-  await stepOutToLine(page, 15);
-  await stepInToLine(page, 10);
-  await stepOutToLine(page, 15);
-  await stepInToLine(page, 5);
-  await stepOutToLine(page, 15);
+  await stepInToLine(screen, 2);
+  await stepOutToLine(screen, 15);
+  await stepInToLine(screen, 10);
+  await stepOutToLine(screen, 15);
+  await stepInToLine(screen, 5);
+  await stepOutToLine(screen, 15);
 });

--- a/packages/e2e-tests/tests/stepping-06-gecko.test.ts
+++ b/packages/e2e-tests/tests/stepping-06-gecko.test.ts
@@ -1,5 +1,5 @@
-import { test } from "@playwright/test";
 import {
+  test,
   openExample,
   clickDevTools,
   rewindToLine,
@@ -19,41 +19,41 @@ import {
   reverseStepOverToLine,
 } from "../helpers";
 
-test(`Test stepping in async frames and async call stacks.`, async ({ page }) => {
-  await openExample(page, "doc_async.html");
-  await clickDevTools(page);
+test(`Test stepping in async frames and async call stacks.`, async ({ screen }) => {
+  await openExample(screen, "doc_async.html");
+  await clickDevTools(screen);
 
-  await warpToMessage(page, "baz 2");
-  await checkFrames(page, 5);
-  await waitForScopeValue(page, "n", "2");
+  await warpToMessage(screen, "baz 2");
+  await checkFrames(screen, 5);
+  await waitForScopeValue(screen, "n", "2");
 
-  await waitForFrameTimeline(page, "25%");
+  await waitForFrameTimeline(screen, "25%");
 
-  await selectFrame(page, 1);
-  await waitForScopeValue(page, "n", "3");
-  await waitForFrameTimeline(page, "87%");
+  await selectFrame(screen, 1);
+  await waitForScopeValue(screen, "n", "3");
+  await waitForFrameTimeline(screen, "87%");
 
-  await selectFrame(page, 2);
-  await waitForScopeValue(page, "n", "4");
-  await waitForFrameTimeline(page, "87%");
+  await selectFrame(screen, 2);
+  await waitForScopeValue(screen, "n", "4");
+  await waitForFrameTimeline(screen, "87%");
 
-  await selectFrame(page, 3);
-  await waitForFrameTimeline(page, "71%");
+  await selectFrame(screen, 3);
+  await waitForFrameTimeline(screen, "71%");
 
-  await selectFrame(page, 4);
-  await waitForFrameTimeline(page, "100%");
+  await selectFrame(screen, 4);
+  await waitForFrameTimeline(screen, "100%");
 
-  await selectFrame(page, 0);
+  await selectFrame(screen, 0);
 
-  await stepOverToLine(page, 20);
-  await stepOverToLine(page, 21);
-  await stepOverToLine(page, 22);
-  await stepOverToLine(page, 24);
-  await checkEvaluateInTopFrame(page, "n", 2);
-  await stepOutToLine(page, 24);
-  await checkEvaluateInTopFrame(page, "n", 3);
-  await stepOutToLine(page, 24);
-  await checkEvaluateInTopFrame(page, "n", 4);
-  await stepOutToLine(page, 13);
-  await reverseStepOverToLine(page, 12);
+  await stepOverToLine(screen, 20);
+  await stepOverToLine(screen, 21);
+  await stepOverToLine(screen, 22);
+  await stepOverToLine(screen, 24);
+  await checkEvaluateInTopFrame(screen, "n", 2);
+  await stepOutToLine(screen, 24);
+  await checkEvaluateInTopFrame(screen, "n", 3);
+  await stepOutToLine(screen, 24);
+  await checkEvaluateInTopFrame(screen, "n", 4);
+  await stepOutToLine(screen, 13);
+  await reverseStepOverToLine(screen, 12);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3342,6 +3342,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@playwright-testing-library/test@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "@playwright-testing-library/test@npm:4.4.0"
+  dependencies:
+    "@testing-library/dom": ^7.31.2
+    wait-for-expect: ^3.0.2
+  peerDependencies:
+    "@playwright/test": ^1.12.0
+    playwright: ^1.12.0
+  peerDependenciesMeta:
+    "@playwright/test":
+      optional: true
+    playwright:
+      optional: true
+  checksum: 6f6489f66019f04ab06d318376ad347e205a833c716926085d548ad5514d8ee9c8bacc41144f8b2f9d90577d9089624353d7761758d3b60ddcdff44ca990d4d8
+  languageName: node
+  linkType: hard
+
 "@playwright/test@npm:^1.23.1":
   version: 1.23.1
   resolution: "@playwright/test@npm:1.23.1"
@@ -5461,6 +5479,22 @@ __metadata:
   peerDependencies:
     tailwindcss: ">=3.0.0 || >= 3.0.0-alpha.1"
   checksum: 3c4df23491d14b37d8cef88d0f3df80f92b684b801d59c23d600773a4ccac11353a555ca36bea68ae4a82134f9c030d1353c05890a5f0085c1c40c649f806640
+  languageName: node
+  linkType: hard
+
+"@testing-library/dom@npm:^7.31.2":
+  version: 7.31.2
+  resolution: "@testing-library/dom@npm:7.31.2"
+  dependencies:
+    "@babel/code-frame": ^7.10.4
+    "@babel/runtime": ^7.12.5
+    "@types/aria-query": ^4.2.0
+    aria-query: ^4.2.2
+    chalk: ^4.1.0
+    dom-accessibility-api: ^0.5.6
+    lz-string: ^1.4.4
+    pretty-format: ^26.6.2
+  checksum: 54fbedd1ecdfe1d47be2e592b98d18b2ab9d7e731f57231caf9b152593fe7329fe5ebe219e0e5d1e0df5b1ab803121cb8acd8b73bd1fb292bfdc2c55663eb01d
   languageName: node
   linkType: hard
 
@@ -7640,7 +7674,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-regex@npm:^5.0.1":
+"ansi-regex@npm:^5.0.0, ansi-regex@npm:^5.0.1":
   version: 5.0.1
   resolution: "ansi-regex@npm:5.0.1"
   checksum: 2aa4bb54caf2d622f1afdad09441695af2a83aa3fe8b8afa581d205e57ed4261c183c4d3877cee25794443fde5876417d859c108078ab788d6af7e4fe52eb66b
@@ -13199,6 +13233,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "functional-tests@workspace:packages/e2e-tests"
   dependencies:
+    "@playwright-testing-library/test": ^4.4.0
     "@playwright/test": ^1.25.1
     "@replayio/playwright": ^0.2.24
     playwright: ^1.25.1
@@ -19439,6 +19474,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pretty-format@npm:^26.6.2":
+  version: 26.6.2
+  resolution: "pretty-format@npm:26.6.2"
+  dependencies:
+    "@jest/types": ^26.6.2
+    ansi-regex: ^5.0.0
+    ansi-styles: ^4.0.0
+    react-is: ^17.0.1
+  checksum: e3b808404d7e1519f0df1aa1f25cee0054ab475775c6b2b8c5568ff23194a92d54bf93274139b6f584ca70fd773be4eaa754b0e03f12bb0a8d1426b07f079976
+  languageName: node
+  linkType: hard
+
 "pretty-format@npm:^27.0.0, pretty-format@npm:^27.0.2, pretty-format@npm:^27.5.1":
   version: 27.5.1
   resolution: "pretty-format@npm:27.5.1"
@@ -24231,6 +24278,13 @@ __metadata:
   dependencies:
     xml-name-validator: ^4.0.0
   checksum: 0af8589942eeb11c9fe29eb31a1a09f3d5dd136aea53a9848dfbabff79ac0dd26fe13eb54d330d5555fe27bb50b28dca0715e09f9cc2bfa7670ccc8b7f919ca2
+  languageName: node
+  linkType: hard
+
+"wait-for-expect@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "wait-for-expect@npm:3.0.2"
+  checksum: 2ec1ebd78023fa10bdcf53d78bbd65feea68fdfa0de0b00f3a72f3df089118b91517839ff3926e5ef6cfd1ede65085326d85b0378d4db62c266cc9c859c2de56
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR:

- Adds https://github.com/testing-library/playwright-testing-library to let us use the Testing Library DOM query APIs with Playwright
- Updates all tests and helper methods to pass through `screen` instead of `page`, as the `Screen` type is a superset of the `Page` type that adds all the Testing Library queries (such as `screen.getByTestId()` )