### PR TITLE
Rework selected location checks to fix accidental scrolls to top

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/useEditor.ts
+++ b/src/devtools/client/debugger/src/components/Editor/useEditor.ts
@@ -453,10 +453,11 @@ function scrollToLocationHelper(
   if (selectedLocation) {
     let shouldScrollToLocation = false;
     if (
-      selectedSource != null &&
-      selectedSourceContent != null &&
-      selectedLocation?.line != null &&
-      selectedSourceContent?.value != null
+      selectedSource &&
+      selectedSourceContent &&
+      // Intentionally bail out if line is 0
+      selectedLocation?.line &&
+      selectedSourceContent?.value
     ) {
       const isFirstLoad = prevSelectedSourceContent?.value == null;
       const locationChanged = prevSelectedLocation !== selectedLocation;


### PR DESCRIPTION
Per [this bug repro replay](https://app.replay.io/recording/fe-860-scroll-position-resets--fb1fb2e7-76d7-48bb-9ae7-052a2cc45e1d?point=29206669838329388894545426312593751&time=12759.55458898265&hasFrames=true&focusRegion=eyJiZWdpbiI6eyJwb2ludCI6IjIzMzY1MzM1ODY4MzI4MTQxNTU2MTA1NzQ2MjE4NzUwNjM0IiwidGltZSI6MTA3NTIsInNjcmVlblNob3RzIjpbeyJtaW1lVHlwZSI6ImltYWdlL2pwZWciLCJoYXNoIjoiMTQ5MDkwNDk5NiJ9XX0sImVuZCI6eyJwb2ludCI6IjM1MDQ4MDAzODA5Mjk3NTY4NDQwNDY5NzMwMzExMDIwMjU4IiwidGltZSI6MTQ3NzcsImtpbmQiOiJtb3VzZWRvd24iLCJjbGllbnRYIjo1MTUsImNsaWVudFkiOjYyfX0%253D), we were trying to reset the scroll position whenever `selectedLocation.line` was 0, as it is when you normally switch tabs.

Compare to [this earlier working replay pre-Editor-rewrite](https://app.replay.io/recording/fe-860-scroll-position-was-working--c64eeeca-0d65-47d8-a323-6380f7035427?point=25312447189885280135493704105328944&time=9176.440991735537&hasFrames=true&focusRegion=eyJiZWdpbiI6eyJwb2ludCI6IjEzMzA1MjYwNzAyODE2MzAyNzI2NTcwNzg1MDY1OTI3OTI4IiwidGltZSI6NTI3Nywic2NyZWVuU2hvdHMiOlt7Im1pbWVUeXBlIjoiaW1hZ2UvanBlZyIsImhhc2giOiItMTEwMTc2NzE2MCJ9XX0sImVuZCI6eyJwb2ludCI6IjMzMTAwODkyNDc4NTEwMTk0NDgyNTA5NjI5Njc0NzQ5OTUyIiwidGltZSI6MTE3MTd9fQ%253D%253D), where we bailed out in that same situation.

Looks like the issue was swiching from a basic falsy `if (!selectedLocation.line)` to `selectedLocation.line != null)`.