### PR TITLE
Replace remaining Redux-based helper implementations

### DIFF
--- a/packages/e2e-tests/tests/stepping-01.test.ts
+++ b/packages/e2e-tests/tests/stepping-01.test.ts
@@ -3,12 +3,14 @@ import {
   checkEvaluateInTopFrame,
   openExample,
   rewind,
+  rewindToLine,
   reverseStepOver,
   stepOver,
   clickSourceTreeNode,
   clickDevTools,
   toggleBreakpoint,
   togglePausePane,
+  openPauseInformation,
 } from "../helpers";
 
 test("Test basic step-over/back functionality.", async ({ screen }) => {
@@ -22,8 +24,7 @@ test("Test basic step-over/back functionality.", async ({ screen }) => {
 
   // Pause on line 20
   await toggleBreakpoint(screen, 20);
-  await togglePausePane(screen);
-  await rewind(screen);
+  await rewindToLine(screen);
 
   // Should get ten when evaluating number.
   await checkEvaluateInTopFrame(screen, "number", "10");

--- a/src/devtools/client/debugger/src/components/Editor/Tab.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Tab.tsx
@@ -215,6 +215,7 @@ class Tab extends PureComponent<FinalTabProps> {
         onDragStart={onDragStart}
         onDragEnd={onDragEnd}
         className={className}
+        data-status={active ? "active" : undefined}
         data-test-name={`Source-${getTruncatedFileName(source, query)}`}
         key={sourceId}
         onClick={handleTabClick}


### PR DESCRIPTION
- Replaced all remaining uses of `window.app.whatever` in the helpers
- Got `stepping-06` passing

Still seeing some occasional timing-based flakiness