### PR TITLE
Fix FocusRegion persistence (FE-868)

### DIFF
--- a/src/ui/components/Timeline/FocusModePopout.tsx
+++ b/src/ui/components/Timeline/FocusModePopout.tsx
@@ -1,8 +1,12 @@
 import React, { useEffect } from "react";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
-import { exitFocusMode, setFocusRegion, syncFocusedRegion } from "ui/actions/timeline";
+import {
+  exitFocusMode,
+  setFocusRegion,
+  syncFocusedRegion,
+  updateFocusRegionParam,
+} from "ui/actions/timeline";
 import { getFocusRegionBackup, getShowFocusModeControls } from "ui/reducers/timeline";
-import { UnsafeFocusRegion } from "ui/state/timeline";
 import { trackEvent } from "ui/utils/telemetry";
 
 import { PrimaryButton, SecondaryButton } from "../shared/Button";
@@ -14,7 +18,7 @@ export default function FocusModePopout() {
   const showFocusModeControls = useAppSelector(getShowFocusModeControls);
 
   const dispatch = useAppDispatch();
-  const focusRegionBackup = useAppSelector(getFocusRegionBackup) as UnsafeFocusRegion;
+  const focusRegionBackup = useAppSelector(getFocusRegionBackup);
 
   const hideModal = () => dispatch(exitFocusMode());
 
@@ -32,6 +36,7 @@ export default function FocusModePopout() {
   };
   const savePendingChanges = () => {
     dispatch(syncFocusedRegion());
+    dispatch(updateFocusRegionParam());
     trackEvent("timeline.save_focus");
 
     hideModal();

--- a/src/ui/components/Timeline/Focuser.tsx
+++ b/src/ui/components/Timeline/Focuser.tsx
@@ -3,7 +3,6 @@ import React, { useEffect, useRef } from "react";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { setFocusRegion, setTimelineToTime } from "ui/actions/timeline";
 import { selectors } from "ui/reducers";
-import { UnsafeFocusRegion } from "ui/state/timeline";
 import {
   getPositionFromTime,
   getTimeFromPosition,

--- a/src/ui/components/Timeline/UnloadedRegions.tsx
+++ b/src/ui/components/Timeline/UnloadedRegions.tsx
@@ -5,7 +5,6 @@ import { getLoadedRegions } from "ui/reducers/app";
 import { getFocusRegion, getZoomRegion } from "ui/reducers/timeline";
 import { getVisiblePosition, overlap } from "ui/utils/timeline";
 import { TimeStampedPointRange } from "@replayio/protocol";
-import { UnsafeFocusRegion } from "ui/state/timeline";
 
 export const UnloadedRegions: FC = () => {
   const loadedRegions = useAppSelector(getLoadedRegions);
@@ -29,15 +28,14 @@ export const UnloadedRegions: FC = () => {
   if (focusRegion) {
     // Even though we technically focus on the nearest points,
     // We should only show the user a range defining their specified times.
-    const unsafe = focusRegion as UnsafeFocusRegion;
     const userVisibleTimeStampedPointRange: TimeStampedPointRange = {
       begin: {
-        point: unsafe.begin.point,
-        time: unsafe.beginTime,
+        point: focusRegion.begin.point,
+        time: focusRegion.beginTime,
       },
       end: {
-        point: unsafe.end.point,
-        time: unsafe.endTime,
+        point: focusRegion.end.point,
+        time: focusRegion.endTime,
       },
     };
 

--- a/src/ui/reducers/timeline.ts
+++ b/src/ui/reducers/timeline.ts
@@ -6,7 +6,7 @@ import {
   displayedBeginForFocusRegion,
   mergeSortedPointLists,
 } from "ui/utils/timeline";
-import { FocusRegion, HoveredItem, TimelineState, UnsafeFocusRegion } from "ui/state/timeline";
+import { FocusRegion, HoveredItem, TimelineState } from "ui/state/timeline";
 import sortBy from "lodash/sortBy";
 import { UIThunkAction } from "ui/actions";
 
@@ -94,7 +94,7 @@ export const pointsReceivedThunk = (points: TimeStampedPoint[]): UIThunkAction =
   return (dispatch, getState) => {
     const state = getState() as UIState;
     dispatch(pointsReceived(points));
-    const focusRegion = getFocusRegion(state) as UnsafeFocusRegion | null;
+    const focusRegion = getFocusRegion(state);
     if (!focusRegion) {
       return;
     }

--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -259,7 +259,7 @@ export default async function setupDevtools(store: AppStore, replayClient: Repla
   let points: TimeStampedPoint[] = [];
 
   const onPointsReceived = debounce(() => {
-    store.dispatch(pointsReceivedThunk(points));
+    store.dispatch(pointsReceivedThunk(points.map(({ point, time }) => ({ point, time }))));
     store.dispatch(paintsReceived(points.filter(p => "screenShots" in p)));
     points = [];
   }, 1_000);

--- a/src/ui/state/timeline.ts
+++ b/src/ui/state/timeline.ts
@@ -7,14 +7,6 @@ export interface ZoomRegion {
 }
 
 export interface FocusRegion {
-  // We are moving towards using TimeStampedPoints for all ranges on the client,
-  // to that end, we should avoid using fields directly from this object, and
-  // instead use the getters `displayedBeginForFocusRegion` and
-  // `displayedEndForFocusRegion`. If you must access the fields directly, you can
-  // cast instead to an `UnsafeFocusRegion`
-}
-
-export interface UnsafeFocusRegion {
   end: TimeStampedPoint;
   endTime: number;
   begin: TimeStampedPoint;

--- a/src/ui/utils/environment.ts
+++ b/src/ui/utils/environment.ts
@@ -1,4 +1,5 @@
 import { MockedResponse } from "@apollo/client/testing";
+import { TimeStampedPointRange } from "@replayio/protocol";
 import { Editor } from "codemirror";
 import { injectCustomSocketSendMessageForTesting } from "protocol/socket";
 
@@ -117,7 +118,9 @@ export function getPausePointParams() {
   const hasFrames = hasFramesParam ? hasFramesParam == "true" : false;
 
   const focusRegionParam = url.searchParams.get("focusRegion");
-  const focusRegion = focusRegionParam ? decodeBase64FromURL(focusRegionParam) : null;
+  const focusRegion = focusRegionParam
+    ? (decodeBase64FromURL(focusRegionParam) as TimeStampedPointRange)
+    : null;
 
   if (pointParam && timeParam) {
     return { point, time, hasFrames, focusRegion };
@@ -131,7 +134,7 @@ export function getParams() {
   return { q: url.searchParams.get("q") };
 }
 
-export function updateUrlWithParams(params: Record<string, string>) {
+export function updateUrlWithParams(params: Record<string, string | null | undefined>) {
   const url = new URL(window.location.toString());
 
   Object.entries(params).forEach(([key, value]) => {

--- a/src/ui/utils/timeline.ts
+++ b/src/ui/utils/timeline.ts
@@ -3,7 +3,7 @@ import clamp from "lodash/clamp";
 import sortedIndexBy from "lodash/sortedIndexBy";
 import sortedLastIndexBy from "lodash/sortedLastIndexBy";
 import { assert } from "protocol/utils";
-import { FocusRegion, UnsafeFocusRegion, ZoomRegion } from "ui/state/timeline";
+import { FocusRegion, ZoomRegion } from "ui/state/timeline";
 
 import { timelineMarkerWidth } from "../constants";
 
@@ -26,13 +26,11 @@ export function getPixelDistance({
 }
 
 export function displayedBeginForFocusRegion(focusRegion: FocusRegion) {
-  const unsafe = focusRegion as UnsafeFocusRegion;
-  return unsafe.beginTime;
+  return focusRegion.beginTime;
 }
 
 export function displayedEndForFocusRegion(focusRegion: FocusRegion) {
-  const unsafe = focusRegion as UnsafeFocusRegion;
-  return unsafe.endTime;
+  return focusRegion.endTime;
 }
 
 // Get the position of a time on the visible part of the timeline,
@@ -237,8 +235,7 @@ export function isTimeInRegions(time: number, regions?: TimeStampedPointRange[])
 }
 
 export function rangeForFocusRegion(focusRegion: FocusRegion): TimeStampedPointRange {
-  const unsafe = focusRegion as UnsafeFocusRegion;
-  return { begin: unsafe.begin || { time: 0, point: "0" }, end: unsafe.end };
+  return { begin: focusRegion.begin || { time: 0, point: "0" }, end: focusRegion.end };
 }
 
 export const overlap = (a: TimeStampedPointRange[], b: TimeStampedPointRange[]) => {


### PR DESCRIPTION
Fixes two issues that prevented the focus region from being persisted and reapplied:
- the `focusRegion` URL parameter was not set until the user jumped to a new point - now it is set whenever the focus region changes
- the initialization of the focus region from its URL parameter always created a focus region spanning the entire recording
  (it would still ask the backend to load the correct region, but the new region would be saved to the URL and so after reloading
  devtools it would "focus" on the entire recording)

Some cleanups:
- removed the `UnsafeFocusRegion` type
- most of the `TimeStampedPoint`s stored in `state.timeline.points` had additional properties that would then be copied into the focus region and from there into the URL - now they are cleaned up
