### PR TITLE
Try using deep equality checks on breakpoints to avoid flashing

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense, useContext, useDeferredValue, useEffect, useMemo, useState } from "react";
 import classnames from "classnames";
+import isEqual from "lodash/isEqual";
 import PanelEditor from "./PanelEditor";
 import BreakpointNavigation from "devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation";
 import Widget from "./Widget";
@@ -87,8 +88,10 @@ function Panel({
   // If we were fully using concurrent APIs, updates to something like focus range or breakpoint would be done in a transition,
   // which would expose an "is pending" flag that we could use to show e.g. "Loading..." while we're updating breakpoints.
   // In this case, since we're using the deferred API for this, we have to calculate the "is pending" flag ourselves.
-  const isPending =
-    unsafeFocusRegion !== unsafeFocusRegionForSuspense || breakpoint !== breakpointForSuspense;
+
+  // Do a deeper equality check - seems like we sometimes have breakpoints with equivalent contents
+  const breakpointsAreEqual = isEqual(breakpoint, breakpointForSuspense);
+  const isPending = unsafeFocusRegion !== unsafeFocusRegionForSuspense || !breakpointsAreEqual;
 
   // HACK
   // The TimeStampedPoints within the focus region are always at least as large as (often larger than) the user-defined time range.


### PR DESCRIPTION
This PR:

- Tweaks the comparison logic in `<Panel>` to do a deep equality check instead of reference equality, in the hopes that it prevents some flickering

Per https://app.replay.io/recording/replay-disco--a97ed461-7081-4370-9a11-16c7cc2c6040 , Ryan thinks this was responsible for the print statement panel timeline flickering on and off.  I can't repro it locally, but seems like a reasonable change.

Not 100% sure this is _right_ - I could see some potential differences in behavior depending on whether it's meant to be "did this get updated _at all_" or not.  Brian would have more context here.