### PR TITLE
Show app error screen for command messages, and improve messages

### DIFF
--- a/packages/protocol/socket.ts
+++ b/packages/protocol/socket.ts
@@ -215,7 +215,10 @@ export async function sendMessage<M extends CommandMethods>(
 
     console.warn("Message failed", method, { code, id, message }, data);
 
-    throw commandError(message, code);
+    // Include details on the method and params in the error string so that we get more than
+    // _just_ "Internal Error" or similar
+    const finalMessage = `${message} (request: ${method}, ${JSON.stringify(params)})`;
+    throw commandError(finalMessage, code);
   }
 
   return response.result as any;

--- a/src/ui/components/ErrorBoundary.tsx
+++ b/src/ui/components/ErrorBoundary.tsx
@@ -25,9 +25,8 @@ export default function ErrorBoundary({ children }: { children: ReactNode }) {
       return dispatch(setUnexpectedError(ReplayUpdatedError, true));
     }
 
-    if (error.name === "CommandError") {
-      return;
-    }
+    // Otherwise, if it's bubbled up this far, React is crashing anyway.
+    // Let's show the "Oops!" screen and tell the user to refresh.
 
     dispatch(
       setUnexpectedError({


### PR DESCRIPTION
This PR:

- Removes the "don't show `CommandError`s" check from `<ErrorBoundary>`, as it seems like that was another case where we'd end up with a gray screen instead of "Please refresh"
- Updates `socket.ts` to include the method name and params in request error messages, so that we at least can look at this and see what the request was:

![image](https://user-images.githubusercontent.com/1128784/200880286-84db7451-43d1-48f0-9165-6415af4b4e1f.png)
