### PR TITLE
Port remaining node tests

### DIFF
--- a/packages/e2e-tests/helpers/console-panel.ts
+++ b/packages/e2e-tests/helpers/console-panel.ts
@@ -123,8 +123,9 @@ export function findConsoleMessage(
     ? `[data-test-message-type="${messageType}"]`
     : '[data-test-name="Message"]';
 
+  // Use single quotes because a couple messages have double quoted text displayed
   return expected
-    ? page.locator(`${attributeSelector}:has-text("${expected}")`)
+    ? page.locator(`${attributeSelector}:has-text('${expected}')`)
     : page.locator(`${attributeSelector}`);
 }
 

--- a/packages/e2e-tests/helpers/source-panel.ts
+++ b/packages/e2e-tests/helpers/source-panel.ts
@@ -337,21 +337,16 @@ export async function waitForSelectedSource(page: Page, url: string) {
     // 10 lines is no longer an empty string
     const codeMirrorLines = editorPanel.locator(".CodeMirror-code .CodeMirror-line");
 
+    const lineTexts = await mapLocators(codeMirrorLines, lineLocator => lineLocator.textContent());
     const numLines = await codeMirrorLines.count();
-    // Could be fewer than 10 lines visible, and I can't find a `.slice()` on `Locator`
-    const linesToGrab = Math.min(numLines, 10);
-
-    const lineTextPromises = Array.from({ length: linesToGrab }).map((_, i) => {
-      return codeMirrorLines.nth(i).textContent();
-    });
-    const lineTexts = await Promise.all(lineTextPromises);
 
     const combinedLineText = lineTexts
+      .slice(0, 10)
       .join()
       .trim()
       // Remove zero-width spaces, which would be considered non-empty
       .replace(/[\u200B-\u200D\uFEFF]/g, "");
 
-    expect(isTabActive && lineTexts.length > 0 && combinedLineText !== "").toBe(true);
+    expect(isTabActive && numLines > 0 && combinedLineText !== "").toBe(true);
   });
 }

--- a/packages/e2e-tests/helpers/source-panel.ts
+++ b/packages/e2e-tests/helpers/source-panel.ts
@@ -4,7 +4,7 @@ import chalk from "chalk";
 import { openDevToolsTab } from ".";
 import { openPauseInformationPanel } from "./pause-information-panel";
 import { openSource, openSourceExplorerPanel } from "./source-explorer-panel";
