### PR TITLE
Fix the logpoints-04 test

### DIFF
--- a/packages/e2e-tests/tests/logpoints-04.test.ts
+++ b/packages/e2e-tests/tests/logpoints-04.test.ts
@@ -28,8 +28,6 @@ test(`should display exceptions in the console`, async ({ page }) => {
   await seekToConsoleMessage(page, messages.first());
   await waitForFrameTimeline(page, "100%");
 
-  messages = await findConsoleMessage(page, "number: 10", "exception");
-  await seekToConsoleMessage(page, messages.first());
   await executeAndVerifyTerminalExpression(page, "number * 10", "40");
 
   await reverseStepOverToLine(page, 15);


### PR DESCRIPTION
The new version of the test contained an additional jump to a different console message compared with the old version.
Removing that additional jump made the test work for me. 