### PR TITLE
Skip redirecting on login when coming from browser auth

### DIFF
--- a/pages/api/browser/auth.ts
+++ b/pages/api/browser/auth.ts
@@ -7,7 +7,7 @@ globalThis.fetch = globalThis.fetch || require("node-fetch");
 
 const getQueryValue = (query: string | string[]) => (Array.isArray(query) ? query[0] : query);
 const getAppUrl = (path: string) =>
-  `${process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_VERCEL_URL}${path}`;
+  `${process.env.NEXT_PUBLIC_APP_URL || `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`}${path}`;
 
 async function initAuthRequest(key: string) {
   const api = process.env.NEXT_PUBLIC_API_URL;
@@ -70,6 +70,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
         maxAge: 5 * 60 * 1000,
       })
     );
+
     res.redirect(url);
   } catch (e: any) {
     console.error(e);

--- a/pages/api/browser/callback.ts
+++ b/pages/api/browser/callback.ts
@@ -16,7 +16,7 @@ interface Token {
 
 const getQueryValue = (query: string | string[]) => (Array.isArray(query) ? query[0] : query);
 const getAppUrl = (path: string) =>
-  `${process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_VERCEL_URL}${path}`;
+  `${process.env.NEXT_PUBLIC_APP_URL || `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`}${path}`;
 
 async function fulfillAuthRequest(id: string, token: string) {
   const api = process.env.NEXT_PUBLIC_API_URL;

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -10,14 +10,14 @@ export default function LoginPage() {
   const { user } = useAuth0();
   const dispatch = useAppDispatch();
 
-  if (user && typeof router.query.returnTo === "string") {
-    router.push(router.query.returnTo);
-  }
-
   const challenge = Array.isArray(router.query.challenge)
     ? router.query.challenge[0]
     : router.query.challenge;
   const state = Array.isArray(router.query.state) ? router.query.state[0] : router.query.state;
+
+  if (user && typeof router.query.returnTo === "string" && !challenge && !state) {
+    router.push(router.query.returnTo);
+  }
 
   useEffect(() => {
     dispatch(clearExpectedError());


### PR DESCRIPTION
Depending on network and speed of your click, the browser might redirect from the login back to the browser callback without the query parameters from auth0 causing the error.

Skipping that auto-redirect when the browser auth query parameters exist avoids this