### PR TITLE
Use replay:open after browser auth to return to browser

### DIFF
--- a/pages/browser/auth.tsx
+++ b/pages/browser/auth.tsx
@@ -3,7 +3,7 @@ import { LaunchBrowser } from "ui/components/shared/LaunchBrowserModal";
 import { BubbleViewportWrapper } from "ui/components/shared/Viewport";
 
 const BrowserAuth = () => {
-  const library = "replay:library";
+  const library = "replay:open";
 
   return (
     <BubbleViewportWrapper>
@@ -11,7 +11,7 @@ const BrowserAuth = () => {
         <p>You have successfully logged into the Replay Browser. You may close this window.</p>
         <p className="text-center">
           <a
-            className="inline-flex items-center h-12 px-4 rounded-md bg-primaryAccent text-buttontextColor"
+            className="inline-flex h-12 items-center rounded-md bg-primaryAccent px-4 text-buttontextColor"
             href={library}
           >
             Open Replay


### PR DESCRIPTION
Blocked by https://github.com/replayio/gecko-dev/pull/928 (and it's eventual release) so this'll have to wait a week or so