### PR TITLE
Improve error telemetry for browser auth flow

### DIFF
--- a/pages/api/browser/auth.ts
+++ b/pages/api/browser/auth.ts
@@ -2,6 +2,9 @@ import cookie from "cookie";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { pingTelemetry } from "ui/utils/replay-telemetry";
 
+// patch in node-fetch for pingTelemetry without adding it to the FE bundle
+globalThis.fetch = globalThis.fetch || require("node-fetch");
+
 const getQueryValue = (query: string | string[]) => (Array.isArray(query) ? query[0] : query);
 const getAppUrl = (path: string) =>
   `${process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_VERCEL_URL}${path}`;


### PR DESCRIPTION
We're occasionally seeing users hit errors in the browser auth flow but do not get telemetry. Guessing this is because it's relying on `pingTelemetry` which uses `fetch` but that isn't available in node (yet).

* Patching `node-fetch` in as a fallback for `fetch` if it's not defined so we get telemetry messages
* Improve the messaging so we don't send "undefined" as the message