### PR TITLE
Rearranged styles to avoid flex layout issue with SearchFiles > Checkbox

### DIFF
--- a/packages/bvaughn-architecture-demo/components/search-files/SearchFiles.module.css
+++ b/packages/bvaughn-architecture-demo/components/search-files/SearchFiles.module.css
@@ -5,7 +5,7 @@
   padding: 0.5em 0;
 }
 
-.Checkbox {
+.CheckboxWrapper {
   flex: 0 0 auto;
   margin: 0.5em;
 }

--- a/packages/bvaughn-architecture-demo/components/search-files/SearchFiles.tsx
+++ b/packages/bvaughn-architecture-demo/components/search-files/SearchFiles.tsx
@@ -55,13 +55,14 @@ export default function SearchFiles({ limit }: { limit?: number }) {
           </Suspense>
         </div>
 
-        <Checkbox
-          className={styles.Checkbox}
-          dataTestId="SearchFiles-IncludeNodeModules"
-          label="Include node modules"
-          checked={includeNodeModules}
-          onChange={() => setIncludeNodeModules(!includeNodeModules)}
-        />
+        <div className={styles.CheckboxWrapper}>
+          <Checkbox
+            dataTestId="SearchFiles-IncludeNodeModules"
+            label="Include node modules"
+            checked={includeNodeModules}
+            onChange={() => setIncludeNodeModules(!includeNodeModules)}
+          />
+        </div>
 
         <Suspense>
           <ResultsList


### PR DESCRIPTION
This is an irksome fix. On production, the `flex: 0` style we were specifying for the "node modules" checkbox was overridden with `flex: 1` from the `Checkbox` module.
![image](https://user-images.githubusercontent.com/29597/203340120-ed557e39-00ca-4a59-ba2b-a58549bf5f49.png)

On localhost it's the other way around:
![image](https://user-images.githubusercontent.com/29597/203340146-46f940f3-773b-4bde-8a79-716a55c36556.png)

This could bite us in a lot of subtle ways so that sucks. For now though I'm just making the smallest change fix I could think of (that didn't involve adding an `!important` flag).