### PR TITLE
Leverage debugPrint to log to the page context as well

### DIFF
--- a/packages/e2e-tests/helpers/commands.ts
+++ b/packages/e2e-tests/helpers/commands.ts
@@ -4,15 +4,15 @@ import chalk from "chalk";
 import { debugPrint, getCommandKey } from "./utils";
 
 export async function quickOpen(page: Page, url: string): Promise<void> {
-  debugPrint("Opening quick-open dialog", "quickOpen");
+  await debugPrint(page, "Opening quick-open dialog", "quickOpen");
   await page.keyboard.press(`${getCommandKey()}+P`);
   await page.focus('[data-test-id="QuickOpenInput"]');
 
-  debugPrint(`Filtering files by "${chalk.bold(url)}"`, "quickOpen");
+  await debugPrint(page, `Filtering files by "${chalk.bold(url)}"`, "quickOpen");
   await page.keyboard.type(url);
   await page.waitForSelector(`[data-test-id="QuickOpenResultsList"]:has-text("${url}")`);
 
-  debugPrint(`Opening file "${chalk.bold(url)}"`, "quickOpen");
+  await debugPrint(page, `Opening file "${chalk.bold(url)}"`, "quickOpen");
   await page.keyboard.press("Enter");
   await page.waitForSelector(`[data-test-name="Source-${url}"]`);
 }

