### PR TITLE
getExpressionFromString uses Suspense cache for parsing

### DIFF
--- a/packages/bvaughn-architecture-demo/components/sources/utils/getExpressionFromString.ts
+++ b/packages/bvaughn-architecture-demo/components/sources/utils/getExpressionFromString.ts
@@ -1,10 +1,10 @@
-import { highlighter } from "bvaughn-architecture-demo/src/suspense/SyntaxParsingCache";
+import { parse } from "bvaughn-architecture-demo/src/suspense/SyntaxParsingCache";
 
 export default function getExpressionFromString(
   string: string,
   cursorIndex: number
 ): string | null {
-  const parsedString = highlighter(string, ".js");
+  const parsedString = parse(string, ".js");
   if (parsedString == null || parsedString.length === 0) {
     return null;
   }
@@ -78,7 +78,7 @@ export default function getExpressionFromString(
     currentIndex++;
   }
 
-  const parsedExpression = highlighter(expression, ".js");
+  const parsedExpression = parse(expression, ".js");
   if (parsedExpression == null || parsedExpression.length === 0) {
     return null;
   } else {

--- a/packages/bvaughn-architecture-demo/src/suspense/SyntaxParsingCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/SyntaxParsingCache.ts
@@ -273,7 +273,7 @@ function incrementalParser(fileName?: string, contentType?: ContentType): Increm
   };
 }
 
-export function highlighter(code: string, fileName: string): string[] | null {
+function highlighter(code: string, fileName: string): string[] | null {
   const parser = incrementalParser(fileName);
   if (parser === null) {
     return null;


### PR DESCRIPTION
Now that createGenericCache doesn't throw for sync values, this function can use the cache and avoid re-parsing strings.

Follow up to #8115