### PR TITLE
New Source viewer enabled by default (opt-out)

### DIFF
--- a/packages/bvaughn-architecture-demo/components/sources/PointPanelTimeline.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/PointPanelTimeline.tsx
@@ -86,7 +86,7 @@ export default function PointPanelTimeline({
 
   const label =
     currentHitPointIndex !== null
-      ? `${currentHitPointIndex + 1} / ${hitPoints.length}`
+      ? `${currentHitPointIndex + 1}/${hitPoints.length}`
       : hitPoints.length;
 
   let tooManyPointsToFind = false;

--- a/packages/bvaughn-architecture-demo/playwright/tests/source-and-console.ts
+++ b/packages/bvaughn-architecture-demo/playwright/tests/source-and-console.ts
@@ -383,7 +383,7 @@ test("should update the current time when the next/previous log point buttons ar
   });
 
   await goToNextHitPoint(page, lineNumber);
-  await verifyLogPointStep(page, "1 / 2", { lineNumber, sourceId });
+  await verifyLogPointStep(page, "1/2", { lineNumber, sourceId });
   await verifyHitPointButtonsEnabled(page, {
     lineNumber,
     previousEnabled: false,
@@ -391,7 +391,7 @@ test("should update the current time when the next/previous log point buttons ar
   });
 
   await goToNextHitPoint(page, lineNumber);
-  await verifyLogPointStep(page, "2 / 2", { lineNumber, sourceId });
+  await verifyLogPointStep(page, "2/2", { lineNumber, sourceId });
   await verifyHitPointButtonsEnabled(page, {
     lineNumber,
     previousEnabled: true,
@@ -399,7 +399,7 @@ test("should update the current time when the next/previous log point buttons ar
   });
 
   await goToPreviousHitPoint(page, lineNumber);
-  await verifyLogPointStep(page, "1 / 2", { lineNumber, sourceId });
+  await verifyLogPointStep(page, "1/2", { lineNumber, sourceId });
   await verifyHitPointButtonsEnabled(page, {
     lineNumber,
     previousEnabled: false,

--- a/src/devtools/client/debugger/src/components/Editor/EditorPane.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/EditorPane.tsx
@@ -24,7 +24,7 @@ export const EditorPane = () => {
   const selectedSource = useAppSelector(getSelectedSource);
   const panelEl = useRef(null);
   const { value: enableLargeText } = useFeature("enableLargeText");
-  const { value: enableNewSourceViewer } = useFeature("newSourceViewer");
+  const { value: enableLegacySourceViewer } = useFeature("legacySourceViewer");
 
   const nodeWidth = useWidthObserver(panelEl);
 
@@ -64,7 +64,7 @@ export const EditorPane = () => {
         <EditorTabs />
         {selectedSource ? (
           <Redacted className="h-full">
-            {enableNewSourceViewer ? <NewSourceAdapter /> : <Editor />}
+            {enableLegacySourceViewer ? <Editor /> : <NewSourceAdapter />}
           </Redacted>
         ) : (
           <WelcomeBox />

--- a/src/ui/components/SourcesContextAdapter.tsx
+++ b/src/ui/components/SourcesContextAdapter.tsx
@@ -41,12 +41,12 @@ function SourcesContextAdapter({ children }: { children: ReactNode }) {
   const selectedLineNumber = selectedLocation?.line || null;
   const selectedSourceId = selectedLocation?.sourceId || null;
 
-  const { value: enableNewSourceViewer } = useFeature("newSourceViewer");
+  const { value: enableLegacySourceViewer } = useFeature("legacySourceViewer");
 
   const { focusedSourceId, openSource } = useContext(SourcesContext);
 
   useLayoutEffect(() => {
-    if (enableNewSourceViewer) {
+    if (!enableLegacySourceViewer) {
       // The new Source viewer has its own context adapter, NewSourceAdapter.
       // This adapter can skip its update if the new Source viewer is enabled.
       return;
@@ -61,7 +61,7 @@ function SourcesContextAdapter({ children }: { children: ReactNode }) {
 
       openSource(selectedSourceId, lineNumber);
     }
-  }, [enableNewSourceViewer, focusedSourceId, openSource, selectedLineNumber, selectedSourceId]);
+  }, [enableLegacySourceViewer, focusedSourceId, openSource, selectedLineNumber, selectedSourceId]);
 
   return children as any;
 }

--- a/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
+++ b/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
@@ -16,9 +16,9 @@ interface ExperimentalSetting {
 
 const EXPERIMENTAL_SETTINGS: ExperimentalSetting[] = [
   {
-    label: "New source viewer",
-    description: "Enable new source viewer and log point UIs",
-    key: "enableNewSourceViewer",
+    label: "Legacy source viewer",
+    description: "Enable legacy source viewer and log point UIs",
+    key: "enableLegacySourceViewer",
   },
   {
     label: "Column Breakpoints",
@@ -91,8 +91,8 @@ export default function ExperimentalSettings({}) {
   const { value: enableColumnBreakpoints, update: updateEnableColumnBreakpoints } =
     useFeature("columnBreakpoints");
 
-  const { value: enableNewSourceViewer, update: updateEnableNewSourceViewer } =
-    useFeature("newSourceViewer");
+  const { value: enableLegacySourceViewer, update: updateEnableNewSourceViewer } =
+    useFeature("legacySourceViewer");
 
   const { value: enableResolveRecording, update: updateEnableResolveRecording } =
     useFeature("resolveRecording");
@@ -113,8 +113,8 @@ export default function ExperimentalSettings({}) {
   const onChange = (key: ExperimentalKey, value: any) => {
     if (key == "enableColumnBreakpoints") {
       updateEnableColumnBreakpoints(!enableColumnBreakpoints);
-    } else if (key == "enableNewSourceViewer") {
-      updateEnableNewSourceViewer(!enableNewSourceViewer);
+    } else if (key == "enableLegacySourceViewer") {
+      updateEnableNewSourceViewer(!enableLegacySourceViewer);
     } else if (key == "enableResolveRecording") {
       updateEnableResolveRecording(!enableResolveRecording);
     } else if (key === "hitCounts") {
@@ -134,7 +134,7 @@ export default function ExperimentalSettings({}) {
     basicProcessingLoadingBar,
     consoleFilterDrawerDefaultsToOpen,
     enableColumnBreakpoints,
-    enableNewSourceViewer,
+    enableLegacySourceViewer,
     enableResolveRecording,
     enableQueryCache,
     hitCounts,

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -19,7 +19,7 @@ export type LocalExperimentalUserSettings = {
   enableQueryCache: boolean;
   enableColumnBreakpoints: boolean;
   enableLargeText: boolean;
-  enableNewSourceViewer: boolean;
+  enableLegacySourceViewer: boolean;
   enableResolveRecording: boolean;
   hitCounts: boolean;
   profileWorkerThreads: boolean;

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -28,7 +28,7 @@ pref("devtools.features.commentAttachments", false);
 pref("devtools.features.consoleFilterDrawerDefaultsToOpen", false);
 pref("devtools.features.disableUnHitLines", false);
 pref("devtools.features.enableLargeText", false);
-pref("devtools.features.newSourceViewer", false);
+pref("devtools.features.legacySourceViewer", false);
 pref("devtools.features.enableQueryCache", false);
 pref("devtools.features.hitCounts", true);
 pref("devtools.features.logProtocol", false);
@@ -64,7 +64,7 @@ export const features = new PrefsHelper("devtools.features", {
   commentAttachments: ["Bool", "commentAttachments"],
   consoleFilterDrawerDefaultsToOpen: ["Bool", "consoleFilterDrawerDefaultsToOpen"],
   enableQueryCache: ["Bool", "enableQueryCache"],
-  newSourceViewer: ["Bool", "newSourceViewer"],
+  legacySourceViewer: ["Bool", "legacySourceViewer"],
   disableUnHitLines: ["Bool", "disableUnHitLines"],
   enableLargeText: ["Bool", "enableLargeText"],
   hitCounts: ["Bool", "hitCounts"],


### PR DESCRIPTION
- [x] Change feature flag so that the new Source viewer is on by default
- [x] Update new log points panel to show steps as "1/n" instead of "1 / n" (to match)
- [x] Pull e2e test updates from #8138 so they pass with new Source viewer
- [x] Rebase #8138 on top of this branch