### PR TITLE
Fix login loop from failed attempt

### DIFF
--- a/src/ui/components/shared/Login/Login.tsx
+++ b/src/ui/components/shared/Login/Login.tsx
@@ -222,7 +222,8 @@ export default function Login({
   const { loginWithRedirect, error } = useAuth0();
   const [sso, setSSO] = useState(false);
 
-  if (returnToPath.startsWith("/login")) {
+  const url = new URL(returnToPath, window.location.origin);
+  if (url.pathname === "/login" || (url.pathname === "/" && url.searchParams.has("state"))) {
     returnToPath = "/";
   }
 


### PR DESCRIPTION
Just had a case in which the user would get stuck in a login loop because the login UI presented like there was an error but there wasn't. This was caused by retaining the error query string parameters across auth attempts which confused the UI.

The proposed fix looks for the `state` parameter in the callback from an auth attempt and cleans up the `returnToPath` if it exists.