### PR TITLE
Add test:record option for e2e tests

### DIFF
--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "test": "playwright test",
     "test:chromium": "playwright test --project chromium --reporter=@replayio/playwright/reporter,line",
+    "test:record": "RECORD=1 playwright test --reporter=@replayio/playwright/reporter,line",
     "test:replay-chromium": "playwright test --project replay-chromium --reporter=@replayio/playwright/reporter,line",
     "test:debug": "DEBUG=1 playwright test",
     "test:install": "playwright install",

--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -1,7 +1,31 @@
 import { PlaywrightTestConfig, devices } from "@playwright/test";
 import { devices as replayDevices } from "@replayio/playwright";
 
-const { CI, DEBUG, SLOW_MO } = process.env;
+const { CI, DEBUG, RECORD, SLOW_MO } = process.env;
+
+const BROWSERS = {
+  CHROMIUM: {
+    name: "chromium",
+    use: { ...devices["Desktop Chromium"] },
+  },
+  REPLAY_CHROMIUM: {
+    name: "replay-chromium",
+    use: { ...(replayDevices["Replay Chromium"] as any) },
+  },
+  REPLAY_FIREFOX: {
+    name: "replay-firefox",
+    use: { ...(replayDevices["Replay Firefox"] as any) },
+  },
+};
+
+let projects;
+if (CI) {
+  projects = [BROWSERS.REPLAY_CHROMIUM, BROWSERS.CHROMIUM];
+} else if (RECORD) {
+  projects = [BROWSERS.REPLAY_FIREFOX];
+} else {
+  projects = [BROWSERS.CHROMIUM];
+}
 
 const config: PlaywrightTestConfig = {
   use: {
@@ -25,31 +49,8 @@ const config: PlaywrightTestConfig = {
 
   // Limit the number of workers on CI, use default locally
   workers: CI ? 4 : undefined,
-  projects: CI
-    ? [
-        // {
-        //   name: "replay-firefox",
-        //   use: { ...(replayDevices["Replay Firefox"] as any) },
-        // },
-        // {
-        //   name: "firefox",
-        //   use: { ...devices["Desktop Firefox"] },
-        // },
-        {
-          name: "replay-chromium",
-          use: { ...(replayDevices["Replay Chromium"] as any) },
-        },
-        {
-          name: "chromium",
-          use: { ...devices["Desktop Chromium"] },
-        },
-      ]
-    : [
-        {
-          name: "chromium",
-          use: { ...devices["Desktop Chromium"] },
-        },
-      ],
+
+  projects,
 };
 
 if (DEBUG) {


### PR DESCRIPTION
Note that while this seems to work for @jasonLaster, it fails for me:
```
$ yarn test:record logpoint-01

Running 1 test using 1 worker
  1) [replay-firefox] › tests/node_logpoint-01.test.ts:13:1 › Basic node logpoints =================

    browserContext.newPage: Protocol error (Page.setInitScripts): ERROR: method 'Page.setInitScripts' is not supported _dispatch@chrome://juggler/content/protocol/Dispatcher.js:64:15
    receiveMessage@jar:file:///Users/bvaughn/.replay/playwright/firefox/Nightly.app/Contents/Resources/omni.ja!/components/juggler.js:89:18






  1 failed
    [replay-firefox] › tests/node_logpoint-01.test.ts:13:1 › Basic node logpoints ==================
```