### PR TITLE
ReplayClient should not make requests in unloaded regions

### DIFF
--- a/packages/bvaughn-architecture-demo/components/console/ConsoleInput.module.css
+++ b/packages/bvaughn-architecture-demo/components/console/ConsoleInput.module.css
@@ -39,3 +39,15 @@
   height: 1em;
   color: var(--color-dim);
 }
+
+.FallbackState {
+  display: flex;
+  align-items: center;
+  gap: 1ch;
+  padding: 0 1ch;
+  min-height: 2em;
+
+  background-color: var(--background-color-error);
+  border-top: 1px solid var(--border-color-error);
+  color: var(--color-error);
+}

--- a/packages/bvaughn-architecture-demo/components/console/ConsoleInput.tsx
+++ b/packages/bvaughn-architecture-demo/components/console/ConsoleInput.tsx
@@ -1,6 +1,7 @@
 import { FrameId, PauseId } from "@replayio/protocol";
 import { Suspense, useContext, useEffect, useRef, useState } from "react";
 
+import ErrorBoundary from "bvaughn-architecture-demo/components/ErrorBoundary";
 import Icon from "bvaughn-architecture-demo/components/Icon";
 import Loader from "bvaughn-architecture-demo/components/Loader";
 import AutoComplete from "bvaughn-architecture-demo/components/sources/AutoComplete/AutoComplete";
@@ -21,9 +22,11 @@ import styles from "./ConsoleInput.module.css";
 
 export default function ConsoleInput() {
   return (
-    <Suspense fallback={<Loader />}>
-      <ConsoleInputSuspends />
-    </Suspense>
+    <ErrorBoundary fallback={<ErrorFallback />}>
+      <Suspense fallback={<Loader />}>
+        <ConsoleInputSuspends />
+      </Suspense>
+    </ErrorBoundary>
   );
 }
 
@@ -153,3 +156,12 @@ function ConsoleInputSuspends() {
 }
 
 function noop() {}
+
+function ErrorFallback() {
+  return (
+    <div className={styles.FallbackState}>
+      <Icon className={styles.Icon} type="terminal-prompt" />
+      Input disabled for session because of an error
+    </div>
+  );
+}

--- a/packages/bvaughn-architecture-demo/src/utils/testing.tsx
+++ b/packages/bvaughn-architecture-demo/src/utils/testing.tsx
@@ -221,7 +221,6 @@ export function createMockReplayClient() {
     searchFunctions: jest.fn().mockImplementation(async () => {}),
     searchSources: jest.fn().mockImplementation(async () => {}),
     streamSourceContents: jest.fn().mockImplementation(async () => {}),
-    waitForLoadedRegions: jest.fn().mockImplementation(async () => undefined),
     waitForLoadedSources: jest.fn().mockImplementation(async () => undefined),
   };
 }

--- a/packages/shared/client/ReplayClient.ts
+++ b/packages/shared/client/ReplayClient.ts
@@ -52,7 +52,7 @@ import { RecordingCapabilities } from "protocol/thread/thread";
 import { binarySearch, compareNumericStrings, defer } from "protocol/utils";
 import { TOO_MANY_POINTS_TO_FIND } from "shared/constants";
 import { ProtocolError, isCommandError } from "shared/utils/error";
