### PR TITLE
Hide replay logo on login error message

### DIFF
--- a/src/ui/components/shared/Onboarding/index.tsx
+++ b/src/ui/components/shared/Onboarding/index.tsx
@@ -37,7 +37,7 @@ export function OnboardingContentWrapper({
         }
       )}
     >
-      <img src="/images/logo.svg" className="w-full h-24" />
+      {noLogo ? null : <img src="/images/logo.svg" className="h-24 w-full" />}
       {children}
     </div>
   );


### PR DESCRIPTION
Now without logo (but with simulated error msg)

<img width="425" alt="image" src="https://user-images.githubusercontent.com/788456/195670652-f99fe8bd-82b5-4578-9054-0c67534adcbe.png">
