### PR TITLE
Improve new log point panel type-ahead

### DIFF
--- a/packages/bvaughn-architecture-demo/components/sources/AutoComplete/AutoComplete.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/AutoComplete/AutoComplete.tsx
@@ -1,6 +1,7 @@
 import { ChangeEvent, KeyboardEvent, Suspense, useRef, useState } from "react";
 
 import getExpressionFromString from "../utils/getExpressionFromString";
+import updateStringWithExpression from "../utils/updateStringWithExpression";
 import AutoCompleteList from "./AutoCompleteList";
 import styles from "./AutoComplete.module.css";
 
@@ -33,14 +34,9 @@ export default function AutoComplete({
       onChangeProp(newValue);
     }
 
-    const cursorIndex = input.selectionStart;
-    const shouldAutoComplete =
-      cursorIndex === newValue.length &&
-      newValue.length > 0 &&
-      newValue.charAt(newValue.length - 1) !== " ";
-    const expression = shouldAutoComplete
-      ? getExpressionFromString(newValue, cursorIndex - 1)
-      : null;
+    const cursorIndex = input.selectionStart || value.length;
+    const shouldAutoComplete = newValue.length > 0 && newValue.charAt(newValue.length - 1) !== " ";
+    const expression = shouldAutoComplete ? getExpressionFromString(newValue, cursorIndex) : null;
 
     setExpression(expression);
   };
