### PR TITLE
Separate flags for disabling cache and profiling

### DIFF
--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -183,7 +183,7 @@ export function createSocket(
         // Uncomment this to get a new session every time you refresh
         // controllerKey: String(Math.floor(Math.random() * 10e8)),
         listenForMetrics: !!prefs.listenForMetrics,
-        disableCache: !!prefs.disableCache || !!features.profileWorkerThreads,
+        disableCache: !!prefs.disableCache,
         disableQueryCache: !features.enableQueryCache,
         profileWorkerThreads: !!features.profileWorkerThreads,
       };


### PR DESCRIPTION
Initially I set these such that profiling the workers would automatically disable the basic data cache. That's actually not *always* what I want, it can make sense to run them separately, so I've detached that logic.