### PR TITLE
ExceptionsCache accounts for string too-many-points error

### DIFF
--- a/packages/shared/utils/error.ts
+++ b/packages/shared/utils/error.ts
@@ -20,18 +20,19 @@ export const commandError = (message: string, code: number): CommandError => {
 export const isCommandError = (error: unknown, code: number): boolean => {
   if (error instanceof Error) {
     return error.name === "CommandError" && (error as CommandError).code === code;
-  } else if (code === ProtocolError.TooManyPoints) {
-    if (typeof error === "string") {
-      console.error("Unexpected error type encountered (string):", error);
+  } else if (typeof error === "string") {
+    console.error("Unexpected error type encountered (string):\n", error);
 
-      // TODO [BAC-2330] The Analysis endpoint returns an error string instead of an error object.
-      return error === "There are too many points to complete this operation";
+    switch (code) {
+      case ProtocolError.TooManyPoints:
+        // TODO [BAC-2330] The Analysis endpoint returns an error string instead of an error object.
+        // TODO [FE-938] The error string may contain information about the analysis; it may not be an exact match.
+        return error.startsWith("There are too many points to complete this operation");
+      case ProtocolError.LinkerDoesNotSupportAction:
+        return (
+          error === "The linker version used to make this recording does not support this action"
+        );
     }
-  } else if (code === ProtocolError.LinkerDoesNotSupportAction) {
-    if (typeof error === "string") {
-      console.error("Unexpected error type encountered (string):", error);
-    }
-    return error === "The linker version used to make this recording does not support this action";
   }
 
   return false;


### PR DESCRIPTION
See [Replay 59207f3f-ae40-4fa3-8dd9-7aaffc601ece](https://app.replay.io/recording/console-doesnt-load-for-replay-with-large-number-of-exceptions--59207f3f-ae40-4fa3-8dd9-7aaffc601ece) for an explanation of _why_ this was failing. See [this Loom](https://www.loom.com/share/be7cd5be333a42928296f779490f97ee) and [Replay 03fa7e31-090c-4edc-b3f3-617fb1b9cd76](https://app.replay.io/recording/console-exceptions-fix--03fa7e31-090c-4edc-b3f3-617fb1b9cd76) for a demo of it working now.

Basically this was a case of [BAC-2330](https://linear.app/replay/issue/BAC-2330) burning us again. I also noticed and filed [BAC-2484](https://linear.app/replay/issue/BAC-2484) about some weird hit counts and Pause steps issue with the bug report Replay.