### PR TITLE
Fix display of generated scopes (FE-794)

### DIFF
--- a/packages/e2e-tests/tests/object_preview-04.test.ts
+++ b/packages/e2e-tests/tests/object_preview-04.test.ts
@@ -36,8 +36,7 @@ test(`object_preview-04: Test scope mapping and switching between generated/orig
   await toggleMappedSources(page, "off");
   await waitForPaused(page, 12);
 
-  // TODO [FE-794] This test wants to verify the Scopes panel shows minified names if source maps are off– but it doesn't.
-  // await expandAllScopesBlocks(page);
-  // await waitForScopeValue(page, "e", "(3) [");
-  // await waitForScopeValue(page, "o", "{…}");
+  await expandAllScopesBlocks(page);
+  await waitForScopeValue(page, "e", "(3) [");
+  await waitForScopeValue(page, "o", "{…}");
 });

--- a/packages/protocol/thread/pause.ts
+++ b/packages/protocol/thread/pause.ts
@@ -219,34 +219,6 @@ export class Pause {
     );
   }
 
-  async getScopes(frameId: FrameId) {
-    const frame = this.frames.get(frameId);
-    assert(frame, `frame not found (frame ID: ${frameId})`);
-
-    // Normally we use the original scope chain for the frame if there is one,
-    // but when a generated source is marked as preferred we use the generated
-    // scope chain instead. In the original case we still load the frame's
-    // normal scope chain first, as currently the backend does not supply
-    // related objects when loading original scopes and we don't deal with that
-    // properly.
-    let scopeChain = await this.ensureScopeChain(frame.scopeChain);
-    let originalScopesUnavailable = false;
-    if (frame.originalScopeChain && !this.ThreadFront.hasPreferredGeneratedSource(frame.location)) {
-      const originalScopeChain = await this.ensureScopeChain(frame.originalScopeChain);
-
-      // if all original variables are unavailable (usually due to sourcemap issues),
-      // we show the generated scope chain with a warning message instead
-      originalScopesUnavailable = originalScopeChain.every(scope =>
-        (scope.bindings || []).every(binding => binding.unavailable)
-      );
-      if (!originalScopesUnavailable) {
-        scopeChain = originalScopeChain;
-      }
-    }
-
-    return { scopes: scopeChain, originalScopesUnavailable };
-  }
-
   async sendMessage<P, R>(
     method: (parameters: P, sessionId?: SessionId, pauseId?: PauseId) => R,
     params: P

--- a/packages/protocol/thread/thread.ts
+++ b/packages/protocol/thread/thread.ts
@@ -158,10 +158,6 @@ class _ThreadFront {
 
   getCorrespondingSourceIds = (sourceId: SourceId) => [sourceId];
 
-  // Source IDs for generated sources which should be preferred over any
-  // original source.
-  preferredGeneratedSources = new Set<SourceId>();
-
   // Map sourceId to breakpoint positions.
   breakpointPositions = new Map<string, Promise<SameLineSourceLocations[]>>();
 
@@ -707,20 +703,6 @@ class _ThreadFront {
   getFrameSteps(pauseId: PauseId, frameId: FrameId) {
     const pause = Pause.getById(pauseId)!;
     return pause.getFrameSteps(frameId);
-  }
-
-  preferSource(sourceId: SourceId, value: boolean) {
-    if (value) {
-      this.preferredGeneratedSources.add(sourceId);
-    } else {
-      this.preferredGeneratedSources.delete(sourceId);
-    }
-  }
-
-  hasPreferredGeneratedSource(location: MappedLocation) {
-    return location.some(({ sourceId }) => {
-      return this.preferredGeneratedSources.has(sourceId);
-    });
   }
 
   // Replace the sourceId in a location with the first corresponding sourceId

--- a/src/devtools/client/debugger/src/actions/sources/select.ts
+++ b/src/devtools/client/debugger/src/actions/sources/select.ts
@@ -26,6 +26,7 @@ import {
   clearSelectedLocation,
   getSourceIdToDisplayForUrl,
   getSourceToDisplayForUrl,
+  preferSource,
 } from "ui/reducers/sources";
 import { getActiveSearch, getExecutionPoint, getThreadContext, getContext } from "../../selectors";
 import { createLocation } from "../../utils/location";
@@ -218,28 +219,13 @@ export function showAlternateSource(
   oldSourceId: string,
   newSourceId: string
 ): UIThunkAction<Promise<void>> {
-  return async (dispatch, getState, { ThreadFront }) => {
+  return async (dispatch, getState) => {
     const state = getState();
     if (getSourceDetails(state, oldSourceId)?.isSourceMapped) {
-      ThreadFront.preferSource(newSourceId, true);
+      dispatch(preferSource({ sourceId: newSourceId, preferred: true }));
     } else {
-      ThreadFront.preferSource(oldSourceId, false);
+      dispatch(preferSource({ sourceId: oldSourceId, preferred: false }));
     }
-
-    let selectSourceByPausing = false;
-    const selectedFrame = await getSelectedFrameAsync(state);
-    if (
-      selectedFrame?.location.sourceId === oldSourceId &&
-      selectedFrame?.alternateLocation?.sourceId === newSourceId
-    ) {
-      selectSourceByPausing = true;
-    }
-
-    if (selectSourceByPausing) {
-      const executionPoint = getExecutionPoint(state);
-      await dispatch(paused({ executionPoint: executionPoint! }));
-    } else {
-      await dispatch(selectSource(getContext(state), newSourceId));
-    }
+    await dispatch(selectSource(getContext(state), newSourceId));
   };
 }

--- a/src/devtools/client/debugger/src/client/create.ts
+++ b/src/devtools/client/debugger/src/client/create.ts
@@ -11,16 +11,11 @@ import { PauseFrame } from "../reducers/pause";
 
 export function createFrame(
   sources: SourcesState,
-  preferredGeneratedSources: Set<string>,
   frame: Frame,
   pauseId: PauseId,
   index = 0
 ): PauseFrame {
-  const { sourceId, line, column } = getPreferredLocation(
-    sources,
-    frame.location,
-    preferredGeneratedSources
-  );
+  const { sourceId, line, column } = getPreferredLocation(sources, frame.location);
   const location = {
     sourceId,
     line,
@@ -28,7 +23,7 @@ export function createFrame(
   };
 
   let alternateLocation;
-  const alternate = getAlternateLocation(sources, frame.location, preferredGeneratedSources);
+  const alternate = getAlternateLocation(sources, frame.location);
   if (alternate) {
     alternateLocation = {
       sourceId: alternate.sourceId,

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/FrameTimeline.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/FrameTimeline.tsx
@@ -103,9 +103,7 @@ class FrameTimelineRenderer extends Component<FrameTimelineProps, FrameTimelineS
     const frameStep = this.getPosition(progress);
 
     if (frameStep?.frame) {
-      setPreviewPausedLocation(
-        getPreferredLocation(sourcesState, frameStep.frame, ThreadFront.preferredGeneratedSources)
-      );
+      setPreviewPausedLocation(getPreferredLocation(sourcesState, frameStep.frame));
     }
   }
 

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/NewScopes.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/NewScopes.tsx
@@ -3,10 +3,11 @@ import { PauseId, Value } from "@replayio/protocol";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { getSelectedFrameId } from "../../selectors";
 import { isCurrentTimeInLoadedRegion } from "ui/reducers/app";
+import { getPreferredGeneratedSources } from "ui/reducers/sources";
 import { enterFocusMode as enterFocusModeAction } from "ui/actions/timeline";
 import { ConvertedScope, convertScopes } from "../../utils/pause/scopes/convertScopes";
 import { getFrameSuspense } from "ui/suspense/frameCache";
-import { getScopesSuspense } from "ui/suspense/scopeCache";
+import { getScopesSuspense, pickScopes } from "ui/suspense/scopeCache";
 import { Redacted } from "ui/components/Redacted";
 import InspectorContextReduxAdapter from "devtools/client/debugger/src/components/shared/InspectorContextReduxAdapter";
 import ErrorBoundary from "bvaughn-architecture-demo/components/ErrorBoundary";
@@ -16,6 +17,7 @@ import ScopesInspector from "bvaughn-architecture-demo/components/inspector/Scop
 import styles from "./NewObjectInspector.module.css";
 
 function ScopesRenderer() {
+  const preferredGeneratedSources = useAppSelector(getPreferredGeneratedSources);
   const selectedFrameId = useAppSelector(getSelectedFrameId);
   if (!selectedFrameId) {
     return (
@@ -29,9 +31,9 @@ function ScopesRenderer() {
   if (!frame) {
     return null;
   }
-  const { scopes: protocolScopes, originalScopesUnavailable } = getScopesSuspense(
-    selectedFrameId.pauseId,
-    selectedFrameId.frameId
+  const { scopes: protocolScopes, originalScopesUnavailable } = pickScopes(
+    getScopesSuspense(selectedFrameId.pauseId, selectedFrameId.frameId),
+    preferredGeneratedSources
   );
   const scopes = convertScopes(protocolScopes, frame, selectedFrameId.pauseId);
 

--- a/src/devtools/client/debugger/src/reducers/pause.ts
+++ b/src/devtools/client/debugger/src/reducers/pause.ts
@@ -112,11 +112,7 @@ export const executeCommandOperation = createAsyncThunk<
     return { location: null };
   }
 
-  const location = getPreferredLocation(
-    state.sources,
-    resp.frame,
-    ThreadFront.preferredGeneratedSources
-  );
+  const location = getPreferredLocation(state.sources, resp.frame);
 
   return { location };
 });

--- a/src/ui/actions/comments.ts
+++ b/src/ui/actions/comments.ts
@@ -6,6 +6,7 @@ import {
 import { fetchSymbolsForSource, getSymbols } from "devtools/client/debugger/src/reducers/ast";
 import { getExecutionPoint } from "devtools/client/debugger/src/reducers/pause";
 import {
+  getPreferredGeneratedSources,
   getPreferredSourceId,
   getSourceDetailsEntities,
   getTextAtLocation,
@@ -222,12 +223,13 @@ async function getCurrentPauseSourceLocation(
     return;
   }
   await ThreadFront.ensureAllSources();
-  const sourcesById = getSourceDetailsEntities(getState());
+  const state = getState();
+  const sourcesById = getSourceDetailsEntities(state);
   const { location } = frame;
   const preferredSourceId = getPreferredSourceId(
     sourcesById,
     location.map(l => l.sourceId),
-    ThreadFront.preferredGeneratedSources
+    getPreferredGeneratedSources(state)
   );
   const preferredLocation = location.find(l => l.sourceId == preferredSourceId);
   if (!preferredLocation) {

--- a/src/ui/actions/event-listeners.ts
+++ b/src/ui/actions/event-listeners.ts
@@ -74,11 +74,7 @@ const formatEventListener = (
   let location: Location | undefined = undefined;
   let locationUrl: string | undefined = undefined;
   if (functionLocation) {
-    location = getPreferredLocation(
-      state.sources,
-      functionLocation,
-      ThreadFront.preferredGeneratedSources
-    );
+    location = getPreferredLocation(state.sources, functionLocation);
 
     locationUrl = functionLocation?.length > 0 ? sourcesById[location.sourceId]?.url : undefined;
   }

--- a/src/ui/actions/network.ts
+++ b/src/ui/actions/network.ts
@@ -118,7 +118,7 @@ export function selectAndFetchRequest(requestId: RequestId): UIThunkAction {
     await ThreadFront.ensureAllSources();
     state = getState();
     const formattedFrames = frames?.map((frame, i) =>
-      createFrame(state.sources, ThreadFront.preferredGeneratedSources, frame, pause.pauseId!, i)
+      createFrame(state.sources, frame, pause.pauseId!, i)
     );
     dispatch({
       type: "SET_FRAMES",

--- a/src/ui/suspense/frameCache.ts
+++ b/src/ui/suspense/frameCache.ts
@@ -73,9 +73,7 @@ export function getPauseFramesIfCached(pauseId: PauseId, sourcesState: SourcesSt
 
 function createPauseFrames(pauseId: PauseId, frames: Frame[], sourcesState: SourcesState) {
   return formatCallStackFrames(
-    frames.map((frame, index) =>
-      createFrame(sourcesState, ThreadFront.preferredGeneratedSources, frame, pauseId, index)
-    ),
+    frames.map((frame, index) => createFrame(sourcesState, frame, pauseId, index)),
     sourcesState.sourceDetails.entities
   )!;
 }

--- a/src/ui/suspense/scopeCache.ts
+++ b/src/ui/suspense/scopeCache.ts
@@ -1,11 +1,12 @@
-import { FrameId, PauseId, Scope } from "@replayio/protocol";
+import { FrameId, MappedLocation, PauseId, Scope, SourceId } from "@replayio/protocol";
 import { createGenericCache } from "bvaughn-architecture-demo/src/suspense/createGenericCache";
-import { Pause } from "protocol/thread/pause";
+import { Pause, ThreadFront } from "protocol/thread";
 import { assert } from "protocol/utils";
 
-export interface FrameScopes {
-  scopes: Scope[];
-  originalScopesUnavailable: boolean;
+interface FrameScopes {
+  frameLocation: MappedLocation;
+  generatedScopes: Scope[];
+  originalScopes: Scope[] | undefined;
 }
 
 export const {
@@ -18,12 +19,43 @@ export const {
     assert(pause, `no pause for ${pauseId}`);
     // Wait until the pause is "created" to see if we have frames
     await pause.createWaiter;
-    if (!pause.hasFrames) {
-      return { scopes: [], originalScopesUnavailable: true };
-    }
+    const frame = (await pause.getFrames())?.find(frame => frame.frameId === frameId);
+    assert(frame, `no frame with ID ${frameId} found in pause ${pauseId}`);
 
-    const { scopes, originalScopesUnavailable } = await pause.getScopes(frameId);
-    return { scopes, originalScopesUnavailable };
+    const generatedScopes = await pause.ensureScopeChain(frame.scopeChain);
+    const originalScopes = frame.originalScopeChain
+      ? await pause.ensureScopeChain(frame.originalScopeChain)
+      : undefined;
+
+    return { frameLocation: frame.location, generatedScopes, originalScopes };
   },
   (pauseId, frameId) => `${pauseId}:${frameId}`
 );
+
+export interface PickedScopes {
+  scopes: Scope[];
+  originalScopesUnavailable: boolean;
+}
+
+// pick either generated or original scopes, depending on availability and user preference
+export function pickScopes(
+  scopes: FrameScopes,
+  preferredGeneratedSources: SourceId[]
+): PickedScopes {
+  let scopeChain = scopes.generatedScopes;
+  let originalScopesUnavailable = false;
+  const hasPreferredGeneratedSource = scopes.frameLocation.some(location =>
+    preferredGeneratedSources.includes(location.sourceId)
+  );
+  if (scopes.originalScopes && !hasPreferredGeneratedSource) {
+    // if all original variables are unavailable (usually due to sourcemap issues),
+    // we show the generated scope chain with a warning message instead
+    originalScopesUnavailable = scopes.originalScopes.every(scope =>
+      (scope.bindings || []).every(binding => binding.unavailable)
+    );
+    if (!originalScopesUnavailable) {
+      scopeChain = scopes.originalScopes;
+    }
+  }
+  return { scopes: scopeChain, originalScopesUnavailable };
+}

--- a/src/ui/utils/preferredLocation.ts
+++ b/src/ui/utils/preferredLocation.ts
@@ -24,11 +24,7 @@ export function getPreferredLocation(locations: MappedLocation | undefined) {
     ...location,
     sourceId: getCorrespondingSourceIds(state, location.sourceId)[0],
   }));
-  return getPreferredLocationSelector(
-    state.sources,
-    correspondingLocations,
-    ThreadFront.preferredGeneratedSources
-  );
+  return getPreferredLocationSelector(state.sources, correspondingLocations);
 }
 
 export function setupGetPreferredLocation(_store: UIStore) {


### PR DESCRIPTION
- #7745 introduced FE-794: the decision whether to show original or generated scopes was made when the scopes were added to the cache (and couldn't be changed afterwards). Now we cache both original and generated scopes and pick the ones to show while rendering.
- moving `preferredGeneratedSources` into redux (FE-845) ensures that the scopes panel is rerendered after switching between original and alternate source.
- the `showAlternateSource()` thunk doesn't need to call the `paused()` thunk anymore: this was necessary in the past to recompute the frames and scopes stored in redux