### PR TITLE
Enable tracking telemetry events in new codebase

### DIFF
--- a/packages/bvaughn-architecture-demo/components/Initializer.tsx
+++ b/packages/bvaughn-architecture-demo/components/Initializer.tsx
@@ -72,6 +72,7 @@ export default function Initializer({
           recordingId: activeRecordingId,
           sessionId,
           refetchUser: () => {},
+          trackEvent: () => {},
         });
       };
 

--- a/packages/bvaughn-architecture-demo/components/sources/HoverButton.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/HoverButton.tsx
@@ -10,6 +10,7 @@ import {
   DeletePoints,
   EditPoint,
 } from "bvaughn-architecture-demo/src/contexts/PointsContext";
+import { SessionContext } from "bvaughn-architecture-demo/src/contexts/SessionContext";
 import { SourcesContext } from "bvaughn-architecture-demo/src/contexts/SourcesContext";
 import { TimelineContext } from "bvaughn-architecture-demo/src/contexts/TimelineContext";
 import { getHitPointsForLocationSuspense } from "bvaughn-architecture-demo/src/suspense/PointsCache";
@@ -49,6 +50,7 @@ export default function HoverButton({
   const client = useContext(ReplayClientContext);
   const { executionPoint, update } = useContext(TimelineContext);
   const { findClosestFunctionName } = useContext(SourcesContext);
+  const { trackEvent } = useContext(SessionContext);
 
   if (isMetaKeyActive) {
     if (lineHitCounts === null) {
@@ -123,8 +125,9 @@ export default function HoverButton({
       if (point) {
         editPoint(point.id, { content, shouldLog: true });
       } else {
-        // TODO The legacy app uses the closest function name for the content (if there is one).
-        // This app doesn't yet have logic for parsing source contents though.
+        // Distinct from "breakpoint.add" apparently
+        trackEvent("breakpoint.plus_click");
+
         addPoint(
           {
             content,
@@ -140,6 +143,7 @@ export default function HoverButton({
         if (!point.shouldLog || point.shouldBreak) {
           editPoint(point.id, { shouldLog: !point.shouldLog });
         } else {
+          trackEvent("breakpoint.minus_click");
           deletePoints(point.id);
         }
       }

--- a/packages/bvaughn-architecture-demo/components/sources/PointPanel.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/PointPanel.tsx
@@ -48,7 +48,7 @@ function PointPanel({ className, point }: { className: string; point: Point }) {
   const { showCommentsPanel } = useContext(InspectorContext);
   const { editPoint } = useContext(PointsContext);
   const client = useContext(ReplayClientContext);
-  const { accessToken, recordingId } = useContext(SessionContext);
+  const { accessToken, recordingId, trackEvent } = useContext(SessionContext);
   const { executionPoint: currentExecutionPoint, time: curentTime } = useContext(TimelineContext);
 
   const [hitPoints, hitPointStatus] = getHitPointsForLocationSuspense(
@@ -89,10 +89,12 @@ function PointPanel({ className, point }: { className: string; point: Point }) {
     };
 
     const onEditableContentChange = (newContent: string) => {
+      trackEvent("breakpoint.set_log");
       setEditableContent(newContent);
     };
 
     const onEditableConditionChange = (newCondition: string) => {
+      trackEvent("breakpoint.set_condition");
       setEditableCondition(newCondition);
     };
 
@@ -202,6 +204,7 @@ function PointPanel({ className, point }: { className: string; point: Point }) {
     }
 
     const startEditing = () => {
+      trackEvent("breakpoint.start_edit");
       setEditableCondition(point.condition || null);
       setEditableContent(point.content);
       setIsEditing(true);
@@ -216,6 +219,7 @@ function PointPanel({ className, point }: { className: string; point: Point }) {
         if (showCommentsPanel !== null) {
           showCommentsPanel();
         }
+        trackEvent("breakpoint.add_comment");
 
         await addCommentGraphQL(graphQLClient, accessToken, recordingId, {
           content: "",

--- a/packages/bvaughn-architecture-demo/components/sources/PointPanelTimeline.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/PointPanelTimeline.tsx
@@ -36,7 +36,7 @@ export default function PointPanelTimeline({
   point: Point;
 }) {
   const client = useContext(ReplayClientContext);
-  const { duration } = useContext(SessionContext);
+  const { duration, trackEvent } = useContext(SessionContext);
   const {
     executionPoint: currentExecutionPoint,
     isPending,
@@ -59,6 +59,16 @@ export default function PointPanelTimeline({
     // It's only meant to be something shown temporarily.
     setOptimisticTime(null);
   }, [currentTime]);
+
+  useEffect(() => {
+    const hasError = hitPointStatus !== "complete";
+
+    if (!hasError && hitPoints !== null) {
+      trackEvent(hitPoints.length > 0 ? "breakpoint.has_hits" : "breakpoint.no_hits", {
+        hits: hitPoints.length,
+      });
+    }
+  }, [hitPoints, hitPointStatus, trackEvent]);
 
   const [currentHitPoint, currentHitPointIndex] = findHitPoint(hitPoints, currentExecutionPoint);
 

--- a/packages/bvaughn-architecture-demo/src/contexts/SessionContext.ts
+++ b/packages/bvaughn-architecture-demo/src/contexts/SessionContext.ts
@@ -9,6 +9,7 @@ export type SessionContextType = {
   recordingId: string;
   sessionId: string;
   refetchUser: () => void;
+  trackEvent: (event: string, ...args: any[]) => void;
 };
 
 export const SessionContext = createContext<SessionContextType>(null as any);

--- a/packages/bvaughn-architecture-demo/src/utils/testing.tsx
+++ b/packages/bvaughn-architecture-demo/src/utils/testing.tsx
@@ -40,6 +40,7 @@ export async function render(
     recordingId: "fakeRecordingId",
     sessionId: "fakeSessionId",
     refetchUser: () => {},
+    trackEvent: () => {},
     ...options?.sessionContext,
   };
 

--- a/src/ui/components/SessionContextAdapter.tsx
+++ b/src/ui/components/SessionContextAdapter.tsx
@@ -10,6 +10,7 @@ import { useGetRecordingId } from "ui/hooks/recordings";
 import { useGetUserInfo } from "ui/hooks/users";
 import { getRecordingDuration } from "ui/reducers/timeline";
 import { useAppSelector } from "ui/setup/hooks";
+import { trackEvent } from "ui/utils/telemetry";
 
 export default function SessionContextAdapter({ children }: { children: ReactNode }) {
   const recordingId = useGetRecordingId();
@@ -32,6 +33,9 @@ export default function SessionContextAdapter({ children }: { children: ReactNod
           include: ["GetUser"],
         });
       },
+      // Convince TS that the function types line up, since the
+      // context version just accepts `string` and not `MixPanelEvent`
+      trackEvent: trackEvent as SessionContextType["trackEvent"],
     }),
     [currentUserInfo, duration, recordingId, apolloClient]
   );


### PR DESCRIPTION
This PR:

- Injects `trackEvent` from the main codebase into the new codebase via `SessionContext`
- Re-adds Mixpanel telemetry events for breakpoints that were lost during the "Points" refactor PR in #7951 