### PR TITLE
Remove frames from the network redux slice (FE-844)

### DIFF
--- a/src/devtools/client/debugger/src/components/SecondaryPanes/index.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/index.tsx
@@ -14,8 +14,11 @@ import CommandBar from "./CommandBar";
 import FrameTimeline from "./FrameTimeline";
 import NewScopes from "./NewScopes";
 import { useDebuggerPrefs } from "../../utils/prefs";
+import { getPauseId } from "../../reducers/pause";
+import { useAppSelector } from "ui/setup/hooks";
 
 export default function SecondaryPanes() {
+  const pauseId = useAppSelector(getPauseId);
   const { value: scopesExpanded, update: updateScopesExpanded } =
     useDebuggerPrefs("scopes-visible");
   const { value: callstackVisible, update: updateCallstackVisible } =
@@ -52,7 +55,7 @@ export default function SecondaryPanes() {
           expanded={callstackVisible}
           onToggle={() => updateCallstackVisible(!callstackVisible)}
         >
-          <NewFrames panel="debugger" />
+          {pauseId && <NewFrames pauseId={pauseId} panel="debugger" />}
         </AccordionPane>
         <AccordionPane
           header="Scopes"

--- a/src/ui/actions/network.ts
+++ b/src/ui/actions/network.ts
@@ -7,7 +7,7 @@ import {
   Frame,
 } from "@replayio/protocol";
 import { createFrame } from "devtools/client/debugger/src/client/create";
-import { Context, PauseFrame } from "devtools/client/debugger/src/reducers/pause";
+import { Context } from "devtools/client/debugger/src/reducers/pause";
 import { RequestSummary } from "ui/components/NetworkMonitor/utils";
 import { getLoadedRegions } from "ui/reducers/app";
 import { getRequestById, getSummaryById } from "ui/reducers/network";
@@ -30,11 +30,6 @@ type NewRequestBodyPartsAction = {
   payload: { requestBodyParts: requestBodyData };
 };
 
-type SetFramesAction = {
-  type: "SET_FRAMES";
-  payload: { frames: PauseFrame[]; point: string };
-};
-
 type ShowRequestDetailsAction = {
   type: "SHOW_REQUEST_DETAILS";
   requestId: RequestId;
@@ -51,7 +46,6 @@ export type NetworkAction =
   | NewNetworkRequestsAction
   | NewRequestBodyPartsAction
   | NewResponseBodyPartsAction
-  | SetFramesAction
   | ShowRequestDetailsAction
   | HideRequestDetailsAction;
 

--- a/src/ui/components/NetworkMonitor/RequestDetails.tsx
+++ b/src/ui/components/NetworkMonitor/RequestDetails.tsx
@@ -6,7 +6,6 @@ import React, { ReactNode, useEffect, useMemo, useState } from "react";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { hideRequestDetails, selectAndFetchRequest } from "ui/actions/network";
 import { getLoadedRegions } from "ui/reducers/app";
-import { getFormattedFrames } from "ui/reducers/network";
 import { isPointInRegions } from "ui/utils/timeline";
 
 import AddNetworkRequestCommentButton from "./AddNetworkRequestCommentButton";
@@ -14,7 +13,7 @@ import RequestBody from "./RequestBody";
 import styles from "./RequestDetails.module.css";
 import ResponseBody from "./ResponseBody";
 import { findHeader, RequestSummary } from "./utils";
-import { StackTrace } from "./StackTrace";
+import StackTrace from "./StackTrace";
 
 interface Detail {
   name: string;
@@ -270,7 +269,6 @@ const RequestDetails = ({
   nextRequestId: string | null;
 }) => {
   const dispatch = useAppDispatch();
-  const frames = useAppSelector(getFormattedFrames)[request.point.point];
   const [activeTab, setActiveTab] = useState<NetworkTab>(DEFAULT_TAB);
   const loadedRegions = useAppSelector(getLoadedRegions)?.loaded;
 
@@ -340,7 +338,7 @@ const RequestDetails = ({
           {activeTab === "cookies" && <Cookies request={request} />}
           {activeTab === "response" && <ResponseBody request={request} />}
           {activeTab === "request" && <RequestBody request={request} />}
-          {activeTab === "stackTrace" && <StackTrace frames={frames} request={request} />}
+          {activeTab === "stackTrace" && <StackTrace request={request} />}
           {activeTab === "timings" && <Timing request={request} />}
         </div>
       </div>

--- a/src/ui/components/NetworkMonitor/StackTrace.tsx
+++ b/src/ui/components/NetworkMonitor/StackTrace.tsx
@@ -1,32 +1,24 @@
-import React from "react";
-import { useAppDispatch } from "ui/setup/hooks";
-import { seekToRequestFrame } from "ui/actions/network";
-import { PauseFrames } from "devtools/client/debugger/src/components/SecondaryPanes/Frames/NewFrames";
+import React, { Suspense } from "react";
+import Frames from "devtools/client/debugger/src/components/SecondaryPanes/Frames/NewFrames";
 import { RequestSummary } from "./utils";
-import { PauseFrame } from "devtools/client/debugger/src/reducers/pause";
+import { getPauseIdForPointSuspense } from "ui/suspense/util";
 
-export const StackTrace = ({
-  frames,
-  request,
-}: {
-  frames: PauseFrame[];
-  request: RequestSummary;
-}) => {
-  const dispatch = useAppDispatch();
-  const selectFrame = async (cx: any, frame: any) => {
-    dispatch(seekToRequestFrame(request, frame, cx));
-  };
-
+function StackTrace({ request }: { request: RequestSummary }) {
+  const pauseId = getPauseIdForPointSuspense(request.point.point, request.point.time);
   return (
-    <div>
+    <div className="call-stack-pane">
       <h1 className="py-2 px-4 font-bold">Stack Trace</h1>
       <div className="px-2">
-        <div className="pane frames">
-          <div role="list">
-            <PauseFrames frames={frames} panel="networkmonitor" selectFrame={selectFrame} />
-          </div>
-        </div>
+        <Frames pauseId={pauseId} panel="networkmonitor" />
       </div>
     </div>
   );
-};
+}
+
+export default function StackTraceSuspenseWrapper({ request }: { request: RequestSummary }) {
+  return (
+    <Suspense>
+      <StackTrace request={request} />
+    </Suspense>
+  );
+}

--- a/src/ui/reducers/network.ts
+++ b/src/ui/reducers/network.ts
@@ -7,10 +7,6 @@ import {
 
 import { UIState } from "ui/state";
 import { NetworkAction } from "ui/actions/network";
-import { createSelector } from "reselect";
-import { getSourceDetailsEntities } from "ui/reducers/sources";
-import { PauseFrame } from "devtools/client/debugger/src/selectors";
-import { formatCallStackFrames } from "devtools/client/debugger/src/selectors/getCallStackFrames";
 import sortBy from "lodash/sortBy";
 import sortedUniqBy from "lodash/sortedUniqBy";
 import { getFocusRegion } from "./timeline";
@@ -23,7 +19,6 @@ import {
 
 export type NetworkState = {
   events: RequestEventInfo[];
-  frames: Record<string, PauseFrame[]>;
   loading: boolean;
   responseBodies: Record<string, ResponseBodyData[]>;
   requestBodies: Record<string, RequestBodyData[]>;
@@ -33,7 +28,6 @@ export type NetworkState = {
 
 const initialState = (): NetworkState => ({
   events: [],
-  frames: {},
   loading: true,
   requests: [],
   responseBodies: {},
@@ -82,14 +76,6 @@ const update = (state: NetworkState = initialState(), action: NetworkAction): Ne
           ),
         },
       };
-    case "SET_FRAMES":
-      return {
-        ...state,
-        frames: {
-          ...state.frames,
-          [action.payload.point]: action.payload.frames,
-        },
-      };
     case "SHOW_REQUEST_DETAILS":
       return {
         ...state,
@@ -107,7 +93,6 @@ const update = (state: NetworkState = initialState(), action: NetworkAction): Ne
 
 export const getEvents = (state: UIState) => state.network.events;
 export const getRequests = (state: UIState) => state.network.requests;
-const getFrames = (state: UIState) => state.network.frames;
 export const getFocusedEvents = (state: UIState) => {
   const events = getEvents(state);
   const focusRegion = getFocusRegion(state);
@@ -125,16 +110,6 @@ export const getFocusedRequests = (state: UIState) => {
 
   return filterToFocusRegion(requests, focusRegion);
 };
-
-export const getFormattedFrames = createSelector(
-  getFrames,
-  getSourceDetailsEntities,
-  (frames, sources) => {
-    return Object.keys(frames).reduce((acc: Record<string, PauseFrame[]>, frame) => {
-      return { ...acc, [frame]: formatCallStackFrames(frames[frame], sources)! };
-    }, {});
-  }
-);
 
 export const getResponseBodies = (state: UIState) => state.network.responseBodies;
 export const getRequestBodies = (state: UIState) => state.network.requestBodies;


### PR DESCRIPTION
- remove frames from the network redux slice (FE-844)
- for every pause involved in the async stacktrace: check if the pause is in a loaded region and add an `ErrorBoundary` in case loading frames for that pause fails for some other reason (FE-856)