### PR TITLE
Clicking on a comment should not open the DevTools tab

### DIFF
--- a/src/devtools/client/debugger/src/actions/pause/paused.ts
+++ b/src/devtools/client/debugger/src/actions/pause/paused.ts
@@ -85,7 +85,12 @@ export function paused({
         currentLocation.column !== selectedFrame.location.column
       ) {
         const { selectLocation } = await import("../sources");
-        dispatch(selectLocation(cx, selectedFrame.location, true));
+        // This action creator is triggered whenever we seek to a new exception point.
+        // It's pretty far removed from the cause of the seek,
+        // so it shouldn't make the decision of whether to change UI tabs.
+        const openSourcesTab = false;
+
+        dispatch(selectLocation(cx, selectedFrame.location, openSourcesTab));
       }
 
       if (pause !== ThreadFront.currentPause) {

--- a/src/devtools/client/debugger/src/actions/sources/select.ts
+++ b/src/devtools/client/debugger/src/actions/sources/select.ts
@@ -29,10 +29,8 @@ import { Context } from "../../reducers/pause";
 import { getTabExists } from "../../reducers/tabs";
 import { closeActiveSearch } from "../../reducers/ui";
 import { setShownSource } from "../../reducers/ui";
-import { getActiveSearch, getContext, getExecutionPoint, getThreadContext } from "../../selectors";
-import { getSelectedFrameAsync } from "../../selectors/pause";
+import { getActiveSearch, getContext, getThreadContext } from "../../selectors";
 import { createLocation } from "../../utils/location";
-import { paused } from "../pause/paused";
 
 export type PartialLocation = Parameters<typeof createLocation>[0];
 
@@ -129,8 +127,12 @@ export function selectLocation(
     const currentSource = getSelectedSource(getState());
     trackEvent("sources.select_location");
 
-    if (getViewMode(getState()) == "non-dev") {
-      dispatch(setViewMode("dev"));
+    if (openSourcesTab) {
+      // This action should only change view modes if it's also going to open the Sources tab.
+      // Otherwise it's not possible to change locations without also opening the DevTools tab.
+      if (getViewMode(getState()) == "non-dev") {
+        dispatch(setViewMode("dev"));
+      }
     }
 
     let source = getSourceDetails(getState(), location.sourceId);

--- a/src/ui/actions/comments.ts
+++ b/src/ui/actions/comments.ts
@@ -219,7 +219,7 @@ export function createLabels(
   };
 }
 
-export function seekToComment(item: Comment | Reply): UIThunkAction {
+export function seekToComment(item: Comment | Reply, openSourcesTab: boolean): UIThunkAction {
   return (dispatch, getState) => {
     let context = selectors.getThreadContext(getState());
     dispatch(seek(item.point, item.time, item.hasFrames));
@@ -227,7 +227,7 @@ export function seekToComment(item: Comment | Reply): UIThunkAction {
 
     if (item.sourceLocation) {
       context = selectors.getThreadContext(getState());
-      dispatch(selectLocation(context, item.sourceLocation));
+      dispatch(selectLocation(context, item.sourceLocation, openSourcesTab));
     }
   };
 }

--- a/src/ui/components/Comments/CommentCard.tsx
+++ b/src/ui/components/Comments/CommentCard.tsx
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import { MouseEvent } from "react";
 
 import { getExecutionPoint } from "devtools/client/debugger/src/selectors";
 import { seekToComment } from "ui/actions/comments";
@@ -20,8 +21,14 @@ export default function CommentCard({ comment }: { comment: Comment }) {
 
   const dispatch = useAppDispatch();
 
-  const onClick = () => {
-    dispatch(seekToComment(comment));
+  const onClick = (event: MouseEvent) => {
+    event.stopPropagation();
+    dispatch(seekToComment(comment, false));
+  };
+
+  const onPreviewClick = (event: MouseEvent) => {
+    event.stopPropagation();
+    dispatch(seekToComment(comment, true));
   };
 
   const showReplyButton = !isCommentContentEmpty(comment.content);
@@ -33,7 +40,7 @@ export default function CommentCard({ comment }: { comment: Comment }) {
     >
       {isPaused && <div className={styles.PausedOverlay} />}
 
-      <CommentPreview comment={comment} />
+      <CommentPreview comment={comment} onClick={onPreviewClick} />
 
       <EditableRemark remark={comment} type="comment" />
 

--- a/src/ui/components/Comments/CommentMarker.tsx
+++ b/src/ui/components/Comments/CommentMarker.tsx
@@ -41,7 +41,7 @@ class CommentMarker extends React.Component<CommentMarkerProps> {
     e.stopPropagation();
     const { comment, seekToComment } = this.props;
     trackEvent("timeline.comment_select");
-    seekToComment(comment);
+    seekToComment(comment, false);
   };
 
   render() {

--- a/src/ui/components/Comments/CommentPreview.tsx
+++ b/src/ui/components/Comments/CommentPreview.tsx
@@ -1,20 +1,27 @@
-import { useFeature } from "ui/hooks/settings";
+import { MouseEvent } from "react";
+
 import { Comment } from "ui/state/comments";
 
 import CommentSource from "./TranscriptComments/CommentSource";
 import NetworkRequestPreview from "./TranscriptComments/NetworkRequestPreview";
 import styles from "./CommentPreview.module.css";
 
-export default function CommentPreview({ comment }: { comment: Comment }) {
+export default function CommentPreview({
+  comment,
+  onClick,
+}: {
+  comment: Comment;
+  onClick: (event: MouseEvent) => void;
+}) {
   if (comment.sourceLocation) {
     return (
-      <div className={styles.Preview}>
+      <div className={styles.Preview} onClick={onClick}>
         <CommentSource comment={comment} />
       </div>
     );
   } else if (comment.networkRequestId) {
     return (
-      <div className={styles.Preview}>
+      <div className={styles.Preview} onClick={onClick}>
         <NetworkRequestPreview networkRequestId={comment.networkRequestId} />
       </div>
     );


### PR DESCRIPTION
See [ff01dbee-81e1-4737-9108-27cc62778104](https://app.replay.io/recording/clicking-on-a-comment-opens-devtools-tab--ff01dbee-81e1-4737-9108-27cc62778104) for a bit of background.

Essentially, the high level sequence before this change was:
1. Clicking on a comment called `seekToComment` (`ui/actions/comments`)
1. `seekToComment` calls `seek` (`ui/actions/timeline`)
1. `seek` calls `ThreadFront.timeWarp`
1. `timeWarp` emits a "paused" event
1. The `paused` action creator is listening for "paused", and it calls `setLocation`
1. `selectLocation` calls `setViewMode` (which opens DevTools)

This is a lot of indirection. I think the following changes seem reasonable to me though:
1. `seekToComment` should only open the "DevTools" tab if you click on the location preview. (Otherwise it should just seek.)
1. The `paused` action creator should _never_ open a tab directly. It's too far removed from the user interaction to know what the right behavior should be.
1. The `selectLocation` action should only change the view mode (to "DevTools") if it's also been told to open the Sources tab.

[Loom demo](https://www.loom.com/share/db6b2938456142528db18ee33a23b5f6)