### PR TITLE
Add suspense wrapper around new console (FE-848)

### DIFF
--- a/src/ui/components/SecondaryToolbox/index.tsx
+++ b/src/ui/components/SecondaryToolbox/index.tsx
@@ -94,7 +94,9 @@ function ConsolePanel() {
   return (
     <div className="toolbox-bottom-panels">
       <div className={classnames("toolbox-panel")} id="toolbox-content-console">
-        <NewConsoleRoot />
+        <Suspense fallback={<Loader />}>
+          <NewConsoleRoot />
+        </Suspense>
       </div>
     </div>
   );


### PR DESCRIPTION
When opening a replay it can take a long time until the secondary toolbox appears. The reason is that the new console (in particular the `LoggablesContext`) suspends and the next suspense wrapper in the component tree is around the secondary toolbox.
With this PR at least the other panels are usable while the console is still suspended. We should probably figure out how to make the console show up earlier and be (partially) usable as well.