### PR TITLE
Add the ability to cache scan data

### DIFF
--- a/packages/protocol/socket.ts
+++ b/packages/protocol/socket.ts
@@ -91,8 +91,9 @@ if (typeof window !== "undefined") {
 }
 
 export type ExperimentalSettings = {
-  controllerKey?: string;
   listenForMetrics: boolean;
+  cacheScanData?: boolean;
+  controllerKey?: string;
   disableCache?: boolean;
   disableQueryCache?: boolean;
   profileWorkerThreads?: boolean;

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -198,9 +198,10 @@ export function createSocket(
       const experimentalSettings: ExperimentalSettings = {
         // Uncomment this to get a new session every time you refresh
         // controllerKey: String(Math.floor(Math.random() * 10e8)),
-        listenForMetrics: !!prefs.listenForMetrics,
+        cacheScanData: !!features.cacheScanData,
         disableCache: !!prefs.disableCache,
         disableQueryCache: !features.enableQueryCache,
+        listenForMetrics: !!prefs.listenForMetrics,
         profileWorkerThreads: !!features.profileWorkerThreads,
       };
 

--- a/src/ui/components/Events/ReplayInfo.tsx
+++ b/src/ui/components/Events/ReplayInfo.tsx
@@ -100,7 +100,7 @@ function ReplayInfo({ setModal }: PropsFromRedux) {
                   className="overflow-hidden overflow-ellipsis whitespace-pre"
                   title={recording.metadata.source?.branch}
                 >
-                  {time} ago
+                  {time === "Now" ? time : time + " ago"}
                 </div>
               </Row>
 

--- a/src/ui/components/Timeline/Capsule.tsx
+++ b/src/ui/components/Timeline/Capsule.tsx
@@ -1,8 +1,8 @@
 import classNames from "classnames";
-import React, { MutableRefObject, useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { CircularProgressbar, buildStyles } from "react-circular-progressbar";
 
-import { getLoadedAndIndexedProgress, getLoadingStatusSlow } from "ui/actions/app";
+import { getIndexedProgress, getLoadingStatusSlow } from "ui/actions/app";
 import ExternalLink from "ui/components/shared/ExternalLink";
 import { useFeature } from "ui/hooks/settings";
 import useModalDismissSignal from "ui/hooks/useModalDismissSignal";
@@ -21,7 +21,7 @@ export default function Capsule({
 }: {
   setShowLoadingProgress: React.Dispatch<React.SetStateAction<boolean>>;
 }) {
-  const indexingProgress = Math.round(useAppSelector(getLoadedAndIndexedProgress) * 100);
+  const indexingProgress = Math.round(useAppSelector(getIndexedProgress) * 100);
   const basicProcessingProgress = Math.round(useAppSelector(getBasicProcessingProgress) * 100);
   let progress = indexingProgress;
   const { value: basicProcessingLoadingBar } = useFeature("basicProcessingLoadingBar");

--- a/src/ui/components/Timeline/LoadingProgressBars.tsx
+++ b/src/ui/components/Timeline/LoadingProgressBars.tsx
@@ -3,7 +3,6 @@ import clamp from "lodash/clamp";
 import { getLoadedRegions } from "ui/reducers/app";
 import { getZoomRegion } from "ui/reducers/timeline";
 import { useAppSelector } from "ui/setup/hooks";
-import { overlap } from "ui/utils/timeline";
 
 import styles from "./LoadingProgressBars.module.css";
 
@@ -16,9 +15,7 @@ export default function LoadingProgressBars() {
     return null;
   }
 
-  const completedRegions = loadedRegions
-    ? overlap(loadedRegions.indexed, loadedRegions.loaded)
-    : [];
+  const completedRegions = loadedRegions ? loadedRegions.indexed : [];
   const loadingRegions = loadedRegions ? loadedRegions.loading : [];
 
   return (

--- a/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
+++ b/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
@@ -59,6 +59,11 @@ const EXPERIMENTAL_SETTINGS: ExperimentalSetting[] = [
       "Open the console filter settings by default when opening a Replay for the first time",
     key: "consoleFilterDrawerDefaultsToOpen",
   },
+  {
+    label: "Cache Scan Data",
+    description: "Cache the results of indexing the recording",
+    key: "cacheScanData",
+  },
 ];
 
 const RISKY_EXPERIMENTAL_SETTINGS: ExperimentalSetting[] = [];
@@ -94,6 +99,8 @@ export default function ExperimentalSettings({}) {
   const { value: enableLegacySourceViewer, update: updateEnableNewSourceViewer } =
     useFeature("legacySourceViewer");
 
+  const { value: cacheScanData, update: updateCacheScanData } = useFeature("cacheScanData");
+
   const { value: enableResolveRecording, update: updateEnableResolveRecording } =
     useFeature("resolveRecording");
 
@@ -127,16 +134,19 @@ export default function ExperimentalSettings({}) {
       updateBasicProcessingLoadingBar(!basicProcessingLoadingBar);
     } else if (key === "consoleFilterDrawerDefaultsToOpen") {
       updateConsoleFilterDrawerDefaultsToOpen(!consoleFilterDrawerDefaultsToOpen);
+    } else if (key === "cacheScanData") {
+      updateCacheScanData(!cacheScanData);
     }
   };
 
   const localSettings = {
     basicProcessingLoadingBar,
+    cacheScanData,
     consoleFilterDrawerDefaultsToOpen,
     enableColumnBreakpoints,
     enableLegacySourceViewer,
-    enableResolveRecording,
     enableQueryCache,
+    enableResolveRecording,
     hitCounts,
     profileWorkerThreads,
   };

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -233,13 +233,13 @@ export const getIndexedAndLoadedRegions = createSelector(getLoadedRegions, loade
 // For example:
 // If 80% of the regions have been indexed and 50% have been loaded, this method would return 0.65.
 // If 100% of the regions have been indexed and 50% have been loaded, this method would return 0.75.
-export const getLoadedAndIndexedProgress = createSelector(getLoadedRegions, regions => {
+export const getIndexedProgress = createSelector(getLoadedRegions, regions => {
   if (!regions) {
     return 0;
   }
 
-  const { indexed, loaded, loading } = regions;
-  if (indexed == null || loaded == null || loading == null) {
+  const { indexed, loading } = regions;
+  if (indexed == null || loading == null) {
     return 0;
   }
 
@@ -251,17 +251,14 @@ export const getLoadedAndIndexedProgress = createSelector(getLoadedRegions, regi
     return 0;
   }
 
-  const totalLoadedTime = loaded.reduce((totalTime, { begin, end }) => {
-    return totalTime + end.time - begin.time;
-  }, 0);
   const totalIndexedTime = indexed.reduce((totalTime, { begin, end }) => {
     return totalTime + end.time - begin.time;
   }, 0);
 
-  return (totalLoadedTime + totalIndexedTime) / (totalLoadingTime * 2);
+  return totalIndexedTime / totalLoadingTime;
 });
 
-export const getIsIndexed = createSelector(getLoadedAndIndexedProgress, progress => progress === 1);
+export const getIsIndexed = createSelector(getIndexedProgress, progress => progress === 1);
 
 export const getNonLoadingTimeRanges = (state: UIState) => {
   const loadingRegions = getLoadedRegions(state)?.loading || [];

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -15,6 +15,7 @@ export type ExperimentalUserSettings = {
 
 export type LocalExperimentalUserSettings = {
   basicProcessingLoadingBar: boolean;
+  cacheScanData: boolean;
   consoleFilterDrawerDefaultsToOpen: boolean;
   enableQueryCache: boolean;
   enableColumnBreakpoints: boolean;

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -23,6 +23,7 @@ pref("devtools.hitCounts", "hide-counts");
 
 // app features
 pref("devtools.features.basicProcessingLoadingBar", false);
+pref("devtools.features.cacheScanData", false);
 pref("devtools.features.columnBreakpoints", false);
 pref("devtools.features.commentAttachments", false);
 pref("devtools.features.consoleFilterDrawerDefaultsToOpen", false);
@@ -60,6 +61,7 @@ export const prefs = new PrefsHelper("devtools", {
 
 export const features = new PrefsHelper("devtools.features", {
   basicProcessingLoadingBar: ["Bool", "basicProcessingLoadingBar"],
+  cacheScanData: ["Bool", "cacheScanData"],
   columnBreakpoints: ["Bool", "columnBreakpoints"],
   commentAttachments: ["Bool", "commentAttachments"],
   consoleFilterDrawerDefaultsToOpen: ["Bool", "consoleFilterDrawerDefaultsToOpen"],


### PR DESCRIPTION
And change what it means for regions to be "loaded". We have several different things we track on the the region level:

- Loading: are we ever going to try and load this region given the current focus window?
- Indexed: have we processing the manifests which produce scan data for this region, which allows things like hitCounts to work
- Loaded: Have we done a run-to-point and fork at the beginning of this region yet or not?

Ironically, for the colloquial "loading" case (can I interact with the recording) we don't really care about the `loaded` state as defined above. If we have not RTP and forked in a region, then doing things like pause operations/analyses will be slow there, but we can totally get started queueing up those requests, they'll just take a little longer to respond. By not including that in the loading percentage we can get people interacting with editor, hitcounts, paints, etc. faster.

As always, it's been a while since I was fluent in devtools, so happy to get feedback from @bvaughn or @markerikson if there are better ways to accomplish these same goals!