### PR TITLE
Sync breakpoints to server and map server IDs

### DIFF
--- a/packages/bvaughn-architecture-demo/components/console/ContextMenu.tsx
+++ b/packages/bvaughn-architecture-demo/components/console/ContextMenu.tsx
@@ -1,9 +1,10 @@
 import { FocusContext } from "@bvaughn/src/contexts/FocusContext";
-import { Badge, PointsContext } from "@bvaughn/src/contexts/PointsContext";
+import { PointsContext } from "@bvaughn/src/contexts/PointsContext";
 import { SessionContext } from "@bvaughn/src/contexts/SessionContext";
 import useModalDismissSignal from "@bvaughn/src/hooks/useModalDismissSignal";
 import { getLoggableTime, isPointInstance } from "@bvaughn/src/utils/loggables";
 import { useContext, useRef } from "react";
+import { Badge } from "shared/client/types";
 
 import { ConsoleContextMenuContext, Coordinates } from "./ConsoleContextMenuContext";
 import styles from "./ContextMenu.module.css";

--- a/packages/bvaughn-architecture-demo/components/console/renderers/LogPointRenderer.tsx
+++ b/packages/bvaughn-architecture-demo/components/console/renderers/LogPointRenderer.tsx
@@ -5,7 +5,7 @@ import Loader from "@bvaughn/components/Loader";
 import { ConsoleFiltersContext } from "@bvaughn/src/contexts/ConsoleFiltersContext";
 import { FocusContext } from "@bvaughn/src/contexts/FocusContext";
 import { InspectableTimestampedPointContext } from "@bvaughn/src/contexts/InspectorContext";
-import { Badge, PointInstance } from "@bvaughn/src/contexts/PointsContext";
+import { PointInstance } from "@bvaughn/src/contexts/PointsContext";
 import { TimelineContext } from "@bvaughn/src/contexts/TimelineContext";
 import { runAnalysis } from "@bvaughn/src/suspense/AnalysisCache";
 import { primitiveToClientValue } from "@bvaughn/src/utils/protocol";
@@ -14,6 +14,7 @@ import { Fragment, MouseEvent, useMemo, useRef, useState } from "react";
 import { useLayoutEffect } from "react";
 import { memo, Suspense, useContext } from "react";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
+import { Badge } from "shared/client/types";
 
 import { ConsoleContextMenuContext } from "../ConsoleContextMenuContext";
 import MessageHoverButton from "../MessageHoverButton";

--- a/packages/bvaughn-architecture-demo/components/sources/PointPanel.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/PointPanel.tsx
@@ -1,10 +1,12 @@
 import Icon from "@bvaughn/components/Icon";
 import { FocusContext } from "@bvaughn/src/contexts/FocusContext";
-import { Point, PointsContext } from "@bvaughn/src/contexts/PointsContext";
+import { PointsContext } from "@bvaughn/src/contexts/PointsContext";
 import { getHitPointsForLocation } from "@bvaughn/src/suspense/PointsCache";
 import { validate } from "@bvaughn/src/utils/points";
 import { KeyboardEvent, Suspense, useContext, useMemo, useState } from "react";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
+import { Point } from "shared/client/types";
+
 import Loader from "../Loader";
 
 import styles from "./PointPanel.module.css";

