### PR TITLE
Show BreakpointNavigation with loading state instead of hiding it

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.tsx
@@ -184,8 +184,9 @@ function Panel({
             key={breakpoint?.id}
             breakpoint={breakpoint}
             editing={editing}
-            hitPoints={isPending ? null : filteredHitPoints}
-            hitPointStatus={isPending ? null : hitPointStatus}
+            hitPoints={filteredHitPoints}
+            hitPointStatus={hitPointStatus}
+            isTransitionPending={isPending}
             showCondition={showCondition}
             setShowCondition={setShowCondition}
           />

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.css
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.css
@@ -5,6 +5,11 @@
   align-items: center;
 }
 
+.breakpoint-navigation.bp-nav-pending {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
 .breakpoint-navigation.empty .breakpoint-navigation-status-container,
 .breakpoint-navigation.empty .breakpoint-navigation-status {
   width: 100%;

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.tsx
@@ -20,6 +20,7 @@ type ExternalProps = {
   hitPoints: TimeStampedPoint[] | null;
   hitPointStatus: HitPointStatus | null;
   showCondition: boolean;
+  isTransitionPending: boolean;
   setShowCondition: (showCondition: boolean) => void;
 };
 
@@ -40,6 +41,7 @@ function BreakpointNavigation({
   executionPoint,
   hitPoints,
   hitPointStatus,
+  isTransitionPending,
   seek,
   setShowCondition,
   showCondition,
@@ -89,6 +91,7 @@ function BreakpointNavigation({
     <div
       className={classnames("breakpoint-navigation justify-between p-1.5 pr-4 pt-2", {
         empty: isEmpty,
+        "bp-nav-pending": isTransitionPending,
       })}
     >
       <BreakpointNavigationCommands prev={prev} next={next} navigateToPoint={navigateToPoint} />


### PR DESCRIPTION
This PR:

- Changes the print statement panel to keep the `<BreakpointNavigation>` (timeline, controls) visible but disabled when we're in a loading state, instead of hiding it completely

Result:

![image](https://user-images.githubusercontent.com/1128784/199093037-e40de5c9-7dde-4b2c-818f-57ed82202ada.png)
