### PR TITLE
Improve focus region error handling

### DIFF
--- a/packages/bvaughn-architecture-demo/components/ErrorBoundary.module.css
+++ b/packages/bvaughn-architecture-demo/components/ErrorBoundary.module.css
@@ -1,6 +1,10 @@
 .Error {
-  padding: 0.5em;
-  text-align: center;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   background-color: var(--background-color-error);
   color: var(--color-default);
 }

--- a/packages/bvaughn-architecture-demo/components/console/ConsoleRoot.tsx
+++ b/packages/bvaughn-architecture-demo/components/console/ConsoleRoot.tsx
@@ -44,26 +44,28 @@ export default function ConsoleRoot({
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   return (
-    <Suspense fallback={<IndeterminateLoader />}>
-      <ConsoleContextMenuContextRoot>
-        <ConsoleFiltersContextRoot>
-          <LoggablesContextRoot messageListRef={messageListRef}>
-            <ConsoleSearchContextRoot
-              messageListRef={messageListRef}
-              searchInputRef={searchInputRef}
-              showSearchInputByDefault={showSearchInputByDefault}
-            >
-              <Console
+    <ErrorBoundary>
+      <Suspense fallback={<IndeterminateLoader />}>
+        <ConsoleContextMenuContextRoot>
+          <ConsoleFiltersContextRoot>
+            <LoggablesContextRoot messageListRef={messageListRef}>
+              <ConsoleSearchContextRoot
                 messageListRef={messageListRef}
-                nagHeader={nagHeader}
                 searchInputRef={searchInputRef}
-                showFiltersByDefault={showFiltersByDefault}
-              />
-            </ConsoleSearchContextRoot>
-          </LoggablesContextRoot>
-        </ConsoleFiltersContextRoot>
-      </ConsoleContextMenuContextRoot>
-    </Suspense>
+                showSearchInputByDefault={showSearchInputByDefault}
+              >
+                <Console
+                  messageListRef={messageListRef}
+                  nagHeader={nagHeader}
+                  searchInputRef={searchInputRef}
+                  showFiltersByDefault={showFiltersByDefault}
+                />
+              </ConsoleSearchContextRoot>
+            </LoggablesContextRoot>
+          </ConsoleFiltersContextRoot>
+        </ConsoleContextMenuContextRoot>
+      </Suspense>
+    </ErrorBoundary>
   );
 }
 

--- a/packages/bvaughn-architecture-demo/components/console/LoggablesContext.tsx
+++ b/packages/bvaughn-architecture-demo/components/console/LoggablesContext.tsx
@@ -94,6 +94,10 @@ export function LoggablesContextRoot({
 
   // Pre-filter in-focus messages by non text based search criteria.
   const preFilteredMessages = useMemo<ProtocolMessage[]>(() => {
+    if (messages === null) {
+      return EMPTY_ARRAY;
+    }
+
     return messages.filter((message: ProtocolMessage) => {
       switch (message.level) {
         case "warning": {

--- a/packages/bvaughn-architecture-demo/components/console/filters/FilterToggles.tsx
+++ b/packages/bvaughn-architecture-demo/components/console/filters/FilterToggles.tsx
@@ -149,21 +149,41 @@ function ToggleCategoryCount({ category }: { category: keyof CategoryCounts }) {
   const { range: focusRange } = useContext(FocusContext);
   const client = useContext(ReplayClientContext);
 
-  const { categoryCounts } = getMessagesSuspense(client, focusRange);
+  const { didError, categoryCounts } = getMessagesSuspense(client, focusRange);
   const count = categoryCounts[category];
 
-  return count === 0 ? null : <Badge label={count} />;
+  if (didError) {
+    return (
+      <span title="Something went wrong loading message counts.">
+        <Icon className={styles.ExceptionsErrorIcon} type="warning" />
+      </span>
+    );
+  } else if (count > 0) {
+    return <Badge label={count} />;
+  } else {
+    return null;
+  }
 }
 
 function NodeModulesCount() {
   const client = useContext(ReplayClientContext);
   const { range } = useContext(FocusContext);
 
-  const { messages } = getMessagesSuspense(client, range);
+  const { didError, messages } = getMessagesSuspense(client, range);
 
   const count = useMemo(() => {
-    return messages.filter(message => isInNodeModules(message)).length;
+    return messages ? messages.filter(message => isInNodeModules(message)).length : 0;
   }, [messages]);
 
-  return count === 0 ? null : <Badge label={count} />;
+  if (didError) {
+    return (
+      <span title="Something went wrong loading message counts.">
+        <Icon className={styles.ExceptionsErrorIcon} type="warning" />
+      </span>
+    );
+  } else if (count > 0) {
+    return <Badge label={count} />;
+  } else {
+    return null;
+  }
 }

--- a/packages/bvaughn-architecture-demo/src/suspense/MessagesCache.test.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/MessagesCache.test.ts
@@ -92,7 +92,7 @@ describe("MessagesCache", () => {
     expect(data.categoryCounts).toEqual({ errors: 0, logs: 3, warnings: 0 });
     expect(data.countAfter).toBe(0);
     expect(data.countBefore).toBe(0);
-    expect(data.messages.map(({ point }) => point.time)).toEqual([0, 1, 2]);
+    expect(data.messages!.map(({ point }) => point.time)).toEqual([0, 1, 2]);
     expect(data.didOverflow).toBe(false);
     expect(client.findMessages).toHaveBeenCalledTimes(1);
 
@@ -108,7 +108,7 @@ describe("MessagesCache", () => {
     expect(data.categoryCounts).toEqual({ errors: 0, logs: 2, warnings: 0 });
     expect(data.countAfter).toBe(-1);
     expect(data.countBefore).toBe(-1);
-    expect(data.messages.map(({ point }) => point.time)).toEqual([1, 2]);
+    expect(data.messages!.map(({ point }) => point.time)).toEqual([1, 2]);
     expect(data.didOverflow).toBe(false);
     expect(client.findMessages).toHaveBeenCalledTimes(1);
 
@@ -121,7 +121,7 @@ describe("MessagesCache", () => {
     mockHelper([createM(1)], true);
 
     const data = await getMessagesHelper(null);
-    expect(data.messages.map(({ point }) => point.time)).toEqual([1]);
+    expect(data.messages!.map(({ point }) => point.time)).toEqual([1]);
     expect(data.didOverflow).toBe(true);
     expect(client.findMessages).toHaveBeenCalledTimes(1);
   });
@@ -130,7 +130,7 @@ describe("MessagesCache", () => {
     mockHelper([createM(0), createM(1), createM(2), createM(3)]);
 
     let data = await getMessagesHelper(null);
-    expect(data.messages.map(({ point }) => point.time)).toEqual([0, 1, 2, 3]);
+    expect(data.messages!.map(({ point }) => point.time)).toEqual([0, 1, 2, 3]);
     expect(data.categoryCounts).toEqual({ errors: 0, logs: 4, warnings: 0 });
     expect(data.countAfter).toBe(0);
     expect(data.countBefore).toBe(0);
@@ -140,7 +140,7 @@ describe("MessagesCache", () => {
     expect(data.categoryCounts).toEqual({ errors: 0, logs: 2, warnings: 0 });
     expect(data.countAfter).toBe(1);
     expect(data.countBefore).toBe(1);
-    expect(data.messages.map(({ point }) => point.time)).toEqual([1, 2]);
+    expect(data.messages!.map(({ point }) => point.time)).toEqual([1, 2]);
     expect(client.findMessages).toHaveBeenCalledTimes(1);
   });
 
@@ -148,14 +148,14 @@ describe("MessagesCache", () => {
     mockHelper([createM(0), createM(1), createM(2), createM(3)]);
 
     let data = await getMessagesHelper(toTSPR(0, 3));
-    expect(data.messages.map(({ point }) => point.time)).toEqual([0, 1, 2, 3]);
+    expect(data.messages!.map(({ point }) => point.time)).toEqual([0, 1, 2, 3]);
     expect(data.categoryCounts).toEqual({ errors: 0, logs: 4, warnings: 0 });
     expect(data.countAfter).toBe(-1);
     expect(data.countBefore).toBe(-1);
     expect(client.findMessages).toHaveBeenCalledTimes(1);
 
     data = await getMessagesHelper(toTSPR(1, 2));
-    expect(data.messages.map(({ point }) => point.time)).toEqual([1, 2]);
+    expect(data.messages!.map(({ point }) => point.time)).toEqual([1, 2]);
     expect(data.categoryCounts).toEqual({ errors: 0, logs: 2, warnings: 0 });
     expect(data.countAfter).toBe(-1);
     expect(data.countBefore).toBe(-1);
@@ -166,13 +166,13 @@ describe("MessagesCache", () => {
     mockHelper([createM(1), createM(2)]);
 
     let data = await getMessagesHelper(toTSPR(1, 2));
-    expect(data.messages.map(({ point }) => point.time)).toEqual([1, 2]);
+    expect(data.messages!.map(({ point }) => point.time)).toEqual([1, 2]);
     expect(client.findMessages).toHaveBeenCalledTimes(1);
 
     mockHelper([createM(0), createM(1), createM(2), createM(3)]);
 
     data = await getMessagesHelper(toTSPR(0, 3));
-    expect(data.messages.map(({ point }) => point.time)).toEqual([0, 1, 2, 3]);
+    expect(data.messages!.map(({ point }) => point.time)).toEqual([0, 1, 2, 3]);
     expect(client.findMessages).toHaveBeenCalledTimes(2);
   });
 
@@ -180,13 +180,13 @@ describe("MessagesCache", () => {
     mockHelper([createM(1), createM(2)]);
 
     let data = await getMessagesHelper(toTSPR(1, 2));
-    expect(data.messages.map(({ point }) => point.time)).toEqual([1, 2]);
+    expect(data.messages!.map(({ point }) => point.time)).toEqual([1, 2]);
     expect(client.findMessages).toHaveBeenCalledTimes(1);
 
     mockHelper([createM(0), createM(1), createM(2), createM(3)]);
 
     data = await getMessagesHelper(null);
-    expect(data.messages.map(({ point }) => point.time)).toEqual([0, 1, 2, 3]);
+    expect(data.messages!.map(({ point }) => point.time)).toEqual([0, 1, 2, 3]);
     expect(client.findMessages).toHaveBeenCalledTimes(2);
   });
 
@@ -194,17 +194,17 @@ describe("MessagesCache", () => {
     mockHelper([createM(1)], true);
 
     let data = await getMessagesHelper(toTSPR(0, 3));
-    expect(data.messages.map(({ point }) => point.time)).toEqual([1]);
+    expect(data.messages!.map(({ point }) => point.time)).toEqual([1]);
     expect(data.didOverflow).toBe(true);
     expect(client.findMessages).toHaveBeenCalledTimes(1);
 
     data = await getMessagesHelper(toTSPR(1, 3));
-    expect(data.messages.map(({ point }) => point.time)).toEqual([1]);
+    expect(data.messages!.map(({ point }) => point.time)).toEqual([1]);
     expect(data.didOverflow).toBe(true);
     expect(client.findMessages).toHaveBeenCalledTimes(2);
 
     data = await getMessagesHelper(toTSPR(1, 2));
-    expect(data.messages.map(({ point }) => point.time)).toEqual([1]);
+    expect(data.messages!.map(({ point }) => point.time)).toEqual([1]);
     expect(data.didOverflow).toBe(true);
     expect(client.findMessages).toHaveBeenCalledTimes(3);
   });
@@ -247,7 +247,7 @@ describe("MessagesCache", () => {
     await promise1;
 
     const data = await getMessagesHelper(toTSPR(2, 3));
-    expect(data.messages.map(({ point }) => point.time)).toEqual([2, 3]);
+    expect(data.messages!.map(({ point }) => point.time)).toEqual([2, 3]);
     expect(client.findMessages).toHaveBeenCalledTimes(2);
   });
 
@@ -266,6 +266,22 @@ describe("MessagesCache", () => {
     getMessagesHelper(null);
 
     expect(client.findMessages).toHaveBeenCalledTimes(2);
+  });
+
+  it("should catch errors and report them in the response data", async () => {
+    const error = new Error("Expected");
+
+    client.findMessages.mockImplementation(() => {
+      throw error;
+    });
+
+    console.error = jest.fn();
+
+    const response = await getMessagesHelper(toTSPR(0, 1));
+    expect(response.didError).toBe(true);
+    expect(response.error).toBe(error);
+    expect(response.messages).toBe(null);
+    expect(console.error).toHaveBeenCalledTimes(1);
   });
 
   it("should not continue to re-request the same messages after a failure", async () => {

--- a/packages/design/Badge/Badge.module.css
+++ b/packages/design/Badge/Badge.module.css
@@ -1,4 +1,4 @@
-.Root {
+.Badge {
   display: inline-block;
   padding: 0 0.25rem;
   border-radius: 0.25rem;

--- a/packages/design/Badge/index.tsx
+++ b/packages/design/Badge/index.tsx
@@ -3,5 +3,5 @@ import * as React from "react";
 import styles from "./Badge.module.css";
 
 export function Badge({ label }: { label: React.ReactNode }) {
-  return <div className={styles.Root}>{label}</div>;
+  return <div className={styles.Badge}>{label}</div>;
 }

--- a/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
@@ -41,12 +41,15 @@ export function TestCase({
         })
       );
     } else {
-      dispatch(
-        setFocusRegion({
-          beginTime: testStartTime,
-          endTime: testEndTime,
-        })
-      );
+      // Note this check shouldn't be required but something seems to be broken (see SCS-289)
+      if (!Number.isNaN(testStartTime) && !Number.isNaN(testEndTime)) {
+        dispatch(
+          setFocusRegion({
+            beginTime: testStartTime,
+            endTime: testEndTime,
+          })
+        );
+      }
     }
   };
   const toggleExpand = () => {

--- a/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
@@ -4,13 +4,10 @@ import { useEffect, useState } from "react";
 import { getRecordingDuration } from "ui/actions/app";
 import { seekToTime, setFocusRegion } from "ui/actions/timeline";
 import Icon from "ui/components/shared/Icon";
-import MaterialIcon from "ui/components/shared/MaterialIcon";
 import { getFocusRegion } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { TestItem, TestResult } from "ui/types";
 
-import { selectLocation } from "../../actions/sources";
-import { getThreadContext } from "../../selectors";
 import { TestSteps } from "./TestSteps";
 
 export function TestCase({

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -515,6 +515,12 @@ export function setFocusRegion(
 
       let { endTime, beginTime } = focusRegion;
 
+      if (Number.isNaN(endTime) || Number.isNaN(beginTime)) {
+        // Guard against invalid focus regions; these break the app in a lot of bad ways.
+        console.error("Invalid focus region", focusRegion);
+        return;
+      }
+
       // Basic bounds check.
       if (beginTime < zoomRegion.beginTime) {
         beginTime = zoomRegion.beginTime;


### PR DESCRIPTION
[Loom overview of change](https://www.loom.com/share/4c9039a37f3945b0a7c16023dfea0b0c)

This PR changes multiple things. Commits are atomic to simplify review.
- [x] Wrap Console errors in boundary so they don't take down the larger app.
- [x] Timeline reducer shouldn't accept/apply an invalid focus region.
- [x] `TestCase` UI shouldn't apply an invalid focus region
- [x] Console and `LoggablesContext` should more gracefully handle message loading failures.

Note that d83d6b0c9d0a7aa5fdd3759d30aa9a5db330a19e should not be necessary, but it seems like TypeScript types aren't correct for the Test Suites integration. We probably need to fix this type (or the upstream bug that caused the data to be broken?)
https://github.com/replayio/devtools/blob/93459cfb6a3d147d4329d6647381834b4f4f5dd3/src/ui/types/index.ts#L169-L179