### PR TITLE
Don't request hit counts outside of loaded regions

### DIFF
--- a/packages/bvaughn-architecture-demo/components/sources/SourceListRow.module.css
+++ b/packages/bvaughn-architecture-demo/components/sources/SourceListRow.module.css
@@ -183,6 +183,10 @@
   background-color: var(--color-hit-counts-label-background-3);
 }
 
+.LineHitCountLabelPending {
+  opacity: 0.75;
+}
+
 .LineSegment {
   margin: 0;
 }

--- a/packages/bvaughn-architecture-demo/components/sources/SourceListRow.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/SourceListRow.tsx
@@ -1,8 +1,17 @@
 import { newSource as ProtocolSource } from "@replayio/protocol";
-import { MouseEvent, Suspense, memo, useMemo, useState, useSyncExternalStore } from "react";
+import {
+  MouseEvent,
+  Suspense,
+  memo,
+  useContext,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import { areEqual } from "react-window";
 
 import Icon from "bvaughn-architecture-demo/components/Icon";
+import { FocusContext } from "bvaughn-architecture-demo/src/contexts/FocusContext";
 import {
   AddPoint,
   DeletePoints,
@@ -39,6 +48,8 @@ export type ItemData = {
 
 const SourceListRow = memo(
   ({ data, index, style }: { data: ItemData; index: number; style: Object }) => {
+    const { isTransitionPending: isFocusRangePending } = useContext(FocusContext);
+
     const [isHovered, setIsHovered] = useState(false);
 
     const loadingPlaceholderWidth = useMemo(() => Math.round(5 + Math.random() * 30), []);
@@ -102,6 +113,10 @@ const SourceListRow = memo(
 
       hitCountBarClassName = styles[`LineHitCountBar${hitCountIndex + 1}`];
       hitCountLabelClassName = styles[`LineHitCountLabel${hitCountIndex + 1}`];
+    }
+
+    if (isFocusRangePending) {
+      hitCountLabelClassName = `${hitCountLabelClassName} ${styles.LineHitCountLabelPending}`;
     }
 
     let lineSegments = null;

--- a/packages/bvaughn-architecture-demo/src/utils/testing.tsx
+++ b/packages/bvaughn-architecture-demo/src/utils/testing.tsx
@@ -219,6 +219,7 @@ export function createMockReplayClient() {
     searchFunctions: jest.fn().mockImplementation(async () => {}),
     searchSources: jest.fn().mockImplementation(async () => {}),
     streamSourceContents: jest.fn().mockImplementation(async () => {}),
+    waitForLoadedRegions: jest.fn().mockImplementation(async () => undefined),
     waitForLoadedSources: jest.fn().mockImplementation(async () => undefined),
   };
 }

--- a/packages/bvaughn-architecture-demo/src/utils/time.ts
+++ b/packages/bvaughn-architecture-demo/src/utils/time.ts
@@ -12,6 +12,17 @@ const collator = new Intl.Collator("en", {
   sensitivity: "base",
 });
 
+export function areRangesEqual(
+  prevRanges: Array<TimeStampedPointRange>,
+  nextRanges: Array<TimeStampedPointRange>
+): boolean {
+  return (
+    prevRanges.find((prevRange, index) => {
+      return !isRangeEqual(prevRange, nextRanges[index]);
+    }) == null
+  );
+}
+
 export function compareExecutionPoints(a: ExecutionPoint, b: ExecutionPoint): number {
   return collator.compare(a, b);
 }

--- a/packages/shared/client/ReplayClient.ts
+++ b/packages/shared/client/ReplayClient.ts
@@ -43,7 +43,7 @@ import uniqueId from "lodash/uniqueId";
 
 import { initProtocolMessagesStore } from "bvaughn-architecture-demo/components/protocol/ProtocolMessagesStore";
 import { insert } from "bvaughn-architecture-demo/src/utils/array";
-import { compareExecutionPoints } from "bvaughn-architecture-demo/src/utils/time";
+import { areRangesEqual, compareExecutionPoints } from "bvaughn-architecture-demo/src/utils/time";
 import analysisManager from "protocol/analysisManager";
 // eslint-disable-next-line no-restricted-imports
 import { client, initSocket } from "protocol/socket";
@@ -898,7 +898,9 @@ export class ReplayClient implements ReplayClientInterface {
 
             isLoaded = isRangeInRegions(pointRange.begin, pointRange.end, loadedRegions.loaded);
           } else {
-            isLoaded = loadedRegions.loaded.length > 0 && loadedRegions.loading.length === 0;
+            isLoaded =
+              loadedRegions.loaded.length > 0 &&
+              areRangesEqual(loadedRegions.loaded, loadedRegions.loading);
           }
         }
 

--- a/packages/shared/client/types.ts
+++ b/packages/shared/client/types.ts
@@ -185,5 +185,6 @@ export interface ReplayClientInterface {
     }) => void,
     onSourceContentsChunk: ({ chunk, sourceId }: { chunk: string; sourceId: SourceId }) => void
   ): Promise<void>;
+  waitForLoadedRegions(focusRange: PointRange | null): Promise<void>;
   waitForLoadedSources(): Promise<void>;
 }

--- a/packages/shared/client/types.ts
+++ b/packages/shared/client/types.ts
@@ -185,6 +185,6 @@ export interface ReplayClientInterface {
     }) => void,
     onSourceContentsChunk: ({ chunk, sourceId }: { chunk: string; sourceId: SourceId }) => void
   ): Promise<void>;
-  waitForLoadedRegions(focusRange: PointRange | null): Promise<void>;
+  waitForLoadedRegions(focusRange: TimeStampedPointRange | PointRange | null): Promise<void>;
   waitForLoadedSources(): Promise<void>;
 }

