### PR TITLE
Don't convert CommandError to string

### DIFF
--- a/packages/protocol/analysisManager.ts
+++ b/packages/protocol/analysisManager.ts
@@ -79,7 +79,7 @@ export type FunctionEntryPoint = Omit<addFunctionEntryPointsParameters, OmitPara
 export type EventHandlerEntryPoint = Omit<addEventHandlerEntryPointsParameters, OmitParams>;
 
 export interface AnalysisHandler<T> {
-  onAnalysisError?: (error: string) => void;
+  onAnalysisError?: (error: unknown) => void;
   onAnalysisPoints?: (points: PointDescription[]) => void;
   onAnalysisResult?: (result: AnalysisEntry[]) => void;
   onFinished?(): T;

--- a/packages/shared/client/ReplayClient.ts
+++ b/packages/shared/client/ReplayClient.ts
@@ -378,11 +378,11 @@ export class ReplayClient implements ReplayClientInterface {
               : undefined,
           },
           {
-            onAnalysisError: (errorMessage: string) => {
-              if (errorMessage.includes("too many points")) {
+            onAnalysisError: (error: unknown) => {
+              if (isCommandError(error, ProtocolError.TooManyPoints)) {
                 status = "too-many-points-to-find";
               } else {
-                console.error(errorMessage);
+                console.error(error);
 
                 status = "unknown-error";
               }
@@ -420,11 +420,11 @@ export class ReplayClient implements ReplayClientInterface {
               : undefined,
           },
           {
-            onAnalysisError: (errorMessage: string) => {
-              if (errorMessage.includes("too many points")) {
+            onAnalysisError: (error: unknown) => {
+              if (isCommandError(error, ProtocolError.TooManyPoints)) {
                 status = "too-many-points-to-find";
               } else {
-                throw Error(errorMessage);
+                throw error;
               }
             },
             onAnalysisPoints: (pointDescriptions: PointDescription[]) => {
@@ -711,8 +711,8 @@ export class ReplayClient implements ReplayClientInterface {
 
       try {
         await analysisManager.runAnalysis(analysisParams, {
-          onAnalysisError: (errorMessage: string) => {
-            reject(errorMessage);
+          onAnalysisError: (error: unknown) => {
+            reject(error);
           },
           onAnalysisResult: analysisEntries => {
             results.push(...analysisEntries.map(entry => entry.value));

--- a/packages/shared/utils/error.ts
+++ b/packages/shared/utils/error.ts
@@ -20,6 +20,8 @@ export const isCommandError = (error: unknown, code: number): boolean => {
     return error.name === "CommandError" && (error as CommandError).code === code;
   } else if (code === ProtocolError.TooManyPoints) {
     if (typeof error === "string") {
+      console.error('Unexpected error type encountered (string):', error);
+
       // TODO [BAC-2330] The Analysis endpoint returns an error string instead of an error object.
       return error === "There are too many points to complete this operation";
     }

--- a/packages/shared/utils/error.ts
+++ b/packages/shared/utils/error.ts
@@ -20,7 +20,7 @@ export const isCommandError = (error: unknown, code: number): boolean => {
     return error.name === "CommandError" && (error as CommandError).code === code;
   } else if (code === ProtocolError.TooManyPoints) {
     if (typeof error === "string") {
-      console.error('Unexpected error type encountered (string):', error);
+      console.error("Unexpected error type encountered (string):", error);
 
       // TODO [BAC-2330] The Analysis endpoint returns an error string instead of an error object.
       return error === "There are too many points to complete this operation";


### PR DESCRIPTION
The `Analysis` endpoint might return an error string, in which case we have to handle it– but we can at least avoid converting a `CommandError` to a string in the interim.