### PR TITLE
Allow multiple tabs for sources with the same URL (FE-806)

### DIFF
--- a/src/devtools/client/debugger/src/actions/tabs.ts
+++ b/src/devtools/client/debugger/src/actions/tabs.ts
@@ -13,12 +13,13 @@ import { UIThunkAction } from "ui/actions";
 import {
   MiniSource,
   SourceDetails,
+  clearSelectedLocation,
   getSourceToDisplayForUrl,
   isOriginalSource,
 } from "ui/reducers/sources";
 
 import type { Context } from "../reducers/pause";
-import { getNewSelectedSourceId, getSourceTabs } from "../selectors";
+import { getNewSelectedSourceId, getTabs } from "../selectors";
 import { removeDocument } from "../utils/editor";
 import { selectSource } from "./sources";
 
@@ -32,14 +33,6 @@ export function updateTab(source: SourceDetails, framework: string) {
     framework,
     isOriginal,
     sourceId,
-  };
-}
-
-export function moveTab(url: string, tabIndex: number) {
-  return {
-    type: "MOVE_TAB",
-    url,
-    tabIndex,
   };
 }
 
@@ -59,11 +52,15 @@ export function closeTab(cx: Context, source: MiniSource): UIThunkAction {
   return (dispatch, getState) => {
     removeDocument(source.id);
 
-    const tabs = getSourceTabs(getState());
+    const tabs = getTabs(getState());
     dispatch({ type: "CLOSE_TAB", source });
 
     const sourceId = getNewSelectedSourceId(getState(), tabs);
-    dispatch(selectSource(cx, sourceId));
+    if (sourceId) {
+      dispatch(selectSource(cx, sourceId));
+    } else {
+      dispatch(clearSelectedLocation());
+    }
   };
 }
 
@@ -75,11 +72,15 @@ export function closeTabs(cx: Context, urls: string[]): UIThunkAction {
   return (dispatch, getState) => {
     const sources = urls.map(url => getSourceToDisplayForUrl(getState(), url)!).filter(Boolean);
 
-    const tabs = getSourceTabs(getState());
+    const tabs = getTabs(getState());
     sources.forEach(source => removeDocument(source.id));
     dispatch({ type: "CLOSE_TABS", sources });
 
     const sourceId = getNewSelectedSourceId(getState(), tabs);
-    dispatch(selectSource(cx, sourceId));
+    if (sourceId) {
+      dispatch(selectSource(cx, sourceId));
+    } else {
+      dispatch(clearSelectedLocation());
+    }
   };
 }

--- a/src/devtools/client/debugger/src/utils/tabs.ts
+++ b/src/devtools/client/debugger/src/utils/tabs.ts
@@ -56,16 +56,6 @@ export function getTabMenuItems() {
   };
 }
 
