### PR TITLE
Ensure breakable positions are always sorted by line

### DIFF
--- a/packages/bvaughn-architecture-demo/src/suspense/SourcesCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/SourcesCache.ts
@@ -215,7 +215,7 @@ export const {
     const breakablePositions = await client.getBreakpointPositions(sourceId, null);
 
     const breakablePositionsByLine = new Map<number, ProtocolSameLineSourceLocations>();
-    // The positions are already sorted by line number on the backend
+    // The positions are already sorted by line number in `ReplayClient.getBreakpointPositions`
     for (let position of breakablePositions) {
       // TODO BAC-2329
       // The backend sometimes returns duplicate columns per line;

--- a/packages/shared/client/ReplayClient.ts
+++ b/packages/shared/client/ReplayClient.ts
@@ -636,6 +636,9 @@ export class ReplayClient implements ReplayClientInterface {
       })
     );
 
+    // Ensure breakpoint positions are sorted by line ascending
+    lineLocations!.sort((a, b) => a.line - b.line);
+
     return lineLocations!;
   }
 


### PR DESCRIPTION
Turns out that breakable positions were _not_, in fact, already sorted on the backend.

This causes binary search for values to return wonky results, causing a partial set of line locations to be sent to the backend when requesting hit counts, causing different requests for the same 100-line chunk to return different results, causing the hit counts for a given line to flip back and forth depending on what chunk you're looking at.