### PR TITLE
Fix the location of column breakpoints (GTM-467)

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/ColumnBreakpoint.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/ColumnBreakpoint.tsx
@@ -71,7 +71,7 @@ export default function ColumnBreakpoint({
     });
 
     const bookmark = doc.setBookmark(
-      { line: point.location.line, ch: point.location.column },
+      { line: point.location.line - 1, ch: point.location.column },
       { widget }
     );
 


### PR DESCRIPTION
The conversion from 1-based to 0-based line numbers was lost in the points refactor.