### PR TITLE
Use the selected frame's pause for console evaluations (FE-857)

### DIFF
--- a/packages/bvaughn-architecture-demo/components/console/Input.tsx
+++ b/packages/bvaughn-architecture-demo/components/console/Input.tsx
@@ -1,7 +1,7 @@
+import { SelectedFrameContext } from "@bvaughn/src/contexts/SelectedFrameContext";
 import { TerminalContext } from "@bvaughn/src/contexts/TerminalContext";
 import { TimelineContext } from "@bvaughn/src/contexts/TimelineContext";
 import useCurrentPause from "@bvaughn/src/hooks/useCurrentPause";
-import { FrameId, PauseId } from "@replayio/protocol";
 import { useContext, useEffect, useRef } from "react";
 
 import Icon from "../Icon";
@@ -25,14 +25,10 @@ export default function Input() {
     searchStateVisibleRef.current = searchState.visible;
   }, [searchState.visible]);
 
-  const pause = useCurrentPause();
-
-  let frameId: FrameId | null = null;
-  let pauseId: PauseId | null = null;
-  if (pause) {
-    frameId = pause.data.frames?.[0]?.frameId ?? null;
-    pauseId = pause.pauseId;
-  }
+  const currentPause = useCurrentPause();
+  const { selectedPauseAndFrameId } = useContext(SelectedFrameContext);
+  const frameId = selectedPauseAndFrameId?.frameId ?? currentPause?.stack?.[0] ?? null;
+  const pauseId = selectedPauseAndFrameId?.pauseId ?? currentPause?.pauseId ?? null;
 
   const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     switch (event.key) {

--- a/packages/bvaughn-architecture-demo/components/sources/PreviewPopup.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/PreviewPopup.tsx
@@ -1,3 +1,4 @@
+import { SelectedFrameContext } from "@bvaughn/src/contexts/SelectedFrameContext";
 import useCurrentPause from "@bvaughn/src/hooks/useCurrentPause";
 import { evaluate } from "@bvaughn/src/suspense/PauseCache";
 import { createPauseResult as Pause, Value as ProtocolValue } from "@replayio/protocol";
@@ -22,8 +23,9 @@ function SuspendingPreviewPopup({ containerRef, dismiss, expression, pause, targ
 
   const popupRef = useRef<HTMLDivElement>(null);
 
-  const pauseId = pause.pauseId;
-  const frameId = pause.data.frames?.[0]?.frameId ?? null;
+  const { selectedPauseAndFrameId } = useContext(SelectedFrameContext);
+  const frameId = selectedPauseAndFrameId?.frameId ?? null;
+  const pauseId = selectedPauseAndFrameId?.pauseId ?? null;
 
   let value: ProtocolValue | null = null;
   if (frameId !== null && pauseId !== null) {

--- a/packages/bvaughn-architecture-demo/pages/index.tsx
+++ b/packages/bvaughn-architecture-demo/pages/index.tsx
@@ -13,6 +13,7 @@ import { FocusContextRoot } from "@bvaughn/src/contexts/FocusContext";
 import { InspectorContext } from "@bvaughn/src/contexts/InspectorContext";
 import { KeyboardModifiersContextRoot } from "@bvaughn/src/contexts/KeyboardModifiersContext";
 import { PointsContextRoot } from "@bvaughn/src/contexts/PointsContext";
+import SelectedFrameContextWrapper from "@bvaughn/src/contexts/SelectedFrameContext";
 import { SourcesContextRoot } from "@bvaughn/src/contexts/SourcesContext";
 import { TerminalContextRoot } from "@bvaughn/src/contexts/TerminalContext";
 import { TimelineContextRoot } from "@bvaughn/src/contexts/TimelineContext";
@@ -81,68 +82,72 @@ export default function HomePage() {
             <PointsContextRoot>
               <TimelineContextRoot>
                 <FocusContextRoot>
-                  <div className={styles.VerticalContainer}>
-                    <div className={styles.HorizontalContainer}>
-                      <div className={styles.ToolBar}>
-                        <button
-                          className={panel === "comments" ? styles.TabSelected : styles.Tab}
-                          disabled={isPending}
-                          onClick={() => setPanelTransition("comments")}
-                        >
-                          <Icon className={styles.TabIcon} type="comments" />
-                        </button>
-                        <button
-                          className={panel === "sources" ? styles.TabSelected : styles.Tab}
-                          disabled={isPending}
-                          onClick={() => setPanelTransition("sources")}
-                        >
-                          <Icon className={styles.TabIcon} type="source-explorer" />
-                        </button>
-                        <button
-                          className={panel === "protocol-viewer" ? styles.TabSelected : styles.Tab}
-                          disabled={isPending}
-                          onClick={() => setPanelTransition("protocol-viewer")}
-                        >
-                          <Icon className={styles.TabIcon} type="protocol-viewer" />
-                        </button>
-                      </div>
-                      <div className={styles.CommentsContainer}>
-                        <Suspense fallback={<Loader />}>
-                          <LazyOffscreen mode={panel == "comments" ? "visible" : "hidden"}>
-                            <CommentList />
-                          </LazyOffscreen>
-                          <LazyOffscreen mode={panel == "protocol-viewer" ? "visible" : "hidden"}>
-                            <ProtocolViewer />
-                          </LazyOffscreen>
-                          <LazyOffscreen mode={panel == "sources" ? "visible" : "hidden"}>
-                            <SourceExplorer />
-                          </LazyOffscreen>
-                        </Suspense>
-                      </div>
-                      <div className={styles.SourcesContainer}>
-                        <Suspense fallback={<Loader />}>
-                          <Sources />
-                        </Suspense>
-                      </div>
-                      <div className={styles.ConsoleContainer}>
-                        <TerminalContextRoot>
-                          <ConsoleRoot
-                            showSearchInputByDefault={false}
-                            terminalInput={
-                              <Suspense fallback={<Loader />}>
-                                <Input />
-                              </Suspense>
+                  <SelectedFrameContextWrapper>
+                    <div className={styles.VerticalContainer}>
+                      <div className={styles.HorizontalContainer}>
+                        <div className={styles.ToolBar}>
+                          <button
+                            className={panel === "comments" ? styles.TabSelected : styles.Tab}
+                            disabled={isPending}
+                            onClick={() => setPanelTransition("comments")}
+                          >
+                            <Icon className={styles.TabIcon} type="comments" />
+                          </button>
+                          <button
+                            className={panel === "sources" ? styles.TabSelected : styles.Tab}
+                            disabled={isPending}
+                            onClick={() => setPanelTransition("sources")}
+                          >
+                            <Icon className={styles.TabIcon} type="source-explorer" />
+                          </button>
+                          <button
+                            className={
+                              panel === "protocol-viewer" ? styles.TabSelected : styles.Tab
                             }
-                          />
-                        </TerminalContextRoot>
+                            disabled={isPending}
+                            onClick={() => setPanelTransition("protocol-viewer")}
+                          >
+                            <Icon className={styles.TabIcon} type="protocol-viewer" />
+                          </button>
+                        </div>
+                        <div className={styles.CommentsContainer}>
+                          <Suspense fallback={<Loader />}>
+                            <LazyOffscreen mode={panel == "comments" ? "visible" : "hidden"}>
+                              <CommentList />
+                            </LazyOffscreen>
+                            <LazyOffscreen mode={panel == "protocol-viewer" ? "visible" : "hidden"}>
+                              <ProtocolViewer />
+                            </LazyOffscreen>
+                            <LazyOffscreen mode={panel == "sources" ? "visible" : "hidden"}>
+                              <SourceExplorer />
+                            </LazyOffscreen>
+                          </Suspense>
+                        </div>
+                        <div className={styles.SourcesContainer}>
+                          <Suspense fallback={<Loader />}>
+                            <Sources />
+                          </Suspense>
+                        </div>
+                        <div className={styles.ConsoleContainer}>
+                          <TerminalContextRoot>
+                            <ConsoleRoot
+                              showSearchInputByDefault={false}
+                              terminalInput={
+                                <Suspense fallback={<Loader />}>
+                                  <Input />
+                                </Suspense>
+                              }
+                            />
+                          </TerminalContextRoot>
+                        </div>
+                      </div>
+                      <div className={styles.Row}>
+                        <Suspense fallback={<Loader />}>
+                          <Focuser />
+                        </Suspense>
                       </div>
                     </div>
-                    <div className={styles.Row}>
-                      <Suspense fallback={<Loader />}>
-                        <Focuser />
-                      </Suspense>
-                    </div>
-                  </div>
+                  </SelectedFrameContextWrapper>
                 </FocusContextRoot>
               </TimelineContextRoot>
             </PointsContextRoot>

--- a/packages/bvaughn-architecture-demo/src/contexts/SelectedFrameContext.tsx
+++ b/packages/bvaughn-architecture-demo/src/contexts/SelectedFrameContext.tsx
@@ -1,0 +1,66 @@
+import { FrameId, PauseId } from "@replayio/protocol";
+import { createContext, PropsWithChildren, Suspense, useContext, useMemo, useState } from "react";
+import isEqual from "lodash/isEqual";
+import useLoadedRegions from "../hooks/useRegions";
+import { ReplayClientContext } from "shared/client/ReplayClientContext";
+import { TimelineContext } from "./TimelineContext";
+import { isPointInRegions } from "shared/utils/time";
+import { getPauseForExecutionPoint } from "../suspense/PauseCache";
+
+interface PauseAndFrameId {
+  pauseId: PauseId;
+  frameId: FrameId;
+}
+
+export interface SelectedFrameContextType {
+  selectedPauseAndFrameId: PauseAndFrameId | null;
+  setSelectedPauseAndFrameId(pauseAndFrameId: PauseAndFrameId | null): void;
+}
+
+export const SelectedFrameContext = createContext<SelectedFrameContextType>({
+  selectedPauseAndFrameId: null,
+  setSelectedPauseAndFrameId: () => {},
+});
+
+export function SelectedFrameContextRoot({ children }: PropsWithChildren<{}>) {
+  const [selectedPauseAndFrameId, setSelectedPauseAndFrameId] = useState<PauseAndFrameId | null>(
+    null
+  );
+  const context = useMemo(
+    () => ({ selectedPauseAndFrameId, setSelectedPauseAndFrameId }),
+    [selectedPauseAndFrameId, setSelectedPauseAndFrameId]
+  );
+  return <SelectedFrameContext.Provider value={context}>{children}</SelectedFrameContext.Provider>;
+}
+
+function SelectedFrameContextAdapter() {
+  const client = useContext(ReplayClientContext);
+  const loadedRegions = useLoadedRegions(client);
+  const { executionPoint } = useContext(TimelineContext);
+  const { selectedPauseAndFrameId, setSelectedPauseAndFrameId } = useContext(SelectedFrameContext);
+
+  const isLoaded = loadedRegions !== null && isPointInRegions(executionPoint, loadedRegions.loaded);
+
+  const pause = isLoaded ? getPauseForExecutionPoint(client, executionPoint) : undefined;
+
+  const pauseId = pause?.pauseId;
+  const frameId = pause?.stack?.[0] ?? null;
+
+  const pauseAndFrameId = pauseId && frameId ? { pauseId, frameId } : null;
+  if (!isEqual(pauseAndFrameId, selectedPauseAndFrameId)) {
+    setSelectedPauseAndFrameId(pauseAndFrameId);
+  }
+
+  return null;
+}
+
+export default function SelectedFrameContextWrapper({ children }: PropsWithChildren<{}>) {
+  return (
+    <SelectedFrameContextRoot>
+      <Suspense>
+        <SelectedFrameContextAdapter />
+      </Suspense>
+      {children}
+    </SelectedFrameContextRoot>
+  );
+}

--- a/packages/e2e-tests/helpers/timeline.ts
+++ b/packages/e2e-tests/helpers/timeline.ts
@@ -92,3 +92,8 @@ export async function setFocusRangeStartTime(page: Page, timeString: string): Pr
   await clearTimeInput(page, input);
   await input.fill(timeString);
 }
+
+export async function seekToPreviousScreenshot(page: Page) {
+  const timeline = page.locator(".progress-bar");
+  await timeline.press("ArrowLeft");
+}

--- a/packages/e2e-tests/tests/console_async_eval.test.ts
+++ b/packages/e2e-tests/tests/console_async_eval.test.ts
@@ -23,13 +23,9 @@ test("console_async: support global console evaluations in async frames", async 
 
   await executeAndVerifyTerminalExpression(page, '"eval " + n', "eval 2");
   await selectFrame(page, 2);
-  await executeAndVerifyTerminalExpression(page, '"eval " + n', "eval 3");
+  await executeAndVerifyTerminalExpression(page, '"eval " + n', "eval 4");
   await selectFrame(page, 4);
-  await executeAndVerifyTerminalExpression(
-    page,
-    '"eval " + n',
-    "The expression could not be evaluated."
-  );
+  await executeAndVerifyTerminalExpression(page, '"eval " + n', "ReferenceError: n is not defined");
 
   await verifyConsoleMessage(page, "foo", "console-log");
   await verifyConsoleMessage(page, "bar", "console-log");

--- a/packages/e2e-tests/tests/console_eval.test.ts
+++ b/packages/e2e-tests/tests/console_eval.test.ts
@@ -6,6 +6,7 @@ import {
   openConsolePanel,
   warpToMessage,
 } from "../helpers/console-panel";
+import { seekToPreviousScreenshot } from "../helpers/timeline";
 
 const url = "doc_rr_basic.html";
 
@@ -14,7 +15,11 @@ test("console_eval: support global console evaluations", async ({ page }) => {
   await openDevToolsTab(page);
   await openConsolePanel(page);
 
+  // in e2e tests replay always starts at the very end of the recording but at that point
+  // console evaluations always fail, so we seek to the point of the last screenshot instead
+  await seekToPreviousScreenshot(page);
   await executeAndVerifyTerminalExpression(page, "333", 333);
+
   await warpToMessage(page, "ExampleFinished", 7);
   await executeAndVerifyTerminalExpression(page, "number", 10);
   await executeAndVerifyTerminalExpression(page, "window.updateNumber", "ƒupdateNumber()");

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -39,6 +39,7 @@ import tokenManager, { TokenState } from "ui/utils/tokenManager";
 import { isTest } from "ui/utils/environment";
 import { PointsContextRoot } from "bvaughn-architecture-demo/src/contexts/PointsContext";
 import TerminalContextAdapter from "ui/components/SecondaryToolbox/TerminalContextAdapter";
+import SelectedFrameContextWrapper from "./SelectedFrameContextAdapter";
 
 const Viewer = React.lazy(() => import("./Viewer"));
 
@@ -198,16 +199,18 @@ function _DevTools({
     <SessionContextAdapter>
       <SourcesContextAdapter>
         <FocusContextReduxAdapter>
-          <PointsContextRoot>
-            <TerminalContextAdapter>
-              <KeyModifiers>
-                <Header />
-                <Body />
-                {showCommandPalette ? <CommandPaletteModal /> : null}
-                <KeyboardShortcuts />
-              </KeyModifiers>
-            </TerminalContextAdapter>
-          </PointsContextRoot>
+          <SelectedFrameContextWrapper>
+            <PointsContextRoot>
+              <TerminalContextAdapter>
+                <KeyModifiers>
+                  <Header />
+                  <Body />
+                  {showCommandPalette ? <CommandPaletteModal /> : null}
+                  <KeyboardShortcuts />
+                </KeyModifiers>
+              </TerminalContextAdapter>
+            </PointsContextRoot>
+          </SelectedFrameContextWrapper>
         </FocusContextReduxAdapter>
       </SourcesContextAdapter>
     </SessionContextAdapter>

--- a/src/ui/components/SelectedFrameContextAdapter.tsx
+++ b/src/ui/components/SelectedFrameContextAdapter.tsx
@@ -1,0 +1,25 @@
+import {
+  SelectedFrameContext,
+  SelectedFrameContextRoot,
+} from "bvaughn-architecture-demo/src/contexts/SelectedFrameContext";
+import { getSelectedFrameId } from "devtools/client/debugger/src/selectors";
+import { PropsWithChildren, useContext } from "react";
+import { useAppSelector } from "ui/setup/hooks";
+
+function SelectedFrameContextAdapter({ children }: PropsWithChildren) {
+  const selectedPauseAndFrameIdRedux = useAppSelector(getSelectedFrameId);
+  const { selectedPauseAndFrameId, setSelectedPauseAndFrameId } = useContext(SelectedFrameContext);
+  if (selectedPauseAndFrameId !== selectedPauseAndFrameIdRedux) {
+    setSelectedPauseAndFrameId(selectedPauseAndFrameId);
+  }
+  return <>{children}</>;
+}
+
+export default function SelectedFrameContextWrapper({ children }: PropsWithChildren<{}>) {
+  return (
+    <SelectedFrameContextRoot>
+      <SelectedFrameContextAdapter />
+      {children}
+    </SelectedFrameContextRoot>
+  );
+}

--- a/src/ui/components/shared/CodeEditor/useAutocomplete.tsx
+++ b/src/ui/components/shared/CodeEditor/useAutocomplete.tsx
@@ -118,19 +118,17 @@ function useGetEvalMatches(expression: string) {
   const selectedFrameId = useAppSelector(getSelectedFrameId);
   const replayClient = useContext(ReplayClientContext);
 
-  const pauseId = useAppSelector(getPauseId);
-
   const getEvalMatchesForSelectedFrame = useCallback(
     async (expression: string) => {
-      if (!pauseId) {
+      if (!selectedFrameId) {
         return null;
       }
       const fetchObject = async (objectId: string) => {
-        return getObjectWithPreviewHelper(replayClient, pauseId, objectId);
+        return getObjectWithPreviewHelper(replayClient, selectedFrameId.pauseId, objectId);
       };
       return getEvalMatches(expression, selectedFrameId, fetchObject);
     },
-    [selectedFrameId, pauseId, replayClient]
+    [selectedFrameId, replayClient]
   );
   return useGetAsyncMatches(expression, getEvalMatchesForSelectedFrame);
 }


### PR DESCRIPTION
- use the currently selected frame for evaluations
- fix the console_async_eval e2e test:
  - one check for an async evaluation expected a value from a different frame than the selected one
  - one check for a failing evaluation expected an error message that was shown because the selected `frameId` did not exist in the current pause (because it was from a different pause), now we have a different error message because the evaluated expression throws (which is what this check was supposed to test in the first place)
- fix the `executeAndVerifyTerminalExpression()` test helper: it always succeeded if the expected evaluation result was identical to (or a substring of) the evaluated expression
- fix the console_eval e2e test: this test always failed because it tries to evaluate a (global) expression in the initial pause at the very end of the recording but that always fails in the backend, `executeAndVerifyTerminalExpression()` missed these failures in the past