### PR TITLE
Add clipboard-based breakpoint import/export

### DIFF
--- a/packages/bvaughn-architecture-demo/src/contexts/PointsContext.tsx
+++ b/packages/bvaughn-architecture-demo/src/contexts/PointsContext.tsx
@@ -37,6 +37,15 @@ export type PointsContextType = {
   pointsForAnalysis: Point[];
 };
 
+export const isValidPoint = (maybePoint: unknown): maybePoint is Point => {
+  return (
+    typeof maybePoint === "object" &&
+    typeof (maybePoint as Point)?.createdAtTime === "number" &&
+    typeof (maybePoint as Point)?.id === "string" &&
+    typeof (maybePoint as Point)?.location === "object"
+  );
+};
+
 export const PointsContext = createContext<PointsContextType>(null as any);
 
 export function PointsContextRoot({ children }: PropsWithChildren<{}>) {

--- a/src/ui/components/CommandPalette/CommandPalette.tsx
+++ b/src/ui/components/CommandPalette/CommandPalette.tsx
@@ -19,6 +19,7 @@ export type Command = {
   shortcut?: string;
 };
 export type CommandKey =
+  | "copy_points"
   | "open_console"
   | "open_devtools"
   | "open_elements"
@@ -34,6 +35,7 @@ export type CommandKey =
   | "pin_to_bottom"
   | "pin_to_left"
   | "pin_to_bottom_right"
+  | "set_points"
   | "show_comments"
   | "show_console_filters"
   | "show_events"
@@ -72,6 +74,8 @@ const COMMANDS: readonly Command[] = [
   { key: "pin_to_bottom", label: "Pin Toolbox To Bottom" },
   { key: "pin_to_left", label: "Pin Toolbox To Left" },
   { key: "pin_to_bottom_right", label: "Pin Toolbox To Bottom Right" },
+  { key: "copy_points", label: "Copy Print Statement Settings to Clipboard" },
+  { key: "set_points", label: "Overwrite Print Statement Settings From Clipboard" },
 ] as const;
 
 const DEFAULT_COMMANDS: readonly CommandKey[] = [


### PR DESCRIPTION
This PR:

- Implements simple import/export of print statements / breakpoints via the clipboard, with a couple new entries for the Command Palette


![image](https://user-images.githubusercontent.com/1128784/200406176-828c5cae-f8de-47fd-a39c-ed6f09f097f7.png)
