### PR TITLE
Ensure style imports are sorted to the end and `src` is in middle

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/index.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/index.tsx
@@ -1,4 +1,3 @@
-import "reactjs-popup/dist/index.css";
 import { TimeStampedPoint } from "@replayio/protocol";
 import classNames from "classnames";
 import React, { Dispatch, SetStateAction } from "react";
@@ -17,6 +16,7 @@ import useAuth0 from "ui/utils/useAuth0";
 import Condition from "./Condition";
 import Log from "./Log";
 import Popup from "./Popup";
+import "reactjs-popup/dist/index.css";
 
 export type Input = "condition" | "content";
 

--- a/src/devtools/client/debugger/src/components/Editor/NewSourceAdapter.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/NewSourceAdapter.tsx
@@ -1,4 +1,3 @@
-import "bvaughn-architecture-demo/components/sources/CodeMirror.css";
 import { KeyboardEvent, useContext, useEffect, useLayoutEffect, useRef } from "react";
 
 import LazyOffscreen from "bvaughn-architecture-demo/components/LazyOffscreen";
@@ -18,6 +17,7 @@ import { getSelectedLocation } from "ui/reducers/sources";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 
 import { setViewport } from "../../selectors";
+import "bvaughn-architecture-demo/components/sources/CodeMirror.css";
 
 export default function NewSourceAdapterRoot() {
   return (

--- a/src/devtools/client/debugger/src/components/Editor/Preview/NewObjectInspector.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Preview/NewObjectInspector.tsx
@@ -1,9 +1,10 @@
-import "bvaughn-architecture-demo/pages/variables.css";
 import { Value as ProtocolValue } from "@replayio/protocol";
 
 import ErrorBoundary from "bvaughn-architecture-demo/components/ErrorBoundary";
 import SourcePreviewInspector from "bvaughn-architecture-demo/components/inspector/SourcePreviewInspector";
 import { useAppSelector } from "ui/setup/hooks";
+
+import "bvaughn-architecture-demo/pages/variables.css";
 
 export default function NewObjectInspector({ protocolValue }: { protocolValue: ProtocolValue }) {
   const pauseId = useAppSelector(state => state.pause.id);

--- a/src/stories/SourceOutline/SourceOutline.stories.tsx
+++ b/src/stories/SourceOutline/SourceOutline.stories.tsx
@@ -1,5 +1,3 @@
-import "devtools/client/debugger/src/components/SourceOutline/Outline.css";
-import "devtools/client/debugger/src/components/shared/PreviewFunction.css";
 import { Meta, Story } from "@storybook/react";
 import React, { ComponentProps } from "react";
 
@@ -7,6 +5,8 @@ import { SourceOutline } from "devtools/client/debugger/src/components/SourceOut
 import { SymbolDeclarations } from "devtools/client/debugger/src/reducers/ast";
 
 import symbols from "../fixtures/symbols";
+import "devtools/client/debugger/src/components/shared/PreviewFunction.css";
+import "devtools/client/debugger/src/components/SourceOutline/Outline.css";
 
 export default {
   title: "Soure Outline/Outline",


### PR DESCRIPTION
This PR:

- Updates the import sorting rules to fix a couple issues:
  - all style files are now sorted to the end, instead of having a few sort to the very top (something like `bvaughn/whatever/Component.css` was getting matched by the "built-ins" rule because that didn't exclude styles)
  - Added the `src` prefix to the "general absolute imports" section