### PR TITLE
Add Controller Key experimental feature

### DIFF
--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -196,14 +196,15 @@ export function createSocket(
       }
 
       const experimentalSettings: ExperimentalSettings = {
-        // Uncomment this to get a new session every time you refresh
-        // controllerKey: String(Math.floor(Math.random() * 10e8)),
         cacheScanData: !!features.cacheScanData,
         disableCache: !!prefs.disableCache,
         disableQueryCache: !features.enableQueryCache,
         listenForMetrics: !!prefs.listenForMetrics,
         profileWorkerThreads: !!features.profileWorkerThreads,
       };
+      if (features.newControllerOnRefresh) {
+        experimentalSettings.controllerKey = String(Date.now());
+      }
 
       const loadPoint = new URL(window.location.href).searchParams.get("point") || undefined;
 

--- a/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
+++ b/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
@@ -95,12 +95,9 @@ export default function ExperimentalSettings({}) {
   // TODO: This is bad and should be updated with a better generalized hook
   const { value: enableColumnBreakpoints, update: updateEnableColumnBreakpoints } =
     useFeature("columnBreakpoints");
-
   const { value: enableLegacySourceViewer, update: updateEnableNewSourceViewer } =
     useFeature("legacySourceViewer");
-
   const { value: cacheScanData, update: updateCacheScanData } = useFeature("cacheScanData");
-
   const { value: enableResolveRecording, update: updateEnableResolveRecording } =
     useFeature("resolveRecording");
 

--- a/src/ui/components/shared/UserSettingsModal/UserSettingsModal.tsx
+++ b/src/ui/components/shared/UserSettingsModal/UserSettingsModal.tsx
@@ -129,6 +129,8 @@ function Advanced() {
   const { value: protocolTimeline, update: updateProtocolTimeline } =
     useFeature("protocolTimeline");
   const { value: logProtocol, update: updateLogProtocol } = useFeature("logProtocol");
+  const { value: newControllerOnRefresh, update: updateNewControllerOnRefresh } =
+    useFeature("newControllerOnRefresh");
 
   return (
     <div>
@@ -150,13 +152,21 @@ function Advanced() {
           description={""}
         />
       </div>
-
       <div className="mb-4">
         <CheckboxRow
           id={"protocol-viewer"}
           onChange={() => updateLogProtocol(!logProtocol)}
           checked={logProtocol}
           label={"View protocol requests and responses in the panel"}
+          description={""}
+        />
+      </div>
+      <div className="mb-4">
+        <CheckboxRow
+          id={"new-controller-on-refresh"}
+          onChange={() => updateNewControllerOnRefresh(!newControllerOnRefresh)}
+          checked={newControllerOnRefresh}
+          label={"Get a new controller upon each page refresh"}
           description={""}
         />
       </div>

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -34,6 +34,7 @@ pref("devtools.features.enableQueryCache", false);
 pref("devtools.features.hitCounts", true);
 pref("devtools.features.logProtocol", false);
 pref("devtools.features.logProtocolEvents", false);
+pref("devtools.features.newControllerOnRefresh", false);
 pref("devtools.features.originalClassNames", false);
 pref("devtools.features.profileWorkerThreads", false);
 pref("devtools.features.protocolTimeline", false);
@@ -72,6 +73,7 @@ export const features = new PrefsHelper("devtools.features", {
   hitCounts: ["Bool", "hitCounts"],
   logProtocol: ["Bool", "logProtocol"],
   logProtocolEvents: ["Bool", "logProtocolEvents"],
+  newControllerOnRefresh: ["Bool", "newControllerOnRefresh"],
   originalClassNames: ["Bool", "originalClassNames"],
   profileWorkerThreads: ["Bool", "profileWorkerThreads"],
   protocolTimeline: ["Bool", "protocolTimeline"],


### PR DESCRIPTION
This is a nice flag to have in prod, because it allows you to easily get a new session whenever you want. It's not super useful for users, so I've stuck it under the experimental tab. This is especially useful for testing scan data caching, since you need to get a new session to see the caches come in.