--- a/packages/bvaughn-architecture-demo/components/sources/Source.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/Source.tsx
@@ -47,7 +47,7 @@ export default function Source({
   const hitCounts = getSourceHitCounts(client, sourceId, locationRange, focusRange);
   const [minHitCount, maxHitCount] = getCachedMinMaxSourceHitCounts(sourceId, focusRange);
 
-  const onAddPointButtonClick = (lineNumber: number) => {
+  const onAddPointButtonClick = async (lineNumber: number) => {
     const lineHasHits = hitCounts.has(lineNumber);
     if (!lineHasHits) {
       return;
@@ -57,6 +57,8 @@ export default function Source({
     const closestColumnNumber = hitCountsForLine.columnHits[0]!.location.column;
     const fileName = source?.url?.split("/")?.pop();
 
+    // TODO The legacy app uses the closest function name for the content (if there is one).
+    // This app doesn't yet have logic for parsing source contents though.
     addPoint(
       {
         content: `"${fileName}", ${lineNumber}`,

--- a/packages/bvaughn-architecture-demo/playwright/playwright.config.ts
+++ b/packages/bvaughn-architecture-demo/playwright/playwright.config.ts
@@ -2,7 +2,12 @@ import { FullConfig } from "@playwright/test";
 
 const { CI, RECORD_PROTOCOL_DATA, RECORD_VIDEO, VISUAL_DEBUG } = process.env;
 
-const slowMo = VISUAL_DEBUG ? 250 : 10;
+let slowMo = 10;
+if (VISUAL_DEBUG) {
+  slowMo = 250;
+} else if (RECORD_PROTOCOL_DATA) {
+  slowMo = 100;
+}
 
 const config: FullConfig = {
   forbidOnly: !!CI,

--- a/packages/bvaughn-architecture-demo/src/contexts/PointsContext.tsx
+++ b/packages/bvaughn-architecture-demo/src/contexts/PointsContext.tsx
@@ -9,25 +9,12 @@ import {
   useState,
   useTransition,
 } from "react";
+import { Point, PointId } from "shared/client/types";
 
+import useBreakpointIdsFromServer from "../hooks/useBreakpointIdsFromServer";
 import useLocalStorage from "../hooks/useLocalStorage";
 
 import { SessionContext } from "./SessionContext";
-
-// TODO [FE-757] Replace this with number once old code is fully deleted
-export type PointId = number | string;
-
-export type Badge = "blue" | "green" | "orange" | "purple" | "unicorn" | "yellow";
-
-export type Point = {
-  badge: Badge | null;
-  condition: string | null;
-  content: string;
-  id: PointId;
-  location: Location;
-  shouldBreak: boolean;
-  shouldLog: boolean;
-};
 
 export type PointInstance = {
   point: Point;
@@ -110,6 +97,8 @@ export function PointsContextRoot({ children }: PropsWithChildren<{}>) {
     },
     [setPointsHelper]
   );
+
+  useBreakpointIdsFromServer(points, editPoint);
 
   const context = useMemo(
     () => ({ addPoint, deletePoints, editPoint, isPending, points, pointsForAnalysis }),

--- a/packages/bvaughn-architecture-demo/src/contexts/SessionContext.ts
+++ b/packages/bvaughn-architecture-demo/src/contexts/SessionContext.ts
@@ -1,4 +1,3 @@
-import { ExecutionPoint, SourceId } from "@replayio/protocol";
 import { createContext } from "react";
 import { UserInfo } from "../graphql/types";
 

--- a/packages/bvaughn-architecture-demo/src/hooks/useBreakpointIdsFromServer.ts
+++ b/packages/bvaughn-architecture-demo/src/hooks/useBreakpointIdsFromServer.ts
@@ -1,0 +1,68 @@
+import { BreakpointId } from "@replayio/protocol";
+import { useContext, useEffect, useRef } from "react";
+import { ReplayClientContext } from "shared/client/ReplayClientContext";
+import { Point, PointId } from "shared/client/types";
+
+// Breakpoints must be synced with the server so the stepping controls will work.
+export default function useBreakpointIdsFromServer(
+  points: Point[],
+  editPoint: (id: PointId, partialPoint: Partial<Point>) => void
+): void {
+  const client = useContext(ReplayClientContext);
+
+  const prevPointsRef = useRef<Point[] | null>(null);
+  const pointIdToBreakpointIdMapRef = useRef<Map<PointId, BreakpointId>>(new Map());
+
+  useEffect(() => {
+    const pointIdToBreakpointIdMap = pointIdToBreakpointIdMapRef.current;
+    const prevPoints = prevPointsRef.current;
+    if (prevPoints !== points) {
+      if (prevPoints === null) {
+        points.forEach(point => {
+          // TODO [BAC-2328] Remove the async update
+          client.breakpointAdded(point).then(serverId => {
+            pointIdToBreakpointIdMap.set(point.id, serverId);
+          });
+        });
+      } else {
+        points.forEach(point => {
+          const prevPoint = prevPoints.find(({ id }) => id === point.id);
+          if (prevPoint == null) {
+            if (point.shouldBreak) {
+              // TODO [BAC-2328] Remove the async update
+              client.breakpointAdded(point).then(serverId => {
+                pointIdToBreakpointIdMap.set(point.id, serverId);
+              });
+            }
+          } else if (prevPoint.shouldBreak !== point.shouldBreak) {
+            if (point.shouldBreak) {
+              // TODO [BAC-2328] Remove the async update
+              client.breakpointAdded(point).then(serverId => {
+                pointIdToBreakpointIdMap.set(point.id, serverId);
+              });
+            } else {
+              const serverId = pointIdToBreakpointIdMap.get(point.id);
+              if (serverId != null) {
+                // TODO [BAC-2328] Pass location and condition as id
+                client.breakpointRemoved(serverId);
+              }
+            }
+          }
+        });
+
+        prevPoints.forEach(prevPoint => {
+          const point = prevPoints.find(({ id }) => id === prevPoint.id);
+          if (point == null) {
+            const serverId = pointIdToBreakpointIdMap.get(prevPoint.id);
+            if (serverId != null) {
+              // TODO [BAC-2328] Pass location and condition as id
+              client.breakpointRemoved(serverId);
+            }
+          }
+        });
+      }
+    }
+
+    prevPointsRef.current = points;
+  }, [client, editPoint, points]);
+}

--- a/packages/bvaughn-architecture-demo/src/utils/testing.tsx
+++ b/packages/bvaughn-architecture-demo/src/utils/testing.tsx
@@ -165,6 +165,8 @@ export function createMockReplayClient() {
       return null;
     },
     addEventListener: jest.fn(),
+    breakpointAdded: jest.fn(),
+    breakpointRemoved: jest.fn(),
     configure: jest.fn().mockImplementation(async () => {}),
     createPause: jest.fn().mockImplementation(async () => ({
       frames: [],

--- a/packages/shared/client/ReplayClient.ts
+++ b/packages/shared/client/ReplayClient.ts
@@ -31,6 +31,7 @@ import {
   MappedLocation,
   SameLineSourceLocations,
   PointRange,
+  BreakpointId,
 } from "@replayio/protocol";
 import uniqueId from "lodash/uniqueId";
 import analysisManager from "protocol/analysisManager";
@@ -47,6 +48,7 @@ import {
   HitPointsAndStatusTuple,
   HitPointStatus,
   LineHits,
+  Point,
   ReplayClientEvents,
   ReplayClientInterface,
   RunAnalysisParams,
@@ -110,6 +112,24 @@ export class ReplayClient implements ReplayClientInterface {
 
     const handlers = this._eventHandlers.get(type)!;
     handlers.push(handler);
+  }
+
+  async breakpointAdded(point: Point): Promise<BreakpointId> {
+    const sessionId = this.getSessionIdThrows();
+    const { breakpointId } = await client.Debugger.setBreakpoint(
+      {
+        location: point.location,
+        condition: point.condition || undefined,
+      },
+      sessionId
+    );
+
+    return breakpointId;
+  }
+
+  async breakpointRemoved(breakpointId: BreakpointId): Promise<void> {
+    const sessionId = this.getSessionIdThrows();
+    await client.Debugger.removeBreakpoint({ breakpointId }, sessionId);
   }
 
   async getRecordingCapabilities(): Promise<RecordingCapabilities> {

--- a/packages/shared/client/types.ts
+++ b/packages/shared/client/types.ts
@@ -32,6 +32,7 @@ import {
   SameLineSourceLocations,
   getPointsBoundingTimeResult as PointsBoundingTime,
   PointRange,
+  BreakpointId,
 } from "@replayio/protocol";
 import { AnalysisParams } from "protocol/analysisManager";
 import { RecordingCapabilities } from "protocol/thread/thread";
@@ -59,6 +60,19 @@ export type Events = {
   navigationEvents: NavigationEvent[];
 };
 
+// TODO [FE-757] Replace this with number once old code is fully deleted
+export type PointId = number | string;
+export type Badge = "blue" | "green" | "orange" | "purple" | "unicorn" | "yellow";
+export type Point = {
+  badge: Badge | null;
+  condition: string | null;
+  content: string;
+  id: PointId;
+  location: Location;
+  shouldBreak: boolean;
+  shouldLog: boolean;
+};
+
 export type RunAnalysisParams = Omit<AnalysisParams, "locations"> & { location?: Location };
 
 export type ReplayClientEvents = "loadedRegionsChange";
@@ -78,6 +92,8 @@ export interface SourceLocationRange {
 export interface ReplayClientInterface {
   get loadedRegions(): LoadedRegions | null;
   addEventListener(type: ReplayClientEvents, handler: Function): void;
+  breakpointAdded(point: Point): Promise<BreakpointId>;
+  breakpointRemoved(breakpointId: BreakpointId): Promise<void>;
   configure(sessionId: string): void;
   createPause(executionPoint: ExecutionPoint): Promise<createPauseResult>;
   evaluateExpression(

--- a/packages/shared/utils/client.ts
+++ b/packages/shared/utils/client.ts
@@ -1,6 +1,7 @@
-import { ExecutionPoint, TimeStampedPoint } from "@replayio/protocol";
+import { TimeStampedPoint } from "@replayio/protocol";
 import { Wakeable } from "bvaughn-architecture-demo/src/suspense/types";
 import { createWakeable } from "bvaughn-architecture-demo/src/utils/suspense";
+import { preCacheExecutionPointForTime } from "bvaughn-architecture-demo/src/suspense/PointsCache";
 import { ThreadFront } from "protocol/thread";
 import { useContext, useLayoutEffect, useMemo } from "react";
 import createReplayClientPlayer from "shared/client/createReplayClientPlayer";
@@ -12,7 +13,6 @@ import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { ReplayClientInterface } from "shared/client/types";
 
 import { getFlag, hasFlag } from "./url";
-import { preCacheExecutionPointForTime } from "@bvaughn/src/suspense/PointsCache";
 
 type ReplayClientRecorderAdditionalData = {
   points: TimeStampedPoint[];

--- a/src/ui/components/SecondaryToolbox/NewConsole.tsx
+++ b/src/ui/components/SecondaryToolbox/NewConsole.tsx
@@ -2,11 +2,7 @@ import { ExecutionPoint, PauseId } from "@replayio/protocol";
 import ConsoleRoot from "bvaughn-architecture-demo/components/console";
 import { SearchContext } from "bvaughn-architecture-demo/components/console/SearchContext";
 import { FocusContext } from "bvaughn-architecture-demo/src/contexts/FocusContext";
-import {
-  Point,
-  PointId,
-  PointsContext,
-} from "bvaughn-architecture-demo/src/contexts/PointsContext";
+import { PointsContext } from "bvaughn-architecture-demo/src/contexts/PointsContext";
 import {
   NewTerminalExpression,
   TerminalContext,
@@ -56,6 +52,7 @@ import styles from "./NewConsole.module.css";
 import { ConsoleNag } from "../shared/Nags/Nags";
 import useTerminalHistory from "./useTerminalHistory";
 import { useGetUserInfo } from "ui/hooks/users";
+import { Point, PointId } from "shared/client/types";
 
 // Adapter that connects the legacy app Redux stores to the newer React Context providers.
 export default function NewConsoleRoot() {


### PR DESCRIPTION
Split off from #7790

- [x] Sync breakpoints to server
- [x] Move hovered line node into React context (so the transition to update the index stays in sync)