### PR TITLE
fix object preview test

### DIFF
--- a/packages/e2e-tests/helpers.ts
+++ b/packages/e2e-tests/helpers.ts
@@ -149,7 +149,11 @@ export async function warpToMessage(screen: Screen, text: string, line?: number)
 }
 
 export async function executeInConsole(screen: Screen, text: string) {
-  // TODO [PR 7550]
+  const consoleTextArea = screen.locator('[data-test-id="ConsoleRoot"] textarea');
+
+  await consoleTextArea.focus();
+  await consoleTextArea.fill(text);
+  await consoleTextArea.press("Enter");
 }
 
 export async function checkMessageObjectContents(

--- a/packages/e2e-tests/helpers.ts
+++ b/packages/e2e-tests/helpers.ts
@@ -1,4 +1,4 @@
-import { expect, test as base, PlaywrightTestArgs, Locator } from "@playwright/test";
+import { expect, test as base, PlaywrightTestArgs, Locator, ElementHandle } from "@playwright/test";
 import { waitFor } from "@playwright-testing-library/test";
 import {
   locatorFixtures as fixtures,
@@ -134,7 +134,7 @@ export async function waitForConsoleMessage(
     ? `[data-test-message-type="${messageType}"]`
     : '[data-test-name="Message"]';
 
-  await screen.waitForSelector(`${attributeSelector}:has-text("${expected}")`);
+  return screen.waitForSelector(`${attributeSelector}:has-text("${expected}")`);
 }
 
 export async function warpToMessage(screen: Screen, text: string, line?: number) {
@@ -158,7 +158,7 @@ export async function executeInConsole(screen: Screen, text: string) {
 
 export async function checkMessageObjectContents(
   screen: Screen,
-  message: HTMLElement,
+  message: ElementHandle<HTMLElement | SVGElement>,
   expectedContents: Expected[]
 ) {
   // TODO [PR 7550]

--- a/packages/e2e-tests/tests/object_preview-01.test.ts
+++ b/packages/e2e-tests/tests/object_preview-01.test.ts
@@ -60,8 +60,8 @@ test(`expressions in the console after time warping.`, async ({ screen }) => {
 
   await warpToMessage(screen, "Done");
 
-  // await executeInConsole(screen, "Error('helo')");
-  // await waitForConsoleMessage(screen, 'Error: "helo"');
+  await executeInConsole(screen, "Error('helo')");
+  await waitForConsoleMessage(screen, "Error: helo");
 
   // await executeInConsole(
   //   screen,

--- a/packages/e2e-tests/tests/object_preview-01.test.ts
+++ b/packages/e2e-tests/tests/object_preview-01.test.ts
@@ -3,17 +3,12 @@ import {
   openExample,
   clickDevTools,
   executeInConsole,
-  checkMessageObjectContents,
-  checkJumpIcon,
   selectConsole,
   warpToMessage,
   waitForConsoleMessage,
 } from "../helpers";
 
-// Test the objects produced by console.log() calls and by evaluating various
 test(`expressions in the console after time warping.`, async ({ screen }) => {
-  let message;
-
   await openExample(screen, "doc_rr_objects.html");
   await clickDevTools(screen);
   await selectConsole(screen);
@@ -33,30 +28,15 @@ test(`expressions in the console after time warping.`, async ({ screen }) => {
   await waitForConsoleMessage(screen, "Sun Aug 14 2022 12:23:25 GMT-0700 (Pacific Daylight Time)");
 
   await waitForConsoleMessage(screen, `RangeError: foo`);
-  // await waitForConsoleMessage(
-  //   screen,
-  //   '<div id="foo" class="bar" style="visibility: visible" blahblah="">BAR<div>'
-  // );
 
   await waitForConsoleMessage(screen, "ƒbar()");
-  // await checkJumpIcon(screen, "ƒbar()");
-  // await new Promise(r => setTimeout(r, 100_000));
 
-  // await waitForConsoleMessage(screen, '(6) [undefined, true, 3, null, "z", …]');
   await waitForConsoleMessage(screen, "Proxy{}");
   await waitForConsoleMessage(screen, "Symbol()");
   await waitForConsoleMessage(screen, "Symbol(symbol)");
   await waitForConsoleMessage(screen, `{Symbol(): 42, Symbol(symbol): Symbol()}`);
 
-  message = await waitForConsoleMessage(screen, "{_foo: C{…}, foo: ƒ()}");
-
-  // // TODO: add support for expanding objects in the console
-  // await checkMessageObjectContents(
-  //   screen,
-  //   message,
-  //   ['foo: C { baz: "baz" }', 'bar: "bar"', 'baz: "baz"'],
-  //   ["foo", "bar"]
-  // );
+  await waitForConsoleMessage(screen, "{_foo: C{…}, foo: ƒ()}");
 
   await warpToMessage(screen, "Done");
 
@@ -68,68 +48,35 @@ test(`expressions in the console after time warping.`, async ({ screen }) => {
   await waitForConsoleMessage(screen, "Error: there");
 
   await executeInConsole(screen, "Array(1, 2, 3)");
-  message = await waitForConsoleMessage(screen, "(3) [1, 2, 3]");
-  // await checkMessageObjectContents(screen, message, ["0: 1", "1: 2", "2: 3", "length: 3"]);
+  await waitForConsoleMessage(screen, "(3) [1, 2, 3]");
 
   await executeInConsole(screen, "new Uint8Array([1, 2, 3, 4])");
-  message = await waitForConsoleMessage(screen, "Uint8Array(4) [1, 2, 3, 4]");
-  // await checkMessageObjectContents(screen, message, ["0: 1", "1: 2", "2: 3", "3: 4", "length: 4"]);
+  await waitForConsoleMessage(screen, "Uint8Array(4) [1, 2, 3, 4]");
 
   await executeInConsole(screen, `RegExp("abd", "g")`);
-  message = await waitForConsoleMessage(screen, "/abd/g");
-
-  // RegExp object properties are not currently available in chromium.
-
-  // await checkMessageObjectContents(screen, message, ["global: true", `source: "abd"`]);
+  await waitForConsoleMessage(screen, "/abd/g");
 
   await executeInConsole(screen, "new Set([1, 2, 3])");
-  message = await waitForConsoleMessage(screen, "Set(3) [1, 2, 3]");
-  // await checkMessageObjectContents(screen, message, ["0: 1", "1: 2", "2: 3", "size: 3"], ["<entries>"]);
+  await waitForConsoleMessage(screen, "Set(3) [1, 2, 3]");
 
   await executeInConsole(screen, "new Map([[1, {a:1}], [2, {b:2}]])");
-  message = await waitForConsoleMessage(screen, "Map(2) {1 → {…}, 2 → {…}}");
-  // await checkMessageObjectContents(
-  //   screen,
-  //   message,
-  //   ["0: 1 → Object { a: 1 }", "1: 2 → Object { b: 2 }", "size: 2"],
-  //   ["<entries>"]
-  // );
+  await waitForConsoleMessage(screen, "Map(2) {1 → {…}, 2 → {…}}");
 
   await executeInConsole(screen, "new WeakSet([{a:1}, {b:2}])");
-  message = await waitForConsoleMessage(screen, "WeakSet(2) [{…}, {…}]");
-  // await checkMessageObjectContents(
-  //   screen,
-  //   message,
-  //   ["Object { a: 1 }", "Object { b: 2 }"],
-  //   ["<entries>"]
-  // );
+  await waitForConsoleMessage(screen, "WeakSet(2) [{…}, {…}]");
 
   await executeInConsole(screen, "new WeakMap([[{a:1},{b:1}], [{a:2},{b:2}]])");
-  message = await waitForConsoleMessage(screen, "WeakMap(2) {{…} → {…}, {…} → {…}}");
-  // await checkMessageObjectContents(
-  //   screen,
-  //   message,
-  //   ["Object { a: 1 } → Object { b: 1 }", "Object { a: 2 } → Object { b: 2 }"],
-  //   ["<entries>"]
-  // );
+  await waitForConsoleMessage(screen, "WeakMap(2) {{…} → {…}, {…} → {…}}");
 
   await executeInConsole(screen, "new Promise(() => {})");
-  message = await waitForConsoleMessage(screen, "Promise{}");
-
-  // Promise contents aren't currently available in chromium.
-
-  // await checkMessageObjectContents(screen, message, ['"pending"'], []);
+  await waitForConsoleMessage(screen, "Promise{}");
 
   await executeInConsole(screen, "Promise.resolve({ a: 1 })");
-  message = await waitForConsoleMessage(screen, "Promise{}");
-
-  // await checkMessageObjectContents(screen, message, ['"fulfilled"', "a: 1"], ["<value>"]);
+  await waitForConsoleMessage(screen, "Promise{}");
 
   await executeInConsole(screen, "Promise.reject({ a: 1 })");
-  message = await waitForConsoleMessage(screen, "Promise{}");
+  await waitForConsoleMessage(screen, "Promise{}");
 
   await executeInConsole(screen, "baz");
-  message = await waitForConsoleMessage(screen, "ƒbaz()");
-  // const text = await message.textContent();
-  // checkJumpIcon(screen, text!);
+  await waitForConsoleMessage(screen, "ƒbaz()");
 });

--- a/packages/e2e-tests/tests/object_preview-01.test.ts
+++ b/packages/e2e-tests/tests/object_preview-01.test.ts
@@ -44,7 +44,6 @@ test(`expressions in the console after time warping.`, async ({ screen }) => {
   await waitForConsoleMessage(screen, "Error: helo");
 
   await executeInConsole(screen, 'function f() { throw Error("there"); }()');
-  // FIXME the first line in this stack isn't right.
   await waitForConsoleMessage(screen, "Error: there");
 
   await executeInConsole(screen, "Array(1, 2, 3)");

--- a/packages/e2e-tests/tests/object_preview-01.test.ts
+++ b/packages/e2e-tests/tests/object_preview-01.test.ts
@@ -12,7 +12,8 @@ import {
 
 // Test the objects produced by console.log() calls and by evaluating various
 test(`expressions in the console after time warping.`, async ({ screen }) => {
-  let msg;
+  let message;
+
   await openExample(screen, "doc_rr_objects.html");
   await clickDevTools(screen);
   await selectConsole(screen);
@@ -37,17 +38,17 @@ test(`expressions in the console after time warping.`, async ({ screen }) => {
   //   '<div id="foo" class="bar" style="visibility: visible" blahblah="">BAR<div>'
   // );
 
-  // await waitForConsoleMessage(screen, "function bar()");
-  // await checkJumpIcon(screen, "function bar()");
-  // // await new Promise(r => setTimeout(r, 100_000));
+  await waitForConsoleMessage(screen, "ƒbar()");
+  // await checkJumpIcon(screen, "ƒbar()");
+  // await new Promise(r => setTimeout(r, 100_000));
 
-  // await waitForConsoleMessage(screen, 'Array(6) [ undefined, true, 3, null, "z", 40n ]');
-  // await waitForConsoleMessage(screen, "Proxy {  }");
-  // await waitForConsoleMessage(screen, "Symbol()");
-  // await waitForConsoleMessage(screen, "Symbol(symbol)");
-  // await waitForConsoleMessage(screen, `Object { "Symbol()": 42, "Symbol(symbol)": "Symbol()" }`);
+  // await waitForConsoleMessage(screen, '(6) [undefined, true, 3, null, "z", …]');
+  await waitForConsoleMessage(screen, "Proxy{}");
+  await waitForConsoleMessage(screen, "Symbol()");
+  await waitForConsoleMessage(screen, "Symbol(symbol)");
+  await waitForConsoleMessage(screen, `{Symbol(): 42, Symbol(symbol): Symbol()}`);
 
-  // msg = await waitForConsoleMessage(screen, "Object { _foo: C }");
+  message = await waitForConsoleMessage(screen, "{_foo: C{…}, foo: ƒ()}");
 
   // // TODO: add support for expanding objects in the console
   // await checkMessageObjectContents(
@@ -57,7 +58,7 @@ test(`expressions in the console after time warping.`, async ({ screen }) => {
   //   ["foo", "bar"]
   // );
 
-  // await warpToMessage(screen, "Done");
+  await warpToMessage(screen, "Done");
 
   // await executeInConsole(screen, "Error('helo')");
   // await waitForConsoleMessage(screen, 'Error: "helo"');

--- a/packages/e2e-tests/tests/object_preview-01.test.ts
+++ b/packages/e2e-tests/tests/object_preview-01.test.ts
@@ -53,7 +53,7 @@ test(`expressions in the console after time warping.`, async ({ screen }) => {
   // // TODO: add support for expanding objects in the console
   // await checkMessageObjectContents(
   //   screen,
-  //   msg,
+  //   message,
   //   ['foo: C { baz: "baz" }', 'bar: "bar"', 'baz: "baz"'],
   //   ["foo", "bar"]
   // );
@@ -63,81 +63,73 @@ test(`expressions in the console after time warping.`, async ({ screen }) => {
   await executeInConsole(screen, "Error('helo')");
   await waitForConsoleMessage(screen, "Error: helo");
 
-  // await executeInConsole(
-  //   screen,
-  //   `
-  //       function f() {
-  //         throw Error("there");
-  //       }
-  //       f();
-  //     `
-  // );
-  // // FIXME the first line in this stack isn't right.
-  // await waitForConsoleMessage(screen, 'Error: "there"');
+  await executeInConsole(screen, 'function f() { throw Error("there"); }()');
+  // FIXME the first line in this stack isn't right.
+  await waitForConsoleMessage(screen, "Error: there");
 
-  // executeInConsole(screen, "Array(1, 2, 3)");
-  // msg = await waitForConsoleMessage(screen, "Array(3) [ 1, 2, 3 ]");
-  // await checkMessageObjectContents(screen, msg, ["0: 1", "1: 2", "2: 3", "length: 3"]);
+  await executeInConsole(screen, "Array(1, 2, 3)");
+  message = await waitForConsoleMessage(screen, "(3) [1, 2, 3]");
+  // await checkMessageObjectContents(screen, message, ["0: 1", "1: 2", "2: 3", "length: 3"]);
 
-  // await executeInConsole(screen, "new Uint8Array([1, 2, 3, 4])");
-  // msg = await waitForConsoleMessage(screen, "Uint8Array(4) [ 1, 2, 3, 4 ]");
-  // await checkMessageObjectContents(screen, msg, ["0: 1", "1: 2", "2: 3", "3: 4", "length: 4"]);
+  await executeInConsole(screen, "new Uint8Array([1, 2, 3, 4])");
+  message = await waitForConsoleMessage(screen, "Uint8Array(4) [1, 2, 3, 4]");
+  // await checkMessageObjectContents(screen, message, ["0: 1", "1: 2", "2: 3", "3: 4", "length: 4"]);
 
-  // await executeInConsole(screen, `RegExp("abd", "g")`);
-  // msg = await waitForConsoleMessage(screen, "/abd/g");
+  await executeInConsole(screen, `RegExp("abd", "g")`);
+  message = await waitForConsoleMessage(screen, "/abd/g");
 
-  // // RegExp object properties are not currently available in chromium.
+  // RegExp object properties are not currently available in chromium.
 
-  // await checkMessageObjectContents(screen, msg, ["global: true", `source: "abd"`]);
+  // await checkMessageObjectContents(screen, message, ["global: true", `source: "abd"`]);
 
-  // await executeInConsole(screen, "new Set([1, 2, 3])");
-  // msg = await waitForConsoleMessage(screen, "Set(3) [ 1, 2, 3 ]");
-  // await checkMessageObjectContents(screen, msg, ["0: 1", "1: 2", "2: 3", "size: 3"], ["<entries>"]);
+  await executeInConsole(screen, "new Set([1, 2, 3])");
+  message = await waitForConsoleMessage(screen, "Set(3) [1, 2, 3]");
+  // await checkMessageObjectContents(screen, message, ["0: 1", "1: 2", "2: 3", "size: 3"], ["<entries>"]);
 
-  // await executeInConsole(screen, "new Map([[1, {a:1}], [2, {b:2}]])");
-  // msg = await waitForConsoleMessage(screen, "Map { 1 → {…}, 2 → {…} }");
+  await executeInConsole(screen, "new Map([[1, {a:1}], [2, {b:2}]])");
+  message = await waitForConsoleMessage(screen, "Map(2) {1 → {…}, 2 → {…}}");
   // await checkMessageObjectContents(
   //   screen,
-  //   msg,
+  //   message,
   //   ["0: 1 → Object { a: 1 }", "1: 2 → Object { b: 2 }", "size: 2"],
   //   ["<entries>"]
   // );
 
-  // await executeInConsole(screen, "new WeakSet([{a:1}, {b:2}])");
-  // msg = await waitForConsoleMessage(screen, "WeakSet(2) [ {…}, {…} ]");
+  await executeInConsole(screen, "new WeakSet([{a:1}, {b:2}])");
+  message = await waitForConsoleMessage(screen, "WeakSet(2) [{…}, {…}]");
   // await checkMessageObjectContents(
   //   screen,
-  //   msg,
+  //   message,
   //   ["Object { a: 1 }", "Object { b: 2 }"],
   //   ["<entries>"]
   // );
 
-  // await executeInConsole(screen, "new WeakMap([[{a:1},{b:1}], [{a:2},{b:2}]])");
-  // msg = await waitForConsoleMessage(screen, "WeakMap { {…} → {…}, {…} → {…} }");
+  await executeInConsole(screen, "new WeakMap([[{a:1},{b:1}], [{a:2},{b:2}]])");
+  message = await waitForConsoleMessage(screen, "WeakMap(2) {{…} → {…}, {…} → {…}}");
   // await checkMessageObjectContents(
   //   screen,
-  //   msg,
+  //   message,
   //   ["Object { a: 1 } → Object { b: 1 }", "Object { a: 2 } → Object { b: 2 }"],
   //   ["<entries>"]
   // );
 
-  // await executeInConsole(screen, "new Promise(() => {})");
-  // msg = await waitForConsoleMessage(screen, "Promise {  }");
+  await executeInConsole(screen, "new Promise(() => {})");
+  message = await waitForConsoleMessage(screen, "Promise{}");
 
-  // // Promise contents aren't currently available in chromium.
+  // Promise contents aren't currently available in chromium.
 
-  // await checkMessageObjectContents(screen, msg, ['"pending"'], []);
+  // await checkMessageObjectContents(screen, message, ['"pending"'], []);
 
-  // await executeInConsole(screen, "Promise.resolve({ a: 1 })");
-  // msg = await waitForConsoleMessage(screen, "Promise {  }");
+  await executeInConsole(screen, "Promise.resolve({ a: 1 })");
+  message = await waitForConsoleMessage(screen, "Promise{}");
 
-  // await checkMessageObjectContents(screen, msg, ['"fulfilled"', "a: 1"], ["<value>"]);
+  // await checkMessageObjectContents(screen, message, ['"fulfilled"', "a: 1"], ["<value>"]);
 
-  // await executeInConsole(screen, "Promise.reject({ a: 1 })");
-  // msg = await waitForConsoleMessage(screen, "Promise {  }");
+  await executeInConsole(screen, "Promise.reject({ a: 1 })");
+  message = await waitForConsoleMessage(screen, "Promise{}");
 
-  // await executeInConsole(screen, "baz");
-  // msg = await waitForConsoleMessage(screen, "function baz()");
-  // const text = await msg.textContent();
+  await executeInConsole(screen, "baz");
+  message = await waitForConsoleMessage(screen, "ƒbaz()");
+  // const text = await message.textContent();
   // checkJumpIcon(screen, text!);
 });

--- a/packages/e2e-tests/tests/object_preview-01.test.ts
+++ b/packages/e2e-tests/tests/object_preview-01.test.ts
@@ -17,123 +17,126 @@ test(`expressions in the console after time warping.`, async ({ screen }) => {
   await clickDevTools(screen);
   await selectConsole(screen);
 
-  await waitForConsoleMessage(screen, "Array(20) [ 0, 1, 2, 3, 4, 5,");
-  await waitForConsoleMessage(screen, "Uint8Array(20) [ 0, 1, 2, 3, 4, 5,");
-  await waitForConsoleMessage(screen, "Set(22) [ {…}, {…}, 0, 1, 2, 3, 4, 5,");
+  await waitForConsoleMessage(screen, "(20) [0, 1, 2, 3, 4, …]");
+  await waitForConsoleMessage(screen, "Uint8Array(20) [0, 1, 2, 3, 4, …]");
+  await waitForConsoleMessage(screen, "Set(22) [{…}, {…}, 0, 1, 2, …]");
 
-  await waitForConsoleMessage(screen, "Map(21) { {…} → {…}, 0 → 1, 1 → 2, 2 → 3, 3 → 4, 4 → 5,");
-  await waitForConsoleMessage(screen, "WeakSet(20) [ {…}, {…}, {…},");
-  await waitForConsoleMessage(screen, "WeakMap(20) { {…} → {…}, {…} → {…},");
-  await waitForConsoleMessage(screen, "Object { a: 0, a0: 0, a1: 1, a2: 2, a3: 3, a4: 4,");
-  await waitForConsoleMessage(screen, "/abc/gi");
-  await waitForConsoleMessage(screen, "Date");
-
-  await waitForConsoleMessage(screen, `RangeError: "foo"`);
+  await waitForConsoleMessage(screen, "Map(21) {{…} → {…}, 0 → 1, 1 → 2, 2 → 3, 3 → 4, …}");
+  await waitForConsoleMessage(screen, "WeakSet(20) [{…}, {…}, {…}, {…}, {…}, …]");
   await waitForConsoleMessage(
     screen,
-    '<div id="foo" class="bar" style="visibility: visible" blahblah="">'
+    "WeakMap(20) {{…} → {…}, {…} → {…}, {…} → {…}, {…} → {…}, {…} → {…}, …}"
   );
+  await waitForConsoleMessage(screen, "{a: 0, a0: 0, a1: 1, a2: 2, a3: 3, …}");
+  await waitForConsoleMessage(screen, "/abc/gi");
+  await waitForConsoleMessage(screen, "Sun Aug 14 2022 12:23:25 GMT-0700 (Pacific Daylight Time)");
 
-  await waitForConsoleMessage(screen, "function bar()");
-  await checkJumpIcon(screen, "function bar()");
-  // await new Promise(r => setTimeout(r, 100_000));
+  await waitForConsoleMessage(screen, `RangeError: foo`);
+  // await waitForConsoleMessage(
+  //   screen,
+  //   '<div id="foo" class="bar" style="visibility: visible" blahblah="">BAR<div>'
+  // );
 
-  await waitForConsoleMessage(screen, 'Array(6) [ undefined, true, 3, null, "z", 40n ]');
-  await waitForConsoleMessage(screen, "Proxy {  }");
-  await waitForConsoleMessage(screen, "Symbol()");
-  await waitForConsoleMessage(screen, "Symbol(symbol)");
-  await waitForConsoleMessage(screen, `Object { "Symbol()": 42, "Symbol(symbol)": "Symbol()" }`);
+  // await waitForConsoleMessage(screen, "function bar()");
+  // await checkJumpIcon(screen, "function bar()");
+  // // await new Promise(r => setTimeout(r, 100_000));
 
-  msg = await waitForConsoleMessage(screen, "Object { _foo: C }");
+  // await waitForConsoleMessage(screen, 'Array(6) [ undefined, true, 3, null, "z", 40n ]');
+  // await waitForConsoleMessage(screen, "Proxy {  }");
+  // await waitForConsoleMessage(screen, "Symbol()");
+  // await waitForConsoleMessage(screen, "Symbol(symbol)");
+  // await waitForConsoleMessage(screen, `Object { "Symbol()": 42, "Symbol(symbol)": "Symbol()" }`);
 
-  // TODO: add support for expanding objects in the console
-  await checkMessageObjectContents(
-    screen,
-    msg,
-    ['foo: C { baz: "baz" }', 'bar: "bar"', 'baz: "baz"'],
-    ["foo", "bar"]
-  );
+  // msg = await waitForConsoleMessage(screen, "Object { _foo: C }");
 
-  await warpToMessage(screen, "Done");
+  // // TODO: add support for expanding objects in the console
+  // await checkMessageObjectContents(
+  //   screen,
+  //   msg,
+  //   ['foo: C { baz: "baz" }', 'bar: "bar"', 'baz: "baz"'],
+  //   ["foo", "bar"]
+  // );
 
-  await executeInConsole(screen, "Error('helo')");
-  await waitForConsoleMessage(screen, 'Error: "helo"');
+  // await warpToMessage(screen, "Done");
 
-  await executeInConsole(
-    screen,
-    `
-        function f() {
-          throw Error("there");
-        }
-        f();
-      `
-  );
-  // FIXME the first line in this stack isn't right.
-  await waitForConsoleMessage(screen, 'Error: "there"');
+  // await executeInConsole(screen, "Error('helo')");
+  // await waitForConsoleMessage(screen, 'Error: "helo"');
 
-  executeInConsole(screen, "Array(1, 2, 3)");
-  msg = await waitForConsoleMessage(screen, "Array(3) [ 1, 2, 3 ]");
-  await checkMessageObjectContents(screen, msg, ["0: 1", "1: 2", "2: 3", "length: 3"]);
+  // await executeInConsole(
+  //   screen,
+  //   `
+  //       function f() {
+  //         throw Error("there");
+  //       }
+  //       f();
+  //     `
+  // );
+  // // FIXME the first line in this stack isn't right.
+  // await waitForConsoleMessage(screen, 'Error: "there"');
 
-  await executeInConsole(screen, "new Uint8Array([1, 2, 3, 4])");
-  msg = await waitForConsoleMessage(screen, "Uint8Array(4) [ 1, 2, 3, 4 ]");
-  await checkMessageObjectContents(screen, msg, ["0: 1", "1: 2", "2: 3", "3: 4", "length: 4"]);
+  // executeInConsole(screen, "Array(1, 2, 3)");
+  // msg = await waitForConsoleMessage(screen, "Array(3) [ 1, 2, 3 ]");
+  // await checkMessageObjectContents(screen, msg, ["0: 1", "1: 2", "2: 3", "length: 3"]);
 
-  await executeInConsole(screen, `RegExp("abd", "g")`);
-  msg = await waitForConsoleMessage(screen, "/abd/g");
+  // await executeInConsole(screen, "new Uint8Array([1, 2, 3, 4])");
+  // msg = await waitForConsoleMessage(screen, "Uint8Array(4) [ 1, 2, 3, 4 ]");
+  // await checkMessageObjectContents(screen, msg, ["0: 1", "1: 2", "2: 3", "3: 4", "length: 4"]);
 
-  // RegExp object properties are not currently available in chromium.
+  // await executeInConsole(screen, `RegExp("abd", "g")`);
+  // msg = await waitForConsoleMessage(screen, "/abd/g");
 
-  await checkMessageObjectContents(screen, msg, ["global: true", `source: "abd"`]);
+  // // RegExp object properties are not currently available in chromium.
 
-  await executeInConsole(screen, "new Set([1, 2, 3])");
-  msg = await waitForConsoleMessage(screen, "Set(3) [ 1, 2, 3 ]");
-  await checkMessageObjectContents(screen, msg, ["0: 1", "1: 2", "2: 3", "size: 3"], ["<entries>"]);
+  // await checkMessageObjectContents(screen, msg, ["global: true", `source: "abd"`]);
 
-  await executeInConsole(screen, "new Map([[1, {a:1}], [2, {b:2}]])");
-  msg = await waitForConsoleMessage(screen, "Map { 1 → {…}, 2 → {…} }");
-  await checkMessageObjectContents(
-    screen,
-    msg,
-    ["0: 1 → Object { a: 1 }", "1: 2 → Object { b: 2 }", "size: 2"],
-    ["<entries>"]
-  );
+  // await executeInConsole(screen, "new Set([1, 2, 3])");
+  // msg = await waitForConsoleMessage(screen, "Set(3) [ 1, 2, 3 ]");
+  // await checkMessageObjectContents(screen, msg, ["0: 1", "1: 2", "2: 3", "size: 3"], ["<entries>"]);
 
-  await executeInConsole(screen, "new WeakSet([{a:1}, {b:2}])");
-  msg = await waitForConsoleMessage(screen, "WeakSet(2) [ {…}, {…} ]");
-  await checkMessageObjectContents(
-    screen,
-    msg,
-    ["Object { a: 1 }", "Object { b: 2 }"],
-    ["<entries>"]
-  );
+  // await executeInConsole(screen, "new Map([[1, {a:1}], [2, {b:2}]])");
+  // msg = await waitForConsoleMessage(screen, "Map { 1 → {…}, 2 → {…} }");
+  // await checkMessageObjectContents(
+  //   screen,
+  //   msg,
+  //   ["0: 1 → Object { a: 1 }", "1: 2 → Object { b: 2 }", "size: 2"],
+  //   ["<entries>"]
+  // );
 
-  await executeInConsole(screen, "new WeakMap([[{a:1},{b:1}], [{a:2},{b:2}]])");
-  msg = await waitForConsoleMessage(screen, "WeakMap { {…} → {…}, {…} → {…} }");
-  await checkMessageObjectContents(
-    screen,
-    msg,
-    ["Object { a: 1 } → Object { b: 1 }", "Object { a: 2 } → Object { b: 2 }"],
-    ["<entries>"]
-  );
+  // await executeInConsole(screen, "new WeakSet([{a:1}, {b:2}])");
+  // msg = await waitForConsoleMessage(screen, "WeakSet(2) [ {…}, {…} ]");
+  // await checkMessageObjectContents(
+  //   screen,
+  //   msg,
+  //   ["Object { a: 1 }", "Object { b: 2 }"],
+  //   ["<entries>"]
+  // );
 
-  await executeInConsole(screen, "new Promise(() => {})");
-  msg = await waitForConsoleMessage(screen, "Promise {  }");
+  // await executeInConsole(screen, "new WeakMap([[{a:1},{b:1}], [{a:2},{b:2}]])");
+  // msg = await waitForConsoleMessage(screen, "WeakMap { {…} → {…}, {…} → {…} }");
+  // await checkMessageObjectContents(
+  //   screen,
+  //   msg,
+  //   ["Object { a: 1 } → Object { b: 1 }", "Object { a: 2 } → Object { b: 2 }"],
+  //   ["<entries>"]
+  // );
 
-  // Promise contents aren't currently available in chromium.
+  // await executeInConsole(screen, "new Promise(() => {})");
+  // msg = await waitForConsoleMessage(screen, "Promise {  }");
 
-  await checkMessageObjectContents(screen, msg, ['"pending"'], []);
+  // // Promise contents aren't currently available in chromium.
 
-  await executeInConsole(screen, "Promise.resolve({ a: 1 })");
-  msg = await waitForConsoleMessage(screen, "Promise {  }");
+  // await checkMessageObjectContents(screen, msg, ['"pending"'], []);
 
-  await checkMessageObjectContents(screen, msg, ['"fulfilled"', "a: 1"], ["<value>"]);
+  // await executeInConsole(screen, "Promise.resolve({ a: 1 })");
+  // msg = await waitForConsoleMessage(screen, "Promise {  }");
 
-  await executeInConsole(screen, "Promise.reject({ a: 1 })");
-  msg = await waitForConsoleMessage(screen, "Promise {  }");
+  // await checkMessageObjectContents(screen, msg, ['"fulfilled"', "a: 1"], ["<value>"]);
 
-  await executeInConsole(screen, "baz");
-  msg = await waitForConsoleMessage(screen, "function baz()");
-  const text = await msg.textContent();
-  checkJumpIcon(screen, text!);
+  // await executeInConsole(screen, "Promise.reject({ a: 1 })");
+  // msg = await waitForConsoleMessage(screen, "Promise {  }");
+
+  // await executeInConsole(screen, "baz");
+  // msg = await waitForConsoleMessage(screen, "function baz()");
+  // const text = await msg.textContent();
+  // checkJumpIcon(screen, text!);
 });


### PR DESCRIPTION
Cleans up the first object preview test. Brian Vaughn and I chatted whether these tests were worth having anymore since the new console tests cover most of these situations already. Something worth noting is the `executeInConsole` helper is quite similar to `checkEvaluateInTopFrame` so we may want to consolidate this after the dust settles.