### PR TITLE
Revert swcminify flag to see if that fixes our sourcemaps

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -36,7 +36,6 @@ const baseNextConfig = {
   },
 
   productionBrowserSourceMaps: true,
-  swcMinify: true,
 
   async redirects() {
     return [


### PR DESCRIPTION
Debugging recent recordings of our client has been hard because our own sourcemaps appear to be busted and misleading.  Trying out a reversion of the `swcminify` flag to see if that improves things.