### PR TITLE
Fix Console errors

### DIFF
--- a/packages/shared/utils/error.ts
+++ b/packages/shared/utils/error.ts
@@ -16,7 +16,14 @@ export const commandError = (message: string, code: number): CommandError => {
 };
 
 export const isCommandError = (error: unknown, code: number): boolean => {
-  return (
-    error instanceof Error && error.name === "CommandError" && (error as CommandError).code === code
-  );
+  if (error instanceof Error) {
+    return error.name === "CommandError" && (error as CommandError).code === code;
+  } else if (code === ProtocolError.TooManyPoints) {
+    if (typeof error === "string") {
+      // TODO [BAC-2330] The Analysis endpoint returns an error string instead of an error object.
+      return error === "There are too many points to complete this operation";
+    }
+  }
+
+  return false;
 };

--- a/src/ui/utils/timeline.test.ts
+++ b/src/ui/utils/timeline.test.ts
@@ -234,7 +234,7 @@ describe("filterToFocusRegion", () => {
 });
 
 describe("mergeSortedPointLists", () => {
-  fit("will correctly interleave overlapping ranges", () => {
+  it("will correctly interleave overlapping ranges", () => {
     expect(mergeSortedPointLists([point(5), point(10)], [point(7), point(12)])).toEqual([
       point(5),
       point(7),
@@ -243,7 +243,7 @@ describe("mergeSortedPointLists", () => {
     ]);
   });
 
-  fit("will correctly concat non-overlapping ranges", () => {
+  it("will correctly concat non-overlapping ranges", () => {
     expect(mergeSortedPointLists([point(5), point(7)], [point(10), point(12)])).toEqual([
       point(5),
       point(7),
@@ -252,7 +252,7 @@ describe("mergeSortedPointLists", () => {
     ]);
   });
 
-  fit("will raise an error if things are not sorted", () => {
+  it("will raise an error if things are not sorted", () => {
     expect(() =>
       mergeSortedPointLists([point(7), point(5)], [point(10), point(12)])
     ).toThrowError();

--- a/src/ui/utils/timeline.ts
+++ b/src/ui/utils/timeline.ts
@@ -314,7 +314,9 @@ export function filterToFocusRegion<T extends TimeStampedPoint>(
 function assertSorted(a: TimeStampedPoint[]) {
   a.reduce(
     (prev, curr) => {
-      assert(prev.time <= curr.time);
+      // It would be cheaper to compare time but at least one recording has a bizarre time (see BAC-2339).
+      // Truthfully, since points are more fine-grained than time, we should be comparing them anyway.
+      assert(BigInt(prev.point) <= BigInt(curr.point));
       return curr;
     },
     { point: "0", time: 0 }
@@ -325,8 +327,10 @@ export function mergeSortedPointLists(
   a: TimeStampedPoint[],
   b: TimeStampedPoint[]
 ): TimeStampedPoint[] {
-  assertSorted(a);
-  assertSorted(b);
+  if (process.env.NODE_ENV === "development") {
+    assertSorted(a);
+    assertSorted(b);
+  }
 
   // Merge from the smaller array into the larger one.
   let [source, destination] = a.length < b.length ? [a, b] : [b, a];

--- a/src/ui/utils/timeline.ts
+++ b/src/ui/utils/timeline.ts
@@ -327,7 +327,7 @@ export function mergeSortedPointLists(
   a: TimeStampedPoint[],
   b: TimeStampedPoint[]
 ): TimeStampedPoint[] {
-  if (process.env.NODE_ENV === "development") {
+  if (process.env.NODE_ENV !== "production") {
     assertSorted(a);
     assertSorted(b);
   }


### PR DESCRIPTION
- Add handling for string literal "too many points" error returned by Analysis API (see BAC-2330)
  - Added tests
- Change sort assertions to only run in DEV and to sort by points rather than time (more accurate) to account for a bad recording (see BAC-2339)

