### PR TITLE
Update react-devtools-inline to 4.18.0 to fix node_modules size

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "react-circular-progressbar": "^2.0.4",
     "react-codemirror2": "^7.2.1",
     "react-devtools-inline": "^4.24.5",
-    "react-devtools-inline_4_17_0": "npm:react-devtools-inline@4.17.0",
+    "react-devtools-inline_4_18_0": "npm:react-devtools-inline@4.18.0",
     "react-dom": "0.0.0-experimental-1e5245df8-20220817",
     "react-dom-factories": "^1.0.2",
     "react-is": "^18.2.0",

--- a/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
+++ b/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
@@ -325,7 +325,7 @@ async function loadReactDevToolsInlineModuleFromProtocol(
     if (version >= 2) {
       stateUpdaterCallback(await import("react-devtools-inline/frontend"));
     } else if (version === 1) {
-      stateUpdaterCallback(await import("react-devtools-inline_4_17_0/frontend"));
+      stateUpdaterCallback(await import("react-devtools-inline_4_18_0/frontend"));
     }
   }
 }

--- a/src/ui/components/SecondaryToolbox/react-devtools-inline.d.ts
+++ b/src/ui/components/SecondaryToolbox/react-devtools-inline.d.ts
@@ -188,6 +188,6 @@ https: declare module "react-devtools-inline/frontend" {
   ): typeof ReactDevTools;
 }
 
-https: declare module "react-devtools-inline_4_17_0/frontend" {
+declare module "react-devtools-inline_4_18_0/frontend" {
   export * from "@types/react-devtools-inline/frontend";
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -20034,10 +20034,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-devtools-inline_4_17_0@npm:react-devtools-inline@4.17.0":
-  version: 4.17.0
-  resolution: "react-devtools-inline@npm:4.17.0"
-  checksum: 0d7766bdfd3bbdcd629b91a77fc45acd1455971ea3663cd4550d9a865247b6ef28407f758770be1ff1cb6d471ed677ac1b10c9400cd5164dc86380e3196cdea7
+"react-devtools-inline_4_18_0@npm:react-devtools-inline@4.18.0":
+  version: 4.18.0
+  resolution: "react-devtools-inline@npm:4.18.0"
+  checksum: f7ce6ea90bb2bf3b554927fd34f36eb3f6d458ad4ba9b7c4c6070b4f9601e9765bcdc8348715f58e29157ffb6020d298f3d0b5bef77c930ed397ecda450168c2
   languageName: node
   linkType: hard
 
@@ -20650,7 +20650,7 @@ __metadata:
     react-circular-progressbar: ^2.0.4
     react-codemirror2: ^7.2.1
     react-devtools-inline: ^4.24.5
-    react-devtools-inline_4_17_0: "npm:react-devtools-inline@4.17.0"
+    react-devtools-inline_4_18_0: "npm:react-devtools-inline@4.18.0"
     react-dom: 0.0.0-experimental-1e5245df8-20220817
     react-dom-factories: ^1.0.2
     react-is: ^18.2.0


### PR DESCRIPTION
Ref: https://github.com/facebook/react/issues/22220

4.17.0 was a known bad release with an unzipped size of 400MB+.  4.18 only has a couple changes, and it's still before the React DevTools "protocol bridge" version changed in 4.22.0:

- https://github.com/facebook/react/blob/main/packages/react-devtools/CHANGELOG.md#4220


So, bumping this to use 4.18 as our "old protocol bridge version" package should still be safe, and shrink the install size we need locally.