### PR TITLE
Source parser perf optimization (bailout)

### DIFF
--- a/packages/bvaughn-architecture-demo/components/sources/Source.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/Source.tsx
@@ -1,5 +1,5 @@
 import { getSourceContents } from "@bvaughn/src/suspense/SourcesCache";
-import { highlight } from "@bvaughn/src/suspense/TokenizerCache";
+import { parse } from "@bvaughn/src/suspense/SyntaxParsingCache";
 import { getSourceFileName } from "@bvaughn/src/utils/source";
 import { newSource as ProtocolSource } from "@replayio/protocol";
 import { useContext, useRef, useState } from "react";
@@ -27,7 +27,7 @@ export default function Source({ source }: { source: ProtocolSource }) {
 
   // TODO Incrementally parse code using SourceContext -> visibleLines
   const code = sourceContents.contents;
-  const htmlLines = highlight(code, fileName);
+  const htmlLines = parse(code, fileName);
   if (htmlLines === null) {
     return null;
   }

--- a/packages/bvaughn-architecture-demo/components/sources/SourceList.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/SourceList.tsx
@@ -187,6 +187,7 @@ export default function SourceList({
   return (
     <List
       className={styles.List}
+      estimatedItemSize={LINE_HEIGHT}
       height={height}
       innerRef={innerRef}
       itemCount={htmlLines.length}

--- a/packages/bvaughn-architecture-demo/src/suspense/SourcesCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/SourcesCache.ts
@@ -11,6 +11,7 @@ import {
   ReplayClientInterface,
   SourceLocationRange,
 } from "shared/client/types";
+import { isCommandError, ProtocolError } from "shared/utils/error";
 
 import { createWakeable } from "../utils/suspense";
 import { createGenericCache } from "./createGenericCache";
@@ -279,10 +280,15 @@ async function fetchSourceHitCounts(
 
     wakeable.resolve(record.value);
   } catch (error) {
-    record.status = STATUS_REJECTED;
-    record.value = error;
+    if (isCommandError(error, ProtocolError.TooManyLocationsToPerformAnalysis)) {
+      record.status = STATUS_RESOLVED;
+      record.value = new Map();
+    } else {
+      record.status = STATUS_REJECTED;
+      record.value = error;
 
-    wakeable.reject(error);
+      wakeable.reject(error);
+    }
   }
 }
 

--- a/packages/bvaughn-architecture-demo/src/suspense/SyntaxParsingCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/SyntaxParsingCache.ts
@@ -8,12 +8,13 @@ import { jsonLanguage } from "@codemirror/lang-json";
 import { htmlLanguage } from "@codemirror/lang-html";
 import { LRLanguage, ensureSyntaxTree } from "@codemirror/language";
 import { EditorState } from "@codemirror/state";
-import { classHighlighter, highlightTree, tags } from "@lezer/highlight";
+import { classHighlighter, highlightTree } from "@lezer/highlight";
 
 import { createGenericCache } from "./createGenericCache";
 
 // TODO
-// Suspense can be async; we could move this to a Worker if it's slow.
+// Lower the initial threshold to only parse the first ~1k lines
+// then continue parsing off thread and stream the HTML in.
 async function highlighter(code: string, fileName: string): Promise<string[] | null> {
   const language = urlToLanguage(fileName);
   const state = EditorState.create({

--- a/packages/bvaughn-architecture-demo/src/suspense/SyntaxParsingCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/SyntaxParsingCache.ts
@@ -130,7 +130,7 @@ function urlToLanguage(fileName: string): LRLanguage {
   }
 }
 
-export const { getValueSuspense: highlight } = createGenericCache<
+export const { getValueSuspense: parse } = createGenericCache<
   [code: string, fileName: string],
   string[] | null
 >(highlighter, identity);

--- a/packages/shared/utils/error.ts
+++ b/packages/shared/utils/error.ts
@@ -4,8 +4,9 @@ export interface CommandError extends Error {
 }
 
 export enum ProtocolError {
-  TooManyPoints = 55,
   RecordingUnloaded = 38,
+  TooManyLocationsToPerformAnalysis = 67,
+  TooManyPoints = 55,
 }
 
 export const commandError = (message: string, code: number): CommandError => {


### PR DESCRIPTION
Build on top of #7960

Updated so the parser stops after a certain time/character threshold and then falls back to plain text. (This threshold can be tuned. I set it low for testing.) Here's a video of a local (DEV + StrictMode) React build running this:

https://user-images.githubusercontent.com/29597/196546367-e3526530-a626-4276-ab02-8356f31dd0a8.mp4

Feels fast enough to be usable!