### PR TITLE
Base print statement width on CSS vars updated from CM element widths

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.css
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.css
@@ -2,6 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
+:root {
+  /* This will be overridden by `ColumnBreakpoints.tsx` at runtime */
+  --print-statement-max-width: 100%;
+}
+
 .breakpoint-panel {
   margin: 0.25rem 0 0.5rem -1px;
   background: var(--theme-toolbar-background);
@@ -11,6 +16,7 @@
   flex-direction: column;
   position: relative;
   overflow: hidden;
+  max-width: var(--print-statement-max-width);
 }
 
 .breakpoint-panel .CodeMirror-lines {

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.css
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.css
@@ -5,6 +5,7 @@
 :root {
   /* This will be overridden by `ColumnBreakpoints.tsx` at runtime */
   --print-statement-max-width: 100%;
+  --codemirror-gutter-width: 0px;
 }
 
 .breakpoint-panel {

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.tsx
@@ -153,7 +153,15 @@ function Panel({
 
   return (
     <Widget location={breakpoint!.location} editor={editor} insertAt={insertAt}>
-      <div onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+      <div
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+        style={{
+          position: "sticky",
+          left: "var(--codemirror-gutter-width)",
+          maxWidth: "var(--print-statement-max-width)",
+        }}
+      >
         <FirstEditNag editing={editing} />
         <div className={classnames("breakpoint-panel", { editing })}>
           <div className="flex items-center space-x-0.5 pt-2 pl-1 pr-4">

--- a/src/devtools/client/debugger/src/components/Editor/ColumnBreakpoints.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/ColumnBreakpoints.tsx
@@ -54,6 +54,7 @@ function ColumnBreakpoints2({ editor }: CBProps) {
 
       let root = document.documentElement;
       root.style.setProperty("--print-statement-max-width", newWidth + "px");
+      root.style.setProperty("--codemirror-gutter-width", gutterWidth + "px");
     };
 
     editor.editor.on("refresh", updateWidth);

--- a/src/devtools/client/debugger/src/components/Editor/ColumnBreakpoints.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/ColumnBreakpoints.tsx
@@ -4,14 +4,17 @@
 
 //
 
-import React, { Component } from "react";
+import React, { Component, useEffect } from "react";
 import ColumnBreakpoint from "./ColumnBreakpoint";
 
 import { getVisibleColumnBreakpoints, getContext } from "../../selectors";
 import { getSelectedSource } from "ui/reducers/sources";
 import { connect, ConnectedProps } from "react-redux";
 import type { UIState } from "ui/state";
+import { useAppSelector } from "ui/setup/hooks";
 import { getLocationKey } from "../../utils/breakpoint";
+import type { SourceEditor } from "devtools/client/debugger/src/utils/editor/source-editor";
+import { useFeature, useStringPref } from "ui/hooks/settings";
 
 // eslint-disable-next-line max-len
 
@@ -26,33 +29,58 @@ type PropsFromRedux = ConnectedProps<typeof connector>;
 
 type $FixTypeLater = any;
 interface CBProps {
-  editor: $FixTypeLater;
+  editor: SourceEditor;
 }
 
-class ColumnBreakpoints extends Component<PropsFromRedux & CBProps> {
-  render() {
-    const { cx, editor, columnBreakpoints, selectedSource } = this.props;
+function ColumnBreakpoints2({ editor }: CBProps) {
+  const cx = useAppSelector(getContext);
+  const selectedSource = useAppSelector(getSelectedSource);
+  const columnBreakpoints = useAppSelector(getVisibleColumnBreakpoints);
+  const { value: hitCountsMode } = useStringPref("hitCounts");
 
-    if (!selectedSource || columnBreakpoints.length === 0) {
-      return null;
-    }
+  useEffect(() => {
+    const updateWidth = () => {
+      const editorElement = editor.editor.getWrapperElement();
+      const gutter = editor.editor.getGutterElement();
 
-    let breakpoints;
-    // TODO Is this a safe thing to do while rendering?
-    editor.codeMirror.operation(() => {
-      breakpoints = columnBreakpoints.map((breakpoint, i) => (
-        <ColumnBreakpoint
-          cx={cx}
-          key={getLocationKey(breakpoint.location)}
-          columnBreakpoint={breakpoint}
-          editor={editor}
-          source={selectedSource}
-          insertAt={i}
-        />
-      ));
-    });
-    return <div>{breakpoints}</div>;
+      const gutterWidth = gutter.getBoundingClientRect().width;
+      const scrollWidth = editorElement.getBoundingClientRect().width;
+
+      // Magic formula to determine scrollbar width: https://stackoverflow.com/a/60008044/62937
+      let scrollbarWidth = window.innerWidth - document.body.clientWidth;
+
+      // Fill the _visible_ width of the editor, minus scrollbar, minus a small bit of padding
+      const newWidth = scrollWidth - gutterWidth - scrollbarWidth - 10;
+
+      let root = document.documentElement;
+      root.style.setProperty("--print-statement-max-width", newWidth + "px");
+    };
+
+    editor.editor.on("refresh", updateWidth);
+
+    updateWidth();
+
+    return () => {
+      editor.editor.off("refresh", updateWidth);
+    };
+  }, [editor, hitCountsMode]);
+
+  if (!selectedSource || columnBreakpoints.length === 0) {
+    return null;
   }
+
+  const breakpoints = columnBreakpoints.map((breakpoint, i) => (
+    <ColumnBreakpoint
+      cx={cx}
+      key={getLocationKey(breakpoint.location)}
+      columnBreakpoint={breakpoint}
+      editor={editor}
+      source={selectedSource}
+      insertAt={i}
+    />
+  ));
+
+  return <div>{breakpoints}</div>;
 }
 
-export default connector(ColumnBreakpoints);
+export default React.memo(ColumnBreakpoints2);


### PR DESCRIPTION
An alternative to #7837 .

In this PR, I'm just listening for CM's `"refresh"` event to indicate a resize, reading the actual client widths of  the main CM editor element and the gutter element, subtracting them plus a bit of buffer, and setting that as a CSS var to be used as the print statement max width.

This _appears_ to work correctly as I drag-resize the editor, dock it into the "Console" tabs, or change the hit counts options.