### PR TITLE
Toggle shouldPause for logpoints when enabling breakpoint

### DIFF
--- a/src/devtools/client/debugger/src/actions/breakpoints/breakpoints.ts
+++ b/src/devtools/client/debugger/src/actions/breakpoints/breakpoints.ts
@@ -43,9 +43,16 @@ export function addBreakpointAtLine(cx: Context, line: number): UIThunkAction {
   return (dispatch, getState) => {
     const logpoints = getBreakpointsForSelectedSource(getState());
     const breakpoint = logpoints.find(ps => ps.location.line === line);
-    const logValue = isLogpoint(breakpoint);
 
-    dispatch(_addBreakpointAtLine(cx, line, logValue, false, true));
+    if (breakpoint && isLogpoint(breakpoint)) {
+      // if we already have a log point and are adding a pause point too, only
+      // toggle shouldPause
+      return dispatch(
+        addBreakpoint(cx, breakpoint.location, { ...breakpoint.options, shouldPause: true }, false)
+      );
+    } else {
+      dispatch(_addBreakpointAtLine(cx, line, false, false, true));
+    }
   };
 }
 


### PR DESCRIPTION
Was:
https://app.replay.io/recording/replay-bug-with-debugger--75a9ec67-4535-4071-ac0a-6bae588cc394

Now:
https://app.replay.io/recording/replay-bug-with-debugger--d36299c9-cafc-40bf-9732-3d796062c562#