### PR TITLE
Enable swcMinify in next config (FE-820)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -36,6 +36,7 @@ const baseNextConfig = {
   },
 
   productionBrowserSourceMaps: true,
+  swcMinify: true,
 
   async redirects() {
     return [


### PR DESCRIPTION
With this setting, the sources are minified with swc instead of terser, providing more fine-grained sourcemaps.

Stepping through our sources without `swcMinify`:
Recording: https://app.replay.io/recording/d8e86713-5b2f-44c2-9108-f298e46fb011
Original recording: https://app.replay.io/recording/05f2c272-86e0-46bf-8c89-19c2b21ba611

With `swcMinify`:
Recording: https://app.replay.io/recording/465b95fc-d5cd-46b2-aea3-42a03751257e
Original recording: https://app.replay.io/recording/e55cf93d-6282-4d8d-b82d-f12622ac9a3c