### PR TITLE
Change new Console to show side filters by default

### DIFF
--- a/packages/bvaughn-architecture-demo/components/console/ConsoleRoot.tsx
+++ b/packages/bvaughn-architecture-demo/components/console/ConsoleRoot.tsx
@@ -27,14 +27,14 @@ import { SessionContext } from "@bvaughn/src/contexts/SessionContext";
 
 export default function ConsoleRoot({
   nagHeader = null,
-  showSearchInputByDefault = true,
   showFiltersByDefault = true,
+  showSearchInputByDefault = true,
   terminalInput = null,
 }: {
   filterDrawerOpenDefault?: boolean;
   nagHeader?: ReactNode;
-  showSearchInputByDefault?: boolean;
   showFiltersByDefault?: boolean;
+  showSearchInputByDefault?: boolean;
   terminalInput?: ReactNode;
 }) {
   const { clearMessages: clearConsoleEvaluations, messages: consoleEvaluations } =

--- a/packages/bvaughn-architecture-demo/components/console/ConsoleRoot.tsx
+++ b/packages/bvaughn-architecture-demo/components/console/ConsoleRoot.tsx
@@ -28,7 +28,7 @@ import { SessionContext } from "@bvaughn/src/contexts/SessionContext";
 export default function ConsoleRoot({
   nagHeader = null,
   showSearchInputByDefault = true,
-  showFiltersByDefault = false,
+  showFiltersByDefault = true,
   terminalInput = null,
 }: {
   filterDrawerOpenDefault?: boolean;

--- a/src/ui/components/SecondaryToolbox/NewConsole.tsx
+++ b/src/ui/components/SecondaryToolbox/NewConsole.tsx
@@ -91,8 +91,8 @@ export default function NewConsoleRoot() {
               <PointsContextReduxAdapter>
                 <ConsoleRoot
                   nagHeader={<ConsoleNag />}
-                  showSearchInputByDefault={false}
                   showFiltersByDefault={consoleFilterDrawerDefaultsToOpen}
+                  showSearchInputByDefault={false}
                   terminalInput={<JSTermWrapper />}
                 />
               </PointsContextReduxAdapter>


### PR DESCRIPTION
This preserves the  behavior of the side filters being hidden by default in Replay itself (since we pass an explicit `false` value there). It just changes the default prop value in the Console (which I think should fix the e2e tests that have been failing since #7870 landed).