### PR TITLE
Use standard "something failed" display in <ErrorBoundary>

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Footer.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Footer.tsx
@@ -1,6 +1,6 @@
 import React, { Suspense, memo, useEffect, useLayoutEffect, useRef, useState } from "react";
 
-import ErrorBoundary from "ui/components/ErrorBoundary";
+import ErrorBoundary from "bvaughn-architecture-demo/components/ErrorBoundary";
 import { getSelectedSource } from "ui/reducers/sources";
 import { useAppSelector } from "ui/setup/hooks";
 import { localStorageGetItem, localStorageSetItem } from "ui/utils/storage";

--- a/src/ui/components/ErrorBoundary.tsx
+++ b/src/ui/components/ErrorBoundary.tsx
@@ -7,6 +7,7 @@ import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { UnexpectedError } from "ui/state/app";
 import { isDevelopment } from "ui/utils/environment";
 
+import Error from "./shared/Error";
 import { BlankViewportWrapper } from "./shared/Viewport";
 
 export const ReplayUpdatedError: UnexpectedError = {
@@ -24,20 +25,22 @@ export default function ErrorBoundary({ children }: { children: ReactNode }) {
       return dispatch(setUnexpectedError(ReplayUpdatedError, true));
     }
 
-    if (error.name === "CommandError" || isDevelopment()) {
+    if (error.name === "CommandError") {
       return;
     }
 
-    setUnexpectedError({
-      message: "Unexpected error",
-      content: "An unexpected error occurred. Please refresh the page.",
-      action: "refresh",
-    });
+    dispatch(
+      setUnexpectedError({
+        message: "Unexpected error",
+        content: "Something went wrong, but you can refresh the page to try again.",
+        action: "refresh",
+      })
+    );
   };
 
   return (
     <Sentry.ErrorBoundary onError={onError}>
-      {unexpectedError ? <BlankViewportWrapper /> : children}
+      {unexpectedError ? <Error /> : children}
     </Sentry.ErrorBoundary>
   );
 }


### PR DESCRIPTION
This PR:

- Updates the existing main app `<ErrorBoundary>` component to use our standard `<Error>` component to say "something went wrong, please refresh", instead of leaving the entire page as a blank gray screen

Turns out it was already trying to do half of that by dispatching `setUnexpectedError`, but it wasn't actually _dispatching_ that action.

Updated to render the `<Error>` component if appropriate, and actually dispatch the action:

![image](https://user-images.githubusercontent.com/1128784/200671789-43652998-8052-4e1f-89bc-3a89bb0a3427.png)