--- a/packages/e2e-tests/helpers/console-panel.ts
+++ b/packages/e2e-tests/helpers/console-panel.ts
@@ -21,7 +21,8 @@ export async function addEventListenerLogpoints(page: Page, eventTypes: string[]
   for (let eventType of eventTypes) {
     const [, categoryKey, eventName] = eventType.split(".");
 
-    debugPrint(
+    await debugPrint(
+      page,
       `Adding event type "${chalk.bold(eventName)}" in category "${chalk.bold(categoryKey)}"`,
       "addEventListenerLogpoints"
     );
@@ -51,7 +52,11 @@ export async function enableConsoleMessageType(
 }
 
 export async function executeTerminalExpression(page: Page, text: string): Promise<void> {
-  debugPrint(`Executing terminal expression "${chalk.bold(text)}"`, "executeTerminalExpression");
+  await debugPrint(
+    page,
+    `Executing terminal expression "${chalk.bold(text)}"`,
+    "executeTerminalExpression"
+  );
 
   await openConsolePanel(page);
 
@@ -92,7 +97,8 @@ export async function expandConsoleMessage(message: Locator) {
 }
 
 export async function expandFilterCategory(page: Page, categoryName: string) {
-  debugPrint(
+  await debugPrint(
+    page,
     `Expanding Console event filter category "${chalk.bold(categoryName)}"`,
     "expandFilterCategory"
   );
@@ -111,12 +117,13 @@ export async function expandFilterCategory(page: Page, categoryName: string) {
   }
 }
 
-export function findConsoleMessage(
+export async function findConsoleMessage(
   page: Page,
   expected?: Expected,
   messageType?: MessageType
-): Locator {
-  debugPrint(
+): Promise<Locator> {
+  await debugPrint(
+    page,
     `Searching for console message${
       messageType ? ` of type "${chalk.bold(messageType)}" ` : " "
     }with text "${chalk.bold(expected)}"`,
@@ -149,11 +156,15 @@ export async function openConsolePanel(page: Page): Promise<void> {
   await page.locator('[data-test-id="PanelButton-console"]').click();
 }
 
-export async function openMessageSource(message: Locator): Promise<void> {
+export async function openMessageSource(page: Page, message: Locator): Promise<void> {
   const sourceLink = getMessageSourceLink(message);
   const textContent = await sourceLink.textContent();
 
-  debugPrint(`Opening message source "${chalk.bold(textContent)}"`, "openMessageSource");
+  await debugPrint(
+    page,
+    `Opening message source "${chalk.bold(textContent)}"`,
+    "openMessageSource"
+  );
 
   await sourceLink.click();
 }
@@ -165,7 +176,7 @@ export async function seekToConsoleMessage(
 ): Promise<void> {
   const textContent = await consoleMessage.locator('[data-test-name="LogContents"]').textContent();
 
-  debugPrint(`Seeking to message "${chalk.bold(textContent)}"`, "seekToConsoleMessage");
+  await debugPrint(page, `Seeking to message "${chalk.bold(textContent)}"`, "seekToConsoleMessage");
 
   await consoleMessage.scrollIntoViewIfNeeded();
   await consoleMessage.hover();
@@ -179,7 +190,8 @@ export async function toggleSideFilters(page: Page, open: boolean): Promise<void
   const state = await button.getAttribute("data-test-state");
   const isOpen = state === "open";
   if (isOpen !== open) {
-    debugPrint(
+    await debugPrint(
+      page,
       `${chalk.bold(open ? "Opening" : "Closing")} the side filters panel`,
       "toggleSideFilters"
     );
@@ -194,14 +206,15 @@ export async function verifyConsoleMessage(
   messageType?: MessageType,
   expectedCount?: number
 ) {
-  debugPrint(
+  await debugPrint(
+    page,
     `Verifying the presence of a console message${
       messageType ? ` of type "${chalk.bold(messageType)}" ` : " "
     }with text "${chalk.bold(expected)}"`,
     "verifyConsoleMessage"
   );
 
-  const messages = findConsoleMessage(page, expected, messageType);
+  const messages = await findConsoleMessage(page, expected, messageType);
 
   if (expectedCount != null) {
     // Verify a specific number of messages
@@ -225,7 +238,8 @@ export async function verifyPausedAtMessage(
   expected: Expected,
   messageType?: MessageType
 ): Promise<void> {
-  debugPrint(
+  await debugPrint(
+    page,
     `Verifying currently paused at console message${
       messageType ? ` of type "${chalk.bold(messageType)}" ` : " "
     }with text "${chalk.bold(expected)}"`,
@@ -283,7 +297,8 @@ export async function verifyTrimmedConsoleMessages(
   const afterString =
     expectedAfter === 1 ? "1 message" : `${expectedAfter === 0 ? "no" : expectedAfter} messages`;
 
-  debugPrint(
+  await debugPrint(
+    page,
     `Verifying console has trimmed ${beforeString} before and ${afterString} after`,
     "verifyTrimmedConsoleMessages"
   );
@@ -303,6 +318,7 @@ export async function verifyTrimmedConsoleMessages(
 }
 
 export async function warpToMessage(page: Page, text: string, line?: number) {
-  const message = findConsoleMessage(page, text).first();
+  const messages = await findConsoleMessage(page, text);
+  const message = messages.first();
   await seekToConsoleMessage(page, message, line);
 }

--- a/packages/e2e-tests/helpers/elements-panel.ts
+++ b/packages/e2e-tests/helpers/elements-panel.ts
@@ -132,8 +132,8 @@ export async function getComputedStyle(page: Page, style: string) {
   }, style);
 }
 
-export function getElementsPanelSelection(page: Page): Locator {
-  debugPrint(`Getting Elements panel selection`, "getElementsPanelSelection");
+export async function getElementsPanelSelection(page: Page): Promise<Locator> {
+  await debugPrint(page, `Getting Elements panel selection`, "getElementsPanelSelection");
 
   const elements = page.locator("#inspector-main-content");
   const selectedLine = elements.locator(".tag-line.selected");
@@ -141,12 +141,13 @@ export function getElementsPanelSelection(page: Page): Locator {
   return selectedLine;
 }
 
-export function getElementsRowWithText(
+export async function getElementsRowWithText(
   page: Page,
   text: string,
   isSelected: boolean = false
-): Locator {
-  debugPrint(
+): Promise<Locator> {
+  await debugPrint(
+    page,
     `Searching for Elements row containing "${chalk.bold(text)}"`,
     "getElementsRowWithText"
   );
@@ -171,7 +172,7 @@ export async function inspectCanvasCoordinates(
     );
   }
 
-  debugPrint(`Inspecting preview Canvas`, "inspectCanvasCoordinates");
+  await debugPrint(page, `Inspecting preview Canvas`, "inspectCanvasCoordinates");
 
   await activateInspectorTool(page);
 
@@ -184,7 +185,8 @@ export async function inspectCanvasCoordinates(
   const x = xPercentage * (width as any as number);
   const y = yPercentage * (height as any as number);
 
-  debugPrint(
+  await debugPrint(
+    page,
     `Clicking Canvas coordinates ${chalk.bold(x)}px (${Math.round(
       xPercentage * 100
     )}%), ${chalk.bold(y)}px (${Math.round(yPercentage * 100)}%)`,
@@ -211,7 +213,11 @@ export async function openElementsPanel(page: Page): Promise<void> {
 }
 
 export async function searchElementsPanel(page: Page, searchText: string): Promise<void> {
-  debugPrint(`Searching Elements for text ${chalk.bold(`"${searchText}"`)}`, "searchElementsPanel");
+  await debugPrint(
+    page,
+    `Searching Elements for text ${chalk.bold(`"${searchText}"`)}`,
+    "searchElementsPanel"
+  );
 
   await activateInspectorTool(page);
 
@@ -224,7 +230,7 @@ export async function searchElementsPanel(page: Page, searchText: string): Promi
 export async function selectElementsRowWithText(page: Page, text: string): Promise<void> {
   const elementsTab = page.locator(`button:has-text("Elements")`);
   await elementsTab.click();
-  const node = getElementsRowWithText(page, text);
+  const node = await getElementsRowWithText(page, text);
   await node.waitFor();
   await node.click();
 }
@@ -236,7 +242,7 @@ export async function selectNextElementsPanelSearchResult(page: Page): Promise<v
 }
 
 export async function waitForElementsToLoad(page: Page): Promise<void> {
-  debugPrint("Waiting for elements to load", "waitForElementsToLoad");
+  await debugPrint(page, "Waiting for elements to load", "waitForElementsToLoad");
 
   const elements = page.locator("#markup-box");
   await elements.waitFor();
@@ -245,8 +251,12 @@ export async function waitForElementsToLoad(page: Page): Promise<void> {
   await tree.waitFor();
 }
 
-export async function toggleMarkupNode(locator: Locator, open: boolean): Promise<void> {
-  debugPrint(`Toggling element node ${chalk.bold(open ? "open" : "closed")}`, "toggleMarkupNode");
+export async function toggleMarkupNode(page: Page, locator: Locator, open: boolean): Promise<void> {
+  await debugPrint(
+    page,
+    `Toggling element node ${chalk.bold(open ? "open" : "closed")}`,
+    "toggleMarkupNode"
+  );
 
   const expander = locator.locator(".expander");
   await expander.waitFor();
@@ -258,6 +268,6 @@ export async function toggleMarkupNode(locator: Locator, open: boolean): Promise
 }
 
 export async function waitForSelectedElementsRow(page: Page, text: string): Promise<void> {
-  const locator = getElementsRowWithText(page, text, true);
+  const locator = await getElementsRowWithText(page, text, true);
   await locator.waitFor();
 }

--- a/packages/e2e-tests/helpers/index.ts
+++ b/packages/e2e-tests/helpers/index.ts
@@ -33,7 +33,7 @@ export async function startTest(page: Page, example: string) {
   const base = process.env.PLAYWRIGHT_TEST_BASE_URL || "http://localhost:8080";
   const url = `${base}/recording/${recordingId}?e2e=1`;
 
-  debugPrint(`Navigating to ${chalk.bold(url)}`, "startTest");
+  await debugPrint(page, `Navigating to ${chalk.bold(url)}`, "startTest");
 
   await page.goto(url);
 

--- a/packages/e2e-tests/helpers/pause-information-panel.ts
+++ b/packages/e2e-tests/helpers/pause-information-panel.ts
@@ -5,31 +5,31 @@ import { openSource } from "./source-explorer-panel";
 import { Expected } from "./types";
 import { debugPrint, forEach, toggleExpandable, waitFor } from "./utils";
 
-async function toggleAccordionPane(pane: Locator, targetState: "open" | "closed") {
+async function toggleAccordionPane(page: Page, pane: Locator, targetState: "open" | "closed") {
   const name = (await pane.getAttribute("data-test-id"))!.split("-")[1];
   const currentState = await pane.getAttribute("date-test-state");
   if (targetState !== currentState) {
-    debugPrint(`${name} pane to ${targetState}`, "toggleAccordionPane");
+    await debugPrint(page, `${name} pane to ${targetState}`, "toggleAccordionPane");
     await pane.locator('[role="button"]').click();
   } else {
-    debugPrint(`${name} pane already ${targetState}`, "toggleAccordionPane");
+    await debugPrint(page, `${name} pane already ${targetState}`, "toggleAccordionPane");
   }
 }
 
 export async function closeBreakpointsAccordionPane(page: Page): Promise<void> {
-  await toggleAccordionPane(getBreakpointsAccordionPane(page), "closed");
+  await toggleAccordionPane(page, getBreakpointsAccordionPane(page), "closed");
 }
 
 export async function closeCallStackAccordionPane(page: Page): Promise<void> {
-  await toggleAccordionPane(getCallStackAccordionPane(page), "closed");
+  await toggleAccordionPane(page, getCallStackAccordionPane(page), "closed");
 }
 
 export async function closePrintStatementsAccordionPane(page: Page): Promise<void> {
-  await toggleAccordionPane(getPrintStatementsAccordionPane(page), "closed");
+  await toggleAccordionPane(page, getPrintStatementsAccordionPane(page), "closed");
 }
 
 export async function expandAllScopesBlocks(page: Page): Promise<void> {
-  debugPrint("Expanding all Scopes blocks", "expandAllScopesBlocks");
+  await debugPrint(page, "Expanding all Scopes blocks", "expandAllScopesBlocks");
 
   const scopesPanel = getScopesPanel(page);
   const blocks = scopesPanel.locator('[data-test-name="ScopesInspector"]');
@@ -97,11 +97,11 @@ export function getScopesPanel(page: Page): Locator {
 }
 
 export async function openBreakpointsAccordionPane(page: Page): Promise<void> {
-  await toggleAccordionPane(getBreakpointsAccordionPane(page), "open");
+  await toggleAccordionPane(page, getBreakpointsAccordionPane(page), "open");
 }
 
 export async function openCallStackPane(page: Page): Promise<void> {
-  await toggleAccordionPane(getCallStackAccordionPane(page), "open");
+  await toggleAccordionPane(page, getCallStackAccordionPane(page), "open");
 }
 
 export async function openPauseInformationPanel(page: Page): Promise<void> {
@@ -116,11 +116,11 @@ export async function openPauseInformationPanel(page: Page): Promise<void> {
 }
 
 export async function openPrintStatementsAccordionPane(page: Page): Promise<void> {
-  await toggleAccordionPane(getPrintStatementsAccordionPane(page), "open");
+  await toggleAccordionPane(page, getPrintStatementsAccordionPane(page), "open");
 }
 
 export async function openScopesAccordionPane(page: Page): Promise<void> {
-  await toggleAccordionPane(getScopesAccordionPane(page), "open");
+  await toggleAccordionPane(page, getScopesAccordionPane(page), "open");
 }
 
 export async function openScopeBlocks(page: Page, text: string): Promise<void> {
@@ -131,12 +131,16 @@ export async function openScopeBlocks(page: Page, text: string): Promise<void> {
     throw Error(`No Scope blocks found containing text "${text}"`);
   }
 
-  debugPrint(`Found ${count} Scope blocks with text "${chalk.bold(text)}"`, "openScopeBlocks");
+  await debugPrint(
+    page,
+    `Found ${count} Scope blocks with text "${chalk.bold(text)}"`,
+    "openScopeBlocks"
+  );
 
   await forEach(blocks, async block => {
     const expandable = block.locator('[data-test-name="Expandable"][data-test-state="closed"]');
     if ((await expandable.count()) > 0) {
-      debugPrint(`Opening Scope block`, "openScopeBlocks");
+      await debugPrint(page, `Opening Scope block`, "openScopeBlocks");
 
       await expandable.click();
     }
@@ -152,7 +156,8 @@ export async function resumeToLine(
 ): Promise<void> {
   const { url = null, lineNumber } = options;
 
-  debugPrint(
+  await debugPrint(
+    page,
     `Resuming to line ${chalk.bold(url ? `${url}:${lineNumber}` : lineNumber)}`,
     "resumeToLine"
   );
@@ -178,14 +183,14 @@ export async function resumeToLine(
 }
 
 export async function reverseStepOver(page: Page): Promise<void> {
-  debugPrint("Reverse step over", "reverseStepOver");
+  await debugPrint(page, "Reverse step over", "reverseStepOver");
 
   await openPauseInformationPanel(page);
   await page.locator('[title="Reverse Step Over"]').click();
 }
 
 export async function reverseStepOverToLine(page: Page, line: number) {
-  debugPrint(`Reverse step over to line ${chalk.bold(line)}`, "reverseStepOverToLine");
+  await debugPrint(page, `Reverse step over to line ${chalk.bold(line)}`, "reverseStepOverToLine");
 
   await openPauseInformationPanel(page);
   await page.locator('[title="Reverse Step Over"]').click();
@@ -194,7 +199,7 @@ export async function reverseStepOverToLine(page: Page, line: number) {
 }
 
 export async function rewind(page: Page) {
-  debugPrint("Rewinding", "rewind");
+  await debugPrint(page, "Rewinding", "rewind");
 
   await openPauseInformationPanel(page);
 
@@ -211,7 +216,7 @@ export async function rewindToLine(
 ): Promise<void> {
   const { url = null, lineNumber = null } = options;
 
-  debugPrint(`Rewinding to line ${chalk.bold(lineNumber)}`, "rewindToLine");
+  await debugPrint(page, `Rewinding to line ${chalk.bold(lineNumber)}`, "rewindToLine");
 
   if (url !== null) {
     await openSource(page, url);
@@ -238,7 +243,7 @@ export async function rewindToLine(
 }
 
 export async function selectFrame(page: Page, index: number): Promise<void> {
-  debugPrint(`Select frame ${chalk.bold(index)}`, "selectFrame");
+  await debugPrint(page, `Select frame ${chalk.bold(index)}`, "selectFrame");
 
   const framesPanel = getFramesPanel(page);
 
@@ -247,7 +252,7 @@ export async function selectFrame(page: Page, index: number): Promise<void> {
 }
 
 export async function stepInToLine(page: Page, line: number) {
-  debugPrint(`Step in to line ${chalk.bold(line)}`, "stepInToLine");
+  await debugPrint(page, `Step in to line ${chalk.bold(line)}`, "stepInToLine");
 
   await openPauseInformationPanel(page);
   await page.locator('[title="Step In"]').click();
@@ -256,7 +261,7 @@ export async function stepInToLine(page: Page, line: number) {
 }
 
 export async function stepOutToLine(page: Page, line: number) {
-  debugPrint(`Step out to line ${chalk.bold(line)}`, "stepOutToLine");
+  await debugPrint(page, `Step out to line ${chalk.bold(line)}`, "stepOutToLine");
 
   await openPauseInformationPanel(page);
   await page.locator('[title="Step Out"]').click();
@@ -265,7 +270,7 @@ export async function stepOutToLine(page: Page, line: number) {
 }
 
 export async function stepOverToLine(page: Page, line: number) {
-  debugPrint(`Step over to line ${chalk.bold(line)}`, "stepOverToLine");
+  await debugPrint(page, `Step over to line ${chalk.bold(line)}`, "stepOverToLine");
 
   await openPauseInformationPanel(page);
   await page.locator('[title="Step Over"]').click();
@@ -274,7 +279,7 @@ export async function stepOverToLine(page: Page, line: number) {
 }
 
 export async function stepOver(page: Page): Promise<void> {
-  debugPrint("Step over", "stepOver");
+  await debugPrint(page, "Step over", "stepOver");
 
   await openPauseInformationPanel(page);
   await page.locator('[title="Step Over"]').click();
@@ -290,7 +295,11 @@ export async function verifyFramesCount(page: Page, expectedCount: number) {
 }
 
 export async function waitForFrameTimeline(page: Page, widthPercentage: string) {
-  debugPrint(`Waiting for frame progress ${chalk.bold(widthPercentage)}`, "waitForFrameTimeline");
+  await debugPrint(
+    page,
+    `Waiting for frame progress ${chalk.bold(widthPercentage)}`,
+    "waitForFrameTimeline"
+  );
 
   await openPauseInformationPanel(page);
 
@@ -314,7 +323,11 @@ export async function waitForFrameTimeline(page: Page, widthPercentage: string) 
 }
 
 export async function waitForPaused(page: Page, line?: number): Promise<void> {
-  debugPrint(`Waiting for pause ${line != null ? `at ${chalk.bold(line)}` : ""}`, "waitForPaused");
+  await debugPrint(
+    page,
+    `Waiting for pause ${line != null ? `at ${chalk.bold(line)}` : ""}`,
+    "waitForPaused"
+  );
 
   await openPauseInformationPanel(page);
 
@@ -338,7 +351,8 @@ export async function waitForPaused(page: Page, line?: number): Promise<void> {
 }
 
 export async function waitForScopeValue(page: Page, name: string, expectedValue: Expected) {
-  debugPrint(
+  await debugPrint(
+    page,
     `Waiting for scope with variable "${chalk.bold(name)}" to have value "${chalk.bold(
       expectedValue
     )}"`,

--- a/packages/e2e-tests/helpers/source-explorer-panel.ts
+++ b/packages/e2e-tests/helpers/source-explorer-panel.ts
@@ -5,7 +5,7 @@ import { getSourceTab, waitForSelectedSource } from "./source-panel";
 import { debugPrint, waitFor } from "./utils";
 
 export async function clickSourceTreeNode(page: Page, node: string) {
-  debugPrint(`Selecting source tree node: ${chalk.bold(node)}`);
+  await debugPrint(page, `Selecting source tree node: ${chalk.bold(node)}`);
 
   await page.locator(`div[role="tree"] div:has-text("${node}")`).nth(1).click();
 }
@@ -22,11 +22,11 @@ export async function openSource(page: Page, url: string): Promise<void> {
   // If the source is already open, just focus it.
   const sourceTab = getSourceTab(page, url);
   if (await sourceTab.isVisible()) {
-    debugPrint(`Source "${chalk.bold(url)}" already open`, "openSource");
+    await debugPrint(page, `Source "${chalk.bold(url)}" already open`, "openSource");
     return;
   }
 
-  debugPrint(`Opening source "${chalk.bold(url)}"`, "openSource");
+  await debugPrint(page, `Opening source "${chalk.bold(url)}"`, "openSource");
 
   await openSourceExplorerPanel(page);
 

--- a/packages/e2e-tests/helpers/source-panel.ts
+++ b/packages/e2e-tests/helpers/source-panel.ts
@@ -16,7 +16,11 @@ export async function addBreakpoint(
 ): Promise<void> {
   const { lineNumber, url } = options;
 
-  debugPrint(`Adding breakpoint at ${chalk.bold(`${url}:${lineNumber}`)}`, "addBreakpoint");
+  await debugPrint(
+    page,
+    `Adding breakpoint at ${chalk.bold(`${url}:${lineNumber}`)}`,
+    "addBreakpoint"
+  );
 
   await openDevToolsTab(page);
 
@@ -100,7 +104,11 @@ export async function addLogpoint(
 ): Promise<void> {
   const { condition, content, lineNumber, url } = options;
 
-  debugPrint(`Adding log-point at ${chalk.bold(`${url}:${lineNumber}`)}`, "addLogpoint");
+  await debugPrint(
+    page,
+    `Adding log-point at ${chalk.bold(`${url}:${lineNumber}`)}`,
+    "addLogpoint"
+  );
 
   await openDevToolsTab(page);
 
@@ -120,7 +128,11 @@ export async function addLogpoint(
     await line.locator('[data-test-name="LogpointContentSummary"]').click();
 
     if (condition) {
-      debugPrint(`Setting log-point condition "${chalk.bold(condition)}"`, "addLogpoint");
+      await debugPrint(
+        page,
+        `Setting log-point condition "${chalk.bold(condition)}"`,
+        "addLogpoint"
+      );
 
       await line.locator('[data-test-name="EditLogpointConditionButton"]').click();
 
@@ -134,7 +146,7 @@ export async function addLogpoint(
     }
 
     if (content) {
-      debugPrint(`Setting log-point content "${chalk.bold(content)}"`, "addLogpoint");
+      await debugPrint(page, `Setting log-point content "${chalk.bold(content)}"`, "addLogpoint");
 
       // Condition and content both have text areas.
       // Content will always be the last one regardless of whether the condition text area is visible.
@@ -155,7 +167,7 @@ export async function addLogpoint(
 }
 
 export async function closeSource(page: Page, url: string): Promise<void> {
-  debugPrint(`Closing source "${chalk.bold(url)}"`, "openSource");
+  await debugPrint(page, `Closing source "${chalk.bold(url)}"`, "openSource");
 
   const sourceTab = getSourceTab(page, url);
 
@@ -185,7 +197,7 @@ export function getSourceTab(page: Page, url: string): Locator {
 }
 
 export async function removeAllBreakpoints(page: Page): Promise<void> {
-  debugPrint(`Removing all breakpoints for the current source`, "removeBreakpoint");
+  await debugPrint(page, `Removing all breakpoints for the current source`, "removeBreakpoint");
 
   while (true) {
     const breakpoint = page.locator(".editor.new-breakpoint");
@@ -199,7 +211,7 @@ export async function removeAllBreakpoints(page: Page): Promise<void> {
 }
 
 export async function removeAllLogpoints(page: Page): Promise<void> {
-  debugPrint(`Removing all logpoints for the current source`, "removeAllLogpoints");
+  await debugPrint(page, `Removing all logpoints for the current source`, "removeAllLogpoints");
 
   while (true) {
     const panels = page.locator(".breakpoint-panel");
@@ -224,7 +236,11 @@ export async function removeBreakpoint(
 ): Promise<void> {
   const { lineNumber, url } = options;
 
-  debugPrint(`Removing breakpoint at ${chalk.bold(`${url}:${lineNumber}`)}`, "removeBreakpoint");
+  await debugPrint(
+    page,
+    `Removing breakpoint at ${chalk.bold(`${url}:${lineNumber}`)}`,
+    "removeBreakpoint"
+  );
 
   await openDevToolsTab(page);
 
@@ -255,7 +271,8 @@ export async function waitForBreakpoint(
 ): Promise<void> {
   const { columnIndex, lineNumber, url } = options;
 
-  debugPrint(
+  await debugPrint(
+    page,
     `Waiting for breakpoint at ${chalk.bold(`${url}:${lineNumber}`)}`,
     "waitForBreakpoint"
   );
@@ -283,7 +300,11 @@ export async function waitForLogpoint(
 ): Promise<void> {
   const { lineNumber, url } = options;
 
-  debugPrint(`Waiting for log-point at ${chalk.bold(`${url}:${lineNumber}`)}`, "waitForLogpoint");
+  await debugPrint(
+    page,
+    `Waiting for log-point at ${chalk.bold(`${url}:${lineNumber}`)}`,
+    "waitForLogpoint"
+  );
 
   await openDevToolsTab(page);
 
@@ -312,7 +333,8 @@ export async function verifyLogpointStep(
     await openSource(page, url);
   }
 
-  debugPrint(
+  await debugPrint(
+    page,
     `Verifying breakpoint status "${chalk.bold(expectedStatus)}" for line ${chalk.bold(
       options.lineNumber
     )}`,

--- a/packages/e2e-tests/helpers/timeline.ts
+++ b/packages/e2e-tests/helpers/timeline.ts
@@ -4,7 +4,7 @@ import chalk from "chalk";
 import { debugPrint } from "./utils";
 
 export async function clearFocusRange(page: Page): Promise<void> {
-  debugPrint(`Clearing focus range`, "clearFocusRange");
+  await debugPrint(page, `Clearing focus range`, "clearFocusRange");
 
   await enterFocusMode(page);
   await setFocusRangeStartTime(page, "");
@@ -24,7 +24,7 @@ async function clearTimeInput(page: Page, input: Locator): Promise<void> {
 }
 
 export async function enterFocusMode(page: Page): Promise<void> {
-  debugPrint("Entering focus range", "enterFocusMode");
+  await debugPrint(page, "Entering focus range", "enterFocusMode");
 
   const button = page.locator('[data-test-id="EditFocusButton"]');
   const state = await button.getAttribute("data-test-state");
@@ -34,7 +34,7 @@ export async function enterFocusMode(page: Page): Promise<void> {
 }
 
 export async function exitFocusMode(page: Page): Promise<void> {
-  debugPrint("Exiting focus range", "exitFocusMode");
+  await debugPrint(page, "Exiting focus range", "exitFocusMode");
 
   const button = page.locator('[data-test-id="EditFocusButton"]');
   const state = await button.getAttribute("data-test-state");
@@ -44,7 +44,7 @@ export async function exitFocusMode(page: Page): Promise<void> {
 }
 
 export async function saveFocusRange(page: Page): Promise<void> {
-  debugPrint("Saving focus range", "setFocusRange");
+  await debugPrint(page, "Saving focus range", "setFocusRange");
 
   await page.locator('[data-test-id="SaveFocusModeButton"]').click();
 }
@@ -55,7 +55,8 @@ export async function setFocusRange(
 ): Promise<void> {
   const { endTimeString, startTimeString } = options;
 
-  debugPrint(
+  await debugPrint(
+    page,
     `Setting focus to ${chalk.bold(`${startTimeString}`)}–${chalk.bold(`${endTimeString}`)}`,
     "setFocusRange"
   );
@@ -67,7 +68,11 @@ export async function setFocusRange(
 }
 
 export async function setFocusRangeEndTime(page: Page, timeString: string): Promise<void> {
-  debugPrint(`Setting focus start time to ${chalk.bold(`${timeString}`)}`, "setFocusRangeEndTime");
+  await debugPrint(
+    page,
+    `Setting focus start time to ${chalk.bold(`${timeString}`)}`,
+    "setFocusRangeEndTime"
+  );
 
   const input = page.locator('[data-test-id="FocusEndTimeInput"]');
   await input.focus();
@@ -76,7 +81,11 @@ export async function setFocusRangeEndTime(page: Page, timeString: string): Prom
 }
 
 export async function setFocusRangeStartTime(page: Page, timeString: string): Promise<void> {
-  debugPrint(`Setting focus end time to ${chalk.bold(`${timeString}`)}`, "setFocusRangeStartTime");
+  await debugPrint(
+    page,
+    `Setting focus end time to ${chalk.bold(`${timeString}`)}`,
+    "setFocusRangeStartTime"
+  );
 
   const input = page.locator('[data-test-id="FocusStartTimeInput"]');
   await input.focus();

--- a/packages/e2e-tests/helpers/utils.ts
+++ b/packages/e2e-tests/helpers/utils.ts
@@ -8,7 +8,7 @@ export function getCommandKey() {
 
 // Playwright doesn't provide a good way to do this (yet).
 export async function clearTextArea(page: Page, textArea: Locator) {
-  debugPrint(`Clearing content from textarea`, "clearTextArea");
+  await debugPrint(page, `Clearing content from textarea`, "clearTextArea");
 
   const selectAllCommand = `${getCommandKey()}+A`;
 
@@ -18,8 +18,15 @@ export async function clearTextArea(page: Page, textArea: Locator) {
 }
 
 // Other test utils can use this to print formatted status messages that help visually monitor test progress.
-export function debugPrint(message: string, scope?: string) {
+export async function debugPrint(page: Page, message: string, scope?: string) {
   console.log(message, scope ? chalk.dim(`(${scope})`) : "");
+
+  await page.evaluate(
+    ({ message, scope }) => {
+      console.log(`${message} %c${scope || ""}`, "color: #999;");
+    },
+    { message, scope }
+  );
 }
 
 // This helper can be useful when debugging tests but should not be used in committed tests.
@@ -84,11 +91,15 @@ export async function toggleExpandable(
     : scope.locator(`[data-test-name="Expandable"]`).first();
   const currentState = await expander.getAttribute("data-test-state");
   if (currentState !== targetState) {
-    debugPrint(`${targetState === "open" ? "Opening" : "Closing"} ${label}`, "toggleExpandable");
+    await debugPrint(
+      page,
+      `${targetState === "open" ? "Opening" : "Closing"} ${label}`,
+      "toggleExpandable"
+    );
 
     await expander.click();
   } else {
-    debugPrint(`The ${label} is already ${targetState}`, "toggleExpandable");
+    await debugPrint(page, `The ${label} is already ${targetState}`, "toggleExpandable");
   }
 }
 

--- a/packages/e2e-tests/tests/breakpoints-07.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-07.test.ts
@@ -45,7 +45,7 @@ test(`rewind and seek using command bar and console messages`, async ({ page }) 
 
   // Verify that clicking on the source location in the Console opens the source editor.
   await sourceTab.waitFor({ state: "detached" });
-  await openMessageSource(message.first());
+  await openMessageSource(page, message.first());
   await sourceTab.waitFor({ state: "visible" });
 
   // Verify that the active source and breakpoints/logpoints are restored after a reload.

--- a/packages/e2e-tests/tests/inspector-01.test.ts
+++ b/packages/e2e-tests/tests/inspector-01.test.ts
@@ -21,18 +21,22 @@ test("Test that scopes are rerendered.", async ({ page }) => {
   await warpToMessage(page, "ExampleFinished");
 
   await activateInspectorTool(page);
-  let node = getElementsRowWithText(page, '<div id="maindiv" style="color: red"');
+  let node = await getElementsRowWithText(page, '<div id="maindiv" style="color: red"');
   await node.waitFor();
-  await toggleMarkupNode(node, true);
-  await getElementsRowWithText(page, "GOODBYE").waitFor();
+  await toggleMarkupNode(page, node, true);
+
+  node = await getElementsRowWithText(page, "GOODBYE");
+  await node.waitFor();
 
   await addBreakpoint(page, { url: "doc_inspector_basic.html", lineNumber: 9 });
   await rewindToLine(page, { lineNumber: 9 });
 
-  node = getElementsRowWithText(page, '<div id="maindiv" style="color: red"');
+  node = await getElementsRowWithText(page, '<div id="maindiv" style="color: red"');
   await node.waitFor();
-  await toggleMarkupNode(node, true);
-  await getElementsRowWithText(page, "HELLO").waitFor();
+  await toggleMarkupNode(page, node, true);
+
+  node = await getElementsRowWithText(page, "HELLO");
+  await node.waitFor();
 
   await searchElementsPanel(page, "STUFF");
   await waitForSelectedElementsRow(page, "STUFF");

--- a/packages/e2e-tests/tests/node_object_preview-01.test.ts
+++ b/packages/e2e-tests/tests/node_object_preview-01.test.ts
@@ -27,7 +27,7 @@ test("Showing console objects in node", async ({ page }) => {
 
   await verifyConsoleMessage(page, "RangeError: foo");
 
-  const functionMessage = findConsoleMessage(page, "bar()");
+  const functionMessage = await findConsoleMessage(page, "bar()");
   const jumpIcon = functionMessage.locator('[date-test-name="JumpToDefinitionButton"]');
   const count = await jumpIcon.count();
   expect(count).toBe(1);

--- a/packages/e2e-tests/tests/react_devtools.test.ts
+++ b/packages/e2e-tests/tests/react_devtools.test.ts
@@ -34,7 +34,7 @@ test("Test React DevTools.", async ({ page }) => {
   await waitForReactComponentCount(page, 4);
 
   await executeTerminalExpression(page, "document.querySelector('li').getBoundingClientRect()");
-  const message = findConsoleMessage(page, "DOMRect");
+  const message = await findConsoleMessage(page, "DOMRect");
   const left = +(await getPropertyValue(message, "left"));
   const right = +(await getPropertyValue(message, "right"));
   const top = +(await getPropertyValue(message, "top"));

--- a/packages/e2e-tests/tests/sourcemap_stacktrace.test.ts
+++ b/packages/e2e-tests/tests/sourcemap_stacktrace.test.ts
@@ -12,7 +12,7 @@ test("Test that stacktraces are sourcemapped.", async ({ page }) => {
   await openDevToolsTab(page);
   await openConsolePanel(page);
 
-  const message = findConsoleMessage(page, "Error: Baz", "console-error");
+  const message = await findConsoleMessage(page, "Error: Baz", "console-error");
   const locations = await getFrameLocationsFromMessage(message);
   expect(locations).toEqual([
     "App.js:28",


### PR DESCRIPTION
This PR takes what we're already printing to the terminal:
![Screen Shot 2022-10-03 at 11 10 13 PM](https://user-images.githubusercontent.com/29597/193726456-173a6739-8440-43f9-8a95-a5cfde6bf656.png)

And also logs it to the page we're testing:
![Screen Shot 2022-10-03 at 11 10 08 PM](https://user-images.githubusercontent.com/29597/193726455-77b761fb-0c85-4ca0-9a4d-840988e1d5c6.png)

This way the logs will show up in failed tests, and may provide a better hint about exactly which step failed.

I think we should probably do _more_ like this in terms of also injecting assertion failures/errors into the page (so it's clear _exactly_ why we considered the test a failure– even if there's no visual error) but that can be follow up.