@@ -70,16 +66,8 @@ export default function AutoComplete({
     const input = inputRef.current;
     if (input) {
       const value = input.value;
-      let cursorIndex = input.selectionStart || value.length;
-      while (cursorIndex >= 0) {
-        const character = value.charAt(cursorIndex - 1);
-        if (character === "." || character === " ") {
-          break;
-        }
-        cursorIndex--;
-      }
-
-      const newValue = value.substr(0, cursorIndex) + match;
+      const cursorIndex = input.selectionStart || value.length;
+      const newValue = updateStringWithExpression(value, cursorIndex, match);
 
       onChangeProp(newValue);
 

--- a/packages/bvaughn-architecture-demo/components/sources/AutoComplete/AutoComplete.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/AutoComplete/AutoComplete.tsx
@@ -26,19 +26,38 @@ export default function AutoComplete({
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [expression, setExpression] = useState<string | null>(null);
+  const [cursorIndex, setCursorIndex] = useState<number | null>(null);
+
+  useLayoutEffect(() => {
+    if (cursorIndex !== null) {
+      const input = inputRef.current;
+      if (input) {
+        input.setSelectionRange(cursorIndex, cursorIndex);
+        setCursorIndex(null);
+      }
+    }
+  }, [cursorIndex]);
 
   const onChange = (event: ChangeEvent) => {
     const input = event.currentTarget as HTMLInputElement;
     const newValue = input.value;
     if (newValue !== value) {
       onChangeProp(newValue);
+
+      updateExpression();
     }
+  };
 
-    const cursorIndex = input.selectionStart || value.length;
-    const shouldAutoComplete = newValue.length > 0 && newValue.charAt(newValue.length - 1) !== " ";
-    const expression = shouldAutoComplete ? getExpressionFromString(newValue, cursorIndex) : null;
+  const updateExpression = () => {
+    const input = inputRef.current;
+    if (input) {
+      const value = input.value;
+      const cursorIndex = input.selectionStart || value.length;
+      // const shouldAutoComplete = value.length > 0 && value.charAt(value.length - 1) !== " ";
+      const expression = getExpressionFromString(value, cursorIndex);
 
-    setExpression(expression);
+      setExpression(expression);
+    }
   };
 
   const onKeyDown = (event: KeyboardEvent) => {
@@ -57,6 +76,11 @@ export default function AutoComplete({
         } else {
           onCancelProp();
         }
+        break;
+      }
+      case "ArrowLeft":
+      case "ArrowRight": {
+        updateExpression();
         break;
       }
     }
@@ -78,17 +102,6 @@ export default function AutoComplete({
 
     setExpression(null);
   };
-
-  const [cursorIndex, setCursorIndex] = useState<number | null>(null);
-  useLayoutEffect(() => {
-    if (cursorIndex !== null) {
-      const input = inputRef.current;
-      if (input) {
-        input.setSelectionRange(cursorIndex, cursorIndex);
-        setCursorIndex(null);
-      }
-    }
-  }, [cursorIndex]);
 
   return (
     <>

--- a/packages/bvaughn-architecture-demo/components/sources/AutoComplete/AutoComplete.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/AutoComplete/AutoComplete.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, KeyboardEvent, Suspense, useRef, useState } from "react";
+import { ChangeEvent, KeyboardEvent, Suspense, useLayoutEffect, useRef, useState } from "react";
 
 import getExpressionFromString from "../utils/getExpressionFromString";
 import updateStringWithExpression from "../utils/updateStringWithExpression";
@@ -67,15 +67,28 @@ export default function AutoComplete({
     if (input) {
       const value = input.value;
       const cursorIndex = input.selectionStart || value.length;
-      const newValue = updateStringWithExpression(value, cursorIndex, match);
+      const [newValue, newCursorIndex] = updateStringWithExpression(value, cursorIndex, match);
 
       onChangeProp(newValue);
+
+      setCursorIndex(newCursorIndex);
 
       input.focus();
     }
 
     setExpression(null);
   };
+
+  const [cursorIndex, setCursorIndex] = useState<number | null>(null);
+  useLayoutEffect(() => {
+    if (cursorIndex !== null) {
+      const input = inputRef.current;
+      if (input) {
+        input.setSelectionRange(cursorIndex, cursorIndex);
+        setCursorIndex(null);
+      }
+    }
+  }, [cursorIndex]);
 
   return (
     <>

--- a/packages/bvaughn-architecture-demo/components/sources/AutoComplete/AutoComplete.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/AutoComplete/AutoComplete.tsx
@@ -53,7 +53,6 @@ export default function AutoComplete({
     if (input) {
       const value = input.value;
       const cursorIndex = input.selectionStart || value.length;
-      // const shouldAutoComplete = value.length > 0 && value.charAt(value.length - 1) !== " ";
       const expression = getExpressionFromString(value, cursorIndex);
 
       setExpression(expression);

--- a/packages/bvaughn-architecture-demo/components/sources/AutoComplete/AutoCompleteList.module.css
+++ b/packages/bvaughn-architecture-demo/components/sources/AutoComplete/AutoCompleteList.module.css
@@ -1,6 +1,7 @@
 .List {
   border-radius: 0.25em;
   background-color: var(--background-color-default);
+  color: var(--color-default);
   border: 1px solid var(--border-color);
 
   font-family: var(--font-family-monospace);

--- a/packages/bvaughn-architecture-demo/components/sources/utils/getExpressionFromString.test.ts
+++ b/packages/bvaughn-architecture-demo/components/sources/utils/getExpressionFromString.test.ts
@@ -118,4 +118,17 @@ describe("getExpressionFromString", () => {
     expect(getExpressionHelper("`foo ${bar.ba|z")).toBe("bar.baz");
     expect(getExpressionHelper("`foo ${bar.baz|")).toBe("bar.baz");
   });
+
+  it("should return expressions that are in the middle of a larger string", () => {
+    expect(getExpressionHelper("foo, |bar, baz")).toBe("bar");
+    expect(getExpressionHelper("foo, b|ar, baz")).toBe("bar");
+    expect(getExpressionHelper("foo, ba|r, baz")).toBe("bar");
+    expect(getExpressionHelper("foo, bar|, baz")).toBe("bar");
+
+    expect(getExpressionHelper("foo, bar.|prop, baz")).toBe("bar.prop");
+    expect(getExpressionHelper("foo, bar.p|rop, baz")).toBe("bar.prop");
+    expect(getExpressionHelper("foo, bar.pr|op, baz")).toBe("bar.prop");
+    expect(getExpressionHelper("foo, bar.pro|p, baz")).toBe("bar.prop");
+    expect(getExpressionHelper("foo, bar.prop|, baz")).toBe("bar.prop");
+  });
 });

--- a/packages/bvaughn-architecture-demo/components/sources/utils/getExpressionFromString.test.ts
+++ b/packages/bvaughn-architecture-demo/components/sources/utils/getExpressionFromString.test.ts
@@ -1,0 +1,121 @@
+import getExpressionFromString from "./getExpressionFromString";
+
+// Converts a string like: "foo |bar"
+// Into the string "foo bar" and the cursor index 4
+function getExpressionHelper(expression: string): string | null {
+  let text = expression;
+  let cursorIndex = expression.length;
+
+  for (let index = 0; index < expression.length; index++) {
+    const character = expression.charAt(index);
+    if (character === "|") {
+      cursorIndex = index;
+
+      text = expression.substring(0, index) + expression.substring(index + 1);
+      break;
+    }
+  }
+
+  return getExpressionFromString(text, cursorIndex);
+}
+
+describe("getExpressionFromString", () => {
+  it("should handle empty or all-whitespace strings", () => {
+    expect(getExpressionHelper("|")).toBe(null);
+    expect(getExpressionHelper(" |")).toBe(null);
+    expect(getExpressionHelper(" | ")).toBe(null);
+  });
+
+  it("should not try to auto-complete empty tokens", () => {
+    expect(getExpressionHelper("foo |")).toBe(null);
+  });
+
+  it("should parse expressions up to the current cursor location", () => {
+    expect(getExpressionHelper("|foo")).toBe("foo");
+    expect(getExpressionHelper("f|oo")).toBe("foo");
+    expect(getExpressionHelper("fo|o")).toBe("foo");
+    expect(getExpressionHelper("foo|")).toBe("foo");
+    expect(getExpressionHelper("foo| ")).toBe("foo");
+  });
+
+  it("should not include previous tokens", () => {
+    expect(getExpressionHelper("foo |bar")).toBe("bar");
+    expect(getExpressionHelper("foo b|ar")).toBe("bar");
+    expect(getExpressionHelper("foo ba|r")).toBe("bar");
+    expect(getExpressionHelper("foo bar|")).toBe("bar");
+    expect(getExpressionHelper("foo bar| ")).toBe("bar");
+  });
+
+  it("should include tokens joined by periods", () => {
+    expect(getExpressionHelper("foo bar.|baz")).toBe("bar.baz");
+    expect(getExpressionHelper("foo bar.b|az")).toBe("bar.baz");
+    expect(getExpressionHelper("foo bar.ba|z")).toBe("bar.baz");
+    expect(getExpressionHelper("foo bar.baz|")).toBe("bar.baz");
+    expect(getExpressionHelper("foo bar.baz| ")).toBe("bar.baz");
+  });
+
+  it("should not consider booleans auto-completeable expressions", () => {
+    expect(getExpressionHelper("|true")).toBe(null);
+    expect(getExpressionHelper("t|rue")).toBe(null);
+    expect(getExpressionHelper("tr|ue")).toBe(null);
+    expect(getExpressionHelper("tru|e")).toBe(null);
+    expect(getExpressionHelper("true|")).toBe(null);
+    expect(getExpressionHelper("true| ")).toBe(null);
+
+    expect(getExpressionHelper("|false")).toBe(null);
+    expect(getExpressionHelper("f|alse")).toBe(null);
+    expect(getExpressionHelper("fa|lse")).toBe(null);
+    expect(getExpressionHelper("fal|se")).toBe(null);
+    expect(getExpressionHelper("fals|e")).toBe(null);
+    expect(getExpressionHelper("false|")).toBe(null);
+    expect(getExpressionHelper("false| ")).toBe(null);
+  });
+
+  it("should not consider numbers auto-completeable expressions", () => {
+    expect(getExpressionHelper("|12")).toBe(null);
+    expect(getExpressionHelper("1|2")).toBe(null);
+    expect(getExpressionHelper("12|")).toBe(null);
+    expect(getExpressionHelper("1.|12")).toBe(null);
+    expect(getExpressionHelper("1.1|2")).toBe(null);
+    expect(getExpressionHelper("1.12|")).toBe(null);
+  });
+
+  it("should not return expressions that are part of a string", () => {
+    expect(getExpressionHelper('"|foo')).toBe(null);
+    expect(getExpressionHelper('"f|oo')).toBe(null);
+    expect(getExpressionHelper('"fo|o')).toBe(null);
+    expect(getExpressionHelper('"foo|')).toBe(null);
+    expect(getExpressionHelper('"foo| ')).toBe(null);
+
+    expect(getExpressionHelper('"foo |bar')).toBe(null);
+    expect(getExpressionHelper('"foo b|ar')).toBe(null);
+    expect(getExpressionHelper('"foo ba|r')).toBe(null);
+    expect(getExpressionHelper('"foo bar|')).toBe(null);
+    expect(getExpressionHelper('"foo bar| ')).toBe(null);
+
+    expect(getExpressionHelper("'|foo")).toBe(null);
+    expect(getExpressionHelper("'f|oo")).toBe(null);
+    expect(getExpressionHelper("'fo|o")).toBe(null);
+    expect(getExpressionHelper("'foo|")).toBe(null);
+    expect(getExpressionHelper("'foo| ")).toBe(null);
+
+    expect(getExpressionHelper("'foo |bar")).toBe(null);
+    expect(getExpressionHelper("'foo b|ar")).toBe(null);
+    expect(getExpressionHelper("'foo ba|r")).toBe(null);
+    expect(getExpressionHelper("'foo bar|")).toBe(null);
+    expect(getExpressionHelper("'foo bar| ")).toBe(null);
+  });
+
+  it("should return expressions that are inside of a template string variable", () => {
+    expect(getExpressionHelper("`foo ${|bar")).toBe("bar");
+    expect(getExpressionHelper("`foo ${b|ar")).toBe("bar");
+    expect(getExpressionHelper("`foo ${ba|r")).toBe("bar");
+    expect(getExpressionHelper("`foo ${bar|")).toBe("bar");
+    expect(getExpressionHelper("`foo ${bar|")).toBe("bar");
+
+    expect(getExpressionHelper("`foo ${bar.|baz")).toBe("bar.baz");
+    expect(getExpressionHelper("`foo ${bar.b|az")).toBe("bar.baz");
+    expect(getExpressionHelper("`foo ${bar.ba|z")).toBe("bar.baz");
+    expect(getExpressionHelper("`foo ${bar.baz|")).toBe("bar.baz");
+  });
+});

--- a/packages/bvaughn-architecture-demo/components/sources/utils/getExpressionFromString.test.ts
+++ b/packages/bvaughn-architecture-demo/components/sources/utils/getExpressionFromString.test.ts
@@ -143,4 +143,14 @@ describe("getExpressionFromString", () => {
     expect(getExpressionHelper('`URL: "${window.lo|c}"')).toBe("window.loc");
     expect(getExpressionHelper('`URL: "${window.loc|}"')).toBe("window.loc");
   });
+
+  it("should not consider property tokens to the right of the cursor as part of an expression", () => {
+    expect(getExpressionHelper('`URL: "${|window.loc}"')).toBe("window");
+    expect(getExpressionHelper('`URL: "${w|indow.loc}"')).toBe("window");
+    expect(getExpressionHelper('`URL: "${wi|ndow.loc}"')).toBe("window");
+    expect(getExpressionHelper('`URL: "${win|dow.loc}"')).toBe("window");
+    expect(getExpressionHelper('`URL: "${wind|ow.loc}"')).toBe("window");
+    expect(getExpressionHelper('`URL: "${windo|w.loc}"')).toBe("window");
+    expect(getExpressionHelper('`URL: "${window|.loc}"')).toBe("window");
+  });
 });

--- a/packages/bvaughn-architecture-demo/components/sources/utils/getExpressionFromString.test.ts
+++ b/packages/bvaughn-architecture-demo/components/sources/utils/getExpressionFromString.test.ts
@@ -131,4 +131,16 @@ describe("getExpressionFromString", () => {
     expect(getExpressionHelper("foo, bar.pro|p, baz")).toBe("bar.prop");
     expect(getExpressionHelper("foo, bar.prop|, baz")).toBe("bar.prop");
   });
+
+  it("should return expressions that are in the middle of a template string", () => {
+    expect(getExpressionHelper('`URL: "${|win}"')).toBe("win");
+    expect(getExpressionHelper('`URL: "${w|in}"')).toBe("win");
+    expect(getExpressionHelper('`URL: "${wi|n}"')).toBe("win");
+    expect(getExpressionHelper('`URL: "${win|}"')).toBe("win");
+
+    expect(getExpressionHelper('`URL: "${window.|loc}"')).toBe("window.loc");
+    expect(getExpressionHelper('`URL: "${window.l|oc}"')).toBe("window.loc");
+    expect(getExpressionHelper('`URL: "${window.lo|c}"')).toBe("window.loc");
+    expect(getExpressionHelper('`URL: "${window.loc|}"')).toBe("window.loc");
+  });
 });

--- a/packages/bvaughn-architecture-demo/components/sources/utils/getExpressionFromString.ts
+++ b/packages/bvaughn-architecture-demo/components/sources/utils/getExpressionFromString.ts
@@ -1,37 +1,55 @@
+import { highlighter } from "bvaughn-architecture-demo/src/suspense/SyntaxParsingCache";
+
 export default function getExpressionFromString(
-  string: string,
-  characterIndex: number
+  expression: string,
+  cursorIndex: number
 ): string | null {
-  let expression = "";
-  let currentIndex = characterIndex;
+  const parsed = highlighter(expression, ".js");
+  if (parsed == null || parsed.length === 0) {
+    return null;
+  } else {
+    const line = parsed[parsed.length - 1];
+
+    const element = document.createElement("div");
+    element.innerHTML = line;
+
+    const lastChild = element.children[element.children.length - 1];
+    switch (lastChild.className) {
+      case "tok-bool":
+        // Don't try to auto-complete booleans.
+        return null;
+      case "tok-number":
+        // Don't try to auto-complete numbers.
+        return null;
+      case "tok-string":
+      case "tok-string2":
+        // Don't try to auto-complete strings.
+        return null;
+    }
+  }
+
+  let token = "";
+  let currentIndex = cursorIndex - 1;
   while (currentIndex >= 0) {
-    const character = string.charAt(currentIndex);
-    if (character === " ") {
+    const character = expression.charAt(currentIndex);
+    if (character === " " || character === "{") {
       break;
     }
 
-    expression = character + expression;
+    token = character + token;
     currentIndex--;
   }
 
-  // Do some basic validation to make sure the expression is valid
+  currentIndex = cursorIndex;
+  while (currentIndex < expression.length) {
+    const character = expression.charAt(currentIndex);
+    if (character === " " || character === "}") {
+      break;
+    }
 
-  // Don't try to auto-complete numbers.
-  if (`${parseFloat(expression)}` === expression) {
-    return null;
+    token += character;
+    currentIndex++;
   }
 
-  // Don't try to auto-complete booleans.
-  if (expression === "true" || expression === "false") {
-    return null;
-  }
-
-  // Don't try to auto-complete strings.
-  switch (expression.charAt(0)) {
-    case '"':
-    case "'":
-      return null;
-  }
-
-  return expression || null;
+  return token || null;
 }

--- a/packages/bvaughn-architecture-demo/components/sources/utils/getExpressionFromString.ts
+++ b/packages/bvaughn-architecture-demo/components/sources/utils/getExpressionFromString.ts
@@ -43,7 +43,7 @@ export default function getExpressionFromString(
   currentIndex = cursorIndex;
   while (currentIndex < expression.length) {
     const character = expression.charAt(currentIndex);
-    if (character === " " || character === "}") {
+    if (character === " " || character === "}" || character === ",") {
       break;
     }
 

--- a/packages/bvaughn-architecture-demo/components/sources/utils/getExpressionFromString.ts
+++ b/packages/bvaughn-architecture-demo/components/sources/utils/getExpressionFromString.ts
@@ -58,7 +58,7 @@ export default function getExpressionFromString(
   currentIndex = cursorIndex;
   while (currentIndex < expression.length) {
     const character = expression.charAt(currentIndex);
-    if (character === " " || character === "}" || character === ",") {
+    if (character === " " || character === "}" || character === "," || character === ".") {
       break;
     }
 

--- a/packages/bvaughn-architecture-demo/components/sources/utils/getExpressionFromString.ts
+++ b/packages/bvaughn-architecture-demo/components/sources/utils/getExpressionFromString.ts
@@ -13,8 +13,23 @@ export default function getExpressionFromString(
     const element = document.createElement("div");
     element.innerHTML = line;
 
-    const lastChild = element.children[element.children.length - 1];
-    switch (lastChild.className) {
+    let childIndex = 0;
+    let textIndex = 0;
+    while (childIndex < element.children.length) {
+      const child = element.children[childIndex];
+      if (child.textContent !== null) {
+        textIndex += child.textContent.length;
+      }
+
+      if (textIndex >= cursorIndex) {
+        break;
+      } else {
+        childIndex++;
+      }
+    }
+
+    const child = element.children[Math.min(childIndex, element.children.length - 1)];
+    switch (child.className) {
       case "tok-bool":
         // Don't try to auto-complete booleans.
         return null;

--- a/packages/bvaughn-architecture-demo/components/sources/utils/updateStringWithExpression.test.ts
+++ b/packages/bvaughn-architecture-demo/components/sources/utils/updateStringWithExpression.test.ts
@@ -2,7 +2,7 @@ import updateStringWithExpression from "./updateStringWithExpression";
 
 // Converts a string like: "foo |bar"
 // Into the string "foo bar" and the cursor index 4
-function getExpressionHelper(text: string, expression: string): string | null {
+function updateExpressionHelper(text: string, expression: string): [string, number] {
   let cursorIndex = text.length;
 
   for (let index = 0; index < text.length; index++) {
@@ -19,43 +19,84 @@ function getExpressionHelper(text: string, expression: string): string | null {
 
 describe("updateStringWithExpression", () => {
   it("should replace the current token with the selected expression", () => {
-    expect(getExpressionHelper("w|in", "window")).toBe("window");
-    expect(getExpressionHelper("wi|n", "window")).toBe("window");
-    expect(getExpressionHelper("win|", "window")).toBe("window");
+    expect(updateExpressionHelper("w|in", "window")).toEqual(["window", 6]);
+    expect(updateExpressionHelper("wi|n", "window")).toEqual(["window", 6]);
+    expect(updateExpressionHelper("win|", "window")).toEqual(["window", 6]);
 
-    expect(getExpressionHelper("123, w|in", "window")).toBe("123, window");
-    expect(getExpressionHelper("123, wi|n", "window")).toBe("123, window");
-    expect(getExpressionHelper("123, win|", "window")).toBe("123, window");
+    expect(updateExpressionHelper("123, w|in", "window")).toEqual(["123, window", 11]);
+    expect(updateExpressionHelper("123, wi|n", "window")).toEqual(["123, window", 11]);
+    expect(updateExpressionHelper("123, win|", "window")).toEqual(["123, window", 11]);
   });
 
   it("should replace the an object attribute with the selected expression", () => {
-    expect(getExpressionHelper("window.|loc", "location")).toBe("window.location");
-    expect(getExpressionHelper("window.l|oc", "location")).toBe("window.location");
-    expect(getExpressionHelper("window.lo|c", "location")).toBe("window.location");
-    expect(getExpressionHelper("window.loc|", "location")).toBe("window.location");
+    expect(updateExpressionHelper("window.|loc", "location")).toEqual(["window.location", 15]);
+    expect(updateExpressionHelper("window.l|oc", "location")).toEqual(["window.location", 15]);
+    expect(updateExpressionHelper("window.lo|c", "location")).toEqual(["window.location", 15]);
+    expect(updateExpressionHelper("window.loc|", "location")).toEqual(["window.location", 15]);
   });
 
   it("should only replace the variable portion of a template string", () => {
-    expect(getExpressionHelper("`URL: ${|win", "window")).toBe("`URL: ${window");
-    expect(getExpressionHelper("`URL: ${w|in", "window")).toBe("`URL: ${window");
-    expect(getExpressionHelper("`URL: ${wi|n", "window")).toBe("`URL: ${window");
-    expect(getExpressionHelper("`URL: ${win|", "window")).toBe("`URL: ${window");
+    expect(updateExpressionHelper("`URL: ${|win", "window")).toEqual(["`URL: ${window", 14]);
+    expect(updateExpressionHelper("`URL: ${w|in", "window")).toEqual(["`URL: ${window", 14]);
+    expect(updateExpressionHelper("`URL: ${wi|n", "window")).toEqual(["`URL: ${window", 14]);
+    expect(updateExpressionHelper("`URL: ${win|", "window")).toEqual(["`URL: ${window", 14]);
 
-    expect(getExpressionHelper("`URL: ${window.|loc", "location")).toBe("`URL: ${window.location");
-    expect(getExpressionHelper("`URL: ${window.l|oc", "location")).toBe("`URL: ${window.location");
-    expect(getExpressionHelper("`URL: ${window.lo|c", "location")).toBe("`URL: ${window.location");
-    expect(getExpressionHelper("`URL: ${window.loc|", "location")).toBe("`URL: ${window.location");
+    expect(updateExpressionHelper("`URL: ${window.|loc", "location")).toEqual([
+      "`URL: ${window.location",
+      23,
+    ]);
+    expect(updateExpressionHelper("`URL: ${window.l|oc", "location")).toEqual([
+      "`URL: ${window.location",
+      23,
+    ]);
+    expect(updateExpressionHelper("`URL: ${window.lo|c", "location")).toEqual([
+      "`URL: ${window.location",
+      23,
+    ]);
+    expect(updateExpressionHelper("`URL: ${window.loc|", "location")).toEqual([
+      "`URL: ${window.location",
+      23,
+    ]);
+
+    expect(updateExpressionHelper('`URL: "${window.|loc}"`', "location")).toEqual([
+      '`URL: "${window.location}"`',
+      24,
+    ]);
+    expect(updateExpressionHelper('`URL: "${window.l|oc}"`', "location")).toEqual([
+      '`URL: "${window.location}"`',
+      24,
+    ]);
+    expect(updateExpressionHelper('`URL: "${window.lo|c}"`', "location")).toEqual([
+      '`URL: "${window.location}"`',
+      24,
+    ]);
+    expect(updateExpressionHelper('`URL: "${window.loc|}"`', "location")).toEqual([
+      '`URL: "${window.location}"`',
+      24,
+    ]);
   });
 
   it("should support replacing tokens in the middle of a larger string", () => {
-    expect(getExpressionHelper("foo, |bar, baz", "barber")).toBe("foo, barber, baz");
-    expect(getExpressionHelper("foo, b|ar, baz", "barber")).toBe("foo, barber, baz");
-    expect(getExpressionHelper("foo, ba|r, baz", "barber")).toBe("foo, barber, baz");
-    expect(getExpressionHelper("foo, bar|, baz", "barber")).toBe("foo, barber, baz");
+    expect(updateExpressionHelper("foo, |bar, baz", "barber")).toEqual(["foo, barber, baz", 11]);
+    expect(updateExpressionHelper("foo, b|ar, baz", "barber")).toEqual(["foo, barber, baz", 11]);
+    expect(updateExpressionHelper("foo, ba|r, baz", "barber")).toEqual(["foo, barber, baz", 11]);
+    expect(updateExpressionHelper("foo, bar|, baz", "barber")).toEqual(["foo, barber, baz", 11]);
 
-    expect(getExpressionHelper("foo bar.|pro three", "property")).toBe("foo bar.property three");
-    expect(getExpressionHelper("foo bar.p|ro three", "property")).toBe("foo bar.property three");
-    expect(getExpressionHelper("foo bar.pr|o three", "property")).toBe("foo bar.property three");
-    expect(getExpressionHelper("foo bar.pro| three", "property")).toBe("foo bar.property three");
+    expect(updateExpressionHelper("foo bar.|pro three", "property")).toEqual([
+      "foo bar.property three",
+      16,
+    ]);
+    expect(updateExpressionHelper("foo bar.p|ro three", "property")).toEqual([
+      "foo bar.property three",
+      16,
+    ]);
+    expect(updateExpressionHelper("foo bar.pr|o three", "property")).toEqual([
+      "foo bar.property three",
+      16,
+    ]);
+    expect(updateExpressionHelper("foo bar.pro| three", "property")).toEqual([
+      "foo bar.property three",
+      16,
+    ]);
   });
 });

--- a/packages/bvaughn-architecture-demo/components/sources/utils/updateStringWithExpression.test.ts
+++ b/packages/bvaughn-architecture-demo/components/sources/utils/updateStringWithExpression.test.ts
@@ -36,14 +36,26 @@ describe("updateStringWithExpression", () => {
   });
 
   it("should only replace the variable portion of a template string", () => {
-    expect(getExpressionHelper("URL: ${|win", "window")).toBe("URL: ${window");
-    expect(getExpressionHelper("URL: ${w|in", "window")).toBe("URL: ${window");
-    expect(getExpressionHelper("URL: ${wi|n", "window")).toBe("URL: ${window");
-    expect(getExpressionHelper("URL: ${win|", "window")).toBe("URL: ${window");
+    expect(getExpressionHelper("`URL: ${|win", "window")).toBe("`URL: ${window");
+    expect(getExpressionHelper("`URL: ${w|in", "window")).toBe("`URL: ${window");
+    expect(getExpressionHelper("`URL: ${wi|n", "window")).toBe("`URL: ${window");
+    expect(getExpressionHelper("`URL: ${win|", "window")).toBe("`URL: ${window");
 
-    expect(getExpressionHelper("URL: ${window.|loc", "location")).toBe("URL: ${window.location");
-    expect(getExpressionHelper("URL: ${window.l|oc", "location")).toBe("URL: ${window.location");
-    expect(getExpressionHelper("URL: ${window.lo|c", "location")).toBe("URL: ${window.location");
-    expect(getExpressionHelper("URL: ${window.loc|", "location")).toBe("URL: ${window.location");
+    expect(getExpressionHelper("`URL: ${window.|loc", "location")).toBe("`URL: ${window.location");
+    expect(getExpressionHelper("`URL: ${window.l|oc", "location")).toBe("`URL: ${window.location");
+    expect(getExpressionHelper("`URL: ${window.lo|c", "location")).toBe("`URL: ${window.location");
+    expect(getExpressionHelper("`URL: ${window.loc|", "location")).toBe("`URL: ${window.location");
+  });
+
+  it("should support replacing tokens in the middle of a larger string", () => {
+    expect(getExpressionHelper("foo, |bar, baz", "barber")).toBe("foo, barber, baz");
+    expect(getExpressionHelper("foo, b|ar, baz", "barber")).toBe("foo, barber, baz");
+    expect(getExpressionHelper("foo, ba|r, baz", "barber")).toBe("foo, barber, baz");
+    expect(getExpressionHelper("foo, bar|, baz", "barber")).toBe("foo, barber, baz");
+
+    expect(getExpressionHelper("foo bar.|pro three", "property")).toBe("foo bar.property three");
+    expect(getExpressionHelper("foo bar.p|ro three", "property")).toBe("foo bar.property three");
+    expect(getExpressionHelper("foo bar.pr|o three", "property")).toBe("foo bar.property three");
+    expect(getExpressionHelper("foo bar.pro| three", "property")).toBe("foo bar.property three");
   });
 });

--- a/packages/bvaughn-architecture-demo/components/sources/utils/updateStringWithExpression.test.ts
+++ b/packages/bvaughn-architecture-demo/components/sources/utils/updateStringWithExpression.test.ts
@@ -1,0 +1,49 @@
+import updateStringWithExpression from "./updateStringWithExpression";
+
+// Converts a string like: "foo |bar"
+// Into the string "foo bar" and the cursor index 4
+function getExpressionHelper(text: string, expression: string): string | null {
+  let cursorIndex = text.length;
+
+  for (let index = 0; index < text.length; index++) {
+    const character = text.charAt(index);
+    if (character === "|") {
+      cursorIndex = index;
+      text = text.substring(0, index) + text.substring(index + 1);
+      break;
+    }
+  }
+
+  return updateStringWithExpression(text, cursorIndex, expression);
+}
+
+describe("updateStringWithExpression", () => {
+  it("should replace the current token with the selected expression", () => {
+    expect(getExpressionHelper("w|in", "window")).toBe("window");
+    expect(getExpressionHelper("wi|n", "window")).toBe("window");
+    expect(getExpressionHelper("win|", "window")).toBe("window");
+
+    expect(getExpressionHelper("123, w|in", "window")).toBe("123, window");
+    expect(getExpressionHelper("123, wi|n", "window")).toBe("123, window");
+    expect(getExpressionHelper("123, win|", "window")).toBe("123, window");
+  });
+
+  it("should replace the an object attribute with the selected expression", () => {
+    expect(getExpressionHelper("window.|loc", "location")).toBe("window.location");
+    expect(getExpressionHelper("window.l|oc", "location")).toBe("window.location");
+    expect(getExpressionHelper("window.lo|c", "location")).toBe("window.location");
+    expect(getExpressionHelper("window.loc|", "location")).toBe("window.location");
+  });
+
+  it("should only replace the variable portion of a template string", () => {
+    expect(getExpressionHelper("URL: ${|win", "window")).toBe("URL: ${window");
+    expect(getExpressionHelper("URL: ${w|in", "window")).toBe("URL: ${window");
+    expect(getExpressionHelper("URL: ${wi|n", "window")).toBe("URL: ${window");
+    expect(getExpressionHelper("URL: ${win|", "window")).toBe("URL: ${window");
+
+    expect(getExpressionHelper("URL: ${window.|loc", "location")).toBe("URL: ${window.location");
+    expect(getExpressionHelper("URL: ${window.l|oc", "location")).toBe("URL: ${window.location");
+    expect(getExpressionHelper("URL: ${window.lo|c", "location")).toBe("URL: ${window.location");
+    expect(getExpressionHelper("URL: ${window.loc|", "location")).toBe("URL: ${window.location");
+  });
+});

--- a/packages/bvaughn-architecture-demo/components/sources/utils/updateStringWithExpression.ts
+++ b/packages/bvaughn-architecture-demo/components/sources/utils/updateStringWithExpression.ts
@@ -3,14 +3,23 @@ export default function updateStringWithExpression(
   cursorIndex: number,
   expression: string
 ): string {
-  let index = cursorIndex;
-  while (index >= 0) {
-    const character = string.charAt(index - 1);
-    if (character === "." || character === " " || character === "{") {
+  let startIndex = cursorIndex;
+  while (startIndex >= 0) {
+    const prevCharacter = string.charAt(startIndex - 1);
+    if (prevCharacter === "." || prevCharacter === " " || prevCharacter === "{") {
       break;
     }
-    index--;
+    startIndex--;
   }
 
-  return string.substring(0, index) + expression;
+  let endIndex = cursorIndex;
+  while (endIndex < string.length) {
+    const character = string.charAt(endIndex);
+    if (character === "." || character === " " || character === "}" || character === ",") {
+      break;
+    }
+    endIndex++;
+  }
+
+  return string.substring(0, startIndex) + expression + string.substring(endIndex);
 }

--- a/packages/bvaughn-architecture-demo/components/sources/utils/updateStringWithExpression.ts
+++ b/packages/bvaughn-architecture-demo/components/sources/utils/updateStringWithExpression.ts
@@ -1,0 +1,16 @@
+export default function updateStringWithExpression(
+  string: string,
+  cursorIndex: number,
+  expression: string
+): string {
+  let index = cursorIndex;
+  while (index >= 0) {
+    const character = string.charAt(index - 1);
+    if (character === "." || character === " " || character === "{") {
+      break;
+    }
+    index--;
+  }
+
+  return string.substring(0, index) + expression;
+}

--- a/packages/bvaughn-architecture-demo/components/sources/utils/updateStringWithExpression.ts
+++ b/packages/bvaughn-architecture-demo/components/sources/utils/updateStringWithExpression.ts
@@ -2,7 +2,7 @@ export default function updateStringWithExpression(
   string: string,
   cursorIndex: number,
   expression: string
-): string {
+): [newString: string, newCursorIndex: number] {
   let startIndex = cursorIndex;
   while (startIndex >= 0) {
     const prevCharacter = string.charAt(startIndex - 1);
@@ -21,5 +21,10 @@ export default function updateStringWithExpression(
     endIndex++;
   }
 
-  return string.substring(0, startIndex) + expression + string.substring(endIndex);
+  const head = string.substring(0, startIndex);
+  const tail = string.substring(endIndex);
+  const newString = head + expression + tail;
+  const newCursorIndex = head.length + expression.length;
+
+  return [newString, newCursorIndex];
 }

--- a/packages/bvaughn-architecture-demo/src/suspense/SyntaxParsingCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/SyntaxParsingCache.ts
@@ -264,8 +264,8 @@ function incrementalParser(fileName?: string, contentType?: ContentType): Increm
   };
 }
 
-async function highlighter(code: string, fileName: string): Promise<string[] | null> {
-  const parser = await incrementalParser(fileName);
+export function highlighter(code: string, fileName: string): string[] | null {
+  const parser = incrementalParser(fileName);
   if (parser === null) {
     return null;
   }

--- a/packages/bvaughn-architecture-demo/src/suspense/createGenericCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/createGenericCache.ts
@@ -18,7 +18,7 @@ interface HookState<TValue> {
 }
 
 export function createGenericCache<TParams extends Array<any>, TValue>(
-  fetchValue: (...args: TParams) => Promise<TValue>,
+  fetchValue: (...args: TParams) => Promise<TValue> | TValue,
   getCacheKey: (...args: TParams) => string
 ): GenericCache<TParams, TValue> {
   const recordMap = new Map<string, Record<TValue>>();


### PR DESCRIPTION
- [x] Use Lezer output for auto-complete expression parsing
- [x] Support template string variables and mid-token cursor positions
- [x] Support auto-completing variables in the middle of a string
  - [x] Support restoring the cursor position after auto-complete
- [x] Add unit tests

This PR is a big step toward JS terminal. The primary thing that's missing after it lands is syntax highlighting while in edit mode.

Overview / demo:
https://www.loom.com/share/c9063f20cd984183a8f3cef0054c35ee