### PR TITLE
New Source viewer shows selected frame id

### DIFF
--- a/packages/bvaughn-architecture-demo/components/sources/CurrentLineHighlight.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/CurrentLineHighlight.tsx
@@ -1,14 +1,12 @@
 import { SourceId } from "@replayio/protocol";
 import { Suspense, useContext } from "react";
 
-import useCurrentPause from "bvaughn-architecture-demo/src/hooks/useCurrentPause";
+import { getPauseDataSuspense } from "bvaughn-architecture-demo/src/suspense/PauseCache";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
 import { SelectedFrameContext } from "../../src/contexts/SelectedFrameContext";
 import { SourceSearchContext } from "./SourceSearchContext";
 import styles from "./CurrentLineHighlight.module.css";
-
-import { getPauseDataSuspense } from "@bvaughn/src/suspense/PauseCache";
 
 type Props = {
   lineNumber: number;

--- a/packages/bvaughn-architecture-demo/components/sources/CurrentLineHighlight.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/CurrentLineHighlight.tsx
@@ -2,9 +2,13 @@ import { SourceId } from "@replayio/protocol";
 import { Suspense, useContext } from "react";
 
 import useCurrentPause from "bvaughn-architecture-demo/src/hooks/useCurrentPause";
+import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
+import { SelectedFrameContext } from "../../src/contexts/SelectedFrameContext";
 import { SourceSearchContext } from "./SourceSearchContext";
 import styles from "./CurrentLineHighlight.module.css";
+
+import { getPauseDataSuspense } from "@bvaughn/src/suspense/PauseCache";
 
 type Props = {
   lineNumber: number;
@@ -19,26 +23,30 @@ export default function CurrentLineHighlight(props: Props) {
   );
 }
 function CurrentLineHighlightSuspends({ lineNumber, sourceId }: Props) {
+  const client = useContext(ReplayClientContext);
   const [sourceSearchState] = useContext(SourceSearchContext);
 
-  const pauseData = useCurrentPause();
-  if (pauseData !== null && pauseData.data && pauseData.data.frames) {
-    // TODO [source viewer]
-    // Top frame is not necessarily the selected frame.
-    // Look at Holger's new SelectedFrameContext (PR 7987)
-    const topFrame = pauseData.data.frames[0];
-    if (topFrame) {
-      if (
-        topFrame.location.find(
-          location => location.line === lineNumber && location.sourceId === sourceId
-        )
-      ) {
-        return (
-          <div
-            className={styles.CurrentExecutionPoint}
-            data-test-name="CurrentExecutionPointLineHighlight"
-          />
-        );
+  const { selectedPauseAndFrameId } = useContext(SelectedFrameContext);
+  const frameId = selectedPauseAndFrameId?.frameId || null;
+  const pauseId = selectedPauseAndFrameId?.pauseId || null;
+
+  if (pauseId !== null && frameId !== null) {
+    const pauseData = getPauseDataSuspense(client, pauseId);
+    if (pauseData !== null && pauseData.frames) {
+      const selectedFrame = pauseData.frames.find(frame => frame.frameId === frameId);
+      if (selectedFrame) {
+        if (
+          selectedFrame.location.find(
+            location => location.line === lineNumber && location.sourceId === sourceId
+          )
+        ) {
+          return (
+            <div
+              className={styles.CurrentExecutionPoint}
+              data-test-name="CurrentExecutionPointLineHighlight"
+            />
+          );
+        }
       }
     }
   }

--- a/packages/bvaughn-architecture-demo/src/contexts/SelectedFrameContext.tsx
+++ b/packages/bvaughn-architecture-demo/src/contexts/SelectedFrameContext.tsx
@@ -1,6 +1,7 @@
 import { FrameId, PauseId } from "@replayio/protocol";
 import isEqual from "lodash/isEqual";
 import {
+  ComponentType,
   Dispatch,
   PropsWithChildren,
   SetStateAction,
@@ -34,12 +35,20 @@ export const SelectedFrameContext = createContext<SelectedFrameContextType>({
   setSelectedPauseAndFrameId: () => {},
 });
 
-export function SelectedFrameContextRoot({ children }: PropsWithChildren<{}>) {
+export function SelectedFrameContextRoot({
+  children,
+  SelectedFrameContextAdapter = DefaultSelectedFrameContextAdapter,
+}: PropsWithChildren & {
+  SelectedFrameContextAdapter?: ComponentType;
+}) {
   const [selectedPauseAndFrameId, setSelectedPauseAndFrameId] = useState<PauseAndFrameId | null>(
     null
   );
   const context = useMemo(
-    () => ({ selectedPauseAndFrameId, setSelectedPauseAndFrameId }),
+    () => ({
+      selectedPauseAndFrameId,
+      setSelectedPauseAndFrameId,
+    }),
     [selectedPauseAndFrameId, setSelectedPauseAndFrameId]
   );
 
@@ -53,7 +62,7 @@ export function SelectedFrameContextRoot({ children }: PropsWithChildren<{}>) {
   );
 }
 
-function SelectedFrameContextAdapter() {
+function DefaultSelectedFrameContextAdapter() {
   const client = useContext(ReplayClientContext);
   const loadedRegions = useLoadedRegions(client);
   const { executionPoint } = useContext(TimelineContext);

--- a/packages/bvaughn-architecture-demo/src/contexts/SelectedFrameContext.tsx
+++ b/packages/bvaughn-architecture-demo/src/contexts/SelectedFrameContext.tsx
@@ -86,6 +86,8 @@ function DefaultSelectedFrameContextAdapter() {
         return;
       }
 
+      // TODO
+      // Select the top frame by default because the test harness doesn't have a Call Stack UI yet.
       const pauseId = pause.pauseId;
       const frameId = pause.stack?.[0] ?? null;
 

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -35,6 +35,7 @@ import KeyboardShortcuts from "./KeyboardShortcuts";
 import { KeyModifiers } from "./KeyModifiers";
 import { ReduxAnnotationsProvider } from "./SecondaryToolbox/redux-devtools/ReduxAnnotationsProvider";
 import TimelineContextAdapter from "./SecondaryToolbox/TimelineContextAdapter";
+import SelectedFrameContextAdapter from "./SelectedFrameContextAdapter";
 import SessionContextAdapter from "./SessionContextAdapter";
 import LoadingScreen from "./shared/LoadingScreen";
 import ReplayLogo from "./shared/ReplayLogo";
@@ -207,7 +208,7 @@ function _DevTools({
         <FocusContextReduxAdapter>
           <PointsContextRoot>
             <TimelineContextAdapter>
-              <SelectedFrameContextRoot>
+              <SelectedFrameContextRoot SelectedFrameContextAdapter={SelectedFrameContextAdapter}>
                 <TerminalContextAdapter>
                   <InspectorContextReduxAdapter>
                     <KeyModifiers>

--- a/src/ui/components/SelectedFrameContextAdapter.tsx
+++ b/src/ui/components/SelectedFrameContextAdapter.tsx
@@ -1,0 +1,18 @@
+import isEqual from "lodash/isEqual";
+import { useContext } from "react";
+
+import { SelectedFrameContext } from "bvaughn-architecture-demo/src/contexts/SelectedFrameContext";
+import { getSelectedFrameId } from "devtools/client/debugger/src/selectors";
+import { useAppSelector } from "ui/setup/hooks";
+
+export default function SelectedFrameContextAdapter() {
+  const selectedPauseAndFrameIdRedux = useAppSelector(getSelectedFrameId);
+  const { selectedPauseAndFrameId, setSelectedPauseAndFrameId } = useContext(SelectedFrameContext);
+
+  // We create a new pause-and-frame-id wrapper object each time we update,
+  // so use deep comparison to avoid scheduling unnecessary/no-op state updates.
+  if (!isEqual(selectedPauseAndFrameId, selectedPauseAndFrameIdRedux)) {
+    setSelectedPauseAndFrameId(selectedPauseAndFrameIdRedux);
+  }
+  return null;
+}

--- a/src/ui/components/SelectedFrameContextAdapter.tsx
+++ b/src/ui/components/SelectedFrameContextAdapter.tsx
@@ -1,5 +1,5 @@
 import isEqual from "lodash/isEqual";
-import { useContext } from "react";
+import { useContext, useEffect } from "react";
 
 import { SelectedFrameContext } from "bvaughn-architecture-demo/src/contexts/SelectedFrameContext";
 import { getSelectedFrameId } from "devtools/client/debugger/src/selectors";
@@ -9,10 +9,13 @@ export default function SelectedFrameContextAdapter() {
   const selectedPauseAndFrameIdRedux = useAppSelector(getSelectedFrameId);
   const { selectedPauseAndFrameId, setSelectedPauseAndFrameId } = useContext(SelectedFrameContext);
 
-  // We create a new pause-and-frame-id wrapper object each time we update,
-  // so use deep comparison to avoid scheduling unnecessary/no-op state updates.
-  if (!isEqual(selectedPauseAndFrameId, selectedPauseAndFrameIdRedux)) {
-    setSelectedPauseAndFrameId(selectedPauseAndFrameIdRedux);
-  }
+  useEffect(() => {
+    // We create a new pause-and-frame-id wrapper object each time we update,
+    // so use deep comparison to avoid scheduling unnecessary/no-op state updates.
+    if (!isEqual(selectedPauseAndFrameId, selectedPauseAndFrameIdRedux)) {
+      setSelectedPauseAndFrameId(selectedPauseAndFrameIdRedux);
+    }
+  }, [selectedPauseAndFrameId, selectedPauseAndFrameIdRedux, setSelectedPauseAndFrameId]);
+
   return null;
 }


### PR DESCRIPTION
- [x] Change `CurrentLineHighlight` to use `SelectedFrameContext` so we highlight the _selected frame_. (It was previously highlighting the top frame only.)
- [x] Fixes a regression in the `SelectedFrameContextAdapter` component.