### PR TITLE
Fix framework icon color

### DIFF
--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/Frames.css
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/Frames.css
@@ -54,7 +54,6 @@
 
 :root.theme-dark .frames .location {
   color: var(--body-color);
-  opacity: 0.6;
 }
 
 .frames .title {
@@ -126,6 +125,18 @@
 .frames .img.annotation-logo {
   margin-inline-end: 4px;
   background-color: var(--theme-tab-toolbar-background);
+}
+
+/* Frameworks */
+:root.theme-dark .frames .img.annotation-logo:not(.angular) {
+  background-color: var(--blue-30);
+}
+:root.theme-light .frames .img.annotation-logo:not(.angular) {
+  background-color: var(--blue-50);
+}
+:root.theme-dark .frames .selected .img.annotation-logo:not(.angular),
+:root.theme-light .frames .selected .img.annotation-logo:not(.angular) {
+  background-color: var(--theme-selection-color);
 }
 
 /*

--- a/src/devtools/client/shared/components/SmartTrace.css
+++ b/src/devtools/client/shared/components/SmartTrace.css
@@ -129,14 +129,6 @@
    * See https://github.com/firefox-devtools/debugger.html/issues/7782.
    */
   display: none;
-  /*
-  background-color:var(--body-color);
-  display: inline-block;
-  width: 12px;
-  height:12px;
-  vertical-align: middle;
-  margin-inline-end:4px;
-  */
 }
 
 .expanded .img.annotation-logo {
@@ -161,6 +153,9 @@
 }
 
 /* Frameworks */
-:root.theme-dark .annotation-logo:not(.angular) {
-  background-color: var(--theme-highlight-blue);
+:root.theme-light .frames .img.annotation-logo:not(.angular) {
+  background-color: var(--blue-50);
+}
+:root.theme-dark .frames .img.annotation-logo:not(.angular) {
+  background-color: var(--blue-30);
 }


### PR DESCRIPTION
I guess this is okay 🤷🏼  The legacy CSS is a mess

| Before  | After |
|:---|:---|
| ![Screen Shot 2022-11-04 at 11 27 40 AM](https://user-images.githubusercontent.com/29597/200013734-0d5279ae-5951-4140-b629-341426b47680.png) | ![Screen Shot 2022-11-04 at 11 22 45 AM](https://user-images.githubusercontent.com/29597/200013327-655fc044-ea89-4312-a1b2-c97012f781e2.png)  |
| ![Screen Shot 2022-11-04 at 11 27 29 AM](https://user-images.githubusercontent.com/29597/200013749-03a9695c-3c20-4392-b7ac-cacac1b94a0c.png) | ![Screen Shot 2022-11-04 at 11 25 12 AM](https://user-images.githubusercontent.com/29597/200013330-05ff0db5-9b5b-44a1-b4af-2063ef8e6989.png)  |