-import { clearTextArea, debugPrint, delay, forEach, waitFor } from "./utils";
+import { clearTextArea, debugPrint, delay, forEach, waitFor, mapLocators } from "./utils";
 
 export async function addBreakpoint(
   page: Page,
@@ -44,14 +44,14 @@ async function scrollUntilLineIsVisible(page: Page, lineNumber: number) {
       break;
     } else {
       if (loopCounter > 10) {
-        throw new Error("Stuck in infinite scrolling loop looking for  line: " + lineNumber);
+        throw new Error("Stuck in infinite scrolling loop looking for line: " + lineNumber);
       }
     }
     // it must not be on screen, we have to scroll
     const [first] = visibleLineNumbers;
 
     const scrollUp = lineNumber < first;
-    const deltaY = scrollUp ? -1000 : 1000;
+    const deltaY = scrollUp ? -500 : 500;
     const scroller = page.locator(".CodeMirror-scroll").first();
     await scroller.click();
     await page.mouse.wheel(0, deltaY);
@@ -61,18 +61,31 @@ async function scrollUntilLineIsVisible(page: Page, lineNumber: number) {
 
 async function getVisibleLineNumbers(page: Page) {
   const lineNumberElements = page.locator(".CodeMirror-linenumber");
-  const numElements = await lineNumberElements.count();
 
-  const textContents = await lineNumberElements.allTextContents();
-  const allLineNumbers = textContents.map(s => Number(s));
+  // Start by finding all line number elements within the CodeMirror editor.
+  // For each element, retrieve its full bounding rect, and actual line number value.
+  const lineNumbersWithBounds = await lineNumberElements.evaluateAll(elements => {
+    const linesWithNumbers = elements.map(
+      el => [Number(el.textContent), el.getBoundingClientRect()] as const
+    );
+    return linesWithNumbers.sort((a, b) => {
+      // Sort lines in ascending numerical order
+      return a[0] - b[0];
+    });
+  });
 
-  const isLine1Visible = allLineNumbers.includes(1);
-  const firstSliceIndex = isLine1Visible ? 0 : 9;
-  // CodeMirror normally has a 10-line buffer on either side of the viewport.
-  // Limit to just what's actually on screen
-  const lineNumbers = allLineNumbers.slice(firstSliceIndex, allLineNumbers.length - 10);
+  const codeMirrorElement = page.locator(".CodeMirror").first();
+  const codeMirrorBounds = await codeMirrorElement.evaluate(e => e.getBoundingClientRect());
 
-  return lineNumbers;
+  // If there's more lines than will fit on screen, CodeMirror will keep a buffer of up to
+  // 10 lines above or below the viewport. Filter it down to just lines that are visible.
+  const visibleLines = lineNumbersWithBounds
+    .filter(([lineNumber, lineBounds]) => {
+      return lineBounds.bottom > codeMirrorBounds.top && lineBounds.top < codeMirrorBounds.bottom;
+    })
+    .map(([lineNumber]) => lineNumber);
+
+  return visibleLines;
 }
 
 export async function addLogpoint(

--- a/packages/e2e-tests/helpers/utils.ts
+++ b/packages/e2e-tests/helpers/utils.ts
@@ -51,6 +51,18 @@ export async function forEach(
   }
 }
 
+export async function mapLocators<T>(
+  locatorList: Locator,
+  callback: (singleLocator: Locator, index: number) => Promise<T>
+) {
+  const count = await locatorList.count();
+  return Promise.all(
+    Array.from({ length: count }).map((_, i) => {
+      return callback(locatorList.nth(i), i);
+    })
+  );
+}
+
 export async function toggleExpandable(
   page: Page,
   options: {

--- a/packages/e2e-tests/tests/node_logpoint-01.test.ts
+++ b/packages/e2e-tests/tests/node_logpoint-01.test.ts
@@ -1,17 +1,9 @@
-import test, { Page } from "@playwright/test";
+import test from "@playwright/test";
 
-import { openDevToolsTab, startTest } from "../helpers";
-import {
-  resumeToLine,
-  rewindToLine,
-  reverseStepOverToLine,
-} from "../helpers/pause-information-panel";
-import {
-  openConsolePanel,
-  warpToMessage,
-  executeAndVerifyTerminalExpression,
-} from "../helpers/console-panel";
-import { openSource, openSourceExplorerPanel } from "../helpers/source-explorer-panel";
+import { startTest } from "../helpers";
+import { reverseStepOverToLine } from "../helpers/pause-information-panel";
+import { openConsolePanel, warpToMessage } from "../helpers/console-panel";
+import { openSource } from "../helpers/source-explorer-panel";
 import { addLogpoint } from "../helpers/source-panel";
 
 test("Basic node logpoints", async ({ page }) => {

--- a/packages/e2e-tests/tests/node_logpoint-02.test.ts
+++ b/packages/e2e-tests/tests/node_logpoint-02.test.ts
@@ -1,17 +1,11 @@
-import test, { Page, expect } from "@playwright/test";
+import test, { expect } from "@playwright/test";
 
-import { openDevToolsTab, startTest } from "../helpers";
-import {
-  resumeToLine,
-  rewindToLine,
-  reverseStepOverToLine,
-  waitForFrameTimeline,
-} from "../helpers/pause-information-panel";
+import { startTest } from "../helpers";
+import { reverseStepOverToLine, waitForFrameTimeline } from "../helpers/pause-information-panel";
 import {
   openConsolePanel,
   warpToMessage,
   executeTerminalExpression,
-  executeAndVerifyTerminalExpression,
   enableConsoleMessageType,
   verifyConsoleMessage,
 } from "../helpers/console-panel";

--- a/packages/e2e-tests/tests/node_object_preview-01.test.ts
+++ b/packages/e2e-tests/tests/node_object_preview-01.test.ts
@@ -1,0 +1,41 @@
+import test, { expect } from "@playwright/test";
+
+import { startTest } from "../helpers";
+import { rewindToLine, stepOverToLine } from "../helpers/pause-information-panel";
+import {
+  openConsolePanel,
+  warpToMessage,
+  verifyConsoleMessage,
+  findConsoleMessage,
+} from "../helpers/console-panel";
+import { addBreakpoint } from "../helpers/source-panel";
+
+test("Showing console objects in node", async ({ page }) => {
+  await startTest(page, "node/objects.js");
+
+  await openConsolePanel(page);
+
+  await verifyConsoleMessage(page, "(20) [0, 1, 2, 3, 4,");
+  await verifyConsoleMessage(page, "Uint8Array(20) [0, 1, 2, 3, 4,");
+  await verifyConsoleMessage(page, "Set(22) [{…}, {…}, 0, 1, 2,");
+  await verifyConsoleMessage(page, "Map(21) {{…} → {…}, 0 → 1, 1 → 2, 2 → 3, 3 → 4,");
+  await verifyConsoleMessage(page, "WeakSet(20) [{…}, {…}, {…},");
+  await verifyConsoleMessage(page, "WeakMap(20) {{…} → {…}, {…} → {…},");
+  await verifyConsoleMessage(page, "{a: 0, a0: 0, a1: 1, a2: 2, a3: 3,");
+  await verifyConsoleMessage(page, "/abc/gi");
+  await verifyConsoleMessage(page, "Thu Sep 29 2022");
+
+  await verifyConsoleMessage(page, "RangeError: foo");
+
+  const functionMessage = findConsoleMessage(page, "bar()");
+  const jumpIcon = functionMessage.locator('[date-test-name="JumpToDefinitionButton"]');
+  const count = await jumpIcon.count();
+  expect(count).toBe(1);
+
+  // Note the ellipsis character here
+  await verifyConsoleMessage(page, `(6) [undefined, true, 3, null, "z", …]`);
+  await verifyConsoleMessage(page, "Proxy");
+  await verifyConsoleMessage(page, "Symbol()");
+  await verifyConsoleMessage(page, "Symbol(symbol)");
+  await verifyConsoleMessage(page, `{Symbol(): 42, Symbol(symbol): Symbol()}`);
+});

--- a/packages/e2e-tests/tests/node_spawn-01.test.ts
+++ b/packages/e2e-tests/tests/node_spawn-01.test.ts
@@ -1,25 +1,8 @@
-import test, { Page, expect } from "@playwright/test";
+import test from "@playwright/test";
 
-import { openDevToolsTab, startTest } from "../helpers";
-import {
-  resumeToLine,
-  rewindToLine,
-  reverseStepOverToLine,
-  waitForFrameTimeline,
-  waitForScopeValue,
-  expandAllScopesBlocks,
-  waitForPaused,
-} from "../helpers/pause-information-panel";
-import {
-  openConsolePanel,
-  warpToMessage,
-  executeTerminalExpression,
-  executeAndVerifyTerminalExpression,
-  enableConsoleMessageType,
-  verifyConsoleMessage,
-} from "../helpers/console-panel";
-import { openSource, openSourceExplorerPanel } from "../helpers/source-explorer-panel";
-import { addLogpoint } from "../helpers/source-panel";
+import { startTest } from "../helpers";
+import { waitForScopeValue, waitForPaused } from "../helpers/pause-information-panel";
+import { openConsolePanel, warpToMessage } from "../helpers/console-panel";
 
 test("Basic subprocess spawning", async ({ page }) => {
   await startTest(page, "node/spawn.js");

--- a/packages/e2e-tests/tests/node_stepping-01.test.ts
+++ b/packages/e2e-tests/tests/node_stepping-01.test.ts
@@ -1,0 +1,54 @@
+import test, { Page, expect } from "@playwright/test";
+
+import { startTest } from "../helpers";
+import {
+  reverseStepOverToLine,
+  waitForFrameTimeline,
+  waitForScopeValue,
+  stepOverToLine,
+  verifyFramesCount,
+  selectFrame,
+  stepOutToLine,
+  openPauseInformationPanel,
+} from "../helpers/pause-information-panel";
+import { warpToMessage, executeAndVerifyTerminalExpression } from "../helpers/console-panel";
+
+test("Test stepping in async frames and async call stacks", async ({ page }) => {
+  await startTest(page, "node/async.js");
+
+  await openPauseInformationPanel(page);
+
+  await warpToMessage(page, "baz 2");
+  await verifyFramesCount(page, 5);
+
+  await waitForScopeValue(page, "n", "2");
+  await waitForFrameTimeline(page, "0%");
+
+  await selectFrame(page, 1);
+  await waitForScopeValue(page, "n", "3");
+  await waitForFrameTimeline(page, "80%");
+
+  await selectFrame(page, 2);
+  await waitForScopeValue(page, "n", "4");
+  await waitForFrameTimeline(page, "80%");
+
+  await selectFrame(page, 3);
+  await waitForFrameTimeline(page, "75%");
+
+  await selectFrame(page, 4);
+  await waitForFrameTimeline(page, "0%");
+
+  await selectFrame(page, 0);
+
+  await stepOverToLine(page, 20);
+  await stepOverToLine(page, 21);
+  await stepOverToLine(page, 22);
+  await stepOverToLine(page, 24);
+  await executeAndVerifyTerminalExpression(page, "n", 2);
+  await stepOutToLine(page, 24);
+  await executeAndVerifyTerminalExpression(page, "n", 3);
+  await stepOutToLine(page, 24);
+  await executeAndVerifyTerminalExpression(page, "n", 4);
+  await stepOutToLine(page, 13);
+  await reverseStepOverToLine(page, 12);
+});

--- a/packages/e2e-tests/tests/node_worker-01.test.ts
+++ b/packages/e2e-tests/tests/node_worker-01.test.ts
@@ -1,0 +1,39 @@
+import test, { Page, expect } from "@playwright/test";
+
+import { openDevToolsTab, startTest } from "../helpers";
+import {
+  resumeToLine,
+  rewindToLine,
+  reverseStepOverToLine,
+  waitForFrameTimeline,
+  waitForScopeValue,
+  expandAllScopesBlocks,
+  waitForPaused,
+  stepOverToLine,
+} from "../helpers/pause-information-panel";
+import {
+  openConsolePanel,
+  warpToMessage,
+  executeTerminalExpression,
+  executeAndVerifyTerminalExpression,
+  enableConsoleMessageType,
+  verifyConsoleMessage,
+} from "../helpers/console-panel";
+import { openSource, openSourceExplorerPanel } from "../helpers/source-explorer-panel";
+import { addLogpoint, addBreakpoint } from "../helpers/source-panel";
+import { delay, waitFor } from "../helpers/utils";
+
+test("Basic subprocess spawning", async ({ page }) => {
+  await startTest(page, "node/run_worker.js");
+
+  await openConsolePanel(page);
+
+  await warpToMessage(page, "GotWorkerMessage pong");
+  await stepOverToLine(page, 18);
+
+  await addBreakpoint(page, { url: "run_worker.js", lineNumber: 13 });
+  await rewindToLine(page, { lineNumber: 13 });
+
+  await addBreakpoint(page, { url: "run_worker.js", lineNumber: 6 });
+  await rewindToLine(page, { lineNumber: 6 });
+});

--- a/packages/e2e-tests/tests/node_worker-01.test.ts
+++ b/packages/e2e-tests/tests/node_worker-01.test.ts
@@ -1,27 +1,9 @@
-import test, { Page, expect } from "@playwright/test";
+import test from "@playwright/test";
 
-import { openDevToolsTab, startTest } from "../helpers";
-import {
-  resumeToLine,
-  rewindToLine,
-  reverseStepOverToLine,
-  waitForFrameTimeline,
-  waitForScopeValue,
-  expandAllScopesBlocks,
-  waitForPaused,
-  stepOverToLine,
-} from "../helpers/pause-information-panel";
-import {
-  openConsolePanel,
-  warpToMessage,
-  executeTerminalExpression,
-  executeAndVerifyTerminalExpression,
-  enableConsoleMessageType,
-  verifyConsoleMessage,
-} from "../helpers/console-panel";
-import { openSource, openSourceExplorerPanel } from "../helpers/source-explorer-panel";
-import { addLogpoint, addBreakpoint } from "../helpers/source-panel";
-import { delay, waitFor } from "../helpers/utils";
+import { startTest } from "../helpers";
+import { rewindToLine, stepOverToLine } from "../helpers/pause-information-panel";
+import { openConsolePanel, warpToMessage } from "../helpers/console-panel";
+import { addBreakpoint } from "../helpers/source-panel";
 
 test("Basic subprocess spawning", async ({ page }) => {
   await startTest(page, "node/run_worker.js");

--- a/packages/e2e-tests/tests/stacking.test.ts
+++ b/packages/e2e-tests/tests/stacking.test.ts
@@ -6,7 +6,7 @@ import { openDevToolsTab, startTest } from "../helpers";
 import { openConsolePanel, warpToMessage } from "../helpers/console-panel";
 import { selectElementsRowWithText } from "../helpers/elements-panel";
 import { getBreakpointsAccordionPane } from "../helpers/pause-information-panel";
-import { waitFor } from "../helpers/utils";
+import { waitFor, mapLocators } from "../helpers/utils";
 
 interface StackingTestCase {
   id: string;
@@ -185,15 +185,10 @@ async function verifySelectedElementUnderCursor(
   // and parse out the name of each rule.
   await waitFor(async () => {
     const rulesEntries = rulesContainer.locator(".ruleview-rule");
-    const numEntries = await rulesEntries.count();
 
-    // Why does `Locator` not have a `.map()` function built in?
-    const ruleSelectorPromises = Array.from({ length: numEntries }).map((_, i) => {
-      // Dig the selector text like ".box2" out of the rule list item
-      return rulesEntries.nth(i).locator(".ruleview-selectorcontainer").textContent();
-    });
-
-    const ruleSelectors = await Promise.all(ruleSelectorPromises);
+    const ruleSelectors = await mapLocators(rulesEntries, entryLocator =>
+      entryLocator.textContent()
+    );
 
     expect(ruleSelectors, `Incorrect rules found for test case: ${testCase.id}`).toEqual(
       testCase.expectedRules


### PR DESCRIPTION
- Ported `node_worker`, `node_stepping`, and `node_object_preview`
- Rewrote the "find visible lines" logic to use actual DOM bounding boxes on the target side