### PR TITLE
Handle "linker version" errors for hit counts

### DIFF
--- a/packages/bvaughn-architecture-demo/src/suspense/SourcesCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/SourcesCache.ts
@@ -371,7 +371,10 @@ async function fetchSourceHitCounts(
 
     wakeable.resolve(record.value);
   } catch (error) {
-    if (isCommandError(error, ProtocolError.TooManyLocationsToPerformAnalysis)) {
+    if (
+      isCommandError(error, ProtocolError.TooManyLocationsToPerformAnalysis) ||
+      isCommandError(error, ProtocolError.LinkerDoesNotSupportAction)
+    ) {
       record.status = STATUS_RESOLVED;
       record.value = new Map();
     } else {

--- a/packages/shared/utils/error.ts
+++ b/packages/shared/utils/error.ts
@@ -7,6 +7,7 @@ export enum ProtocolError {
   RecordingUnloaded = 38,
   TooManyLocationsToPerformAnalysis = 67,
   TooManyPoints = 55,
+  LinkerDoesNotSupportAction = 48,
 }
 
 export const commandError = (message: string, code: number): CommandError => {
@@ -26,6 +27,11 @@ export const isCommandError = (error: unknown, code: number): boolean => {
       // TODO [BAC-2330] The Analysis endpoint returns an error string instead of an error object.
       return error === "There are too many points to complete this operation";
     }
+  } else if (code === ProtocolError.LinkerDoesNotSupportAction) {
+    if (typeof error === "string") {
+      console.error("Unexpected error type encountered (string):", error);
+    }
+    return error === "The linker version used to make this recording does not support this action";
   }
 
   return false;

--- a/src/devtools/client/debugger/src/components/SourceOutline/SourceOutline.tsx
+++ b/src/devtools/client/debugger/src/components/SourceOutline/SourceOutline.tsx
@@ -12,6 +12,7 @@ import React, {
 import AutoSizer from "react-virtualized-auto-sizer";
 import { FixedSizeList as List } from "react-window";
 
+import ErrorBoundary from "bvaughn-architecture-demo/components/ErrorBoundary";
 import { FocusContext } from "bvaughn-architecture-demo/src/contexts/FocusContext";
 import { SourcesContext } from "bvaughn-architecture-demo/src/contexts/SourcesContext";
 import { getSourceHitCountsSuspense } from "bvaughn-architecture-demo/src/suspense/SourcesCache";
@@ -187,12 +188,14 @@ export default function SourceOutlineWrapper() {
   );
 
   return (
-    <Suspense fallback={null}>
-      <SourceOutline
-        cursorPosition={cursorPosition || null}
-        selectedSource={selectedSource || null}
-        symbols={symbols}
-      />
-    </Suspense>
+    <ErrorBoundary>
+      <Suspense fallback={null}>
+        <SourceOutline
+          cursorPosition={cursorPosition || null}
+          selectedSource={selectedSource || null}
+          symbols={symbols}
+        />
+      </Suspense>
+    </ErrorBoundary>
   );
 }


### PR DESCRIPTION
This PR:

- Fixes UI crashes when the recording is so old it doesn't support requesting hit counts:
  - Wraps `<SourceOutline>`in an `<ErrorBoundary>` just in case
  - Updates `fetchSourceHitCounts` to treat "linker version" errors as a "nope, no hit counts available" result

As a specific example, currently loading up https://app.replay.io/recording/503-clicks--7b36ed70-b486-459d-97af-367ae6e49c03 and opening any source file will crash the entire UI.  (I actually find this surprising given that we have the entire app wrapped in an `<ErrorBoundary>`)