--- a/packages/shared/utils/time.test.ts
+++ b/packages/shared/utils/time.test.ts
@@ -1,0 +1,47 @@
+import { ExecutionPoint, TimeStampedPointRange } from "@replayio/protocol";
+
+import { isRangeInRegions } from "./time";
+
+describe("time util", () => {
+  describe("isRangeInRegions", () => {
+    function toTimeStampedPointRange(...tuples: ExecutionPoint[]): TimeStampedPointRange[] {
+      const range: TimeStampedPointRange[] = [];
+      for (let i = 0; i < tuples.length; i += 2) {
+        const beginPoint = tuples[i];
+        const endPoint = tuples[i + 1];
+        range.push({
+          begin: {
+            point: beginPoint,
+            time: parseInt(beginPoint, 10),
+          },
+          end: {
+            point: endPoint,
+            time: parseInt(endPoint, 10),
+          },
+        });
+      }
+      return range;
+    }
+
+    it("should accept exact matches", () => {
+      expect(isRangeInRegions("0", "10", toTimeStampedPointRange("0", "10"))).toBe(true);
+    });
+
+    it("should accept subsets", () => {
+      expect(isRangeInRegions("0", "1", toTimeStampedPointRange("0", "10"))).toBe(true);
+      expect(isRangeInRegions("1", "9", toTimeStampedPointRange("0", "10"))).toBe(true);
+      expect(isRangeInRegions("5", "10", toTimeStampedPointRange("0", "10"))).toBe(true);
+    });
+
+    it("should reject partial overlaps", () => {
+      expect(isRangeInRegions("0", "5", toTimeStampedPointRange("5", "10"))).toBe(false);
+      expect(isRangeInRegions("2", "7", toTimeStampedPointRange("5", "10"))).toBe(false);
+      expect(isRangeInRegions("0", "15", toTimeStampedPointRange("5", "10"))).toBe(false);
+      expect(isRangeInRegions("7", "12", toTimeStampedPointRange("5", "10"))).toBe(false);
+    });
+
+    it("should reject non-contiguous overlaps", () => {
+      expect(isRangeInRegions("2", "5", toTimeStampedPointRange("0", "3", "4", "8"))).toBe(false);
+    });
+  });
+});

--- a/packages/shared/utils/time.ts
+++ b/packages/shared/utils/time.ts
@@ -1,4 +1,19 @@
-import { ExecutionPoint, TimeStampedPointRange } from "@replayio/protocol";
+import { ExecutionPoint, PointRange, TimeStampedPointRange } from "@replayio/protocol";
+
+export function isRangeInRegions(
+  startPoint: ExecutionPoint,
+  endPoint: ExecutionPoint,
+  regions: TimeStampedPointRange[]
+): boolean {
+  const startPointNumber = BigInt(startPoint);
+  const endPointNumber = BigInt(endPoint);
+  return (
+    regions.find(
+      ({ begin, end }) =>
+        startPointNumber >= BigInt(begin.point) && endPointNumber <= BigInt(end.point)
+    ) != null
+  );
+}
 
 export function isPointInRegions(point: ExecutionPoint, regions: TimeStampedPointRange[]): boolean {
   const pointNumber = BigInt(point);
@@ -9,6 +24,21 @@ export function isPointInRegions(point: ExecutionPoint, regions: TimeStampedPoin
   );
 }
 
+export function isPointRange(range: TimeStampedPointRange | PointRange): range is PointRange {
+  return typeof range.begin === "string";
+}
+
 export function isTimeInRegions(time: number, regions: TimeStampedPointRange[]) {
   return regions.find(({ begin, end }) => time >= begin.time && time <= end.time);
+}
+
+export function toPointRange(range: TimeStampedPointRange | PointRange): PointRange {
+  if (isPointRange(range)) {
+    return range;
+  } else {
+    return {
+      begin: range.begin.point,
+      end: range.end.point,
+    };
+  }
 }

--- a/packages/shared/utils/time.ts
+++ b/packages/shared/utils/time.ts
@@ -1,9 +1,11 @@
 import { ExecutionPoint, TimeStampedPointRange } from "@replayio/protocol";
 
-export function isPointInRegions(point: ExecutionPoint, regions: TimeStampedPointRange[]) {
+export function isPointInRegions(point: ExecutionPoint, regions: TimeStampedPointRange[]): boolean {
   const pointNumber = BigInt(point);
-  return regions.find(
-    ({ begin, end }) => pointNumber >= BigInt(begin.point) && pointNumber <= BigInt(end.point)
+  return (
+    regions.find(
+      ({ begin, end }) => pointNumber >= BigInt(begin.point) && pointNumber <= BigInt(end.point)
+    ) != null
   );
 }
 


### PR DESCRIPTION
The gist of the bug was this:
* When editing the focus range, we update the (pending) range in memory and attempt to also show updated values for hit counts, filtered console messages and networks requests, etc.
* If the focus range contracts, we can filter in memory, but if it expands– we need to fetch new hit count values remotely.
* Unfortunately, we don't actually update the focus range (on the backend) until the user hits "Save"
* This means we were potentially requesting hit counts _outside of the focus region_, and so the values returned by the backend were not valid. To make matters worse, our Suspense cache _cached_ these invalid responses so that even after we applied the new focus range, we continued to show incorrect values.

This PR makes the smallest commit I could think of to fix this:
* The `ReplayClient` automatically waits for the focus range to be fully loaded before fetching hit counts or running analysis.
* Source hit counts dim slightly while fetching newer data (so it's not confusing to see them jump-change on a delay).

I'm seeing an error in the Console while fetching messages that may be related to this change (not sure). Need to dig in.