### PR TITLE
No longer fetch frame steps while selecting a frame (fixes fe-768)

### DIFF
--- a/src/devtools/client/debugger/src/actions/pause/selectFrame.ts
+++ b/src/devtools/client/debugger/src/actions/pause/selectFrame.ts
@@ -33,17 +33,6 @@ export function selectFrame(cx: Context, frame: TempFrame): UIThunkAction {
 
     dispatch(frameSelected({ cx, frameId: frame.id }));
 
-    try {
-      await ThreadFront.getFrameSteps(frame.asyncIndex, frame.protocolId);
-    } catch (e) {
-      // TODO [FE-795]: Communicate this to the user
-      if (isCommandError(e, ProtocolError.TooManyPoints)) {
-        console.error(e);
-        return;
-      }
-      throw e;
-    }
-
     dispatch(selectLocation(cx, frame.location));
     dispatch(setFramePositions());
 


### PR DESCRIPTION
This feels like a regression because we're not using the results of `getFrameSteps` in `selectFrame` and there is no reason to block on `selectLocation`