### PR TITLE
Ensure the outer ErrorBoundary in the Frames panel is reset when seeking to a new pause

### DIFF
--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/NewFrames.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/NewFrames.tsx
@@ -209,7 +209,10 @@ export default function Frames({
 
   return (
     <div className="pane frames" data-test-id="FramesPanel">
-      <ErrorBoundary fallback={<div className="pane-info empty">Error loading frames</div>}>
+      <ErrorBoundary
+        key={pauseId}
+        fallback={<div className="pane-info empty">Error loading frames</div>}
+      >
         <Suspense fallback={<div className="pane-info empty">Loading…</div>}>
           <div role="list">
             <FramesRenderer pauseId={pauseId} panel={panel} />


### PR DESCRIPTION
In #8079 the `ErrorBoundary` for async frames was fixed so that it is reset when seeking to a new pause, but there's another `ErrorBoundary` in the `Frames` component that had the same issue.