### PR TITLE
Fix unexpected sources opening while clicking viewer timeline

### DIFF
--- a/src/devtools/client/debugger/src/client/index.ts
+++ b/src/devtools/client/debugger/src/client/index.ts
@@ -29,8 +29,18 @@ export function bootstrap(_store: UIStore, ThreadFront: typeof TF) {
 
   ThreadFront.on(
     "paused",
-    ({ point, time, frame }: { point: string; hasFrames: boolean; time: number; frame: Frame }) => {
-      store.dispatch(paused({ executionPoint: point, time, frame }));
+    ({
+      point,
+      time,
+      frame,
+      hasFrames,
+    }: {
+      point: string;
+      hasFrames: boolean;
+      time: number;
+      frame: Frame;
+    }) => {
+      store.dispatch(paused({ executionPoint: point, time, frame, hasFrames }));
     }
   );
   ThreadFront.on("resumed", () => store.dispatch(resumed()));


### PR DESCRIPTION
Prior to [#7933 ("remove frames from Redux")](https://github.com/replayio/devtools/pull/7933), `ThreadFront` used a passed-through `hasFrames` flag to usually bail out early and not actually fetch frames as users clicked on the viewer timeline.

The newer logic to actually fetch frames via a Suspense cache correctly tried to reimplement the "fetch frames for the point, see if we got any, select the first if there is one" behavior, but missed that there was that early bailout.

This led to clicks on the viewer timeline incorrectly popping open sources any time the point had a frame.

The fix is to pass that flag through to the `paused` thunk and bail out before we mark a frame as selected.  (I've left the "fetch the frames" step in there, because we're paused anyway - might as well fetch them now if they really do exist.)