### PR TITLE
Add a little resilience to failed async frame protocol commands

### DIFF
--- a/packages/bvaughn-architecture-demo/src/suspense/ExceptionsCache.test.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/ExceptionsCache.test.ts
@@ -1,5 +1,6 @@
 import { TimeStampedPoint, TimeStampedPointRange } from "@replayio/protocol";
 import { ReplayClientInterface } from "shared/client/types";
+import { CommandError } from "shared/utils/error";
 
 import { createMockReplayClient } from "../utils/testing";
 
@@ -7,8 +8,9 @@ import { Status, UncaughtException } from "./ExceptionsCache";
 
 describe("ExceptionsCache", () => {
   function createCE() {
-    const error = new Error("There are too many points to complete this operation");
+    const error = new Error("There are too many points to complete this operation") as CommandError;
     error.name = "CommandError";
+    error.code = 55;
     return error;
   }
 

--- a/packages/bvaughn-architecture-demo/src/suspense/ExceptionsCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/ExceptionsCache.ts
@@ -1,6 +1,7 @@
-import { isTooManyPointsError } from "@bvaughn/../shared/utils/error";
 import { TimeStampedPointRange } from "@replayio/protocol";
 import { ReplayClientInterface } from "shared/client/types";
+import { ProtocolError } from "shared/utils/error";
+import { isCommandError } from "shared/utils/error";
 
 import { createWakeable } from "../utils/suspense";
 import { isRangeEqual, isRangeSubset } from "../utils/time";
@@ -142,7 +143,7 @@ async function fetchExceptions(client: ReplayClientInterface) {
     // React doesn't use the resolved value.
     wakeable.resolve(null as any);
   } catch (error) {
-    if (isTooManyPointsError(error) && wakeable === inFlightWakeable) {
+    if (isCommandError(error, ProtocolError.TooManyPoints) && wakeable === inFlightWakeable) {
       lastFetchDidFailTooManyPoints = true;
       lastFetchedExceptions = EMPTY_ARRAY;
       lastFetchedFocusRange = inFlightFocusRange;

--- a/packages/bvaughn-architecture-demo/src/suspense/PointsCache.test.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/PointsCache.test.ts
@@ -6,6 +6,7 @@ import {
   TimeStampedPointRange,
 } from "@replayio/protocol";
 import { HitPointsAndStatusTuple, ReplayClientInterface } from "shared/client/types";
+import { commandError, ProtocolError } from "shared/utils/error";
 
 import { createMockReplayClient } from "../utils/testing";
 
@@ -246,9 +247,7 @@ describe("PointsCache", () => {
       preCacheExecutionPointForTime({ time: 9, point: "9" });
 
       mockClient.getPointsBoundingTime.mockImplementation(() => {
-        const commandError = new Error("unloaded");
-        commandError.name = "CommandError";
-        throw commandError;
+        throw commandError("RecordingUnloaded", ProtocolError.RecordingUnloaded);
       });
       expect(await imperativelyGetClosestPointForTime(replayClient, 3)).toBe("2");
       expect(mockClient.getPointsBoundingTime).toHaveBeenCalledTimes(1);

--- a/packages/bvaughn-architecture-demo/src/suspense/PointsCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/PointsCache.ts
@@ -6,7 +6,7 @@ import {
   TimeStampedPointRange,
 } from "@replayio/protocol";
 import { HitPointsAndStatusTuple, ReplayClientInterface } from "shared/client/types";
-import { isUnloadedRegionError } from "shared/utils/error";
+import { isCommandError, ProtocolError } from "shared/utils/error";
 
 import { createWakeable } from "../utils/suspense";
 import { isExecutionPointsLessThan } from "../utils/time";
@@ -344,7 +344,7 @@ export async function imperativelyGetClosestPointForTime(
     await fetchPointsBoundingTime(client, time, createWakeable<ExecutionPoint>(), true);
     return cachedPointsForTime.get(time)!;
   } catch (error) {
-    if (!isUnloadedRegionError(error)) {
+    if (!isCommandError(error, ProtocolError.RecordingUnloaded)) {
       throw error;
     }
   }

--- a/packages/protocol/socket.ts
+++ b/packages/protocol/socket.ts
@@ -12,6 +12,7 @@ import {
   AnalysisEntry,
   PointDescription,
 } from "@replayio/protocol";
+import { commandError } from "shared/utils/error";
 
 import { makeInfallible } from "./utils";
 
@@ -204,10 +205,7 @@ export async function sendMessage<M extends CommandMethods>(
 
     console.warn("Message failed", method, { code, id, message }, data);
 
-    const err = new Error(message) as any;
-    err.name = "CommandError";
-    err.code = code;
-    throw err;
+    throw commandError(message, code);
   }
 
   return response.result as any;

--- a/packages/shared/client/ReplayClient.ts
+++ b/packages/shared/client/ReplayClient.ts
@@ -40,7 +40,7 @@ import { ThreadFront } from "protocol/thread";
 import { MAX_POINTS_FOR_FULL_ANALYSIS } from "protocol/thread/analysis";
 import { RecordingCapabilities } from "protocol/thread/thread";
 import { binarySearch, compareNumericStrings, defer } from "protocol/utils";
-import { isTooManyPointsError } from "shared/utils/error";
+import { isCommandError, ProtocolError } from "shared/utils/error";
 
 import {
   ColumnHits,
@@ -380,7 +380,7 @@ export class ReplayClient implements ReplayClientInterface {
           }
         );
       } catch (error) {
-        if (isTooManyPointsError(error)) {
+        if (isCommandError(error, ProtocolError.TooManyPoints)) {
           status = "too-many-points-to-find";
         } else {
           console.error(error);
@@ -413,7 +413,7 @@ export class ReplayClient implements ReplayClientInterface {
           }
         );
       } catch (error) {
-        if (isTooManyPointsError(error)) {
+        if (isCommandError(error, ProtocolError.TooManyPoints)) {
           status = "too-many-points-to-find";
         } else {
           console.error(error);

--- a/packages/shared/utils/error.ts
+++ b/packages/shared/utils/error.ts
@@ -1,13 +1,22 @@
-export function isTooManyPointsError(error: any) {
-  return (
-    error instanceof Error &&
-    error.name === "CommandError" &&
-    error.message.includes("too many points")
-  );
+export interface CommandError extends Error {
+  name: "CommandError";
+  code: number;
 }
 
-export function isUnloadedRegionError(error: any) {
-  return (
-    error instanceof Error && error.name === "CommandError" && error.message.includes("unloaded")
-  );
+export enum ProtocolError {
+  TooManyPoints = 55,
+  RecordingUnloaded = 38,
 }
+
+export const commandError = (message: string, code: number): CommandError => {
+  const err = new Error(message) as CommandError;
+  err.name = "CommandError";
+  err.code = code;
+  return err;
+};
+
+export const isCommandError = (error: unknown, code: number): boolean => {
+  return (
+    error instanceof Error && error.name === "CommandError" && (error as CommandError).code === code
+  );
+};

--- a/src/devtools/client/debugger/src/actions/pause/selectFrame.ts
+++ b/src/devtools/client/debugger/src/actions/pause/selectFrame.ts
@@ -9,6 +9,7 @@ import { selectLocation } from "../sources";
 import { fetchScopes, frameSelected } from "../../reducers/pause";
 import { setFramePositions } from "./setFramePositions";
 import { SourceLocation } from "../../reducers/types";
+import { isCommandError, ProtocolError } from "shared/utils/error";
 
 interface TempFrame {
   id: string;
@@ -32,7 +33,16 @@ export function selectFrame(cx: Context, frame: TempFrame): UIThunkAction {
 
     dispatch(frameSelected({ cx, frameId: frame.id }));
 
-    await ThreadFront.getFrameSteps(frame.asyncIndex, frame.protocolId);
+    try {
+      await ThreadFront.getFrameSteps(frame.asyncIndex, frame.protocolId);
+    } catch (e) {
+      // TODO [FE-795]: Communicate this to the user
+      if (isCommandError(e, ProtocolError.TooManyPoints)) {
+        console.error(e);
+        return;
+      }
+      throw e;
+    }
 
     dispatch(selectLocation(cx, frame.location));
     dispatch(setFramePositions());

--- a/src/devtools/client/debugger/src/actions/pause/setFramePositions.ts
+++ b/src/devtools/client/debugger/src/actions/pause/setFramePositions.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 import zip from "lodash/zip";
+import { isCommandError, ProtocolError } from "shared/utils/error";
 import type { UIThunkAction } from "ui/actions";
 import { getPreferredLocation } from "ui/reducers/sources";
 
@@ -19,10 +20,11 @@ export function setFramePositions(): UIThunkAction<Promise<void>> {
     let positions;
     try {
       positions = await ThreadFront.getFrameSteps(frame.asyncIndex, frame.protocolId);
-    } catch (e: any) {
+    } catch (e) {
       // "There are too many points to complete this operation"
       // is expected if the frame is too long and should not be treated as an error.
-      if (e.code == 55) {
+      if (isCommandError(e, ProtocolError.TooManyPoints)) {
+        console.error(e);
         return;
       }
       throw e;

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -139,7 +139,3 @@ export interface Canvas {
   top: number;
   width: number;
 }
-
-export enum ProtocolError {
-  TooManyPoints = 55,
-}

--- a/src/ui/suspense/util.ts
+++ b/src/ui/suspense/util.ts
@@ -1,5 +1,6 @@
 import { Frame, PauseId } from "@replayio/protocol";
 import { ThreadFront } from "protocol/thread";
+import { isCommandError, ProtocolError } from "shared/utils/error";
 import { getFramesSuspense } from "./frameCache";
 import { getFrameStepsSuspense } from "./frameStepsCache";
 
@@ -39,16 +40,25 @@ export function getAsyncParentFramesSuspense(
   pauseId: PauseId,
   asyncIndex: number
 ): Frame[] | undefined {
-  if (asyncIndex === 0) {
-    return getFramesSuspense(pauseId);
+  try {
+    if (asyncIndex === 0) {
+      return getFramesSuspense(pauseId);
+    }
+    const asyncParentPauseId = getAsyncParentPauseIdSuspense(pauseId, asyncIndex);
+    if (!asyncParentPauseId) {
+      return;
+    }
+    const frames = getFramesSuspense(asyncParentPauseId);
+    if (!frames) {
+      return;
+    }
+    return frames.slice(1);
+  } catch (e: any) {
+    // TODO [FE-795]: Communicate this to the user
+    if (isCommandError(e, ProtocolError.TooManyPoints)) {
+      console.error(e);
+      return [];
+    }
+    throw e;
   }
-  const asyncParentPauseId = getAsyncParentPauseIdSuspense(pauseId, asyncIndex);
-  if (!asyncParentPauseId) {
-    return;
-  }
-  const frames = getFramesSuspense(asyncParentPauseId);
-  if (!frames) {
-    return;
-  }
-  return frames.slice(1);
 }


### PR DESCRIPTION
This is a precursor to proper error handling of these `getFrameSteps` calls which can fail with "too many points" errors. In testing this on the customer replay that was failing, this change at least allowed the call stack to show up and the stepper to work most of the time. There were a couple instances where they didn't but I'm not sure why.

TBH, I don't know the implications of "ignoring" these errors in devtools so I'm opening this as draft for feedback from those that know it better (cc: @markerikson , @bvaughn , @hbenl )

A replay of the "fix" in action:
https://app.replay.io/recording/replay-of-localhost8080--c4d8afe5-68b0-4cf9-8852-507a3dcfcb62