### PR TITLE
Fixes for keyboard shortcuts

### DIFF
--- a/packages/e2e-tests/helpers/source-panel.ts
+++ b/packages/e2e-tests/helpers/source-panel.ts
@@ -48,7 +48,7 @@ async function scrollUntilLineIsVisible(page: Page, lineNumber: number) {
   await debugPrint(page, `Scrolling to source line ${chalk.bold(lineNumber)}`, "goToLine");
 
   await page.keyboard.down(getCommandKey());
-  await page.keyboard.type("g");
+  await page.keyboard.type("p");
   await page.keyboard.up(getCommandKey());
 
   const input = page.locator("[data-test-id=QuickOpenInput]");

--- a/src/devtools/client/debugger/src/components/Editor/NewSourceAdapter.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/NewSourceAdapter.tsx
@@ -87,17 +87,19 @@ function NewSourceAdapter() {
         break;
       }
       case "g": {
-        // Unlike Enter / Shift+Enter, this event handler is external to the Search input
-        // so that we can mirror UIs like Chrome and Code and re-open the search UI if it's been closed
-        sourceSearchActions.enable();
-        if (event.shiftKey) {
-          sourceSearchActions.goToPrevious();
-        } else {
-          sourceSearchActions.goToNext();
-        }
+        if (event.ctrlKey || event.metaKey) {
+          // Unlike Enter / Shift+Enter, this event handler is external to the Search input
+          // so that we can mirror UIs like Chrome and Code and re-open the search UI if it's been closed
+          sourceSearchActions.enable();
+          if (event.shiftKey) {
+            sourceSearchActions.goToPrevious();
+          } else {
+            sourceSearchActions.goToNext();
+          }
 
-        event.preventDefault();
-        event.stopPropagation();
+          event.preventDefault();
+          event.stopPropagation();
+        }
         break;
       }
     }


### PR DESCRIPTION
- check meta/ctrl modifiers in NewSourceAdapter
- use CmdOrCtrl+p instead of CmdOrCtrl+g in an e2e test helper