-export function isSimilarTab(tab: Tab, url: string, isOriginal?: boolean) {
-  return tab.url === url && tab.isOriginal === isOriginal;
-}
-
-export function persistTabs(tabs: Tab[]) {
-  return [...tabs]
-    .filter(tab => tab.url)
-    .map(tab => {
-      const newTab = { ...tab };
-      newTab.sourceId = null;
-      return newTab;
-    });
+export function persistTabs(tabs: Tab[]): Tab[] {
+  return tabs.filter(tab => tab.url).map(tab => ({ url: tab.url, sourceId: "" }));
 }

--- a/src/ui/setup/helpers.ts
+++ b/src/ui/setup/helpers.ts
@@ -22,7 +22,7 @@ declare global {
     local: () => void;
     prod: () => void;
     clearIndexedDB: () => void;
-    replaySession: Promise<ReplaySession> | undefined;
+    replaySession: ReplaySession | undefined;
     triggerEvent: typeof triggerEvent;
     sendMessage: typeof sendMessage;
     releaseSession: () => void;

--- a/src/ui/setup/index.ts
+++ b/src/ui/setup/index.ts
@@ -21,10 +21,10 @@ import { getUserInfo } from "ui/hooks/users";
 import { getTheme, initialAppState } from "ui/reducers/app";
 import { syncInitialLayoutState } from "ui/reducers/layout";
 import { getCorrespondingSourceIds } from "ui/reducers/sources";
-import { getReplaySession } from "ui/setup/prefs";
+import { ReplaySession, getReplaySession } from "ui/setup/prefs";
 import type { LayoutState } from "ui/state/layout";
 import { Recording } from "ui/types";
-import { setAccessTokenInBrowserPrefs, setUserInBrowserPrefs } from "ui/utils/browser";
+import { setUserInBrowserPrefs } from "ui/utils/browser";
 import { initLaunchDarkly } from "ui/utils/launchdarkly";
 import { maybeSetMixpanelContext } from "ui/utils/mixpanel";
 import { getPreferredLocation } from "ui/utils/preferredLocation";
@@ -48,7 +48,10 @@ declare global {
 let store: UIStore;
 export type AppDispatch = typeof store.dispatch;
 
-const getDefaultSelectedPrimaryPanel = (session: any, recording?: Recording) => {
+const getDefaultSelectedPrimaryPanel = (
+  session: ReplaySession | undefined,
+  recording?: Recording
+) => {
   if (session) {
     return session.selectedPrimaryPanel;
   }

--- a/src/ui/setup/prefs.ts
+++ b/src/ui/setup/prefs.ts
@@ -1,14 +1,10 @@
 import { RecordingId } from "@replayio/protocol";
 import debounce from "lodash/debounce";
 
-import { getTabs } from "devtools/client/debugger/src/reducers/tabs";
-import {
-  asyncStore as debuggerAsyncPrefs,
-  prefs as debuggerPrefs,
-} from "devtools/client/debugger/src/utils/prefs";
+import { Tab, getTabs } from "devtools/client/debugger/src/reducers/tabs";
+import { prefs as debuggerPrefs } from "devtools/client/debugger/src/utils/prefs";
 import { persistTabs } from "devtools/client/debugger/src/utils/tabs";
 import { UIStore } from "ui/actions";
-import { getRecording } from "ui/hooks/recordings";
 import { getTheme } from "ui/reducers/app";
 import {
   getLocalNags,
@@ -19,7 +15,7 @@ import {
   getViewMode,
 } from "ui/reducers/layout";
 import { UIState } from "ui/state";
-import { ToolboxLayout, ViewMode } from "ui/state/layout";
+import { PrimaryPanelName, SecondaryPanelName, ToolboxLayout, ViewMode } from "ui/state/layout";
 import { asyncStore, prefs } from "ui/utils/prefs";
 import { getRecordingId } from "ui/utils/recording";
 
@@ -30,7 +26,10 @@ export interface ReplaySession {
   viewMode: ViewMode;
   showVideoPanel: boolean;
   toolboxLayout: ToolboxLayout;
-  localNags: string[];
+  selectedPrimaryPanel: PrimaryPanelName;
+  selectedPanel: SecondaryPanelName;
+  localNags: LocalNag[];
+  tabs: Tab[];
 }
 
 export function registerStoreObserver(
@@ -104,29 +103,11 @@ async function getReplaySessions() {
   return replaySessions;
 }
 
-export async function getReplaySession(recordingId: RecordingId) {
+export async function getReplaySession(
+  recordingId: RecordingId
+): Promise<ReplaySession | undefined> {
   return (await asyncStore.replaySessions)[recordingId];
 }
-
-export const getLocalReplaySessionPrefs = async () => {
-  const recordingId = getRecordingId();
-
-  // If we're in the library, there are no preferences to fetch.
-  if (!recordingId) {
-    return null;
-  }
-
-  let recording;
-  try {
-    recording = await getRecording(recordingId);
-  } catch (e) {
-    return null;
-  }
-
-  const session = await getReplaySession(recordingId);
-
-  return session;
-};
 
 export enum LocalNag {
   // Yank the user's select left sidebar panel to show the explorer (sources + outline)


### PR DESCRIPTION
The current source tab logic explicitly avoids showing multiple tabs for sources with the same URL. This means that if there are multiple different sources with the same URL, only one of them will get a source tab and selecting any other of these sources won't show a selected tab (see FE-806).
This PR allows multiple source tabs to be shown in this case and cleans up the tab logic a little.