### PR TITLE
Disable remaining source editor context menu for consistency

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/EditorMenu.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/EditorMenu.tsx
@@ -38,6 +38,10 @@ type PropsFromRedux = ConnectedProps<typeof connector>;
 type FinalEMProps = EditorMenuProps & PropsFromRedux & { replayClient: ReplayClientInterface };
 
 class EditorMenu extends Component<FinalEMProps> {
+  // TODO [FE-926] Review source editor context menu for re-adding later
+  // This includes actual implementation (legacy FF menu vs something new),
+  // as well as what menu items it should contain.
+  /*
   UNSAFE_componentWillUpdate(nextProps: FinalEMProps) {
     this.props.clearContextMenu();
     if (nextProps.contextMenu) {
@@ -70,6 +74,7 @@ class EditorMenu extends Component<FinalEMProps> {
       })
     );
   }
+  */
 
   render() {
     return null;

--- a/src/devtools/client/debugger/src/components/Editor/menus/editor.ts
+++ b/src/devtools/client/debugger/src/components/Editor/menus/editor.ts
@@ -18,6 +18,10 @@ import { getSourcemapVisualizerURLSuspense } from "../../../utils/sourceVisualiz
 
 type EditorActions = ReturnType<typeof editorItemActions>;
 
+// TODO [FE-926] Review source editor context menu for re-adding later
+// This includes actual implementation (legacy FF menu vs something new),
+// as well as what menu items it should contain.
+
 // menu items
 
 const copySourceUri2Item = (selectedSource: SourceDetails) => ({

--- a/src/devtools/client/debugger/src/components/PrimaryPanes/SourcesTreeItem.tsx
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/SourcesTreeItem.tsx
@@ -69,6 +69,9 @@ class SourceTreeItem extends Component<FinalSTIProps> {
   };
 
   onContextMenu = (event: React.MouseEvent, item: $FixTypeLater) => {
+    // TODO [FE-926] Review source editor context menu for re-adding later
+    // This includes actual implementation (legacy FF menu vs something new),
+    // as well as what menu items it should contain.
     const copySourceUri2Label = "Copy source URI";
     const copySourceUri2Key = "u";
 

--- a/src/devtools/client/debugger/src/utils/tabs.ts
+++ b/src/devtools/client/debugger/src/utils/tabs.ts
@@ -1,6 +1,9 @@
 import type { Tab } from "../reducers/tabs";
 
 export function getTabMenuItems() {
+  // TODO [FE-926] Review source editor context menu for re-adding later
+  // This includes actual implementation (legacy FF menu vs something new),
+  // as well as what menu items it should contain.
   return {
     closeTab: {
       id: "node-menu-close-tab",


### PR DESCRIPTION
The source editor context menu was mostly broken in https://github.com/replayio/devtools/pull/7932 when we converted `Editor/index.tsx` to be a function component, as we no longer set state to trigger displaying it.

There was one remaining event listener triggering showing the menu, in `onGutterContextMenu()`, which is still part of the legacy CodeMirror editor implementation.  However, that only ran in FF, not in Chrome.

Given that we're about to switch and rip out the CM editor for the new Source Viewer, _and_ the context menu items were of debatable usefulness, _and_ the menu implementation is an ancient legacy FF feature that we want to replace, I'm just turning this off completely.  We have FE-926 to track re-adding a source context menu, and FE-179 to track building a Better Faster Stronger context menu.