### PR TITLE
Remove children before adding a new editor

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/index.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/index.tsx
@@ -175,8 +175,13 @@ class Editor extends PureComponent<PropsFromRedux, EditorState> {
     // @ts-expect-error initShortcuts doesn't exist
     editor._initShortcuts = () => {};
     const node = ReactDOM.findDOMNode(this);
+
     if (node instanceof HTMLElement) {
-      editor.appendToLocalElement(node.querySelector(".editor-mount")!);
+      const editorMount: HTMLElement = node.querySelector(".editor-mount")!;
+      while (editorMount.firstChild) {
+        editorMount.removeChild(editorMount.firstChild);
+      }
+      editor.appendToLocalElement(editorMount);
     }
 
     const { codeMirror } = editor;


### PR DESCRIPTION
This is stupid, but https://discord.com/channels/779097926135054346/930844769213640794/1025382501809664111 is a really, really annoying bug, so Travis and I figured we would propose *something*.