### PR TITLE
Sync focus and loaded regions between server and client

### DIFF
--- a/src/ui/components/FocusContextReduxAdapter.tsx
+++ b/src/ui/components/FocusContextReduxAdapter.tsx
@@ -1,7 +1,17 @@
-import { PropsWithChildren, useCallback, useEffect, useMemo, useState, useTransition } from "react";
+import isEqual from "lodash/isEqual";
+import {
+  PropsWithChildren,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+} from "react";
 
 import { FocusContext } from "bvaughn-architecture-demo/src/contexts/FocusContext";
 import { Range } from "bvaughn-architecture-demo/src/types";
+import { isPointInRegions, isRangeInRegions } from "shared/utils/time";
 import { setFocusRegion } from "ui/actions/timeline";
 import { getLoadedRegions } from "ui/reducers/app";
 import { getFocusRegion } from "ui/reducers/timeline";
@@ -13,16 +23,55 @@ import { rangeForFocusRegion } from "ui/utils/timeline";
 export default function FocusContextReduxAdapter({ children }: PropsWithChildren) {
   const dispatch = useAppDispatch();
   const loadedRegions = useAppSelector(getLoadedRegions);
+
   const focusRegion = useAppSelector(getFocusRegion);
+  const prevFocusRegionRef = useRef<FocusRegion | null>(focusRegion);
 
   const [isPending, startTransition] = useTransition();
   const [deferredFocusRegion, setDeferredFocusRegion] = useState<FocusRegion | null>(null);
 
   useEffect(() => {
-    startTransition(() => {
-      setDeferredFocusRegion(focusRegion);
-    });
-  }, [focusRegion, loadedRegions]);
+    let newFocusRegion = focusRegion;
+
+    let loading = loadedRegions?.loading || null;
+    let loadingBeginTime = loading?.[0]?.begin.time ?? null;
+    let loadingEndTime = loading?.[0]?.end.time ?? null;
+
+    // If we've updated loading regions, check to ensure our focus region is within the new range.
+    // Sometimes it won't be, because focus is set by times (which are coarser than execution points).
+    // In that case, we should shrink the (local) focus region so that it fits within the loading range.
+    // Otherwise some API requests may end up hung, waiting for execution points to load that will never finish.
+    if (
+      loading !== null &&
+      newFocusRegion !== null &&
+      loadingBeginTime === newFocusRegion.beginTime &&
+      loadingEndTime === newFocusRegion.endTime &&
+      !isRangeInRegions(newFocusRegion, loading)
+    ) {
+      newFocusRegion = { ...newFocusRegion };
+      if (!isPointInRegions(newFocusRegion.begin.point, loading)) {
+        newFocusRegion.begin.point = loading[0].begin.point;
+      }
+      if (!isPointInRegions(newFocusRegion.end.point, loading)) {
+        newFocusRegion.end.point = loading[0].end.point;
+      }
+
+      dispatch(
+        setFocusRegion({
+          beginTime: loadingBeginTime,
+          endTime: loadingEndTime,
+        })
+      );
+    }
+
+    // If the Redux focus region has changed, mirror it in the FocusContext.
+    if (!isEqual(newFocusRegion, prevFocusRegionRef.current)) {
+      prevFocusRegionRef.current = newFocusRegion;
+      startTransition(() => {
+        setDeferredFocusRegion(newFocusRegion);
+      });
+    }
+  }, [dispatch, focusRegion, loadedRegions]);
 
   const update = useCallback(
     (value: Range | null, _: boolean) => {


### PR DESCRIPTION
Refine the in-memory focus region if the backend decides to load a _smaller_ region due to region boundaries.

---

### Background

I think this ties back to the "soft focus" efforts from #7114. My understanding of _why_ we're sending the "soft focus" time rather than the `TimeStampedPoint` time is that we think the backend can find an execution point that more closely matches the time than the client can. (The client may only have paint points, so the data might be pretty sparse.)

Unfortunately this can also break things in the way that's noted in [Replay fe7a5a5d-d483-4634-9d93-ae4ce03bdc80](https://app.replay.io/recording/query-never-happens--fe7a5a5d-d483-4634-9d93-ae4ce03bdc80). Essentially the scenario shown below:
![Screen Shot 2022-11-22 at 3 28 40 PM](https://user-images.githubusercontent.com/29597/203414799-fde660b0-e79d-4c08-8c1b-26ef4671e846.png)

After trying to load the focus range shown above, the frontend might get stuck in a situation where it's waiting for an execution point that's _before_ the nearest region boundary (and will never finish loading).