### PR TITLE
Load regions using TimeStampedPointRange times, not display times

### DIFF
--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -659,8 +659,8 @@ export function syncFocusedRegion(): UIThunkAction {
 
     replayClient.loadRegion(
       {
-        begin: displayedBeginForFocusRegion(focusRegion),
-        end: displayedEndForFocusRegion(focusRegion),
+        begin: focusRegion.begin.time,
+        end: focusRegion.end.time,
       },
       zoomTime.endTime
     );


### PR DESCRIPTION
Potential alternative change for #8195.

---

### Background

I think this ties back to the "soft focus" efforts from #7114. My understanding of _why_ we're sending the "soft focus" time rather than the `TimeStampedPoint` time is that we think the backend can find an execution point that more closely matches the time than the client can. (The client may only have paint points, so the data might be pretty sparse.)

Unfortunately this can also break things in the way that's noted in [Replay fe7a5a5d-d483-4634-9d93-ae4ce03bdc80](https://app.replay.io/recording/query-never-happens--fe7a5a5d-d483-4634-9d93-ae4ce03bdc80). Essentially the scenario shown below:
![Screen Shot 2022-11-22 at 3 28 40 PM](https://user-images.githubusercontent.com/29597/203414799-fde660b0-e79d-4c08-8c1b-26ef4671e846.png)

After trying to load the focus range shown above, the frontend might get stuck in a situation where it's waiting for an execution point that's _before_ the nearest region boundary (and will never finish loading).

---

The fix explored in this PR changes the frontend to instead send the "soft focus" time to the backend. It's probably not great because it's probably more coarse than is ideal in at least some cases.