### PR TITLE
Fixed log point panel scrollbar issue for Firefox

### DIFF
--- a/packages/bvaughn-architecture-demo/components/sources/AutoComplete/AutoComplete.module.css
+++ b/packages/bvaughn-architecture-demo/components/sources/AutoComplete/AutoComplete.module.css
@@ -10,6 +10,10 @@
   font-size: var(--font-size-regular);
   font-family: var(--font-family-monospace);
   color: var(--color-default);
+
+  /* Firefox fixes */
+  scrollbar-width: thin;
+  scrollbar-color: var(--scroll-thumb-color) transparent;
 }
 .Input::-webkit-scrollbar {
   height: 0.5em;


### PR DESCRIPTION
Turns out the `::-webkit-scrollbar` styles we're relying on to customize our scrollbars aren't supported by Firefox.

Screenshots after this change:

<img width="592" alt="Screen Shot 2022-11-17 at 6 28 52 PM" src="https://user-images.githubusercontent.com/29597/202581721-3c2efb1f-a636-414c-9b29-234cca6608ea.png">

<img width="597" alt="Screen Shot 2022-11-17 at 6 28 44 PM" src="https://user-images.githubusercontent.com/29597/202581720-d8f75398-1cf0-41b4-a357-2146cd618d0b.png">

<img width="637" alt="Screen Shot 2022-11-17 at 6 27 55 PM" src="https://user-images.githubusercontent.com/29597/202581718-2a97250a-f7ae-4b29-be2d-103a0f280c67.png">

<img width="638" alt="Screen Shot 2022-11-17 at 6 27 46 PM" src="https://user-images.githubusercontent.com/29597/202581714-610264a3-dc20-484d-adbe-b7df8b1b1352.png">

Firefox shifts text content up to make room for the fatter scrollbar. I think that's fine. The only other fixes would be (a) something not purely CSS based or (b) making the rows really tall to account for this, but that feels like a space waster.