### PR TITLE
Refetch Apollo user data on demand when console nag is dismissed

### DIFF
--- a/packages/bvaughn-architecture-demo/components/Initializer.tsx
+++ b/packages/bvaughn-architecture-demo/components/Initializer.tsx
@@ -71,6 +71,7 @@ export default function Initializer({
           duration: endpoint.time,
           recordingId: activeRecordingId,
           sessionId,
+          refetchUser: () => {},
         });
       };
 

--- a/packages/bvaughn-architecture-demo/src/contexts/SessionContext.ts
+++ b/packages/bvaughn-architecture-demo/src/contexts/SessionContext.ts
@@ -7,6 +7,7 @@ export type SessionContextType = {
   duration: number;
   recordingId: string;
   sessionId: string;
+  refetchUser: () => void;
 };
 
 export const SessionContext = createContext<SessionContextType>(null as any);

--- a/packages/bvaughn-architecture-demo/src/hooks/useDismissNag.ts
+++ b/packages/bvaughn-architecture-demo/src/hooks/useDismissNag.ts
@@ -6,10 +6,10 @@ import { Nag } from "../graphql/types";
 import { dismissNag } from "../graphql/User";
 
 export function useDismissNag() {
-  const { accessToken, currentUserInfo } = useContext(SessionContext);
+  const { accessToken, currentUserInfo, refetchUser } = useContext(SessionContext);
   const graphQLClient = useContext(GraphQLClientContext);
 
-  return (nag: Nag) => {
+  return async (nag: Nag) => {
     if (!accessToken || !currentUserInfo) {
       return;
     }
@@ -20,6 +20,11 @@ export function useDismissNag() {
       return;
     }
 
-    dismissNag(graphQLClient, accessToken, nag);
+    await dismissNag(graphQLClient, accessToken, nag);
+    // The console uses a simple `fetch`-based GraphQL client.
+    // But, our user data  in the main app is stored via Apollo.
+    // Apollo won't refetch automatically when we made this update,
+    // so run this callback to force Apollo to refetch the user.
+    refetchUser();
   };
 }

--- a/packages/bvaughn-architecture-demo/src/utils/testing.tsx
+++ b/packages/bvaughn-architecture-demo/src/utils/testing.tsx
@@ -38,6 +38,7 @@ export async function render(
     duration: 1000,
     recordingId: "fakeRecordingId",
     sessionId: "fakeSessionId",
+    refetchUser: () => {},
     ...options?.sessionContext,
   };
 

--- a/src/ui/components/SessionContextAdapter.tsx
+++ b/src/ui/components/SessionContextAdapter.tsx
@@ -1,3 +1,4 @@
+import { useApolloClient } from "@apollo/client";
 import {
   SessionContext,
   SessionContextType,
@@ -12,6 +13,7 @@ import { useAppSelector } from "ui/setup/hooks";
 export default function SessionContextAdapter({ children }: { children: ReactNode }) {
   const recordingId = useGetRecordingId();
   const currentUserInfo = useGetUserInfo();
+  const apolloClient = useApolloClient();
 
   const duration = useAppSelector(getRecordingDuration)!;
 
@@ -22,8 +24,15 @@ export default function SessionContextAdapter({ children }: { children: ReactNod
       duration,
       recordingId,
       sessionId: ThreadFront.sessionId!,
+      refetchUser: () => {
+        // Force Apollo to refetch the user data on demand,
+        // such as dismissing a nag from the console.
+        apolloClient.refetchQueries({
+          include: ["GetUser"],
+        });
+      },
     }),
-    [currentUserInfo, duration, recordingId]
+    [currentUserInfo, duration, recordingId, apolloClient]
   );
 
   return <SessionContext.Provider value={sessionContext}>{children}</SessionContext.Provider>;


### PR DESCRIPTION
This PR:

- Forces a refresh of the main app's Apollo client whenever we use the console codebase's version of the `useDismissNag` hook, so that dismissals are immediately reflected in the UI

We keep user data in Apollo in the main app, but the new console uses a lighter-weight `fetch`-based GraphQL approach. We also ended up with two copies of a `useDismissNag` hook in the two sections.  When you call the console's `useDismissNag` method, it would update the backend, but Apollo didn't know the data had been changed.

By passing down a `refetchUser` callback from the main app to the console code and running it after the mutation is done, we force the app to load the updated user, and the nag now goes away immediately.