### PR TITLE
Remove lingering references to @bvaughn

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -32,7 +32,7 @@ module.exports = {
       "@recordreplay/accordion": path.resolve(__dirname, "../packages/accordion/index.tsx"),
       "third-party": path.resolve(__dirname, "../packages/third-party"),
       "packages/third-party": path.resolve(__dirname, "../packages/third-party"),
-      "@bvaughn": path.resolve(__dirname, "../packages/bvaugh-architecture-demo"),
+      "bvaughn-architecture-demo": path.resolve(__dirname, "../packages/bvaughn-architecture-demo"),
     };
 
     config.resolve.modules = [

--- a/packages/bvaughn-architecture-demo/components/sources/StreamingSourceLoadingProgressHeader.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/StreamingSourceLoadingProgressHeader.tsx
@@ -1,8 +1,8 @@
 import { useSyncExternalStore } from "react";
 
-import styles from "./StreamingSourceLoadingProgressHeader.module.css";
+import { StreamingParser } from "bvaughn-architecture-demo/src/suspense/SyntaxParsingCache";
 
-import { StreamingParser } from "@bvaughn/src/suspense/SyntaxParsingCache";
+import styles from "./StreamingSourceLoadingProgressHeader.module.css";
 
 export default function StreamingSourceLoadingProgressHeader({
   streamingParser,

--- a/packages/bvaughn-architecture-demo/tsconfig.json
+++ b/packages/bvaughn-architecture-demo/tsconfig.json
@@ -16,7 +16,6 @@
     "jsx": "preserve",
     "baseUrl": ".",
     "paths": {
-      "@bvaughn/*": ["./*"],
       "design/*": ["../design/*"],
       "protocol/*": ["../protocol/*"],
       "shared/*": ["../shared/*"]

--- a/packages/markerikson-stack-client-prototype/src/features/sourcesTree/SourcesTree.tsx
+++ b/packages/markerikson-stack-client-prototype/src/features/sourcesTree/SourcesTree.tsx
@@ -1,6 +1,8 @@
 import classnames from "classnames";
 import { useMemo } from "react";
 
+import Expandable from "bvaughn-architecture-demo/components/Expandable";
+
 import { useAppDispatch, useAppSelector, useAppStore } from "../../app/hooks";
 import { sourceEntrySelected } from "../sources/selectedSourcesSlice";
 import { getSourceDetails } from "../sources/sourcesCache";
@@ -15,8 +17,6 @@ import styles from "./SourcesTree.module.css";
 import fileIcon from "./images/file-small.svg";
 import folderIcon from "./images/folder.svg";
 import globeIcon from "./images/globe-small.svg";
-
-import Expandable from "@bvaughn/components/Expandable";
 
 interface STIProps {
   node: SourceTreeNode;

--- a/packages/markerikson-stack-client-prototype/tsconfig.json
+++ b/packages/markerikson-stack-client-prototype/tsconfig.json
@@ -17,7 +17,7 @@
     "downlevelIteration": true,
     "baseUrl": ".",
     "paths": {
-      "@bvaughn/*": ["../bvaughn-architecture-demo/*"]
+      "bvaughn-architecture-demo/*": ["../bvaughn-architecture-demo/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "../bvaughn-architecture-demo/**/*.ts*"],

--- a/src/ui/suspense/frameCache.ts
+++ b/src/ui/suspense/frameCache.ts
@@ -8,7 +8,6 @@ import { createFrame } from "devtools/client/debugger/src/client/create";
 import { PauseAndFrameId } from "devtools/client/debugger/src/reducers/pause";
 import { formatCallStackFrames } from "devtools/client/debugger/src/selectors/getCallStackFrames";
 import { Pause } from "protocol/thread/pause";
-import { ThreadFront } from "protocol/thread/thread";
 import { assert } from "protocol/utils";
 import { SourcesState } from "ui/reducers/sources";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -51,7 +51,7 @@
         "src/devtools/client/shared/vendor/*",
         "node_modules/*"
       ],
-      "@bvaughn/*": ["packages/bvaughn-architecture-demo/*"],
+      "bvaughn-architecture-demo": ["packages/bvaughn-architecture-demo/*"],
       "@recordreplay/accordion": ["packages/accordion/index.tsx"],
       "components": ["packages/design/index.ts"],
       "components/*": ["packages/design/*"],


### PR DESCRIPTION
- [x] Deleted some references to `@bvaughn` in TS config files. These caused Code to auto-import using the `@bvaughn` prefix, which breaks import sorting.
- [x] Fixed typo in Storybook config file.
- [x] Updated couple of import statements that had slipped in with the `@bvaughn` prefix.