### PR TITLE
add new useDismissNag hook

### DIFF
--- a/packages/bvaughn-architecture-demo/components/console/MessageHoverButton.tsx
+++ b/packages/bvaughn-architecture-demo/components/console/MessageHoverButton.tsx
@@ -65,8 +65,6 @@ export default function MessageHoverButton({
             time,
           });
 
-          dismissNag(Nag.FIRST_CONSOLE_NAVIGATE);
-
           invalidateCache();
         });
       };
@@ -96,6 +94,8 @@ export default function MessageHoverButton({
       if (inspectFunctionDefinition !== null && location !== null) {
         inspectFunctionDefinition([location]);
       }
+
+      dismissNag(Nag.FIRST_CONSOLE_NAVIGATE);
     };
 
     const label =

--- a/packages/bvaughn-architecture-demo/components/console/MessageHoverButton.tsx
+++ b/packages/bvaughn-architecture-demo/components/console/MessageHoverButton.tsx
@@ -15,8 +15,10 @@ import {
 } from "react";
 
 import styles from "./MessageHoverButton.module.css";
+import { useDismissNag } from "@bvaughn/src/hooks/useDismissNag";
 import { isExecutionPointsGreaterThan } from "@bvaughn/src/utils/time";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
+import { Nag } from "@bvaughn/src/graphql/types";
 
 export default function MessageHoverButton({
   executionPoint,
@@ -30,6 +32,7 @@ export default function MessageHoverButton({
   time: number;
 }) {
   const ref = useRef<HTMLButtonElement>(null);
+  const dismissNag = useDismissNag();
   const [isHovered, setIsHovered] = useState(false);
 
   const { inspectFunctionDefinition, showCommentsPanel } = useContext(InspectorContext);
@@ -61,6 +64,8 @@ export default function MessageHoverButton({
             sourceLocation: location,
             time,
           });
+
+          dismissNag(Nag.FIRST_CONSOLE_NAVIGATE);
 
           invalidateCache();
         });

--- a/packages/bvaughn-architecture-demo/src/graphql/User.ts
+++ b/packages/bvaughn-architecture-demo/src/graphql/User.ts
@@ -1,4 +1,5 @@
-import { UserInfo } from "./types";
+import { GraphQLClientInterface } from "./GraphQLClient";
+import { Nag, UserInfo } from "./types";
 
 // TODO Pass this client via Context
 let GRAPHQL_URL = "https://api.replay.io/v1/graphql";
@@ -68,4 +69,27 @@ export async function getCurrentUserInfo(accessToken: string | null): Promise<Us
     unsubscribedEmailTypes: viewer.unsubscribedEmailTypes,
     features: viewer.features || {},
   };
+}
+
+const DismissNagMutation = `
+  mutation DismissNag($nag: String!) {
+    dismissNag(input: { nag: $nag }) {
+      success
+    }
+  }
+`;
+
+export async function dismissNag(
+  graphQLClient: GraphQLClientInterface,
+  accessToken: string,
+  nag: Nag
+) {
+  await graphQLClient.send(
+    {
+      operationName: "DismissNag",
+      query: DismissNagMutation,
+      variables: { nag },
+    },
+    accessToken
+  );
 }

