### PR TITLE
Update all E2E tests to include test filename in description

### DIFF
--- a/packages/e2e-tests/tests/breakpoints-01.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-01.test.ts
@@ -7,7 +7,7 @@ import { addBreakpoint } from "../helpers/source-panel";
 
 const url = "doc_rr_basic.html";
 
-test(`Test basic breakpoint functionality.`, async ({ page }) => {
+test(`breakpoints-01: Test basic breakpoint functionality`, async ({ page }) => {
   await startTest(page, url);
   await openDevToolsTab(page);
 

--- a/packages/e2e-tests/tests/breakpoints-02.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-02.test.ts
@@ -7,7 +7,9 @@ import { addBreakpoint } from "../helpers/source-panel";
 
 const url = "doc_rr_basic.html";
 
-test(`Test unhandled divergence while evaluating at a breakpoint.`, async ({ page }) => {
+test(`breakpoints-02: Test unhandled divergence while evaluating at a breakpoint`, async ({
+  page,
+}) => {
   await startTest(page, url);
   await openDevToolsTab(page);
 

--- a/packages/e2e-tests/tests/breakpoints-03.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-03.test.ts
@@ -7,7 +7,7 @@ import { addBreakpoint, removeBreakpoint } from "../helpers/source-panel";
 
 const url = "doc_rr_basic.html";
 
-test(`Test stepping forward through breakpoints when rewound before the first one.`, async ({
+test(`breakpoints-03: Test stepping forward through breakpoints when rewound before the first one`, async ({
   page,
 }) => {
   await startTest(page, url);

--- a/packages/e2e-tests/tests/breakpoints-04.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-04.test.ts
@@ -7,7 +7,7 @@ import { addBreakpoint } from "../helpers/source-panel";
 const url = "doc_control_flow.html";
 
 // Test hitting breakpoints when using tricky control flow constructs:
-test(`catch, finally, generators, and async/await.`, async ({ page }) => {
+test(`breakpoints-04: catch, finally, generators, and async/await`, async ({ page }) => {
   await startTest(page, url);
   await openDevToolsTab(page);
 

--- a/packages/e2e-tests/tests/breakpoints-05.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-05.test.ts
@@ -10,7 +10,9 @@ import { addBreakpoint, removeBreakpoint } from "../helpers/source-panel";
 
 const url = "doc_debugger_statements.html";
 
-test(`Test interaction of breakpoints with debugger statements.`, async ({ page }) => {
+test(`breakpoints-05: Test interaction of breakpoints with debugger statements`, async ({
+  page,
+}) => {
   await startTest(page, url);
   await openDevToolsTab(page);
   await openPauseInformationPanel(page);

--- a/packages/e2e-tests/tests/breakpoints-06.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-06.test.ts
@@ -10,7 +10,7 @@ async function checkMessageLocation(page: Page, text: string, location: string) 
   expect(textContent!.includes(location)).toBeTruthy();
 }
 
-test(`Test log point in a sourcemapped file.`, async ({ page }) => {
+test(`breakpoints-06: Test log point in a sourcemapped file`, async ({ page }) => {
   await startTest(page, "doc_prod_bundle.html");
   await openDevToolsTab(page);
 

--- a/packages/e2e-tests/tests/breakpoints-07.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-07.test.ts
@@ -15,7 +15,7 @@ import {
   verifyLogpointStep,
 } from "../helpers/source-panel";
 
-test(`rewind and seek using command bar and console messages`, async ({ page }) => {
+test(`breakpoints-07: rewind and seek using command bar and console messages`, async ({ page }) => {
   await startTest(page, "doc_navigate.html");
   await openDevToolsTab(page);
 

--- a/packages/e2e-tests/tests/console_async_eval.test.ts
+++ b/packages/e2e-tests/tests/console_async_eval.test.ts
@@ -12,7 +12,7 @@ import { addLogpoint } from "../helpers/source-panel";
 
 const url = "doc_async.html";
 
-test("support global console evaluations in async frames", async ({ page }) => {
+test("console_async: support global console evaluations in async frames", async ({ page }) => {
   await startTest(page, url);
   await openDevToolsTab(page);
   await openConsolePanel(page);

--- a/packages/e2e-tests/tests/console_errors.test.ts
+++ b/packages/e2e-tests/tests/console_errors.test.ts
@@ -8,7 +8,7 @@ import {
   verifyConsoleMessage,
 } from "../helpers/console-panel";
 
-test("Test that errors and warnings from various sources are shown in the console.", async ({
+test("console_errors: Test that errors and warnings from various sources are shown in the console", async ({
   page,
 }) => {
   await startTest(page, "doc_exceptions_bundle.html");

--- a/packages/e2e-tests/tests/console_eval.test.ts
+++ b/packages/e2e-tests/tests/console_eval.test.ts
@@ -9,7 +9,7 @@ import {
 
 const url = "doc_rr_basic.html";
 
-test("support global console evaluations", async ({ page }) => {
+test("console_eval: support global console evaluations", async ({ page }) => {
   await startTest(page, url);
   await openDevToolsTab(page);
   await openConsolePanel(page);

--- a/packages/e2e-tests/tests/console_warp-01.test.ts
+++ b/packages/e2e-tests/tests/console_warp-01.test.ts
@@ -15,7 +15,7 @@ import { addBreakpoint } from "../helpers/source-panel";
 
 const url = "doc_rr_error.html";
 
-test(`should support warping to console messages.`, async ({ page }) => {
+test(`console_warp-01: should support warping to console messages`, async ({ page }) => {
   await startTest(page, url);
   await openDevToolsTab(page);
   await openConsolePanel(page);

--- a/packages/e2e-tests/tests/console_warp-02.test.ts
+++ b/packages/e2e-tests/tests/console_warp-02.test.ts
@@ -8,11 +8,12 @@ import {
   warpToMessage,
 } from "../helpers/console-panel";
 import { reverseStepOverToLine, stepOverToLine } from "../helpers/pause-information-panel";
-import { delay } from "../helpers/utils";
 
 const url = "doc_rr_logs.html";
 
-test("support pausing, warping, stepping and evaluating console messages", async ({ page }) => {
+test("console_warp-02: support pausing, warping, stepping and evaluating console messages", async ({
+  page,
+}) => {
   await startTest(page, url);
   await openDevToolsTab(page);
   await openConsolePanel(page);

--- a/packages/e2e-tests/tests/focus_mode-01.test.ts
+++ b/packages/e2e-tests/tests/focus_mode-01.test.ts
@@ -12,7 +12,9 @@ import { clearFocusRange, setFocusRange } from "../helpers/timeline";
 
 const url = "doc_rr_region_loading.html";
 
-test("should filter messages as regions based on the active focus mode", async ({ page }) => {
+test("focus_mode-01: should filter messages as regions based on the active focus mode", async ({
+  page,
+}) => {
   await startTest(page, url);
   await openDevToolsTab(page);
 

--- a/packages/e2e-tests/tests/highlighter.test.ts
+++ b/packages/e2e-tests/tests/highlighter.test.ts
@@ -4,7 +4,7 @@ import { openDevToolsTab, startTest } from "../helpers";
 import { openConsolePanel, warpToMessage } from "../helpers/console-panel";
 import { selectElementsRowWithText } from "../helpers/elements-panel";
 
-test("element highlighter works everywhere", async ({ page }) => {
+test("highlighter: element highlighter works everywhere", async ({ page }) => {
   await startTest(page, "doc_inspector_basic.html");
 
   await openDevToolsTab(page);

--- a/packages/e2e-tests/tests/inspector-01.test.ts
+++ b/packages/e2e-tests/tests/inspector-01.test.ts
@@ -13,7 +13,7 @@ import {
 import { rewindToLine } from "../helpers/pause-information-panel";
 import { addBreakpoint } from "../helpers/source-panel";
 
-test("Test that scopes are rerendered.", async ({ page }) => {
+test("inspector-01: Test that scopes are rerendered", async ({ page }) => {
   await startTest(page, "doc_inspector_basic.html");
   await openDevToolsTab(page);
 

--- a/packages/e2e-tests/tests/inspector-02.test.ts
+++ b/packages/e2e-tests/tests/inspector-02.test.ts
@@ -11,7 +11,7 @@ import {
 
 const url = "doc_inspector_basic.html";
 
-test(`the element picker and iframe behavior`, async ({ page }) => {
+test(`inspector-02: element picker and iframe behavior`, async ({ page }) => {
   await startTest(page, url);
   await openDevToolsTab(page);
   await openElementsPanel(page);

--- a/packages/e2e-tests/tests/inspector-03.test.ts
+++ b/packages/e2e-tests/tests/inspector-03.test.ts
@@ -10,7 +10,7 @@ import {
 import { rewindToLine } from "../helpers/pause-information-panel";
 import { addBreakpoint } from "../helpers/source-panel";
 
-test("Test that styles for elements can be viewed.", async ({ page }) => {
+test("inspector-03: Test that styles for elements can be viewed", async ({ page }) => {
   await startTest(page, "doc_inspector_styles.html");
   await openDevToolsTab(page);
   await openConsolePanel(page);

--- a/packages/e2e-tests/tests/inspector-04.test.ts
+++ b/packages/e2e-tests/tests/inspector-04.test.ts
@@ -8,7 +8,7 @@ import {
   selectElementsRowWithText,
 } from "../helpers/elements-panel";
 
-test("Test that styles for elements can be viewed.", async ({ page }) => {
+test("inspector-04: Test that styles for elements can be viewed", async ({ page }) => {
   await startTest(page, "doc_inspector_styles.html");
   await openDevToolsTab(page);
   await openConsolePanel(page);

--- a/packages/e2e-tests/tests/inspector-05.test.ts
+++ b/packages/e2e-tests/tests/inspector-05.test.ts
@@ -8,7 +8,7 @@ import {
   selectElementsRowWithText,
 } from "../helpers/elements-panel";
 
-test("Test that styles for elements can be viewed.", async ({ page }) => {
+test("inspector-05: Test that styles for elements can be viewed", async ({ page }) => {
   await startTest(page, "doc_inspector_sourcemapped.html");
   await openDevToolsTab(page);
   await openConsolePanel(page);

--- a/packages/e2e-tests/tests/inspector-06.test.ts
+++ b/packages/e2e-tests/tests/inspector-06.test.ts
@@ -9,7 +9,7 @@ import {
   selectElementsRowWithText,
 } from "../helpers/elements-panel";
 
-test("Test that styles for elements can be viewed.", async ({ page }) => {
+test("inspector-06: Test that styles for elements can be viewed", async ({ page }) => {
   await startTest(page, "doc_inspector_shorthand.html");
   await openDevToolsTab(page);
   await openConsolePanel(page);

--- a/packages/e2e-tests/tests/inspector-07.test.ts
+++ b/packages/e2e-tests/tests/inspector-07.test.ts
@@ -10,7 +10,7 @@ import {
   selectNextElementsPanelSearchResult,
 } from "../helpers/elements-panel";
 
-test("Test that styles for elements can be viewed.", async ({ page }) => {
+test("inspector-07: Test that styles for elements can be viewed", async ({ page }) => {
   await startTest(page, "doc_inspector_shorthand.html");
   await openDevToolsTab(page);
   await openConsolePanel(page);

--- a/packages/e2e-tests/tests/logpoints-01.test.ts
+++ b/packages/e2e-tests/tests/logpoints-01.test.ts
@@ -12,7 +12,9 @@ import { addBreakpoint, addLogpoint } from "../helpers/source-panel";
 
 const url = "doc_rr_basic.html";
 
-test(`log-points appear in the correct order and allow time warping`, async ({ page }) => {
+test(`logpoints-01: log-points appear in the correct order and allow time warping`, async ({
+  page,
+}) => {
   await startTest(page, url);
   await openDevToolsTab(page);
 

--- a/packages/e2e-tests/tests/logpoints-02.test.ts
+++ b/packages/e2e-tests/tests/logpoints-02.test.ts
@@ -6,7 +6,7 @@ import { addLogpoint } from "../helpers/source-panel";
 
 const url = "doc_rr_basic.html";
 
-test(`conditional log-points`, async ({ page }) => {
+test(`logpoints-02: conditional log-points`, async ({ page }) => {
   await startTest(page, url);
   await openDevToolsTab(page);
 

--- a/packages/e2e-tests/tests/logpoints-03.test.ts
+++ b/packages/e2e-tests/tests/logpoints-03.test.ts
@@ -5,7 +5,7 @@ import { addEventListenerLogpoints, findConsoleMessage } from "../helpers/consol
 
 const url = "doc_events.html";
 
-test(`should display event properties in the console`, async ({ page }) => {
+test(`logpoints-03: should display event properties in the console`, async ({ page }) => {
   await startTest(page, url);
   await openDevToolsTab(page);
 

--- a/packages/e2e-tests/tests/logpoints-04.test.ts
+++ b/packages/e2e-tests/tests/logpoints-04.test.ts
@@ -12,7 +12,7 @@ import { reverseStepOverToLine, waitForFrameTimeline } from "../helpers/pause-in
 
 const url = "doc_exceptions.html";
 
-test(`should display exceptions in the console`, async ({ page }) => {
+test(`logpoints-04: should display exceptions in the console`, async ({ page }) => {
   await startTest(page, url);
   await openDevToolsTab(page);
 

--- a/packages/e2e-tests/tests/node_console-01.test.ts
+++ b/packages/e2e-tests/tests/node_console-01.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../helpers/console-panel";
 import { reverseStepOverToLine, waitForScopeValue } from "../helpers/pause-information-panel";
 
-test("Basic node console behavior", async ({ page }) => {
+test("node_console-01: Basic node console behavior", async ({ page }) => {
   await startTest(page, "node/basic.js");
   await openConsolePanel(page);
 

--- a/packages/e2e-tests/tests/node_console-02.test.ts
+++ b/packages/e2e-tests/tests/node_console-02.test.ts
@@ -4,7 +4,7 @@ import { startTest } from "../helpers";
 import { openConsolePanel, warpToMessage } from "../helpers/console-panel";
 import { reverseStepOverToLine, waitForPaused } from "../helpers/pause-information-panel";
 
-test("Basic node console behavior", async ({ page }) => {
+test("node_console-02: uncaught exceptions should show up", async ({ page }) => {
   await startTest(page, "node/error.js");
   await openConsolePanel(page);
 

--- a/packages/e2e-tests/tests/node_control_flow.test.ts
+++ b/packages/e2e-tests/tests/node_control_flow.test.ts
@@ -10,7 +10,7 @@ async function resumeToBreakpoint(page: Page, line: number) {
   await resumeToLine(page, { lineNumber: line });
 }
 
-test("Basic node console behavior", async ({ page }) => {
+test("node_control_flow: catch, finally, generators, and async/await", async ({ page }) => {
   // Default timeout is 30s. Mostly taking 40s in local dev. Bump to 120s.
   test.setTimeout(120000);
   await startTest(page, "node/control_flow.js");

--- a/packages/e2e-tests/tests/node_logpoint-01.test.ts
+++ b/packages/e2e-tests/tests/node_logpoint-01.test.ts
@@ -10,7 +10,7 @@ import {
 import { openSource } from "../helpers/source-explorer-panel";
 import { addLogpoint } from "../helpers/source-panel";
 
-test("Basic node logpoints", async ({ page }) => {
+test("node_logpoint-01: Basic node logpoints", async ({ page }) => {
   await startTest(page, "node/basic.js");
 
   await openConsolePanel(page);

--- a/packages/e2e-tests/tests/node_logpoint-02.test.ts
+++ b/packages/e2e-tests/tests/node_logpoint-02.test.ts
@@ -12,7 +12,7 @@ import {
 } from "../helpers/console-panel";
 import { waitFor } from "../helpers/utils";
 
-test("Node exception logpoints", async ({ page }) => {
+test("node_logpoint-02: Node exception logpoints", async ({ page }) => {
   await startTest(page, "node/exceptions.js");
 
   await openConsolePanel(page);

--- a/packages/e2e-tests/tests/node_object_preview-01.test.ts
+++ b/packages/e2e-tests/tests/node_object_preview-01.test.ts
@@ -10,7 +10,7 @@ import {
 } from "../helpers/console-panel";
 import { addBreakpoint } from "../helpers/source-panel";
 
-test("Showing console objects in node", async ({ page }) => {
+test("node_object_preview: Showing console objects in node", async ({ page }) => {
   await startTest(page, "node/objects.js");
 
   await openConsolePanel(page);

--- a/packages/e2e-tests/tests/node_spawn-01.test.ts
+++ b/packages/e2e-tests/tests/node_spawn-01.test.ts
@@ -4,7 +4,7 @@ import { startTest } from "../helpers";
 import { waitForScopeValue, waitForPaused } from "../helpers/pause-information-panel";
 import { openConsolePanel, warpToMessage } from "../helpers/console-panel";
 
-test("Basic subprocess spawning", async ({ page }) => {
+test("node_spawn: Basic subprocess spawning", async ({ page }) => {
   await startTest(page, "node/spawn.js");
 
   await openConsolePanel(page);

--- a/packages/e2e-tests/tests/node_stepping-01.test.ts
+++ b/packages/e2e-tests/tests/node_stepping-01.test.ts
@@ -13,7 +13,7 @@ import {
 } from "../helpers/pause-information-panel";
 import { warpToMessage, executeAndVerifyTerminalExpression } from "../helpers/console-panel";
 
-test("Test stepping in async frames and async call stacks", async ({ page }) => {
+test("node_stepping-01: Test stepping in async frames and async call stacks", async ({ page }) => {
   await startTest(page, "node/async.js");
 
   await openPauseInformationPanel(page);

--- a/packages/e2e-tests/tests/node_worker-01.test.ts
+++ b/packages/e2e-tests/tests/node_worker-01.test.ts
@@ -5,7 +5,7 @@ import { rewindToLine, stepOverToLine } from "../helpers/pause-information-panel
 import { openConsolePanel, warpToMessage } from "../helpers/console-panel";
 import { addBreakpoint } from "../helpers/source-panel";
 
-test("Basic subprocess spawning", async ({ page }) => {
+test("node_worker-01: make sure node workers don't cause crashes", async ({ page }) => {
   await startTest(page, "node/run_worker.js");
 
   await openConsolePanel(page);

--- a/packages/e2e-tests/tests/object_preview-01.test.ts
+++ b/packages/e2e-tests/tests/object_preview-01.test.ts
@@ -8,7 +8,7 @@ import {
   warpToMessage,
 } from "../helpers/console-panel";
 
-test(`expressions in the console after time warping.`, async ({ page }) => {
+test(`object_preview-01: expressions in the console after time warping`, async ({ page }) => {
   await startTest(page, "doc_rr_objects.html");
   await openDevToolsTab(page);
   await openConsolePanel(page);

--- a/packages/e2e-tests/tests/object_preview-02.test.ts
+++ b/packages/e2e-tests/tests/object_preview-02.test.ts
@@ -15,7 +15,7 @@ import { toggleExpandable } from "../helpers/utils";
 
 const url = "doc_rr_objects.html";
 
-test(`should allow objects in scope to be inspected`, async ({ page }) => {
+test(`object_preview-02: should allow objects in scope to be inspected`, async ({ page }) => {
   await startTest(page, url);
   await openDevToolsTab(page);
 

--- a/packages/e2e-tests/tests/object_preview-03.test.ts
+++ b/packages/e2e-tests/tests/object_preview-03.test.ts
@@ -21,7 +21,9 @@ const url = "doc_rr_preview.html";
 // Note: Because stepping works differently between gecko and chromium,
 // frame timeline percentages are different in the test below.
 
-test(`Test previews when switching between frames and stepping.`, async ({ page }) => {
+test(`object_preview-03: Test previews when switching between frames and stepping`, async ({
+  page,
+}) => {
   await startTest(page, url);
   await openDevToolsTab(page);
 

--- a/packages/e2e-tests/tests/object_preview-04.test.ts
+++ b/packages/e2e-tests/tests/object_preview-04.test.ts
@@ -11,7 +11,9 @@ import { addBreakpoint, addLogpoint, toggleMappedSources } from "../helpers/sour
 
 const url = "doc_prod_bundle.html";
 
-test(`Test scope mapping and switching between generated/original sources.`, async ({ page }) => {
+test(`object_preview-04: Test scope mapping and switching between generated/original sources`, async ({
+  page,
+}) => {
   await startTest(page, url);
   await openDevToolsTab(page);
 

--- a/packages/e2e-tests/tests/react_devtools.test.ts
+++ b/packages/e2e-tests/tests/react_devtools.test.ts
@@ -19,7 +19,7 @@ import {
 import { hoverScreenshot } from "../helpers/screenshot";
 import { waitFor } from "../helpers/utils";
 
-test("Test React DevTools.", async ({ page }) => {
+test("react_devtools: Test React DevTools.", async ({ page }) => {
   await startTest(page, "cra/dist/index.html");
   await openDevToolsTab(page);
 

--- a/packages/e2e-tests/tests/repaint.test.ts
+++ b/packages/e2e-tests/tests/repaint.test.ts
@@ -7,7 +7,7 @@ import { waitFor } from "../helpers/utils";
 
 const url = "doc_control_flow.html";
 
-test("repaints the screen screen when stepping over code that modifies the DOM", async ({
+test("repaint: repaints the screen screen when stepping over code that modifies the DOM", async ({
   page,
 }) => {
   await startTest(page, url);

--- a/packages/e2e-tests/tests/scopes_rerender.test.ts
+++ b/packages/e2e-tests/tests/scopes_rerender.test.ts
@@ -4,7 +4,7 @@ import { openDevToolsTab, startTest } from "../helpers";
 import { openConsolePanel, warpToMessage } from "../helpers/console-panel";
 import { selectFrame, waitForScopeValue } from "../helpers/pause-information-panel";
 
-test("Test that scopes are rerendered.", async ({ page }) => {
+test("scopes_rerender: Test that scopes are rerendered", async ({ page }) => {
   await startTest(page, "doc_recursion.html");
   await openDevToolsTab(page);
   await openConsolePanel(page);

--- a/packages/e2e-tests/tests/sourcemap_stacktrace.test.ts
+++ b/packages/e2e-tests/tests/sourcemap_stacktrace.test.ts
@@ -7,7 +7,7 @@ import {
   openConsolePanel,
 } from "../helpers/console-panel";
 
-test("Test that stacktraces are sourcemapped.", async ({ page }) => {
+test("sourcemap_stacktrace: Test that stacktraces are sourcemapped", async ({ page }) => {
   await startTest(page, "cra/dist/index.html");
   await openDevToolsTab(page);
   await openConsolePanel(page);

--- a/packages/e2e-tests/tests/stacking.test.ts
+++ b/packages/e2e-tests/tests/stacking.test.ts
@@ -220,7 +220,9 @@ async function readCanvasTransformScale(canvas: Locator) {
   return scale;
 }
 
-test("Element highlighter selects the correct element when they overlap", async ({ page }) => {
+test("stacking: Element highlighter selects the correct element when they overlap", async ({
+  page,
+}) => {
   await startTest(page, "doc_stacking.html");
   await openDevToolsTab(page);
 

--- a/packages/e2e-tests/tests/stepping-01.test.ts
+++ b/packages/e2e-tests/tests/stepping-01.test.ts
@@ -8,7 +8,7 @@ import { addBreakpoint } from "../helpers/source-panel";
 
 const url = "doc_rr_basic.html";
 
-test("Test basic step-over/back functionality.", async ({ page }) => {
+test("stepping-01: Test basic step-over/back functionality", async ({ page }) => {
   await startTest(page, url);
   await openDevToolsTab(page);
 

--- a/packages/e2e-tests/tests/stepping-02.test.ts
+++ b/packages/e2e-tests/tests/stepping-02.test.ts
@@ -14,7 +14,7 @@ import { addBreakpoint } from "../helpers/source-panel";
 
 const url = "doc_rr_basic.html";
 
-test("Test basic step-over/back functionality.", async ({ page }) => {
+test("stepping-02: Test fixes for some simple stepping bugs", async ({ page }) => {
   await startTest(page, url);
   await openDevToolsTab(page);
 

--- a/packages/e2e-tests/tests/stepping-03.test.ts
+++ b/packages/e2e-tests/tests/stepping-03.test.ts
@@ -12,7 +12,7 @@ import { addBreakpoint } from "../helpers/source-panel";
 
 const url = "doc_rr_basic.html";
 
-test(`Stepping past the beginning or end of a frame should act like a step-out.`, async ({
+test(`stepping-03: Stepping past the beginning or end of a frame should act like a step-out`, async ({
   page,
 }) => {
   await startTest(page, url);

--- a/packages/e2e-tests/tests/stepping-05.test.ts
+++ b/packages/e2e-tests/tests/stepping-05.test.ts
@@ -17,7 +17,7 @@ import { addBreakpoint } from "../helpers/source-panel";
 
 const url = "doc_minified.html";
 
-test(`Test stepping in pretty-printed code`, async ({ page }) => {
+test(`stepping-05: Test stepping in pretty-printed code`, async ({ page }) => {
   page.setDefaultTimeout(120000);
   await startTest(page, url);
   await openDevToolsTab(page);

--- a/packages/e2e-tests/tests/stepping-06.test.ts
+++ b/packages/e2e-tests/tests/stepping-06.test.ts
@@ -16,7 +16,7 @@ const url = "doc_async.html";
 
 // Because stepping works differently between gecko and chromium,
 // frame timeline percentages are different in this test.
-test(`Test stepping in async frames and async call stacks.`, async ({ page }) => {
+test(`stepping-06: Test stepping in async frames and async call stacks`, async ({ page }) => {
   await startTest(page, url);
   await openDevToolsTab(page);
 


### PR DESCRIPTION
Our original E2E tests showed up in the Replay bot comment as just the filenames, like `breakpoints-02.js`.

Now, they're showing up as the descriptions, like `"Test unhandled divergence while evaluating at a breakpoint"`.

To help clarify _which_ tests are passing/failing, I've updated all test descriptions to start with the filename as a prefix, like: `"breakpoints-02: Test unhandled divergence while evaluating at a breakpoint"`