### PR TITLE
Re-add "editor hovered" analytics event for onboarding

### DIFF
--- a/packages/bvaughn-architecture-demo/components/Initializer.tsx
+++ b/packages/bvaughn-architecture-demo/components/Initializer.tsx
@@ -73,6 +73,7 @@ export default function Initializer({
           sessionId,
           refetchUser: () => {},
           trackEvent: () => {},
+          trackEventOnce: () => {},
         });
       };
 

--- a/packages/bvaughn-architecture-demo/components/sources/Source.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/Source.tsx
@@ -3,6 +3,7 @@ import debounce from "lodash/debounce";
 import { MouseEvent, Suspense, useContext, useLayoutEffect, useRef, useState } from "react";
 import AutoSizer from "react-virtualized-auto-sizer";
 
+import { SessionContext } from "bvaughn-architecture-demo/src/contexts/SessionContext";
 import {
   StreamingSourceContents,
   getStreamingSourceContentsSuspense,
@@ -84,6 +85,7 @@ function SourceRenderer({
   streamingParser: StreamingParser;
   streamingSourceContents: StreamingSourceContents;
 }) {
+  const { trackEventOnce } = useContext(SessionContext);
   const [hoveredState, setHoveredState] = useState<HoveredState | null>(null);
 
   useLayoutEffect(
@@ -96,6 +98,11 @@ function SourceRenderer({
   );
 
   const sourceRef = useRef<HTMLDivElement>(null);
+
+  const trackMouseHover = () => {
+    // Analytics for onboarding
+    trackEventOnce("editor.mouse_over");
+  };
 
   const onMouseMove = (event: MouseEvent) => {
     const { clientX, clientY, defaultPrevented, target } = event;
@@ -146,6 +153,7 @@ function SourceRenderer({
       className={styles.Source}
       data-test-id={`Source-${source.sourceId}`}
       data-test-name="Source"
+      onMouseEnter={trackMouseHover}
     >
       <div className={styles.SourceList} onMouseMove={onMouseMove} ref={sourceRef}>
         <AutoSizer>

--- a/packages/bvaughn-architecture-demo/src/contexts/SessionContext.ts
+++ b/packages/bvaughn-architecture-demo/src/contexts/SessionContext.ts
@@ -10,6 +10,7 @@ export type SessionContextType = {
   sessionId: string;
   refetchUser: () => void;
   trackEvent: (event: string, ...args: any[]) => void;
+  trackEventOnce: (event: string, ...args: any[]) => void;
 };
 
 export const SessionContext = createContext<SessionContextType>(null as any);

--- a/packages/bvaughn-architecture-demo/src/utils/testing.tsx
+++ b/packages/bvaughn-architecture-demo/src/utils/testing.tsx
@@ -41,6 +41,7 @@ export async function render(
     sessionId: "fakeSessionId",
     refetchUser: () => {},
     trackEvent: () => {},
+    trackEventOnce: () => {},
     ...options?.sessionContext,
   };
 

--- a/src/ui/components/SessionContextAdapter.tsx
+++ b/src/ui/components/SessionContextAdapter.tsx
@@ -10,6 +10,7 @@ import { useGetRecordingId } from "ui/hooks/recordings";
 import { useGetUserInfo } from "ui/hooks/users";
 import { getRecordingDuration } from "ui/reducers/timeline";
 import { useAppSelector } from "ui/setup/hooks";
+import { trackEventOnce } from "ui/utils/mixpanel";
 import { trackEvent } from "ui/utils/telemetry";
 
 export default function SessionContextAdapter({ children }: { children: ReactNode }) {
@@ -36,6 +37,7 @@ export default function SessionContextAdapter({ children }: { children: ReactNod
       // Convince TS that the function types line up, since the
       // context version just accepts `string` and not `MixPanelEvent`
       trackEvent: trackEvent as SessionContextType["trackEvent"],
+      trackEventOnce: trackEventOnce as SessionContextType["trackEventOnce"],
     }),
     [currentUserInfo, duration, recordingId, refetchUser]
   );


### PR DESCRIPTION
- Re-adds the `"editor.mouse_over"` Mixpanel event used as part of our onboarding flow, which was lost during the removal of the old source editor