### PR TITLE
Fix mismatch Pause id in PreviewPopup component

### DIFF
--- a/packages/bvaughn-architecture-demo/components/inspector/SourcePreviewInspector.module.css
+++ b/packages/bvaughn-architecture-demo/components/inspector/SourcePreviewInspector.module.css
@@ -23,6 +23,7 @@
 .FixedSizeInspectorWrapper {
   height: 250px !important;
   width: 400px;
+  overflow-x: hidden;
 }
 
 .Inspector {

--- a/packages/bvaughn-architecture-demo/components/sources/PreviewPopup.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/PreviewPopup.tsx
@@ -1,8 +1,7 @@
-import { createPauseResult as Pause, Value as ProtocolValue } from "@replayio/protocol";
+import { Value as ProtocolValue } from "@replayio/protocol";
 import { RefObject, Suspense, useContext, useEffect, useRef } from "react";
 
 import { SelectedFrameContext } from "bvaughn-architecture-demo/src/contexts/SelectedFrameContext";
-import useCurrentPause from "bvaughn-architecture-demo/src/hooks/useCurrentPause";
 import { evaluateSuspense } from "bvaughn-architecture-demo/src/suspense/PauseCache";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
@@ -14,11 +13,10 @@ type Props = {
   containerRef: RefObject<HTMLElement>;
   dismiss: () => void;
   expression: string;
-  pause: Pause;
   target: HTMLElement;
 };
 
-function SuspendingPreviewPopup({ containerRef, dismiss, expression, pause, target }: Props) {
+function SuspendingPreviewPopup({ containerRef, dismiss, expression, target }: Props) {
   const client = useContext(ReplayClientContext);
 
   const popupRef = useRef<HTMLDivElement>(null);
@@ -56,7 +54,7 @@ function SuspendingPreviewPopup({ containerRef, dismiss, expression, pause, targ
       <Popup containerRef={containerRef} dismiss={dismiss} target={target} showTail={true}>
         <SourcePreviewInspector
           className={styles.Popup}
-          pauseId={pause.pauseId}
+          pauseId={pauseId}
           protocolValue={value}
           ref={popupRef}
         />
@@ -68,14 +66,9 @@ function SuspendingPreviewPopup({ containerRef, dismiss, expression, pause, targ
 }
 
 export default function PreviewPopup(props: Omit<Props, "pause">) {
-  const pause = useCurrentPause();
-  if (pause === null) {
-    return null;
-  }
-
   return (
     <Suspense fallback={null}>
-      <SuspendingPreviewPopup {...props} pause={pause} />
+      <SuspendingPreviewPopup {...props} />
     </Suspense>
   );
 }

--- a/packages/bvaughn-architecture-demo/components/sources/PreviewPopup.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/PreviewPopup.tsx
@@ -16,6 +16,14 @@ type Props = {
   target: HTMLElement;
 };
 
+export default function PreviewPopup(props: Omit<Props, "pause">) {
+  return (
+    <Suspense fallback={null}>
+      <SuspendingPreviewPopup {...props} />
+    </Suspense>
+  );
+}
+
 function SuspendingPreviewPopup({ containerRef, dismiss, expression, target }: Props) {
   const client = useContext(ReplayClientContext);
 
@@ -63,12 +71,4 @@ function SuspendingPreviewPopup({ containerRef, dismiss, expression, target }: P
   } else {
     return null;
   }
-}
-
-export default function PreviewPopup(props: Omit<Props, "pause">) {
-  return (
-    <Suspense fallback={null}>
-      <SuspendingPreviewPopup {...props} />
-    </Suspense>
-  );
 }


### PR DESCRIPTION
This was causing us to fetch hover preview information using one Pause id (the currently selected frame) but then retrieve object previews for hovered values using _a different_ Pause id 😞 I wish this wasn't so complicated.

(See Replay [8cdacfc1-06b1-4252-a684-cb795086681f](https://app.replay.io/recording/8cdacfc1-06b1-4252-a684-cb795086681f)) for a bug repro.)