### PR TITLE
Fix timing issue in the scope cache (FE-931)

### DIFF
--- a/packages/bvaughn-architecture-demo/src/suspense/PauseCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/PauseCache.ts
@@ -63,8 +63,8 @@ export function cachePauseData(
   if (pauseData.objects) {
     preCacheObjects(pauseId, pauseData.objects);
   }
-  if (stack && pauseData.frames) {
-    const frames = sortFramesAndUpdateLocations(client, pauseData.frames, stack);
+  if (stack) {
+    const frames = sortFramesAndUpdateLocations(client, pauseData.frames || [], stack);
     if (frames) {
       cacheFrames(frames, pauseId);
     }

--- a/packages/bvaughn-architecture-demo/src/suspense/ScopeCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/ScopeCache.ts
@@ -1,5 +1,6 @@
 import { FrameId, MappedLocation, PauseId, Scope, ScopeId } from "@replayio/protocol";
 
+import { assert } from "protocol/utils";
 import { ReplayClientInterface } from "shared/client/types";
 
 import { createGenericCache2 } from "./createGenericCache";
@@ -22,7 +23,9 @@ export const {
     const result = await client.getScope(pauseId, scopeId);
     await client.waitForLoadedSources();
     cachePauseData(client, pauseId, result.data);
-    return result.data.scopes!.find(scope => scope.scopeId === scopeId)!;
+    const cached: { value: Scope } | undefined = getScopeIfCached(pauseId, scopeId);
+    assert(cached, `Scope ${scopeId} for pause ${pauseId} not found in cache`);
+    return cached.value;
   },
   (pauseId, scopeId) => `${pauseId}:${scopeId}`
 );

--- a/packages/bvaughn-architecture-demo/src/suspense/createGenericCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/createGenericCache.ts
@@ -134,9 +134,7 @@ export function createGenericCache2<TExtra, TParams extends Array<any>, TValue>(
 
     addValue(value: TValue, ...args: TParams) {
       const cacheKey = getCacheKey(...args);
-      if (!recordMap.has(cacheKey)) {
-        recordMap.set(cacheKey, { status: STATUS_RESOLVED, value });
-      }
+      recordMap.set(cacheKey, { status: STATUS_RESOLVED, value });
     },
   };
 }


### PR DESCRIPTION
The frame and scope suspense caches use the `addValue()` method to "sideload" data into them (this is necessary because the backend may send frames and scopes even if they were not explicitly requested and will not send them again afterwards).
FE-931 shows how this can lead to a timing issue in the scope cache. This PR fixes the issue in the scope cache and applies the same fix to the frame cache.