-import { isPointInRegions, isRangeInRegions, toPointRange } from "shared/utils/time";
+import { isPointInRegions, isRangeInRegions, isTimeInRegions } from "shared/utils/time";
 
 import {
   HitPointStatus,
@@ -535,12 +535,18 @@ export class ReplayClient implements ReplayClientInterface {
 
   async getPointNearTime(time: number): Promise<TimeStampedPoint> {
     const sessionId = this.getSessionIdThrows();
+
+    await this._waitForTimeToBeLoaded(time);
+
     const { point } = await client.Session.getPointNearTime({ time }, sessionId);
     return point;
   }
 
   async getPointsBoundingTime(time: number): Promise<PointsBoundingTime> {
     const sessionId = this.getSessionIdThrows();
+
+    await this._waitForTimeToBeLoaded(time);
+
     const result = await client.Session.getPointsBoundingTime({ time }, sessionId);
     return result;
   }
@@ -986,6 +992,28 @@ export class ReplayClient implements ReplayClientInterface {
               loadedRegions.loaded.length > 0 &&
               areRangesEqual(loadedRegions.loaded, loadedRegions.loading);
           }
+        }
+
+        if (isLoaded) {
+          resolve();
+
+          this.removeEventListener("loadedRegionsChange", checkLoaded);
+        }
+      };
+
+      this.addEventListener("loadedRegionsChange", checkLoaded);
+
+      checkLoaded();
+    });
+  }
+
+  async _waitForTimeToBeLoaded(time: number): Promise<void> {
+    return new Promise(resolve => {
+      const checkLoaded = () => {
+        const loadedRegions = this.loadedRegions;
+        let isLoaded = false;
+        if (loadedRegions !== null) {
+          isLoaded = isTimeInRegions(time, loadedRegions.loaded);
         }
 
         if (isLoaded) {

--- a/packages/shared/client/types.ts
+++ b/packages/shared/client/types.ts
@@ -187,6 +187,5 @@ export interface ReplayClientInterface {
     }) => void,
     onSourceContentsChunk: ({ chunk, sourceId }: { chunk: string; sourceId: SourceId }) => void
   ): Promise<void>;
-  waitForLoadedRegions(focusRange: TimeStampedPointRange | PointRange | null): Promise<void>;
   waitForLoadedSources(): Promise<void>;
 }

--- a/packages/shared/utils/time.test.ts
+++ b/packages/shared/utils/time.test.ts
@@ -4,44 +4,81 @@ import { isRangeInRegions } from "./time";
 
 describe("time util", () => {
   describe("isRangeInRegions", () => {
-    function toTimeStampedPointRange(...tuples: ExecutionPoint[]): TimeStampedPointRange[] {
-      const range: TimeStampedPointRange[] = [];
-      for (let i = 0; i < tuples.length; i += 2) {
-        const beginPoint = tuples[i];
-        const endPoint = tuples[i + 1];
-        range.push({
-          begin: {
-            point: beginPoint,
-            time: parseInt(beginPoint, 10),
-          },
-          end: {
-            point: endPoint,
-            time: parseInt(endPoint, 10),
-          },
-        });
+    function createRange(
+      beginPoint: ExecutionPoint,
+      beginTime: number,
+      endPoint: ExecutionPoint,
+      endTime: number
+    ): TimeStampedPointRange {
+      return {
+        begin: {
+          point: beginPoint,
+          time: beginTime,
+        },
+        end: {
+          point: endPoint,
+          time: endTime,
+        },
+      };
+    }
+
+    function quadruplesToRanges(...quadruples: any[]): TimeStampedPointRange[] {
+      const ranges: TimeStampedPointRange[] = [];
+      for (let i = 0; i < quadruples.length; i += 2) {
+        ranges.push(
+          createRange(quadruples[i], quadruples[i + 1], quadruples[i + 2], quadruples[i + 3])
+        );
       }
-      return range;
+      return ranges;
+    }
+
+    function tuplesToRanges(...tuples: any[]): TimeStampedPointRange[] {
+      const ranges: TimeStampedPointRange[] = [];
+      for (let i = 0; i < tuples.length; i += 2) {
+        ranges.push(tupleToRange(tuples[i], tuples[i + 1]));
+      }
+      return ranges;
+    }
+
+    function tupleToRange(
+      beginPoint: ExecutionPoint,
+      endPoint: ExecutionPoint
+    ): TimeStampedPointRange {
+      return createRange(beginPoint, parseInt(beginPoint, 10), endPoint, parseInt(endPoint, 10));
     }
 
     it("should accept exact matches", () => {
-      expect(isRangeInRegions("0", "10", toTimeStampedPointRange("0", "10"))).toBe(true);
+      expect(isRangeInRegions(tupleToRange("0", "10"), tuplesToRanges("0", "10"))).toBe(true);
     });
 
     it("should accept subsets", () => {
-      expect(isRangeInRegions("0", "1", toTimeStampedPointRange("0", "10"))).toBe(true);
-      expect(isRangeInRegions("1", "9", toTimeStampedPointRange("0", "10"))).toBe(true);
-      expect(isRangeInRegions("5", "10", toTimeStampedPointRange("0", "10"))).toBe(true);
+      expect(isRangeInRegions(tupleToRange("0", "1"), tuplesToRanges("0", "10"))).toBe(true);
+      expect(isRangeInRegions(tupleToRange("1", "9"), tuplesToRanges("0", "10"))).toBe(true);
+      expect(isRangeInRegions(tupleToRange("5", "10"), tuplesToRanges("0", "10"))).toBe(true);
     });
 
     it("should reject partial overlaps", () => {
-      expect(isRangeInRegions("0", "5", toTimeStampedPointRange("5", "10"))).toBe(false);
-      expect(isRangeInRegions("2", "7", toTimeStampedPointRange("5", "10"))).toBe(false);
-      expect(isRangeInRegions("0", "15", toTimeStampedPointRange("5", "10"))).toBe(false);
-      expect(isRangeInRegions("7", "12", toTimeStampedPointRange("5", "10"))).toBe(false);
+      expect(isRangeInRegions(tupleToRange("0", "5"), tuplesToRanges("5", "10"))).toBe(false);
+      expect(isRangeInRegions(tupleToRange("2", "7"), tuplesToRanges("5", "10"))).toBe(false);
+      expect(isRangeInRegions(tupleToRange("0", "15"), tuplesToRanges("5", "10"))).toBe(false);
+      expect(isRangeInRegions(tupleToRange("7", "12"), tuplesToRanges("5", "10"))).toBe(false);
     });
 
     it("should reject non-contiguous overlaps", () => {
-      expect(isRangeInRegions("2", "5", toTimeStampedPointRange("0", "3", "4", "8"))).toBe(false);
+      expect(isRangeInRegions(tupleToRange("2", "5"), tuplesToRanges("0", "3", "4", "8"))).toBe(
+        false
+      );
+    });
+
+    // Imitate scenario where in-memory time-to-points mapping is too coarse
+    // to correctly differentiate between different time ranges.
+    it("should reject ranges where time is outside even if points are inside", () => {
+      expect(
+        isRangeInRegions(createRange("5", 2, "10", 10), quadruplesToRanges("5", 5, "10", 10))
+      ).toBe(false);
+      expect(
+        isRangeInRegions(createRange("5", 2, "10", 15), quadruplesToRanges("0", 0, "10", 10))
+      ).toBe(false);
     });
   });
 });

--- a/packages/shared/utils/time.ts
+++ b/packages/shared/utils/time.ts
@@ -27,10 +27,6 @@ export function isRangeInRegions(
         beginPointBigInt! >= BigInt(begin.point) && endPointBigInt! <= BigInt(end.point)
     ) == null
   ) {
-    console.log(
-      `Point range not loaded:\n  begin: ${beginPointBigInt}\n  end: ${endPointBigInt}\n  loaded:`,
-      JSON.stringify(regions, null, 2)
-    );
     // No loaded regions contain this range of points.
     return false;
   }
@@ -42,10 +38,6 @@ export function isRangeInRegions(
       ({ begin, end }) => beginTime! >= BigInt(begin.time) && endTime! <= BigInt(end.time)
     ) == null
   ) {
-    console.log(
-      `Time range not loaded:\n  begin: ${beginTime}\n  end: ${endTime}\n  loaded:`,
-      JSON.stringify(regions, null, 2)
-    );
     // No loaded regions contain this range of times.
     return false;
   }

--- a/packages/shared/utils/time.ts
+++ b/packages/shared/utils/time.ts
@@ -66,8 +66,8 @@ export function isTimeStampedPointRange(
   );
 }
 
-export function isTimeInRegions(time: number, regions: TimeStampedPointRange[]) {
-  return regions.find(({ begin, end }) => time >= begin.time && time <= end.time);
+export function isTimeInRegions(time: number, regions: TimeStampedPointRange[]): boolean {
+  return regions.find(({ begin, end }) => time >= begin.time && time <= end.time) != null;
 }
 
 export function toPointRange(range: TimeStampedPointRange | PointRange): PointRange {


### PR DESCRIPTION
This is not fool proof, since the backend could unload a region while a request is in-flight, but in general this commit hardens the ReplayClient to check that the execution point or focus range that it is about to make a request for has been loaded before proceeding.