### PR TITLE
Enable scan data caching by default

### DIFF
--- a/packages/protocol/socket.ts
+++ b/packages/protocol/socket.ts
@@ -92,9 +92,9 @@ if (typeof window !== "undefined") {
 
 export type ExperimentalSettings = {
   listenForMetrics: boolean;
-  cacheScanData?: boolean;
   controllerKey?: string;
   disableCache?: boolean;
+  disableScanDataCache?: boolean;
   disableQueryCache?: boolean;
   profileWorkerThreads?: boolean;
 };

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -196,7 +196,7 @@ export function createSocket(
       }
 
       const experimentalSettings: ExperimentalSettings = {
-        cacheScanData: !!features.cacheScanData,
+        disableScanDataCache: !!features.disableScanDataCache,
         disableCache: !!prefs.disableCache,
         disableQueryCache: !features.enableQueryCache,
         listenForMetrics: !!prefs.listenForMetrics,

--- a/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
+++ b/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
@@ -55,9 +55,9 @@ const EXPERIMENTAL_SETTINGS: ExperimentalSetting[] = [
     key: "consoleFilterDrawerDefaultsToOpen",
   },
   {
-    label: "Cache Scan Data",
-    description: "Cache the results of indexing the recording",
-    key: "cacheScanData",
+    label: "Disable Scan Data Cache",
+    description: "Do not cache the results of indexing the recording",
+    key: "disableScanDataCache",
   },
 ];
 
@@ -90,7 +90,8 @@ export default function ExperimentalSettings({}) {
   // TODO: This is bad and should be updated with a better generalized hook
   const { value: enableColumnBreakpoints, update: updateEnableColumnBreakpoints } =
     useFeature("columnBreakpoints");
-  const { value: cacheScanData, update: updateCacheScanData } = useFeature("cacheScanData");
+  const { value: disableScanDataCache, update: updateDisableScanDataCache } =
+    useFeature("disableScanDataCache");
 
   const { value: enableResolveRecording, update: updateEnableResolveRecording } =
     useFeature("resolveRecording");
@@ -123,15 +124,15 @@ export default function ExperimentalSettings({}) {
       updateBasicProcessingLoadingBar(!basicProcessingLoadingBar);
     } else if (key === "consoleFilterDrawerDefaultsToOpen") {
       updateConsoleFilterDrawerDefaultsToOpen(!consoleFilterDrawerDefaultsToOpen);
-    } else if (key === "cacheScanData") {
-      updateCacheScanData(!cacheScanData);
+    } else if (key === "disableScanDataCache") {
+      updateDisableScanDataCache(!disableScanDataCache);
     }
   };
 
   const localSettings = {
     basicProcessingLoadingBar,
-    cacheScanData,
     consoleFilterDrawerDefaultsToOpen,
+    disableScanDataCache,
     enableColumnBreakpoints,
     enableQueryCache,
     enableResolveRecording,

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -15,7 +15,7 @@ export type ExperimentalUserSettings = {
 
 export type LocalExperimentalUserSettings = {
   basicProcessingLoadingBar: boolean;
-  cacheScanData: boolean;
+  disableScanDataCache: boolean;
   consoleFilterDrawerDefaultsToOpen: boolean;
   enableQueryCache: boolean;
   enableColumnBreakpoints: boolean;

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -23,10 +23,10 @@ pref("devtools.hitCounts", "hide-counts");
 
 // app features
 pref("devtools.features.basicProcessingLoadingBar", false);
-pref("devtools.features.cacheScanData", false);
 pref("devtools.features.columnBreakpoints", false);
 pref("devtools.features.commentAttachments", false);
 pref("devtools.features.consoleFilterDrawerDefaultsToOpen", false);
+pref("devtools.features.disableScanDataCache", false);
 pref("devtools.features.disableUnHitLines", false);
 pref("devtools.features.enableLargeText", false);
 pref("devtools.features.enableQueryCache", false);
@@ -61,10 +61,10 @@ export const prefs = new PrefsHelper("devtools", {
 
 export const features = new PrefsHelper("devtools.features", {
   basicProcessingLoadingBar: ["Bool", "basicProcessingLoadingBar"],
-  cacheScanData: ["Bool", "cacheScanData"],
   columnBreakpoints: ["Bool", "columnBreakpoints"],
   commentAttachments: ["Bool", "commentAttachments"],
   consoleFilterDrawerDefaultsToOpen: ["Bool", "consoleFilterDrawerDefaultsToOpen"],
+  disableScanDataCache: ["Bool", "disableScanDataCache"],
   enableQueryCache: ["Bool", "enableQueryCache"],
   disableUnHitLines: ["Bool", "disableUnHitLines"],
   enableLargeText: ["Bool", "enableLargeText"],


### PR DESCRIPTION
This will have the effect of turning it on for everyone, and also still allowing us to turn it off for debugging purposes.

Pairs with https://github.com/replayio/backend/pull/6610