### PR TITLE
Source viewer: Improve handling for large, edge case files

### DIFF
--- a/packages/bvaughn-architecture-demo/components/Popup.tsx
+++ b/packages/bvaughn-architecture-demo/components/Popup.tsx
@@ -10,6 +10,7 @@ type Dismiss = () => void;
 
 export default function Popup({
   children,
+  clientX = null,
   containerRef = null,
   dataTestId,
   dataTestName = "Popup",
@@ -19,6 +20,7 @@ export default function Popup({
   target,
 }: {
   children: ReactNode;
+  clientX?: number | null;
   containerRef?: RefObject<HTMLElement> | null;
   dataTestId?: string;
   dataTestName?: string;
@@ -87,8 +89,6 @@ export default function Popup({
       const popoverRect = popover.getBoundingClientRect();
       const targetRect = target.getBoundingClientRect();
 
-      let arrowUp = true;
-
       // Vertical alignment: Determined entirely by the target location within the parent container.
       // Targets in the top half of the container have popups displayed beneath them,
       // and targets in the bottom half of the container have popups displayed above them.
@@ -106,18 +106,19 @@ export default function Popup({
         popover.style.setProperty("top", `${popoverTop}px`);
 
         arrow.setAttribute("class", styles.DownArrow);
-
-        arrowUp = false;
       }
 
       // TODO
       // Handle horizontal positioning edge case if popup is outside of scroll area when rendered initially.
 
+      const horizontalAlignmentPoint =
+        clientX !== null ? clientX : targetRect.left + targetRect.width / 2;
+
       // Horizontal alignment: Prefer horizontally centered around the target
       // But don't go outside of the bounds of the container.
       const popoverLeftMin = containerRect.left;
       const popoverLeftMax = containerRect.left + containerRect.width - popoverRect.width;
-      const popoverLeftPreferred = targetRect.left + targetRect.width / 2 - popoverRect.width / 2;
+      const popoverLeftPreferred = horizontalAlignmentPoint - popoverRect.width / 2;
       const popoverLeft = Math.max(popoverLeftMin, Math.min(popoverLeftMax, popoverLeftPreferred));
       popover.style.setProperty("left", `${popoverLeft}px`);
 
@@ -126,7 +127,7 @@ export default function Popup({
       const arrowRect = arrow.getBoundingClientRect();
       const arrowLeftMin = targetRect.left;
       const arrowLeftMax = targetRect.left + targetRect.width - arrowRect.width;
-      const arrowLeftPreferred = targetRect.left + targetRect.width / 2 - arrowRect.width / 2;
+      const arrowLeftPreferred = horizontalAlignmentPoint - arrowRect.width / 2;
       const arrowLeft = Math.max(arrowLeftMin, Math.min(arrowLeftMax, arrowLeftPreferred));
       arrow.style.setProperty("margin-left", `${arrowLeft - popoverLeft}px`);
 
@@ -177,7 +178,7 @@ export default function Popup({
 
       clearMouseLeaveTimeout();
     };
-  }, [containerRef, showTail, target]);
+  }, [clientX, containerRef, showTail, target]);
 
   const blockEvent = (event: MouseEvent) => {
     event.preventDefault();

--- a/packages/bvaughn-architecture-demo/components/sources/CodeMirror.css
+++ b/packages/bvaughn-architecture-demo/components/sources/CodeMirror.css
@@ -1,6 +1,4 @@
 .theme-dark {
-  --token-hover-filter-color: brightness(1.25);
-  --token-active-filter-color: brightness(1.5);
   --token-comment-color: #8f8f92;
   --token-definition-color: #fefefe;
   --token-local-color: #fefefe;
@@ -18,8 +16,6 @@
 }
 
 .theme-light {
-  --token-hover-filter-color: brightness(0.8);
-  --token-active-filter-color: brightness(0.6);
   --token-comment-color: #737373;
   --token-definition-color: #3172e0;
   --token-local-color: #4e4e52;

--- a/packages/bvaughn-architecture-demo/components/sources/PreviewPopup.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/PreviewPopup.tsx
@@ -10,6 +10,7 @@ import Popup from "../Popup";
 import styles from "./PreviewPopup.module.css";
 
 type Props = {
+  clientX?: number | null;
   containerRef: RefObject<HTMLElement>;
   dismiss: () => void;
   expression: string;
@@ -24,7 +25,13 @@ export default function PreviewPopup(props: Props) {
   );
 }
 
-function SuspendingPreviewPopup({ containerRef, dismiss, expression, target }: Props) {
+function SuspendingPreviewPopup({
+  clientX = null,
+  containerRef,
+  dismiss,
+  expression,
+  target,
+}: Props) {
   const client = useContext(ReplayClientContext);
 
   const popupRef = useRef<HTMLDivElement>(null);
@@ -59,7 +66,13 @@ function SuspendingPreviewPopup({ containerRef, dismiss, expression, target }: P
 
   if (pauseId !== null && value !== null) {
     return (
-      <Popup containerRef={containerRef} dismiss={dismiss} target={target} showTail={true}>
+      <Popup
+        clientX={clientX}
+        containerRef={containerRef}
+        dismiss={dismiss}
+        target={target}
+        showTail={true}
+      >
         <SourcePreviewInspector
           className={styles.Popup}
           pauseId={pauseId}

--- a/packages/bvaughn-architecture-demo/components/sources/Source.module.css
+++ b/packages/bvaughn-architecture-demo/components/sources/Source.module.css
@@ -25,7 +25,3 @@
   justify-content: center;
   color: var(--color-dim);
 }
-
-.HoveredTarget {
-  filter: var(--token-active-filter-color) !important;
-}

--- a/packages/bvaughn-architecture-demo/components/sources/Source.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/Source.tsx
@@ -92,17 +92,6 @@ function SourceRenderer({
     []
   );
 
-  useLayoutEffect(() => {
-    if (hoveredState) {
-      const target = hoveredState.target;
-      target.classList.add(styles.HoveredTarget);
-
-      return () => {
-        target.classList.remove(styles.HoveredTarget);
-      };
-    }
-  }, [hoveredState]);
-
   const sourceRef = useRef<HTMLDivElement>(null);
 
   const onMouseMove = ({ target }: MouseEvent) => {

--- a/packages/bvaughn-architecture-demo/components/sources/SourceListRow.module.css
+++ b/packages/bvaughn-architecture-demo/components/sources/SourceListRow.module.css
@@ -182,28 +182,6 @@
   margin: 0;
 }
 
-.LineSegment :global(.tok-definition),
-.LineSegment :global(.tok-local),
-.LineSegment :global(.tok-keyword),
-.LineSegment :global(.tok-meta),
-.LineSegment :global(.tok-propertyName),
-.LineSegment :global(.tok-typeName),
-.LineSegment :global(.tok-variableName),
-.LineSegment :global(.tok-variableName2) {
-  transition: all 50ms ease;
-}
-
-.LineSegment :global(.tok-definition):hover,
-.LineSegment :global(.tok-local):hover,
-.LineSegment :global(.tok-keyword):hover,
-.LineSegment :global(.tok-meta):hover,
-.LineSegment :global(.tok-propertyName):hover,
-.LineSegment :global(.tok-typeName):hover,
-.LineSegment :global(.tok-variableName):hover,
-.LineSegment :global(.tok-variableName2):hover {
-  filter: var(--token-hover-filter-color);
-}
-
 .BreakpointButton {
   display: inline-block;
   background: transparent;

--- a/packages/bvaughn-architecture-demo/components/sources/SourceListRow.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/SourceListRow.tsx
@@ -172,7 +172,11 @@ const SourceListRow = memo(
       const plainText = index < rawLines.length ? rawLines[index] : null;
 
       if (plainText !== null) {
-        lineSegments = <pre className={styles.LineSegment}>{plainText}</pre>;
+        lineSegments = (
+          <pre className={styles.LineSegment} data-test-name="SourceListRow-LineSegment-PlainText">
+            {plainText}
+          </pre>
+        );
       } else {
         lineSegments = <SourceLineLoadingPlaceholder width={loadingPlaceholderWidth} />;
       }

--- a/packages/bvaughn-architecture-demo/components/sources/utils/getExpressionFromString.test.ts
+++ b/packages/bvaughn-architecture-demo/components/sources/utils/getExpressionFromString.test.ts
@@ -80,6 +80,15 @@ describe("getExpressionFromString", () => {
     expect(getExpressionHelper("1.12|")).toBe(null);
   });
 
+  it("should not return expressions that are part of a comment", () => {
+    expect(getExpressionHelper("|// Example")).toBe(null);
+    expect(getExpressionHelper("/|/ Example")).toBe(null);
+    expect(getExpressionHelper("//| Example")).toBe(null);
+    expect(getExpressionHelper("//| Example")).toBe(null);
+    expect(getExpressionHelper("// |Example")).toBe(null);
+    expect(getExpressionHelper("// Example|")).toBe(null);
+  });
+
   it("should not return expressions that are part of a string", () => {
     expect(getExpressionHelper('"|foo')).toBe(null);
     expect(getExpressionHelper('"f|oo')).toBe(null);
@@ -152,5 +161,32 @@ describe("getExpressionFromString", () => {
     expect(getExpressionHelper('`URL: "${wind|ow.loc}"')).toBe("window");
     expect(getExpressionHelper('`URL: "${windo|w.loc}"')).toBe("window");
     expect(getExpressionHelper('`URL: "${window|.loc}"')).toBe("window");
+  });
+
+  describe("minified/mangled code", () => {
+    it("keywords", () => {
+      expect(getExpressionHelper('!fu|nction(){"use strict";var e={4:function(e,t,n)')).toBe(
+        "function"
+      );
+
+      expect(getExpressionHelper('!function(){"use strict";v|ar e={4:function(e,t,n)')).toBe(null);
+    });
+
+    it("strings", () => {
+      expect(getExpressionHelper('!function(){"|use strict";var e={4:function(e,t')).toBe(null);
+      expect(getExpressionHelper('!function(){"use| strict";var e={4:function(e,t')).toBe(null);
+      expect(getExpressionHelper('!function(){"use |strict";var e={4:function(e,t')).toBe(null);
+      expect(getExpressionHelper('!function(){"use strict|";var e={4:function(e,t')).toBe(null);
+    });
+
+    it("numbers", () => {
+      expect(getExpressionHelper('!function(){"use strict";var e={|4:function(e,t,n)')).toBe(null);
+      expect(getExpressionHelper('!function(){"use strict";var e={4|:function(e,t')).toBe(null);
+    });
+
+    it("variables", () => {
+      expect(getExpressionHelper('!function(){"use strict";var e={4:function(e,|t,n)')).toBe("t");
+      expect(getExpressionHelper('!function(){"use strict";var e={4:function(e,t|')).toBe("t");
+    });
   });
 });

--- a/packages/bvaughn-architecture-demo/components/sources/utils/getTextAndCursorIndex.ts
+++ b/packages/bvaughn-architecture-demo/components/sources/utils/getTextAndCursorIndex.ts
@@ -1,0 +1,42 @@
+declare global {
+  interface CaretPosition {
+    readonly offset: number;
+    readonly offsetNode: Node;
+    getClientRect(): DOMRect | null;
+  }
+
+  interface Document {
+    readonly caretPositionFromPoint: (clientX: number, clientY: number) => CaretPosition | null;
+  }
+}
+
+export default function getTextAndCursorIndex(
+  clientX: number,
+  clientY: number
+): [text: string, cursorIndex: number] | null {
+  // Firefox
+  // https://developer.mozilla.org/en-US/docs/Web/API/Document/caretPositionFromPoint
+  if (document.caretPositionFromPoint) {
+    const position = document.caretPositionFromPoint(clientX, clientY);
+    if (position !== null) {
+      const textContent = position.offsetNode.textContent;
+      const offset = position.offset;
+      if (textContent) {
+        return [textContent, offset];
+      }
+    }
+  } else if (document.caretRangeFromPoint) {
+    // Chrome, Edge, and Safari
+    // https://developer.mozilla.org/en-US/docs/Web/API/Document/caretRangeFromPoint
+    const range = document.caretRangeFromPoint(clientX, clientY);
+    if (range) {
+      const textContent = range.startContainer.textContent;
+      const offset = range.startOffset;
+      if (textContent) {
+        return [textContent, offset];
+      }
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
- [x] Add more expression parsing edge case handling (and tests) for mangled sources.
- [x] Add utility function to extract text cursor index based on `MouseEvent` `clientX` and `clientY`
- [x] Update new Source viewer to support plaintext previews as well as syntax highlighted previews
- [x] Remove token hover CSS `filter` effect; I was trying this out but decided I didn't like it
- [x] Avoid displaying syntax highlighted contents for unprettified sources without source-maps.

Loom demos:
* Bug fix: https://www.loom.com/share/f0e90de794ed419982b3df436a2ae11d
* Supporting hover previews for plain text: https://www.loom.com/share/686de87955654f0dbde309e06b9129a7