### PR TITLE
fix print statement panel width calculation

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.tsx
@@ -22,6 +22,7 @@ import { Nag } from "ui/hooks/users";
 import { MAX_POINTS_FOR_FULL_ANALYSIS } from "protocol/thread/analysis";
 import { getFocusRegion } from "ui/reducers/timeline";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
+import { useStringPref } from "ui/hooks/settings";
 import { UnsafeFocusRegion } from "ui/state/timeline";
 import { getHitPointsForLocation } from "bvaughn-architecture-demo/src/suspense/PointsCache";
 
@@ -74,6 +75,7 @@ function Panel({
   const [width, setWidth] = useState(getPanelWidth(editor)); // nosemgrep
   const [inputToFocus, setInputToFocus] = useState<"condition" | "logValue">("logValue");
   const dismissNag = hooks.useDismissNag();
+  const { value: hitCountsMode } = useStringPref("hitCounts");
 
   // WARNING
   // React components should not suspend during a synchronous update.
@@ -135,6 +137,10 @@ function Panel({
       editor.editor.off("refresh", updateWidth);
     };
   }, [editor]);
+
+  useEffect(() => {
+    setWidth(getPanelWidth(editor));
+  }, [editor, hitCountsMode]);
 
   useEffect(() => {
     dismissNag(Nag.FIRST_BREAKPOINT_ADD);

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.tsx
@@ -25,10 +25,15 @@ import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { UnsafeFocusRegion } from "ui/state/timeline";
 import { getHitPointsForLocation } from "bvaughn-architecture-demo/src/suspense/PointsCache";
 
-const gutterOffset = 37;
+const lineNumberGutterAndBorderWidth = 31;
 
 function getPanelWidth({ editor }: { editor: $FixTypeLater }) {
-  return editor.getScrollInfo().clientWidth - gutterOffset;
+  const hitMarkersGutter = document.querySelector(".hit-markers") as HTMLElement;
+  const hitMarkersGutterWidth = hitMarkersGutter ? hitMarkersGutter.offsetWidth : 0;
+
+  return (
+    editor.getScrollInfo().clientWidth - lineNumberGutterAndBorderWidth - hitMarkersGutterWidth
+  );
 }
 
 const connector = connect(
@@ -166,7 +171,11 @@ function Panel({
       <div
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
-        style={{ position: "sticky", left: gutterOffset, maxWidth: width }}
+        style={{
+          position: "sticky",
+          left: `calc(${lineNumberGutterAndBorderWidth}px + var(--hit-count-gutter-width))`,
+          maxWidth: width,
+        }}
       >
         <FirstEditNag editing={editing} />
         <div className={classnames("breakpoint-panel", { editing })}>

--- a/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineHitCounts.tsx
@@ -133,14 +133,14 @@ function LineHitCounts({ sourceEditor }: Props) {
     // That component doesn't know about hit counts though, so we can inform its position via a CSS variable.
     const gutterElement = sourceEditor.codeMirror.getGutterElement() as HTMLElement;
 
-    gutterElement.parentElement!.style.setProperty("--hit-count-gutter-width", `-${gutterWidth}`);
+    gutterElement.parentElement!.style.setProperty("--hit-count-gutter-width", gutterWidth);
 
     // If hit counts are shown, the button should not overlap with the gutter.
     // The gutter size changes though based on the number of hits, so we use a CSS variable.
     gutterElement.parentElement!.style.setProperty(
       "--print-statement-right-offset",
       hitCountsMode === "show-counts"
-        ? "calc(var(--hit-count-gutter-width) - 6px)"
+        ? `calc(${gutterWidth} - 6px)`
         : hitCountsMode === "hide-counts"
         ? "-10px"
         : "0px"


### PR DESCRIPTION
Fixes the print statement panel width calculation by updating the panel width when hit counts are collapsed and using the proper left offset based on the actual line counts gutter width rather than a fixed width.