### PR TITLE
Hide Network requests in unloaded regions

### DIFF
--- a/src/ui/components/NetworkMonitor/RequestRow.tsx
+++ b/src/ui/components/NetworkMonitor/RequestRow.tsx
@@ -8,7 +8,6 @@ import { RequestSummary } from "./utils";
 export const RequestRow = ({
   currentTime,
   isFirstInFuture,
-  isInLoadedRegion,
   isInPast,
   isSelected,
   onClick,
@@ -18,7 +17,6 @@ export const RequestRow = ({
 }: {
   currentTime: number;
   isFirstInFuture: boolean;
-  isInLoadedRegion: boolean;
   isInPast: boolean;
   isSelected: boolean;
   onClick: (row: RequestSummary) => void;
@@ -52,7 +50,6 @@ export const RequestRow = ({
         [styles.current]: isFirstInFuture,
         [styles.selected]: isSelected,
         [styles.future]: !isInPast,
-        [styles.unloaded]: !isInLoadedRegion,
       })}
       onClick={() => onClick(row.original)}
       onContextMenu={onContextMenu}

--- a/src/ui/components/NetworkMonitor/RequestRow.tsx
+++ b/src/ui/components/NetworkMonitor/RequestRow.tsx
@@ -8,6 +8,7 @@ import { RequestSummary } from "./utils";
 export const RequestRow = ({
   currentTime,
   isFirstInFuture,
+  isInLoadedRegion,
   isInPast,
   isSelected,
   onClick,
@@ -17,6 +18,7 @@ export const RequestRow = ({
 }: {
   currentTime: number;
   isFirstInFuture: boolean;
+  isInLoadedRegion: boolean;
   isInPast: boolean;
   isSelected: boolean;
   onClick: (row: RequestSummary) => void;
@@ -50,6 +52,7 @@ export const RequestRow = ({
         [styles.current]: isFirstInFuture,
         [styles.selected]: isSelected,
         [styles.future]: !isInPast,
+        [styles.unloaded]: !isInLoadedRegion,
       })}
       onClick={() => onClick(row.original)}
       onContextMenu={onContextMenu}

--- a/src/ui/components/NetworkMonitor/RequestTable.module.css
+++ b/src/ui/components/NetworkMonitor/RequestTable.module.css
@@ -25,10 +25,6 @@ table.requests {
   color: var(--theme-base-80);
 }
 
-.row.unloaded {
-  color: var(--theme-base-90);
-}
-
 .row.selected {
   background: var(--primary-accent-hover);
   border-color: var(--primary-accent-hover);

--- a/src/ui/components/NetworkMonitor/RequestTable.module.css
+++ b/src/ui/components/NetworkMonitor/RequestTable.module.css
@@ -12,6 +12,16 @@ table.requests {
   cursor: pointer;
 }
 
+.banner {
+  background: var(--body-bgcolor);
+  border-top: 2px solid transparent;
+  border-bottom: 2px solid transparent;
+  padding: 0.25rem;
+}
+.banner:not(:first-child) {
+  border-top: 2px solid var(--theme-toolbar-background);
+}
+
 .row:is(:hover, :focus-visible) {
   outline: 0;
   background-color: var(--theme-toolbar-background);
@@ -23,6 +33,10 @@ table.requests {
 
 .row.future {
   color: var(--theme-base-80);
+}
+
+.row.unloaded {
+  color: var(--theme-base-90);
 }
 
 .row.selected {

--- a/src/ui/components/NetworkMonitor/RequestTable.tsx
+++ b/src/ui/components/NetworkMonitor/RequestTable.tsx
@@ -1,12 +1,11 @@
 import classNames from "classnames";
 import React, { useState } from "react";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
-import { Column, Row, TableInstance } from "react-table";
+import { Row, TableInstance } from "react-table";
 import { setFocusRegionEndTime, setFocusRegionBeginTime } from "ui/actions/timeline";
 import { getLoadedRegions } from "ui/reducers/app";
 import type { AppDispatch } from "ui/setup/store";
 import { trackEvent } from "ui/utils/telemetry";
-import { isTimeInRegions } from "ui/utils/timeline";
 
 import { ContextMenu } from "../ContextMenu";
 import { Dropdown, DropdownItem } from "../Library/LibraryDropdown";
@@ -96,17 +95,12 @@ const RequestTable = ({
               firstInFuture = true;
             }
 
-            const isInLoadedRegion = loadedRegions
-              ? isTimeInRegions(row.original.point.time, loadedRegions.loaded)
-              : false;
-
             prepareRow(row);
 
             return (
               <RequestRow
                 currentTime={currentTime}
                 isFirstInFuture={firstInFuture}
-                isInLoadedRegion={isInLoadedRegion}
                 isInPast={inPast}
                 isSelected={selectedRequest?.id === row.original.id}
                 key={row.getRowProps().key}

--- a/src/ui/components/NetworkMonitor/index.tsx
+++ b/src/ui/components/NetworkMonitor/index.tsx
@@ -25,6 +25,8 @@ export const NetworkMonitor = ({
   events,
   loading,
   requests,
+  requestsAfterFilterCount,
+  requestsBeforeFilterCount,
   seek,
 }: PropsFromRedux) => {
   const selectedRequestId = useAppSelector(getSelectedRequestId);
@@ -109,8 +111,10 @@ export const NetworkMonitor = ({
                   startPanel={
                     <RequestTable
                       table={table}
-                      data={data}
                       currentTime={currentTime}
+                      data={data}
+                      filteredAfterCount={requestsAfterFilterCount}
+                      filteredBeforeCount={requestsBeforeFilterCount}
                       onRowSelect={row => {
                         trackEvent("net_monitor.select_request_row");
                         dispatch(selectAndFetchRequest(row.id));
@@ -146,13 +150,20 @@ export const NetworkMonitor = ({
 };
 
 const connector = connect(
-  (state: UIState) => ({
-    currentTime: getCurrentTime(state),
-    cx: getThreadContext(state),
-    events: getFocusedEvents(state),
-    loading: state.network.loading,
-    requests: getFocusedRequests(state),
-  }),
+  (state: UIState) => {
+    const [requests, requestsBeforeFilterCount, requestsAfterFilterCount] =
+      getFocusedRequests(state);
+
+    return {
+      currentTime: getCurrentTime(state),
+      cx: getThreadContext(state),
+      events: getFocusedEvents(state),
+      loading: state.network.loading,
+      requests,
+      requestsAfterFilterCount,
+      requestsBeforeFilterCount,
+    };
+  },
   {
     seek: actions.seek,
   }

--- a/src/ui/reducers/network.ts
+++ b/src/ui/reducers/network.ts
@@ -15,7 +15,9 @@ import {
   displayedEndForFocusRegion,
   filterToFocusRegion,
   displayedBeginForFocusRegion,
+  filterToLoadedRegions,
 } from "ui/utils/timeline";
+import { getLoadedRegions } from "./app";
 
 export type NetworkState = {
   events: RequestEventInfo[];
@@ -108,8 +110,17 @@ export const getFocusedEvents = (state: UIState) => {
 export const getFocusedRequests = (state: UIState) => {
   const requests = getRequests(state);
   const focusRegion = getFocusRegion(state);
+  const loadedRegions = getLoadedRegions(state);
 
-  return filterToFocusRegion(requests, focusRegion);
+  let filteredRequests = requests;
+  if (loadedRegions?.loaded) {
+    filteredRequests = filterToLoadedRegions(filteredRequests, loadedRegions.loaded);
+  }
+  if (focusRegion) {
+    filteredRequests = filterToFocusRegion(filteredRequests, focusRegion);
+  }
+
+  return filteredRequests;
 };
 
 export const getResponseBodies = (state: UIState) => state.network.responseBodies;

--- a/src/ui/reducers/network.ts
+++ b/src/ui/reducers/network.ts
@@ -108,14 +108,15 @@ export const getFocusedEvents = (state: UIState) => {
   return events.filter(e => e.time > beginTime && e.time <= endTime);
 };
 export const getFocusedRequests = (state: UIState) => {
+  const loadedRegions = getLoadedRegions(state);
+  if (loadedRegions?.loaded == null || loadedRegions.loaded.length === 0) {
+    return [];
+  }
+
   const requests = getRequests(state);
   const focusRegion = getFocusRegion(state);
-  const loadedRegions = getLoadedRegions(state);
 
-  let filteredRequests = requests;
-  if (loadedRegions?.loaded) {
-    filteredRequests = filterToLoadedRegions(filteredRequests, loadedRegions.loaded);
-  }
+  let filteredRequests = filterToLoadedRegions(requests, loadedRegions.loaded);
   if (focusRegion) {
     filteredRequests = filterToFocusRegion(filteredRequests, focusRegion);
   }

--- a/src/ui/utils/timeline.test.ts
+++ b/src/ui/utils/timeline.test.ts
@@ -214,21 +214,23 @@ describe("overlap", () => {
 
 describe("filterToFocusRegion", () => {
   it("will not include points before the region", () => {
-    expect(filterToFocusRegion([point(5)], focusRegion(10, 20))).toEqual([]);
+    expect(filterToFocusRegion([point(5)], focusRegion(10, 20))).toEqual([[], 1, 0]);
   });
   it("will not include points after the region", () => {
-    expect(filterToFocusRegion([point(25)], focusRegion(10, 20))).toEqual([]);
+    expect(filterToFocusRegion([point(25)], focusRegion(10, 20))).toEqual([[], 0, 1]);
   });
   it("will include points inside the region", () => {
     expect(filterToFocusRegion([point(5), point(15), point(25)], focusRegion(10, 20))).toEqual([
-      point(15),
+      [point(15)],
+      1,
+      1,
     ]);
   });
   it("will include points on the boundaries the region", () => {
     expect(filterToFocusRegion([point(10), point(15), point(20)], focusRegion(10, 20))).toEqual([
-      point(10),
-      point(15),
-      point(20),
+      [point(10), point(15), point(20)],
+      0,
+      0,
     ]);
   });
 });

--- a/src/ui/utils/timeline.ts
+++ b/src/ui/utils/timeline.ts
@@ -292,6 +292,13 @@ export function isFocusRegionSubset(
   }
 }
 
+export function filterToLoadedRegions<T extends TimeStampedPoint>(
+  sortedPoints: T[],
+  loadedRegions: TimeStampedPointRange[]
+): T[] {
+  return sortedPoints.filter(point => isPointInRegions(loadedRegions, point.point));
+}
+
 export function filterToFocusRegion<T extends TimeStampedPoint>(
   sortedPoints: T[],
   focusRegion: FocusRegion | null

--- a/src/ui/utils/timeline.ts
+++ b/src/ui/utils/timeline.ts
@@ -292,19 +292,12 @@ export function isFocusRegionSubset(
   }
 }
 
-export function filterToLoadedRegions<T extends TimeStampedPoint>(
-  sortedPoints: T[],
-  loadedRegions: TimeStampedPointRange[]
-): T[] {
-  return sortedPoints.filter(point => isPointInRegions(loadedRegions, point.point));
-}
-
 export function filterToFocusRegion<T extends TimeStampedPoint>(
   sortedPoints: T[],
   focusRegion: FocusRegion | null
-): T[] {
+): [filtered: T[], filteredBeforeCount: number, filteredAfterCount: number] {
   if (!focusRegion) {
-    return sortedPoints;
+    return [sortedPoints, 0, 0];
   }
 
   const { begin: beginPoint, end: endPoint } = rangeForFocusRegion(focusRegion);
@@ -312,7 +305,11 @@ export function filterToFocusRegion<T extends TimeStampedPoint>(
   const beginIndex = sortedIndexBy(sortedPoints, beginPoint, ({ point }) => BigInt(point));
   const endIndex = sortedLastIndexBy(sortedPoints, endPoint, ({ point }) => BigInt(point));
 
-  return sortedPoints.slice(beginIndex, endIndex);
+  const filteredBeforeCount = beginIndex;
+  const filteredAfterCount = sortedPoints.length - endIndex;
+  const filtered = sortedPoints.slice(beginIndex, endIndex);
+
+  return [filtered, filteredBeforeCount, filteredAfterCount];
 }
 
 function assertSorted(a: TimeStampedPoint[]) {


### PR DESCRIPTION
This is what I propose:
* We continue filtering/hiding Network requests based _only_ on whether they are inside of outside of the user's _focus region_.
* We continue to _dim_ Network requests that are outside of the _loaded region_ (since you can't inspect them or interact with them quite as fully).
  * Side note: We may want to update our visual styling here so it stands out more from how we render Network requests that are _after the current execution point_. (We also dim those.)
* We add an explicit header footer with the number of requests filtered before/after.

https://user-images.githubusercontent.com/29597/199289378-4161f91c-eb7b-4657-a068-46cd9f4ff62e.mp4

Demo walk through:
https://www.loom.com/share/05322d15d2964f2ebec130f880f19513