### PR TITLE
Expose auth config environment variables to client

### DIFF
--- a/src/ui/utils/auth.ts
+++ b/src/ui/utils/auth.ts
@@ -1,7 +1,7 @@
 export function getAuthHost() {
-  return process.env.RECORD_REPLAY_AUTH_HOST || "webreplay.us.auth0.com";
+  return process.env.NEXT_PUBLIC_AUTH_HOST || "webreplay.us.auth0.com";
 }
 
 export function getAuthClientId() {
-  return process.env.RECORD_REPLAY_AUTH_CLIENT_ID || "4FvFnJJW4XlnUyrXQF8zOLw6vNAH1MAo";
+  return process.env.NEXT_PUBLIC_AUTH_CLIENT_ID || "4FvFnJJW4XlnUyrXQF8zOLw6vNAH1MAo";
 }


### PR DESCRIPTION
## Issue
Public env variables in next.js must be prefixed by NEXT_PUBLIC_ to be included in the build but the auth host and client ID variables were not so they were not overriding the defaults when set.

## Resolution

change the variables to include the next prefix