### PR TITLE
Enforce that network requests are sorted

### DIFF
--- a/packages/protocol/thread/thread.ts
+++ b/packages/protocol/thread/thread.ts
@@ -702,7 +702,7 @@ class _ThreadFront {
     client.Network.addRequestsListener(onRequestsReceived);
     client.Network.addResponseBodyDataListener(onResponseBodyData);
     client.Network.addRequestBodyDataListener(onRequestBodyData);
-    client.Network.findRequests({}, sessionId);
+    await client.Network.findRequests({}, sessionId);
   }
 
   getFrameSteps(pauseId: PauseId, frameId: FrameId) {

--- a/src/ui/reducers/network.ts
+++ b/src/ui/reducers/network.ts
@@ -41,6 +41,7 @@ const update = (state: NetworkState = initialState(), action: NetworkAction): Ne
       return {
         ...state,
         loading: false,
+        requests: sortBy(state.requests, request => BigInt(request.point)),
       };
     case "NEW_NETWORK_REQUESTS":
       return {


### PR DESCRIPTION
Fixes FE-871

This was another example where the frontend assumed it received sorted points. In this case, i'm not sure how safe it is to assume because the events could come back in any order.