### PR TITLE
Select the whole input content on cmd+F

### DIFF
--- a/packages/bvaughn-architecture-demo/components/console/hooks/useConsoleSearchDOM.ts
+++ b/packages/bvaughn-architecture-demo/components/console/hooks/useConsoleSearchDOM.ts
@@ -75,6 +75,7 @@ export default function useConsoleSearchDOM(
         const searchInput = searchInputRef.current;
         if (searchInput) {
           searchInput.focus();
+          searchInput.select();
         }
       },
     }),

--- a/packages/bvaughn-architecture-demo/components/sources/Sources.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/Sources.tsx
@@ -49,6 +49,7 @@ function Sources() {
           const input = sourceSearchInputRef.current;
           if (input) {
             input.focus();
+            input.select();
           }
 
           event.preventDefault();

--- a/src/devtools/client/debugger/src/components/Editor/NewSourceAdapter.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/NewSourceAdapter.tsx
@@ -79,6 +79,7 @@ function NewSourceAdapter() {
           const input = sourceSearchInputRef.current;
           if (input) {
             input.focus();
+            input.select();
           }
 
           event.preventDefault();


### PR DESCRIPTION
This behavior matches VS Code and Chrome. Whenever you press CMD+F in those the search input gets shown+focused+selected.

cc @bvaughn 