### PR TITLE
Suppress telemetry in dev

### DIFF
--- a/src/ui/utils/replay-telemetry.ts
+++ b/src/ui/utils/replay-telemetry.ts
@@ -1,4 +1,8 @@
 export async function pingTelemetry(event: string, tags: any = {}) {
+  if (process.env.NODE_ENV === "development" && !process.env.NEXT_PUBLIC_RECORD_REPLAY_TELEMETRY) {
+    return;
+  }
+
   try {
     const response = await fetch("https://telemetry.replay.io/", {
       method: "POST",


### PR DESCRIPTION
Sending telemetry, particularly auth telemetry, in dev can lead to some misleading data so let's suppress it by default but allow it to be sent when manually overridden (via `NEXT_PUBLIC_RECORD_REPLAY_TELEMETRY`).