### PR TITLE
Close console drawer by default

### DIFF
--- a/packages/bvaughn-architecture-demo/components/console/ConsoleRoot.tsx
+++ b/packages/bvaughn-architecture-demo/components/console/ConsoleRoot.tsx
@@ -23,6 +23,7 @@ import { LoggablesContextRoot } from "./LoggablesContext";
 import MessagesList from "./MessagesList";
 import Search from "./Search";
 import { SearchContextRoot } from "./SearchContext";
+import { SessionContext } from "@bvaughn/src/contexts/SessionContext";
 
 export default function ConsoleRoot({
   nagHeader = null,
@@ -37,7 +38,11 @@ export default function ConsoleRoot({
   const { clearMessages: clearConsoleEvaluations, messages: consoleEvaluations } =
     useContext(TerminalContext);
 
-  const [isMenuOpen, setIsMenuOpen] = useLocalStorage<boolean>("Replay:Console:MenuOpen", true);
+  const { recordingId } = useContext(SessionContext);
+  const [isMenuOpen, setIsMenuOpen] = useLocalStorage<boolean>(
+    `Replay:Console:MenuOpen:${recordingId}`,
+    false
+  );
 
   const messageListRef = useRef<HTMLElement>(null);
 

--- a/packages/bvaughn-architecture-demo/components/console/ConsoleRoot.tsx
+++ b/packages/bvaughn-architecture-demo/components/console/ConsoleRoot.tsx
@@ -8,7 +8,6 @@ import {
   unstable_Offscreen as Offscreen,
   useContext,
   useRef,
-  useLayoutEffect,
   useState,
 } from "react";
 import { TerminalContext } from "@bvaughn/src/contexts/TerminalContext";
@@ -29,11 +28,13 @@ import { SessionContext } from "@bvaughn/src/contexts/SessionContext";
 export default function ConsoleRoot({
   nagHeader = null,
   showSearchInputByDefault = true,
+  showFiltersByDefault = false,
   terminalInput = null,
 }: {
   filterDrawerOpenDefault?: boolean;
   nagHeader?: ReactNode;
   showSearchInputByDefault?: boolean;
+  showFiltersByDefault?: boolean;
   terminalInput?: ReactNode;
 }) {
   const { clearMessages: clearConsoleEvaluations, messages: consoleEvaluations } =
@@ -42,7 +43,7 @@ export default function ConsoleRoot({
   const { recordingId } = useContext(SessionContext);
   const [isMenuOpen, setIsMenuOpen] = useLocalStorage<boolean>(
     `Replay:Console:MenuOpen:${recordingId}`,
-    false
+    showFiltersByDefault
   );
   const [menuValueHasBeenToggled, setMenuValueHasBeenToggled] = useState(false);
 

--- a/src/ui/components/SecondaryToolbox/NewConsole.tsx
+++ b/src/ui/components/SecondaryToolbox/NewConsole.tsx
@@ -1,5 +1,5 @@
 import { ExecutionPoint, PauseId } from "@replayio/protocol";
-import NewConsole from "bvaughn-architecture-demo/components/console";
+import ConsoleRoot from "bvaughn-architecture-demo/components/console";
 import { SearchContext } from "bvaughn-architecture-demo/components/console/SearchContext";
 import { FocusContext } from "bvaughn-architecture-demo/src/contexts/FocusContext";
 import {
@@ -50,6 +50,7 @@ import { getCurrentTime, getFocusRegion, getRecordingDuration } from "ui/reducer
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { FocusRegion } from "ui/state/timeline";
 import { rangeForFocusRegion } from "ui/utils/timeline";
+import { useFeature } from "ui/hooks/settings";
 
 import styles from "./NewConsole.module.css";
 import { ConsoleNag } from "../shared/Nags/Nags";
@@ -58,6 +59,9 @@ import useTerminalHistory from "./useTerminalHistory";
 // Adapter that connects the legacy app Redux stores to the newer React Context providers.
 export default function NewConsoleRoot() {
   const recordingId = useGetRecordingId();
+  const { value: consoleFilterDrawerDefaultsToOpen } = useFeature(
+    "consoleFilterDrawerDefaultsToOpen"
+  );
 
   const duration = useAppSelector(getRecordingDuration)!;
 
@@ -85,9 +89,10 @@ export default function NewConsoleRoot() {
           <TerminalContextController>
             <FocusContextReduxAdapter>
               <PointsContextReduxAdapter>
-                <NewConsole
+                <ConsoleRoot
                   nagHeader={<ConsoleNag />}
                   showSearchInputByDefault={false}
+                  showFiltersByDefault={consoleFilterDrawerDefaultsToOpen}
                   terminalInput={<JSTermWrapper />}
                 />
               </PointsContextReduxAdapter>

--- a/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
+++ b/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
@@ -51,6 +51,12 @@ const EXPERIMENTAL_SETTINGS: ExperimentalSetting[] = [
     description: "Restore the legacy frames and scopes panels",
     key: "legacyFramesPanel",
   },
+  {
+    label: "Console filter drawer defaults to open",
+    description:
+      "Open the console filter settings by default when opening a Replay for the first time",
+    key: "consoleFilterDrawerDefaultsToOpen",
+  },
 ];
 
 const RISKY_EXPERIMENTAL_SETTINGS: ExperimentalSetting[] = [];
@@ -86,6 +92,10 @@ export default function ExperimentalSettings({}) {
   const { value: enableResolveRecording, update: updateEnableResolveRecording } =
     useFeature("resolveRecording");
 
+  const {
+    value: consoleFilterDrawerDefaultsToOpen,
+    update: updateConsoleFilterDrawerDefaultsToOpen,
+  } = useFeature("consoleFilterDrawerDefaultsToOpen");
   const { value: hitCounts, update: updateHitCounts } = useFeature("hitCounts");
   const { value: profileWorkerThreads, update: updateProfileWorkerThreads } =
     useFeature("profileWorkerThreads");
@@ -112,11 +122,14 @@ export default function ExperimentalSettings({}) {
       updateBasicProcessingLoadingBar(!basicProcessingLoadingBar);
     } else if (key === "legacyFramesPanel") {
       updateLegacyFramesPanel(!legacyFramesPanel);
+    } else if (key === "consoleFilterDrawerDefaultsToOpen") {
+      updateConsoleFilterDrawerDefaultsToOpen(!consoleFilterDrawerDefaultsToOpen);
     }
   };
 
   const localSettings = {
     basicProcessingLoadingBar,
+    consoleFilterDrawerDefaultsToOpen,
     enableColumnBreakpoints,
     enableResolveRecording,
     enableQueryCache,

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -15,6 +15,7 @@ export type ExperimentalUserSettings = {
 
 export type LocalExperimentalUserSettings = {
   basicProcessingLoadingBar: boolean;
+  consoleFilterDrawerDefaultsToOpen: boolean;
   enableQueryCache: boolean;
   enableColumnBreakpoints: boolean;
   enableLargeText: boolean;

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -24,6 +24,7 @@ pref("devtools.hitCounts", "hide-counts");
 pref("devtools.features.basicProcessingLoadingBar", false);
 pref("devtools.features.columnBreakpoints", false);
 pref("devtools.features.commentAttachments", false);
+pref("devtools.features.consoleFilterDrawerDefaultsToOpen", false);
 pref("devtools.features.disableUnHitLines", false);
 pref("devtools.features.enableLargeText", false);
 pref("devtools.features.enableQueryCache", false);
@@ -59,6 +60,7 @@ export const features = new PrefsHelper("devtools.features", {
   basicProcessingLoadingBar: ["Bool", "basicProcessingLoadingBar"],
   columnBreakpoints: ["Bool", "columnBreakpoints"],
   commentAttachments: ["Bool", "commentAttachments"],
+  consoleFilterDrawerDefaultsToOpen: ["Bool", "consoleFilterDrawerDefaultsToOpen"],
   enableQueryCache: ["Bool", "enableQueryCache"],
   disableUnHitLines: ["Bool", "disableUnHitLines"],
   enableLargeText: ["Bool", "enableLargeText"],


### PR DESCRIPTION
But add an experimental pref for defaulting to open, and either way, remember the previous state on a per-Replay basis.

Fixes https://linear.app/replay/issue/FE-797/the-console-drawer-should-be-closed-by-default