### PR TITLE
Test suite updates

### DIFF
--- a/packages/e2e-tests/tests/breakpoints-01.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-01.test.ts
@@ -12,7 +12,7 @@ test(`Test basic breakpoint functionality.`, async ({ screen }) => {
   await openExample(screen, "doc_rr_basic.html");
   await clickDevTools(screen);
 
-  await addBreakpoint(screen, "doc_rr_basic.html", 21);
+  await addBreakpoint(screen, { lineNumber: 21, url: "doc_rr_basic.html" });
 
   await rewindToLine(screen, {
     lineNumber: 21,

--- a/packages/e2e-tests/tests/breakpoints-02.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-02.test.ts
@@ -11,9 +11,9 @@ test(`Test unhandled divergence while evaluating at a breakpoint.`, async ({ scr
   await openExample(screen, "doc_rr_basic.html");
   await clickDevTools(screen);
 
-  await addBreakpoint(screen, "doc_rr_basic.html", 21);
+  await addBreakpoint(screen, { lineNumber: 21, url: "doc_rr_basic.html" });
 
-  await rewindToLine(screen, {lineNumber: 21});
+  await rewindToLine(screen, { lineNumber: 21 });
 
   await checkEvaluateInTopFrame(screen, "number", "10");
   await checkEvaluateInTopFrame(screen, "dump(3)", `The expression could not be evaluated.`);

--- a/packages/e2e-tests/tests/breakpoints-03.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-03.test.ts
@@ -15,17 +15,17 @@ test(`Test stepping forward through breakpoints when rewound before the first on
   await openExample(screen, "doc_rr_basic.html");
   await clickDevTools(screen);
 
-  await addBreakpoint(screen, "doc_rr_basic.html", 8);
+  await addBreakpoint(screen, { lineNumber: 8, url: "doc_rr_basic.html" });
   // Rewind to when the point was hit
-  await rewindToLine(screen, {lineNumber: 8});
+  await rewindToLine(screen, { lineNumber: 8 });
   // Rewind further (past the first hit)
   await rewindToLine(screen);
 
-  await removeBreakpoint(screen, "doc_rr_basic.html", 8);
+  await removeBreakpoint(screen, { lineNumber: 8, url: "doc_rr_basic.html" });
 
-  await addBreakpoint(screen, "doc_rr_basic.html", 21);
-  await resumeToLine(screen, {lineNumber: 21});
+  await addBreakpoint(screen, { lineNumber: 21, url: "doc_rr_basic.html" });
+  await resumeToLine(screen, { lineNumber: 21 });
   await checkEvaluateInTopFrame(screen, "number", "1");
-  await resumeToLine(screen, {lineNumber: 21});
+  await resumeToLine(screen, { lineNumber: 21 });
   await checkEvaluateInTopFrame(screen, "number", "2");
 });

--- a/packages/e2e-tests/tests/breakpoints-04.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-04.test.ts
@@ -19,8 +19,8 @@ test(`catch, finally, generators, and async/await.`, async ({ screen }) => {
   await resumeToBreakpoint(screen, 20);
   await resumeToBreakpoint(screen, 32);
   await resumeToBreakpoint(screen, 27);
-  await resumeToLine(screen, {lineNumber: 32});
-  await resumeToLine(screen, {lineNumber: 27});
+  await resumeToLine(screen, { lineNumber: 32 });
+  await resumeToLine(screen, { lineNumber: 27 });
   await resumeToBreakpoint(screen, 42);
   await resumeToBreakpoint(screen, 44);
   await resumeToBreakpoint(screen, 50);
@@ -29,12 +29,12 @@ test(`catch, finally, generators, and async/await.`, async ({ screen }) => {
   await resumeToBreakpoint(screen, 72);
 
   async function rewindToBreakpoint(screen: Screen, lineNumber: number) {
-    await addBreakpoint(screen, "doc_control_flow.html", lineNumber);
-    await rewindToLine(screen, {lineNumber});
+    await addBreakpoint(screen, { lineNumber, url: "doc_control_flow.html" });
+    await rewindToLine(screen, { lineNumber });
   }
 
   async function resumeToBreakpoint(screen: Screen, lineNumber: number) {
-    await addBreakpoint(screen, "doc_control_flow.html", lineNumber);
-    await resumeToLine(screen, {lineNumber});
+    await addBreakpoint(screen, { lineNumber, url: "doc_control_flow.html" });
+    await resumeToLine(screen, { lineNumber });
   }
 });

--- a/packages/e2e-tests/tests/breakpoints-05.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-05.test.ts
@@ -1,24 +1,35 @@
 import {
-  test,
-  openExample,
-  clickDevTools,
-  removeAllBreakpoints,
-  rewindToLine,
   addBreakpoint,
+  clickDevTools,
+  openExample,
+  openPauseInformation,
+  removeBreakpoint,
   resumeToLine,
+  rewindToLine,
+  test,
 } from "../helpers";
 
 test(`Test interaction of breakpoints with debugger statements.`, async ({ screen }) => {
   await openExample(screen, "doc_debugger_statements.html");
   await clickDevTools(screen);
+  await openPauseInformation(screen);
 
-  // TODO: remove timeout
-  await new Promise(r => setTimeout(r, 1000));
-  await rewindToLine(screen, 9);
-  await addBreakpoint(screen, "doc_debugger_statements.html", 8);
-  await rewindToLine(screen, 8);
-  await resumeToLine(screen, 9);
-  await removeAllBreakpoints(screen);
-  await rewindToLine(screen, 7);
-  await resumeToLine(screen, 9);
+  // Without any breakpoints, this test should rewind to the closest debugger statement.
+  await rewindToLine(screen, { lineNumber: 9 });
+
+  // Without a breakpoints being the next nearest thing, we should rewind to it.
+  await addBreakpoint(screen, {
+    lineNumber: 8,
+    url: "doc_debugger_statements.html",
+  });
+  await rewindToLine(screen, { lineNumber: 8 });
+  await resumeToLine(screen, { lineNumber: 9 });
+
+  // Without any breakpoints (again), we should rewind to debugger statements.
+  await removeBreakpoint(screen, {
+    lineNumber: 8,
+    url: "doc_debugger_statements.html",
+  });
+  await rewindToLine(screen, { lineNumber: 7 });
+  await resumeToLine(screen, { lineNumber: 9 });
 });

--- a/packages/e2e-tests/tests/breakpoints-06.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-06.test.ts
@@ -1,37 +1,27 @@
-// TODO fix this test
-
 import {
-  test,
-  openExample,
+  addLogpoint,
   clickDevTools,
-  removeAllBreakpoints,
-  rewindToLine,
-  addBreakpoint,
-  resumeToLine,
-  waitForConsoleMessage,
+  getConsoleMessage,
+  openExample,
+  test,
   Screen,
 } from "../helpers";
 
 async function checkMessageLocation(screen: Screen, text: string, location: string) {
-  const msg = await waitForConsoleMessage(screen, text);
-  expect(
-    msg.querySelector(".frame-link a").innerText == location,
-    `Message location should be ${location}`
-  );
+  const message = await getConsoleMessage(screen, text, "log-point");
+  const textContent = await message.textContent();
+  expect(textContent!.includes(location)).toBeTruthy();
 }
 
 test(`Test breakpoints in a sourcemapped file.`, async ({ screen }) => {
   await openExample(screen, "doc_prod_bundle.html");
   await clickDevTools(screen);
+
   console.log("Test that the breakpoint added to line 15 maps to line 15");
-  await addBreakpoint(screen, "bundle_input.js", 15, undefined, {
-    logValue: "'line 15'",
-  });
+  await addLogpoint(screen, { lineNumber: 15, url: "bundle_input.js" });
   await checkMessageLocation(screen, "line 15", "bundle_input.js:15");
 
   console.log("Test that the breakpoint added to line 17 maps to line 17");
-  await addBreakpoint(screen, "bundle_input.js", 17, undefined, {
-    logValue: "'line 17'",
-  });
+  await addLogpoint(screen, { lineNumber: 17, url: "bundle_input.js" });
   await checkMessageLocation(screen, "line 17", "bundle_input.js:17");
 });

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/CommandBar.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/CommandBar.tsx
@@ -5,12 +5,7 @@
 import React, { Component } from "react";
 
 import { connect, ConnectedProps } from "react-redux";
-import {
-  getThreadContext,
-  getBreakpointSources,
-  getFramePositions,
-  hasFrames,
-} from "../../selectors";
+import { getThreadContext, getFramePositions, hasFrames } from "../../selectors";
 import { formatKeyShortcut } from "../../utils/text";
 import actions from "../../actions";
 import CommandBarButton from "../shared/Button/CommandBarButton";
@@ -19,6 +14,7 @@ import { trackEvent } from "ui/utils/telemetry";
 import type { UIState } from "ui/state";
 
 import Services from "devtools/shared/services";
+
 const { appinfo } = Services;
 
 const isMacOS = appinfo.OS === "Darwin";
@@ -154,37 +150,21 @@ class CommandBar extends Component<PropsFromRedux> {
   }
 
   renderRewindButton() {
-    const { hasBreakpoints } = this.props;
-    const disabled = !hasBreakpoints;
-
-    const disabledTooltip = "Rewinding is disabled until you add a breakpoint";
-    const tooltip = "Rewind Execution";
-
     return (
       <CommandBarButton
-        disabled={disabled}
         key="rewind"
         onClick={this.onRewind}
-        tooltip={tooltip}
-        disabledTooltip={disabledTooltip}
+        tooltip="Rewind Execution"
         type="rewind"
       />
     );
   }
   renderResumeButton() {
-    const { hasBreakpoints } = this.props;
-    const disabled = !hasBreakpoints;
-
-    const disabledTooltip = "Resuming is disabled until you add a breakpoint";
-    const tooltip = `Resume ${formatKey("resume")}`;
-
     return (
       <CommandBarButton
-        disabled={disabled}
         key="resume"
         onClick={this.onResume}
-        tooltip={tooltip}
-        disabledTooltip={disabledTooltip}
+        tooltip={`Resume ${formatKey("resume")}`}
         type="resume"
       />
     );
@@ -248,7 +228,6 @@ class CommandBar extends Component<PropsFromRedux> {
 
 const mapStateToProps = (state: UIState) => ({
   cx: getThreadContext(state),
-  hasBreakpoints: getBreakpointSources(state).length,
   hasFramePositions: getFramePositions(state)?.positions.length,
   isPaused: hasFrames(state),
 });

--- a/src/devtools/client/debugger/src/components/shared/Button/CommandBarButton.js
+++ b/src/devtools/client/debugger/src/components/shared/Button/CommandBarButton.js
@@ -7,7 +7,13 @@ import classnames from "classnames";
 import React from "react";
 import AccessibleImage from "../AccessibleImage";
 
-export default function CommandBarButton({ disabled, disabledTooltip, onClick, tooltip, type }) {
+export default function CommandBarButton({
+  disabled = false,
+  disabledTooltip = "",
+  onClick,
+  tooltip,
+  type,
+}) {
   return (
     <button
       className={classnames("command-bar-button")}


### PR DESCRIPTION
- [x] Fixed breakpoints test 5
  - [x] Also uncovered and fixed an old regression in `CommandBar` for `debugger` support
- [x] Changed add/remove breakpoint method signature to use named params
- [x] Make a few of the test helpers log what they're doing to the console so it's easier to follow progress