### PR TITLE
Update test Proxy library to support event callbacks

### DIFF
--- a/packages/shared/proxy/createPlayer.ts
+++ b/packages/shared/proxy/createPlayer.ts
@@ -14,8 +14,17 @@ export default function createPlayer<T>(entries: Entry[]): T {
 
         return (...args: any[]) => {
           const logEntry = findMatch(entries, prop, args);
+
           if (logEntry != null) {
-            const { isAsync, result } = logEntry;
+            const { isAsync, paramCalls, result } = logEntry;
+
+            if (paramCalls) {
+              paramCalls.forEach(call => {
+                const callback = args[call[0]];
+                callback(...call[1]);
+              });
+            }
+
             return isAsync ? Promise.resolve(result) : result;
           } else {
             if (isIterator(prop)) {

--- a/packages/shared/proxy/types.ts
+++ b/packages/shared/proxy/types.ts
@@ -1,7 +1,10 @@
+export type ParamCall = [paramIndex: number, params: any];
+
 export type Entry = {
   args: any[] | null;
   isAsync: boolean;
   isGetter: boolean;
+  paramCalls?: ParamCall[];
   prop: string;
   result: any;
   thennable: any | null;


### PR DESCRIPTION
Replay APIs sometimes use the pattern of accepting callback parameters and returning a Promise that can be awaited to signal completion. (The promise itself typically has no meaningful resolution/value.)

This commit updates the client Proxy library (used only for frontend Playwright tests) to support this pattern via manual override.

Split off from https://github.com/replayio/devtools/pull/8023