### PR TITLE
Fix Node example recordings

### DIFF
--- a/packages/e2e-tests/examples.json
+++ b/packages/e2e-tests/examples.json
@@ -22,12 +22,12 @@
   "doc_rr_region_loading.html": "7e0c2f3e-ae52-4af2-8603-6234de4eda10",
   "doc_rr_worker.html": "c1ed2491-1138-40f2-972d-ae9bfafe33fd",
   "doc_stacking.html": "233a22c5-428e-46f8-a1ac-4b2488ac517e",
-  "node/control_flow.js": "df10f204-347f-4bc8-aec3-87353c2cc2cf",
-  "node/async.js": "04b8abef-c5c1-47a2-a10e-cd9f6b312c4d",
-  "node/basic.js": "8e536066-96f5-4fc3-a173-18b9bbde6b31",
-  "node/error.js": "d798918e-e39d-4709-a4d2-337cc31e56cf",
-  "node/exceptions.js": "01fe2aac-afd8-434a-b08e-501f26e00edc",
-  "node/objects.js": "1cdc68b5-32d6-451a-8f47-f9b9a34c13f0",
-  "node/run_worker.js": "8ce08cdc-a3ac-4f14-8dc3-001d0817ec32",
-  "node/spawn.js": "26051e54-c408-4832-a13d-ad02214ec732"
+  "node/control_flow.js": "3cb8dda5-7ede-4b98-9bdc-c43c2fb3d52a",
+  "node/async.js": "c81bddb8-3edd-45c3-b7b1-486a7e07f741",
+  "node/basic.js": "2c303b75-0f6d-497f-a4fb-4a9c55fdb67a",
+  "node/error.js": "07300ddd-f074-4524-b538-3d628fddd603",
+  "node/exceptions.js": "12da3cda-262b-4477-9f35-e9e17111f51b",
+  "node/objects.js": "6ea2837c-386e-483a-8ec9-94c7a51a07e4",
+  "node/run_worker.js": "b41107df-8d0e-488f-bad3-a7d26c183043",
+  "node/spawn.js": "c9d0539d-fde0-4949-a9f7-acdb5b56d4a6"
 }

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -9,14 +9,16 @@
   "scripts": {
     "test": "playwright test",
     "test:debug": "DEBUG=1 playwright test",
-    "test:install": "playwright install"
+    "test:install": "playwright install",
+    "ts-node": "ts-node --project ../../tsconfig.json"
   },
   "author": "",
   "license": "ISC",
   "devDependencies": {
     "@playwright/test": "^1.25.1",
     "@replayio/playwright": "^0.2.24",
-    "playwright": "^1.25.1"
+    "playwright": "^1.25.1",
+    "ts-node": "^10.7.0"
   },
   "dependencies": {
     "chalk": "^4"

--- a/packages/e2e-tests/saveExamples.ts
+++ b/packages/e2e-tests/saveExamples.ts
@@ -65,17 +65,22 @@ async function recordExample(example: string) {
   }
 }
 
-async function saveRecording(example: string) {
+async function saveRecording(example: string, recordingId?: string) {
   console.log(`Saving ${example}`);
-  const recordings = listAllRecordings();
-  const lastRecording = recordings[recordings.length - 1];
 
-  const id = await uploadRecording(lastRecording.id, {
+  if (!recordingId) {
+    const recordings = listAllRecordings();
+    const lastRecording = recordings[recordings.length - 1];
+    recordingId = lastRecording.id;
+
+    console.log("Last recording: ", lastRecording);
+  }
+
+  const id = await uploadRecording(recordingId, {
     apiKey: process.env.API_KEY,
   });
 
-  const publicRes = await makeReplayPublic(process.env.API_KEY!, lastRecording.id);
-  console.log("Public res: ", publicRes.data);
+  await makeReplayPublic(process.env.API_KEY!, recordingId);
 
   const text = "" + readFileSync(`${__dirname}/examples.json`);
   const json = JSON.parse(text);
@@ -111,12 +116,14 @@ async function saveNodeExample(nodeExampleName: string) {
     if (recordingId) {
       console.log("Recording succeeded. ID: ", recordingId);
       console.log("Saving recording info...");
-      await saveRecording(`node/${nodeExampleName}`);
+      await saveRecording(`node/${nodeExampleName}`, recordingId);
 
       console.log(`Saved example: ${recordingId}`);
     } else {
       console.error("Did not save a recording!");
     }
+  } else {
+    throw new Error("Could not find example file: " + nodeExampleFilename);
   }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -65,7 +65,7 @@
     } /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */,
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    "types": ["jest", "@testing-library/jest-dom"],
+    "types": ["jest", "@testing-library/jest-dom", "node"],
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -13148,6 +13148,7 @@ __metadata:
     "@replayio/playwright": ^0.2.24
     chalk: ^4
     playwright: ^1.25.1
+    ts-node: ^10.7.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
- Forgot to include a commit that added ts-node support to `packages/e2e-tests`
- Fixed an issue that was causing wrong recording IDs to be saved
- Updated all Node example recordings