### PR TITLE
Catch errors from `Frame.getFrameSteps`

### DIFF
--- a/src/ui/suspense/frameStepsCache.ts
+++ b/src/ui/suspense/frameStepsCache.ts
@@ -12,10 +12,19 @@ export const {
   getValueAsync: getFrameStepsAsync,
   getValueIfCached: getFrameStepsIfCached,
 } = createGenericCache<[pauseId: PauseId, frameId: FrameId], PointDescription[] | undefined>(
-  (pauseId, frameId) => {
+  async (pauseId, frameId) => {
     const pause = Pause.getById(pauseId);
     assert(pause, `no pause for ${pauseId}`);
-    return pause.getFrameSteps(frameId);
+
+    // Handle potential errors by swallowing and returning `undefined`
+    // TODO [BAC-2459] This may not be necessary if the backend
+    // stops throwing internal errors
+    try {
+      const steps = await pause.getFrameSteps(frameId);
+      return steps;
+    } catch (err) {
+      return undefined;
+    }
   },
   (pauseId, frameId) => `${pauseId}:${frameId}`
 );


### PR DESCRIPTION
This PR:

- Updates the frame steps cache to swallow API errors and return `undefined`

Per BAC-2459 , the backend is consistently throwing internal errors in at least one replay when paused at a specific point, and the rethrown errors were taking down our UI entirely.

The cache already allowed returning `undefined`, so swallowing the error here allows the UI to continue operating normally.