--- a/packages/bvaughn-architecture-demo/src/graphql/types.ts
+++ b/packages/bvaughn-architecture-demo/src/graphql/types.ts
@@ -1,8 +1,9 @@
-import { RecordingId, SourceLocation } from "@replayio/protocol";
+import { SourceLocation } from "@replayio/protocol";
 
 export enum Nag {
   FIRST_LOG_IN = "first_log_in",
   FIRST_REPLAY_2 = "first_replay_2",
+  VIEW_DEVTOOLS = "view_devtools",
   FIRST_BREAKPOINT_EDIT = "first_breakpoint_edit",
   FIRST_BREAKPOINT_ADD = "first_breakpoint_add",
   FIRST_BREAKPOINT_SAVE = "first_breakpoint_save",
@@ -26,8 +27,8 @@ export interface User {
 export type UserInfo = {
   motd: string | null;
   acceptedTOSVersion: number | null;
-  name: string;
-  picture: string;
+  name: string | null;
+  picture: string | null;
   email: string;
   id: string;
   internal: boolean;

--- a/packages/bvaughn-architecture-demo/src/hooks/useDismissNag.ts
+++ b/packages/bvaughn-architecture-demo/src/hooks/useDismissNag.ts
@@ -1,0 +1,25 @@
+import { useContext } from "react";
+
+import { GraphQLClientContext } from "../contexts/GraphQLClientContext";
+import { SessionContext } from "../contexts/SessionContext";
+import { Nag } from "../graphql/types";
+import { dismissNag } from "../graphql/User";
+
+export function useDismissNag() {
+  const { accessToken, currentUserInfo } = useContext(SessionContext);
+  const graphQLClient = useContext(GraphQLClientContext);
+
+  return (nag: Nag) => {
+    if (!accessToken || !currentUserInfo) {
+      return;
+    }
+
+    const { id, nags } = currentUserInfo;
+
+    if (!nags || nags.includes(nag) || !id) {
+      return;
+    }
+
+    dismissNag(graphQLClient, accessToken, nag);
+  };
+}

--- a/packages/markerikson-stack-client-prototype/src/graphql/types.ts
+++ b/packages/markerikson-stack-client-prototype/src/graphql/types.ts
@@ -3,6 +3,7 @@ import { RecordingId, SourceLocation } from "@replayio/protocol";
 export enum Nag {
   FIRST_LOG_IN = "first_log_in",
   FIRST_REPLAY_2 = "first_replay_2",
+  VIEW_DEVTOOLS = "view_devtools",
   FIRST_BREAKPOINT_EDIT = "first_breakpoint_edit",
   FIRST_BREAKPOINT_ADD = "first_breakpoint_add",
   FIRST_BREAKPOINT_SAVE = "first_breakpoint_save",
@@ -26,8 +27,8 @@ export interface User {
 export type UserInfo = {
   motd: string | null;
   acceptedTOSVersion: number | null;
-  name: string;
-  picture: string;
+  name: string | null;
+  picture: string | null;
   email: string;
   id: string;
   internal: boolean;

--- a/packages/markerikson-stack-client-prototype/src/pages/index.tsx
+++ b/packages/markerikson-stack-client-prototype/src/pages/index.tsx
@@ -29,7 +29,8 @@ const IndexPage: NextPage = () => {
         Session ID: <span title={sessionData.sessionId}>{sessionData.sessionId.slice(0, 8)}</span>
       </div>
       <div style={{ display: "flex", alignItems: "center" }}>
-        User: {currentUserInfo?.name} <img src={currentUserInfo?.picture} height={24} />
+        User: {currentUserInfo?.name}{" "}
+        {currentUserInfo?.picture ? <img src={currentUserInfo?.picture} height={24} /> : null}
       </div>
       <div style={{ display: "flex" }}>
         <div style={{ minWidth: 300 }}>

--- a/src/ui/components/SecondaryToolbox/NewConsole.tsx
+++ b/src/ui/components/SecondaryToolbox/NewConsole.tsx
@@ -55,6 +55,7 @@ import { useFeature } from "ui/hooks/settings";
 import styles from "./NewConsole.module.css";
 import { ConsoleNag } from "../shared/Nags/Nags";
 import useTerminalHistory from "./useTerminalHistory";
+import { useGetUserInfo } from "ui/hooks/users";
 
 // Adapter that connects the legacy app Redux stores to the newer React Context providers.
 export default function NewConsoleRoot() {
@@ -64,22 +65,20 @@ export default function NewConsoleRoot() {
   );
 
   const duration = useAppSelector(getRecordingDuration)!;
+  const currentUserInfo = useGetUserInfo();
 
   const sessionContext = useMemo<SessionContextType>(
     () => ({
       accessToken: ThreadFront.getAccessToken(),
       recordingId,
       sessionId: ThreadFront.sessionId!,
-
       // Duration info is primarily used by the focus editor (not imported yet)
       // but Console message context menu also allows refining the focus, which uses it.
       duration,
       endPoint: null as any,
-
-      // Current user info is only used by the new Comments UI (which isn't included yet)
-      currentUserInfo: null as any,
+      currentUserInfo,
     }),
-    [duration, recordingId]
+    [currentUserInfo, duration, recordingId]
   );
 
   return (


### PR DESCRIPTION
There was a recent regression when we merged the new console where the new user nag for navigating to the console never gets dismissed. This adds a new dismiss nag graphql mutation and `useDismissNag` hook for clearing these in the new architecture.

closes SCS-148

## Follow-up

Currently the nag does not disappear when navigating because the GraphQL mutation does not trigger a re-render for some reason. (tracking in FE-822)