### PR TITLE
Rewrite sources tree to display separate nodes for multiple versions of a file

### DIFF
--- a/src/devtools/client/debugger/src/components/PrimaryPanes/SourcesTree.tsx
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/SourcesTree.tsx
@@ -88,8 +88,8 @@ interface STState {
   uncollapsedTree: TreeDirectory;
   sourceTree: TreeNode;
   parentMap: WeakMap<object, any>;
-  listItems?: (TreeDirectory | TreeSource)[];
-  highlightItems?: (TreeDirectory | TreeSource)[];
+  listItems?: TreeNode[];
+  highlightItems?: TreeNode[];
 }
 
 class SourcesTree extends Component<PropsFromRedux, STState> {
@@ -178,6 +178,18 @@ class SourcesTree extends Component<PropsFromRedux, STState> {
     return `${path}/${source.id}/`;
   };
 
+  getKey = (item: TreeNode) => {
+    const { path } = item;
+    const source = this.getSource(item);
+
+    if (item.type === "source" && source) {
+      // Probably overkill
+      return `${source.url!}${source.contentHash || ""}${source.id}`;
+    }
+
+    return path;
+  };
+
   onExpand = (item: TreeNode, expandedState: $FixTypeLater) => {
     this.props.setExpandedState(expandedState);
   };
@@ -248,6 +260,7 @@ class SourcesTree extends Component<PropsFromRedux, STState> {
         getChildren={this.getChildren}
         getParent={(item: TreeNode) => parentMap.get(item)}
         getPath={this.getPath}
+        getKey={this.getKey}
         getRoots={() => this.getRoots(sourceTree)}
         highlightItems={highlightItems}
         key={this.isEmpty() ? "empty" : "full"}

--- a/src/devtools/client/debugger/src/components/PrimaryPanes/SourcesTree.tsx
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/SourcesTree.tsx
@@ -52,13 +52,9 @@ function shouldAutoExpand(depth: number, item: TreeNode) {
   return item.name === "";
 }
 
-function findSource(
-  sources: Record<string, SourceDetails>,
-  itemPath: string,
-  source: SourceDetails
-) {
+function findSource(sourcesByUrl: Record<string, SourceDetails>, source: SourceDetails) {
   if (source) {
-    return sources[source.id];
+    return sourcesByUrl[source.url!];
   }
   return source;
 }
@@ -168,7 +164,7 @@ class SourcesTree extends Component<PropsFromRedux, STState> {
   // NOTE: we get the source from sources because item.contents is cached
   getSource(item: TreeNode) {
     const source = getSourceFromNode(item);
-    return findSource(this.props.sources, item.path, source!);
+    return findSource(this.props.sources, source!);
   }
 
   getPath = (item: TreeNode) => {

--- a/src/devtools/client/debugger/src/components/PrimaryPanes/SourcesTreeItem.tsx
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/SourcesTreeItem.tsx
@@ -19,22 +19,21 @@ import { getContext } from "../../selectors";
 import { copyToTheClipboard } from "../../utils/clipboard";
 import { getSourceQueryString } from "../../utils/source";
 import { getPathWithoutThread, isDirectory } from "../../utils/sources-tree";
+import { TreeNode } from "../../utils/sources-tree/types";
 import AccessibleImage from "../shared/AccessibleImage";
 import SourceIcon from "../shared/SourceIcon";
 
-type $FixTypeLater = any;
-
 interface STIProps {
-  item: $FixTypeLater;
+  item: TreeNode;
   depth: number;
   focused: boolean;
   autoExpand: boolean;
   expanded: boolean;
-  focusItem: (item: $FixTypeLater) => void;
-  selectItem: (item: $FixTypeLater) => void;
+  focusItem: (item: TreeNode) => void;
+  selectItem: (item: TreeNode) => void;
   source: SourceDetails;
   debuggeeUrl: string;
-  setExpanded: (item: $FixTypeLater, a: boolean, b: boolean) => void;
+  setExpanded: (item: TreeNode, a: boolean, b: boolean) => void;
 }
 
 const mapStateToProps = (state: UIState, props: STIProps) => {
@@ -68,7 +67,7 @@ class SourceTreeItem extends Component<FinalSTIProps> {
     }
   };
 
-  onContextMenu = (event: React.MouseEvent, item: $FixTypeLater) => {
+  onContextMenu = (event: React.MouseEvent, item: TreeNode) => {
     // TODO [FE-926] Review source editor context menu for re-adding later
     // This includes actual implementation (legacy FF menu vs something new),
     // as well as what menu items it should contain.
@@ -107,7 +106,7 @@ class SourceTreeItem extends Component<FinalSTIProps> {
     showMenu(event, menuOptions);
   };
 
-  addCollapseExpandAllOptions = (menuOptions: ContextMenuItem[], item: $FixTypeLater) => {
+  addCollapseExpandAllOptions = (menuOptions: ContextMenuItem[], item: TreeNode) => {
     const { setExpanded } = this.props;
 
     menuOptions.push({
@@ -134,7 +133,7 @@ class SourceTreeItem extends Component<FinalSTIProps> {
     );
   }
 
-  renderIcon(item: $FixTypeLater, depth: number) {
+  renderIcon(item: TreeNode, depth: number) {
     const { source } = this.props;
 
     if (item.name === "webpack://") {
@@ -174,7 +173,7 @@ class SourceTreeItem extends Component<FinalSTIProps> {
   renderItemTooltip() {
     const { item, depth } = this.props;
 
-    return item.type === "source" ? unescape(item.contents.url) : getPathWithoutThread(item.path);
+    return item.type === "source" ? unescape(item.contents.url!) : getPathWithoutThread(item.path);
   }
 
   render() {

--- a/src/devtools/client/debugger/src/components/PrimaryPanes/SourcesTreeItem.tsx
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/SourcesTreeItem.tsx
@@ -126,7 +126,8 @@ class SourceTreeItem extends Component<FinalSTIProps> {
 
   renderItemArrow() {
     const { item, expanded } = this.props;
-    return isDirectory(item) ? (
+    const shouldShowArrow = isDirectory(item) || item.type === "multiSource";
+    return shouldShowArrow ? (
       <AccessibleImage className={classnames("arrow", { expanded })} />
     ) : (
       <span className="img no-arrow" />

--- a/src/devtools/client/debugger/src/components/shared/ManagedTree.css
+++ b/src/devtools/client/debugger/src/components/shared/ManagedTree.css
@@ -31,11 +31,11 @@
 }
 
 html:not([dir="rtl"]) .managed-tree .tree .node > div {
-  margin-left: 10px;
+  margin-left: 3px;
 }
 
 html[dir="rtl"] .managed-tree .tree .node > div {
-  margin-right: 10px;
+  margin-right: 3px;
 }
 
 .managed-tree .tree-node button {

--- a/src/devtools/client/debugger/src/components/shared/ManagedTree.tsx
+++ b/src/devtools/client/debugger/src/components/shared/ManagedTree.tsx
@@ -11,6 +11,7 @@ export interface ManagedTreeProps<T extends { name: string }>
   extends Omit<TreeProps<T>, "renderItem" | "onExpand" | "onCollapse" | "isExpanded" | "getKey"> {
   expanded?: Set<string>;
   getPath: (item: T) => string;
+  getKey?: (item: T) => string;
   listItems?: T[];
   highlightItems?: T[];
   focused?: T;
@@ -137,7 +138,7 @@ class ManagedTree<T extends { name: string }> extends Component<
           {...this.props}
           isExpanded={(item: T) => expanded.has(this.props.getPath(item))}
           focused={this.props.focused}
-          getKey={this.props.getPath}
+          getKey={this.props.getKey ?? this.props.getPath}
           onExpand={(item: T) => this.setExpanded(item, true)}
           onCollapse={(item: T) => this.setExpanded(item, false)}
           onFocus={this.props.onFocus}

--- a/src/devtools/client/debugger/src/utils/sources-tree/addToTree.ts
+++ b/src/devtools/client/debugger/src/utils/sources-tree/addToTree.ts
@@ -15,6 +15,7 @@ import type { ParentMap, TreeDirectory, TreeNode, TreeSource } from "./types";
 import {
   createDirectoryNode,
   createSourceNode,
+  isDirectory,
   isPathDirectory,
   nodeHasChildren,
   partIsFile,
@@ -61,7 +62,7 @@ function findOrCreateNode(
   // we found a path with the same name as the part. We need to determine
   // if this is the correct child, or if we have a naming conflict
   const child = subTree.contents[childIndex];
-  const childIsFile = !nodeHasChildren(child);
+  const childIsFile = !isDirectory(child);
 
   // if we have a naming conflict, we'll create a new node
   if (childIsFile != addedPartIsFile) {
@@ -113,45 +114,79 @@ function traverseTree(
 /*
  * Add a source file to a directory node in the tree
  */
-function addSourceToNode(node: TreeDirectory, url: ParsedUrl, source: SourceDetails) {
+function addSourceToNode(node: TreeNode, url: ParsedUrl, source: SourceDetails) {
   const isFile = !isPathDirectory(url.path);
 
-  // @ts-expect-error intentional error check apparently
   if (node.type == "source" && !isFile) {
     throw new Error(`Unexpected type "source" at: ${node.name}`);
   }
 
-  // if we have a file, and the subtree has no elements, overwrite the
-  // subtree contents with the source
+  const { filename } = url;
+
+  // if we have a file, update this TreeNode.
   if (isFile) {
-    // @ts-expect-error this is intentional
-    node.type = "source";
-    // This is old and weird, but the `return source` was here already
-    return source;
+    // This part gets weird.
+    // The logic here is partially mutative. We may end up mutating `node` to
+    // change its type depending on what it is already, and what we're adding.
+    switch (node.type) {
+      case "directory": {
+        // This is the first source entry with this filename.
+        // Intentionally convert the node into a "source" node,
+        // with the `SourceDetails` as its contents.
+        // @ts-expect-error this is intentional
+        node.type = "source";
+        return source;
+      }
+      case "source": {
+        // Convert the "single-source" tree node with a `SourceDetails` as its
+        // contents, into a "multiSource" node with an array of 2 "source" nodes
+        // as its contents. We can hardcode the numeric prefixes for multi-versions.
+        const newContents = [
+          createSourceNode(`(1) ${filename}`, node.contents.url!, node.contents),
+          createSourceNode(`(2) ${filename}`, source.url!, source),
+        ];
+
+        // @ts-expect-error this is intentional
+        node.type = "multiSource";
+        return newContents;
+      }
+      case "multiSource": {
+        const newContents = node.contents.concat(createSourceNode(filename, source.url!, source));
+
+        // Recalculate the numeric prefixes for each version of the file.
+        newContents.forEach((node, i) => {
+          node.name = `(${i + 1}) ${filename}`;
+        });
+        return newContents;
+      }
+    }
   }
 
-  const { filename } = url;
-  const { found: childFound, index: childIndex } = findNodeInContents(
-    node,
-    createTreeNodeMatcher(filename, false, undefined)
-  );
+  // If it's not a file, it might be an "(index)" entry or similar.
 
-  // if we are readding an existing file in the node, overwrite the existing
-  // file and return the node's contents
-  if (childFound) {
-    const existingNode = node.contents[childIndex];
-    if (existingNode.type === "source") {
-      existingNode.contents = source;
+  if (Array.isArray(node.contents)) {
+    const { found: childFound, index: childIndex } = findNodeInContents(
+      node,
+      createTreeNodeMatcher(filename, false, undefined)
+    );
+
+    // if we are readding an existing file in the node, overwrite the existing
+    // file and return the node's contents
+    if (childFound) {
+      const existingNode = node.contents[childIndex];
+      if (existingNode.type === "source") {
+        existingNode.contents = source;
+      }
+
+      return node.contents;
     }
 
-    return node.contents;
+    // if this is a new file, add the new file;
+    const newNode = createSourceNode(filename, source.url!, source);
+    const contents = node.contents.slice(0);
+    contents.splice(childIndex, 0, newNode);
+    return contents;
   }
-
-  // if this is a new file, add the new file;
-  const newNode = createSourceNode(filename, source.url!, source);
-  const contents = node.contents.slice(0);
-  contents.splice(childIndex, 0, newNode);
-  return contents;
 }
 
 /**

--- a/src/devtools/client/debugger/src/utils/sources-tree/formatTree.ts
+++ b/src/devtools/client/debugger/src/utils/sources-tree/formatTree.ts
@@ -7,7 +7,7 @@ import type { ParentMap, TreeDirectory, TreeNode, TreeSource } from "./types";
 export function formatTree(tree: TreeNode, depth = 0, str = "") {
   const whitespace = new Array(depth * 2).join(" ");
 
-  if (tree.type === "directory") {
+  if (tree.type !== "source") {
     str += `${whitespace} - ${tree.name} path=${tree.path} \n`;
     tree.contents.forEach(t => {
       str = formatTree(t, depth + 1, str);

--- a/src/devtools/client/debugger/src/utils/sources-tree/getDirectories.ts
+++ b/src/devtools/client/debugger/src/utils/sources-tree/getDirectories.ts
@@ -34,7 +34,7 @@ export function findSourceTreeNodes(sourceTree: TreeDirectory, path: string) {
       return subtree;
     }
 
-    if (subtree.type === "directory") {
+    if (subtree.type !== "source") {
       const matches = subtree.contents.map(child => _traverse(child));
       return matches && (matches.filter(Boolean) as TreeNode[]);
     }

--- a/src/devtools/client/debugger/src/utils/sources-tree/sortTree.ts
+++ b/src/devtools/client/debugger/src/utils/sources-tree/sortTree.ts
@@ -5,7 +5,7 @@
 //
 
 import type { ParentMap, TreeDirectory, TreeNode, TreeSource } from "./types";
-import { isExactUrlMatch, nodeHasChildren } from "./utils";
+import { isDirectory, isExactUrlMatch, nodeHasChildren } from "./utils";
 
 /**
  * Look at the nodes in the source tree, and determine the index of where to
@@ -15,8 +15,8 @@ import { isExactUrlMatch, nodeHasChildren } from "./utils";
  */
 export function sortTree(tree: TreeDirectory, debuggeeUrl = "") {
   return tree.contents.sort((previousNode, currentNode) => {
-    const currentNodeIsDir = nodeHasChildren(currentNode);
-    const previousNodeIsDir = nodeHasChildren(previousNode);
+    const currentNodeIsDir = isDirectory(currentNode);
+    const previousNodeIsDir = isDirectory(previousNode);
     if (currentNode.name === "(index)") {
       return 1;
     } else if (previousNode.name === "(index)") {

--- a/src/devtools/client/debugger/src/utils/sources-tree/tests/__snapshots__/updateTree.test.ts.snap
+++ b/src/devtools/client/debugger/src/utils/sources-tree/tests/__snapshots__/updateTree.test.ts.snap
@@ -2,343 +2,7 @@
 
 exports[`updateTree Generates a correctly sorted nested tree of sources and folders 1`] = `
 Object {
-  "contents": Array [
-    Object {
-      "contents": Array [
-        Object {
-          "contents": Array [
-            Object {
-              "contents": Array [
-                Object {
-                  "contents": Object {
-                    "id": "https://codesandbox.io/static/js/sandbox.js",
-                    "url": "https://codesandbox.io/static/js/sandbox.js",
-                  },
-                  "name": "sandbox.js",
-                  "path": "/codesandbox.io/static/js/sandbox.js",
-                  "type": "source",
-                },
-                Object {
-                  "contents": Object {
-                    "id": "https://codesandbox.io/static/js/vendors.js",
-                    "url": "https://codesandbox.io/static/js/vendors.js",
-                  },
-                  "name": "vendors.js",
-                  "path": "/codesandbox.io/static/js/vendors.js",
-                  "type": "source",
-                },
-              ],
-              "name": "js",
-              "path": "/codesandbox.io/static/js",
-              "type": "directory",
-            },
-          ],
-          "name": "static",
-          "path": "/codesandbox.io/static",
-          "type": "directory",
-        },
-      ],
-      "name": "codesandbox.io",
-      "path": "/codesandbox.io",
-      "type": "directory",
-    },
-    Object {
-      "contents": Array [
-        Object {
-          "contents": Object {
-            "id": "replay-content:///react-devtools-hook-script",
-            "url": "replay-content:///react-devtools-hook-script",
-          },
-          "name": "react-devtools-hook-script",
-          "path": "/replay-content:///react-devtools-hook-script",
-          "type": "source",
-        },
-      ],
-      "name": "replay-content://",
-      "path": "/replay-content://",
-      "type": "directory",
-    },
-    Object {
-      "contents": Array [
-        Object {
-          "contents": Object {
-            "id": "(index)",
-            "url": "https://something.com/(index)",
-          },
-          "name": "(index)",
-          "path": "/something.com/(index)",
-          "type": "source",
-        },
-        Object {
-          "contents": Array [
-            Object {
-              "contents": Array [
-                Object {
-                  "contents": Array [
-                    Object {
-                      "contents": Object {
-                        "id": "node_modules/react-redux/es/index.js",
-                        "url": "https://something.com/node_modules/react-redux/es/index.js",
-                      },
-                      "name": "index.js",
-                      "path": "/something.com/node_modules/react-redux/es/index.js",
-                      "type": "source",
-                    },
-                    Object {
-                      "contents": Object {
-                        "id": "node_modules/react-redux/es/types.js",
-                        "url": "https://something.com/node_modules/react-redux/es/types.js",
-                      },
-                      "name": "types.js",
-                      "path": "/something.com/node_modules/react-redux/es/types.js",
-                      "type": "source",
-                    },
-                  ],
-                  "name": "es",
-                  "path": "/something.com/node_modules/react-redux/es",
-                  "type": "directory",
-                },
-              ],
-              "name": "react-redux",
-              "path": "/something.com/node_modules/react-redux",
-              "type": "directory",
-            },
-            Object {
-              "contents": Array [
-                Object {
-                  "contents": Array [
-                    Object {
-                      "contents": Object {
-                        "id": "node_modules/redux/es/redux.js",
-                        "url": "https://something.com/node_modules/redux/es/redux.js",
-                      },
-                      "name": "redux.js",
-                      "path": "/something.com/node_modules/redux/es/redux.js",
-                      "type": "source",
-                    },
-                  ],
-                  "name": "es",
-                  "path": "/something.com/node_modules/redux/es",
-                  "type": "directory",
-                },
-              ],
-              "name": "redux",
-              "path": "/something.com/node_modules/redux",
-              "type": "directory",
-            },
-          ],
-          "name": "node_modules",
-          "path": "/something.com/node_modules",
-          "type": "directory",
-        },
-        Object {
-          "contents": Array [
-            Object {
-              "contents": Array [
-                Object {
-                  "contents": Object {
-                    "id": "src/app/hooks.ts",
-                    "url": "https://something.com/src/app/hooks.ts",
-                  },
-                  "name": "hooks.ts",
-                  "path": "/something.com/src/app/hooks.ts",
-                  "type": "source",
-                },
-                Object {
-                  "contents": Object {
-                    "id": "src/app/store.ts",
-                    "url": "https://something.com/src/app/store.ts",
-                  },
-                  "name": "store.ts",
-                  "path": "/something.com/src/app/store.ts",
-                  "type": "source",
-                },
-              ],
-              "name": "app",
-              "path": "/something.com/src/app",
-              "type": "directory",
-            },
-            Object {
-              "contents": Array [
-                Object {
-                  "contents": Array [
-                    Object {
-                      "contents": Object {
-                        "id": "src/features/counter/Counter.tsx",
-                        "url": "https://something.com/src/features/counter/Counter.tsx",
-                      },
-                      "name": "Counter.tsx",
-                      "path": "/something.com/src/features/counter/Counter.tsx",
-                      "type": "source",
-                    },
-                    Object {
-                      "contents": Object {
-                        "id": "src/features/counter/counterAPI.ts",
-                        "url": "https://something.com/src/features/counter/counterAPI.ts",
-                      },
-                      "name": "counterAPI.ts",
-                      "path": "/something.com/src/features/counter/counterAPI.ts",
-                      "type": "source",
-                    },
-                    Object {
-                      "contents": Object {
-                        "id": "src/features/counter/counterSlice.ts",
-                        "url": "https://something.com/src/features/counter/counterSlice.ts",
-                      },
-                      "name": "counterSlice.ts",
-                      "path": "/something.com/src/features/counter/counterSlice.ts",
-                      "type": "source",
-                    },
-                  ],
-                  "name": "counter",
-                  "path": "/something.com/src/features/counter",
-                  "type": "directory",
-                },
-              ],
-              "name": "features",
-              "path": "/something.com/src/features",
-              "type": "directory",
-            },
-            Object {
-              "contents": Array [
-                Object {
-                  "contents": Array [
-                    Object {
-                      "contents": Object {
-                        "id": "src/features2/todos/todos.ts?2",
-                        "url": "https://something.com/src/features2/todos/todos.ts?2",
-                      },
-                      "name": "todos.ts",
-                      "path": "/something.com/src/features2/todos/todos.ts",
-                      "type": "source",
-                    },
-                  ],
-                  "name": "todos",
-                  "path": "/something.com/src/features2/todos",
-                  "type": "directory",
-                },
-              ],
-              "name": "features2",
-              "path": "/something.com/src/features2",
-              "type": "directory",
-            },
-            Object {
-              "contents": Object {
-                "id": "src/App.tsx",
-                "url": "https://something.com/src/App.tsx",
-              },
-              "name": "App.tsx",
-              "path": "/something.com/src/App.tsx",
-              "type": "source",
-            },
-            Object {
-              "contents": Object {
-                "id": "src/index.tsx",
-                "url": "https://something.com/src/index.tsx",
-              },
-              "name": "index.tsx",
-              "path": "/something.com/src/index.tsx",
-              "type": "source",
-            },
-          ],
-          "name": "src",
-          "path": "/something.com/src",
-          "type": "directory",
-        },
-      ],
-      "name": "something.com",
-      "path": "/something.com",
-      "type": "directory",
-    },
-    Object {
-      "contents": Array [
-        Object {
-          "contents": Array [
-            Object {
-              "contents": Array [
-                Object {
-                  "contents": Array [
-                    Object {
-                      "contents": Array [
-                        Object {
-                          "contents": Array [
-                            Object {
-                              "contents": Array [
-                                Object {
-                                  "contents": Array [
-                                    Object {
-                                      "contents": Array [
-                                        Object {
-                                          "contents": Object {
-                                            "id": "webpack:////home/circleci/codesandbox-client/node_modules/core-js/fn/array/includes.js",
-                                            "url": "webpack:////home/circleci/codesandbox-client/node_modules/core-js/fn/array/includes.js",
-                                          },
-                                          "name": "includes.js",
-                                          "path": "/webpack:////home/circleci/codesandbox-client/node_modules/core-js/fn/array/includes.js",
-                                          "type": "source",
-                                        },
-                                      ],
-                                      "name": "array",
-                                      "path": "/webpack:////home/circleci/codesandbox-client/node_modules/core-js/fn/array",
-                                      "type": "directory",
-                                    },
-                                  ],
-                                  "name": "fn",
-                                  "path": "/webpack:////home/circleci/codesandbox-client/node_modules/core-js/fn",
-                                  "type": "directory",
-                                },
-                              ],
-                              "name": "core-js",
-                              "path": "/webpack:////home/circleci/codesandbox-client/node_modules/core-js",
-                              "type": "directory",
-                            },
-                          ],
-                          "name": "node_modules",
-                          "path": "/webpack:////home/circleci/codesandbox-client/node_modules",
-                          "type": "directory",
-                        },
-                      ],
-                      "name": "codesandbox-client",
-                      "path": "/webpack:////home/circleci/codesandbox-client",
-                      "type": "directory",
-                    },
-                  ],
-                  "name": "circleci",
-                  "path": "/webpack:////home/circleci",
-                  "type": "directory",
-                },
-              ],
-              "name": "home",
-              "path": "/webpack:////home",
-              "type": "directory",
-            },
-          ],
-          "name": "",
-          "path": "/webpack:///",
-          "type": "directory",
-        },
-        Object {
-          "contents": Array [
-            Object {
-              "contents": Object {
-                "id": "webpack://BrowserFS/webpack/bootstrap",
-                "url": "webpack://BrowserFS/webpack/bootstrap",
-              },
-              "name": "bootstrap",
-              "path": "/webpack:///webpack/bootstrap",
-              "type": "source",
-            },
-          ],
-          "name": "webpack",
-          "path": "/webpack:///webpack",
-          "type": "directory",
-        },
-      ],
-      "name": "webpack://",
-      "path": "/webpack://",
-      "type": "directory",
-    },
-  ],
+  "contents": Array [],
   "name": "root",
   "path": "",
   "type": "directory",
@@ -526,13 +190,29 @@ Object {
             Object {
               "contents": Array [
                 Object {
-                  "contents": Object {
-                    "id": "src/features2/todos/todos.ts?2",
-                    "url": "https://something.com/src/features2/todos/todos.ts?2",
-                  },
+                  "contents": Array [
+                    Object {
+                      "contents": Object {
+                        "id": "src/features2/todos/todos.ts?1",
+                        "url": "https://something.com/src/features2/todos/todos.ts?1",
+                      },
+                      "name": "(1) todos.ts",
+                      "path": "https://something.com/src/features2/todos/todos.ts?1",
+                      "type": "source",
+                    },
+                    Object {
+                      "contents": Object {
+                        "id": "src/features2/todos/todos.ts?2",
+                        "url": "https://something.com/src/features2/todos/todos.ts?2",
+                      },
+                      "name": "(2) todos.ts",
+                      "path": "https://something.com/src/features2/todos/todos.ts?2",
+                      "type": "source",
+                    },
+                  ],
                   "name": "todos.ts",
                   "path": "/something.com/src/features2/todos/todos.ts",
-                  "type": "source",
+                  "type": "multiSource",
                 },
               ],
               "name": "features2/todos",

--- a/src/devtools/client/debugger/src/utils/sources-tree/tests/__snapshots__/updateTree.test.ts.snap
+++ b/src/devtools/client/debugger/src/utils/sources-tree/tests/__snapshots__/updateTree.test.ts.snap
@@ -20,6 +20,7 @@ Object {
               "contents": Array [
                 Object {
                   "contents": Object {
+                    "contentHash": "https://codesandbox.io/static/js/sandbox.js",
                     "id": "https://codesandbox.io/static/js/sandbox.js",
                     "url": "https://codesandbox.io/static/js/sandbox.js",
                   },
@@ -29,6 +30,7 @@ Object {
                 },
                 Object {
                   "contents": Object {
+                    "contentHash": "https://codesandbox.io/static/js/vendors.js",
                     "id": "https://codesandbox.io/static/js/vendors.js",
                     "url": "https://codesandbox.io/static/js/vendors.js",
                   },
@@ -55,6 +57,7 @@ Object {
       "contents": Array [
         Object {
           "contents": Object {
+            "contentHash": "replay-content:///react-devtools-hook-script",
             "id": "replay-content:///react-devtools-hook-script",
             "url": "replay-content:///react-devtools-hook-script",
           },
@@ -71,6 +74,7 @@ Object {
       "contents": Array [
         Object {
           "contents": Object {
+            "contentHash": "(index)",
             "id": "(index)",
             "url": "https://something.com/(index)",
           },
@@ -84,6 +88,7 @@ Object {
               "contents": Array [
                 Object {
                   "contents": Object {
+                    "contentHash": "node_modules/react-redux/es/index.js",
                     "id": "node_modules/react-redux/es/index.js",
                     "url": "https://something.com/node_modules/react-redux/es/index.js",
                   },
@@ -93,6 +98,7 @@ Object {
                 },
                 Object {
                   "contents": Object {
+                    "contentHash": "node_modules/react-redux/es/types.js",
                     "id": "node_modules/react-redux/es/types.js",
                     "url": "https://something.com/node_modules/react-redux/es/types.js",
                   },
@@ -109,6 +115,7 @@ Object {
               "contents": Array [
                 Object {
                   "contents": Object {
+                    "contentHash": "node_modules/redux/es/redux.js",
                     "id": "node_modules/redux/es/redux.js",
                     "url": "https://something.com/node_modules/redux/es/redux.js",
                   },
@@ -132,6 +139,7 @@ Object {
               "contents": Array [
                 Object {
                   "contents": Object {
+                    "contentHash": "src/app/hooks.ts",
                     "id": "src/app/hooks.ts",
                     "url": "https://something.com/src/app/hooks.ts",
                   },
@@ -141,6 +149,7 @@ Object {
                 },
                 Object {
                   "contents": Object {
+                    "contentHash": "src/app/store.ts",
                     "id": "src/app/store.ts",
                     "url": "https://something.com/src/app/store.ts",
                   },
@@ -157,6 +166,7 @@ Object {
               "contents": Array [
                 Object {
                   "contents": Object {
+                    "contentHash": "src/features/counter/Counter.tsx",
                     "id": "src/features/counter/Counter.tsx",
                     "url": "https://something.com/src/features/counter/Counter.tsx",
                   },
@@ -166,6 +176,7 @@ Object {
                 },
                 Object {
                   "contents": Object {
+                    "contentHash": "src/features/counter/counterAPI.ts",
                     "id": "src/features/counter/counterAPI.ts",
                     "url": "https://something.com/src/features/counter/counterAPI.ts",
                   },
@@ -175,6 +186,7 @@ Object {
                 },
                 Object {
                   "contents": Object {
+                    "contentHash": "src/features/counter/counterSlice.ts",
                     "id": "src/features/counter/counterSlice.ts",
                     "url": "https://something.com/src/features/counter/counterSlice.ts",
                   },
@@ -193,6 +205,7 @@ Object {
                   "contents": Array [
                     Object {
                       "contents": Object {
+                        "contentHash": "src/features2/todos/todos.ts?1",
                         "id": "src/features2/todos/todos.ts?1",
                         "url": "https://something.com/src/features2/todos/todos.ts?1",
                       },
@@ -202,6 +215,7 @@ Object {
                     },
                     Object {
                       "contents": Object {
+                        "contentHash": "src/features2/todos/todos.ts?2",
                         "id": "src/features2/todos/todos.ts?2",
                         "url": "https://something.com/src/features2/todos/todos.ts?2",
                       },
@@ -220,7 +234,59 @@ Object {
               "type": "directory",
             },
             Object {
+              "contents": Array [
+                Object {
+                  "contents": Object {
+                    "contentHash": "https://something.com/src/features3/todos/todos.ts",
+                    "id": "src/features3/todos/todos.ts?3",
+                    "url": "https://something.com/src/features3/todos/todos.ts?3",
+                  },
+                  "name": "todos.ts",
+                  "path": "/something.com/src/features3/todos/todos.ts",
+                  "type": "source",
+                },
+              ],
+              "name": "features3/todos",
+              "path": "/something.com/src/features3/todos",
+              "type": "directory",
+            },
+            Object {
+              "contents": Array [
+                Object {
+                  "contents": Array [
+                    Object {
+                      "contents": Object {
+                        "contentHash": "https://something.com/src/features4/todos/todos.ts",
+                        "id": "src/features4/todos/todos.ts?number=5&duplicate=true",
+                        "url": "https://something.com/src/features4/todos/todos.ts?number=5&duplicate=true",
+                      },
+                      "name": "(1) todos.ts",
+                      "path": "https://something.com/src/features4/todos/todos.ts?number=5&duplicate=true",
+                      "type": "source",
+                    },
+                    Object {
+                      "contents": Object {
+                        "contentHash": "src/features4/todos/todos.ts?number=6&duplicate=false",
+                        "id": "src/features4/todos/todos.ts?number=6&duplicate=false",
+                        "url": "https://something.com/src/features4/todos/todos.ts?number=6&duplicate=false",
+                      },
+                      "name": "(2) todos.ts",
+                      "path": "https://something.com/src/features4/todos/todos.ts?number=6&duplicate=false",
+                      "type": "source",
+                    },
+                  ],
+                  "name": "todos.ts",
+                  "path": "/something.com/src/features4/todos/todos.ts",
+                  "type": "multiSource",
+                },
+              ],
+              "name": "features4/todos",
+              "path": "/something.com/src/features4/todos",
+              "type": "directory",
+            },
+            Object {
               "contents": Object {
+                "contentHash": "src/App.tsx",
                 "id": "src/App.tsx",
                 "url": "https://something.com/src/App.tsx",
               },
@@ -230,6 +296,7 @@ Object {
             },
             Object {
               "contents": Object {
+                "contentHash": "src/index.tsx",
                 "id": "src/index.tsx",
                 "url": "https://something.com/src/index.tsx",
               },
@@ -255,6 +322,7 @@ Object {
               "contents": Array [
                 Object {
                   "contents": Object {
+                    "contentHash": "webpack:////home/circleci/codesandbox-client/node_modules/core-js/fn/array/includes.js",
                     "id": "webpack:////home/circleci/codesandbox-client/node_modules/core-js/fn/array/includes.js",
                     "url": "webpack:////home/circleci/codesandbox-client/node_modules/core-js/fn/array/includes.js",
                   },
@@ -276,6 +344,7 @@ Object {
           "contents": Array [
             Object {
               "contents": Object {
+                "contentHash": "webpack://BrowserFS/webpack/bootstrap",
                 "id": "webpack://BrowserFS/webpack/bootstrap",
                 "url": "webpack://BrowserFS/webpack/bootstrap",
               },

--- a/src/devtools/client/debugger/src/utils/sources-tree/treeOrder.ts
+++ b/src/devtools/client/debugger/src/utils/sources-tree/treeOrder.ts
@@ -8,7 +8,7 @@ import { SourceDetails } from "ui/reducers/sources";
 
 import { parse } from "../url";
 import type { ParentMap, TreeDirectory, TreeNode, TreeSource } from "./types";
-import { nodeHasChildren } from "./utils";
+import { isDirectory, nodeHasChildren } from "./utils";
 
 /*
  * Gets domain from url (without www prefix)
@@ -124,7 +124,7 @@ export function createTreeNodeMatcher(
       }
     }
     // Sort directories before files
-    const nodeIsDir = nodeHasChildren(node);
+    const nodeIsDir = isDirectory(node);
     if (nodeIsDir && !isDir) {
       return -1;
     } else if (!nodeIsDir && isDir) {

--- a/src/devtools/client/debugger/src/utils/sources-tree/types.ts
+++ b/src/devtools/client/debugger/src/utils/sources-tree/types.ts
@@ -8,8 +8,9 @@
 // import type { Source } from "devtools/client/debugger/src/reducers/sources";
 import { SourceDetails } from "ui/reducers/sources";
 
-export type TreeNode = TreeSource | TreeDirectory;
+export type TreeNode = TreeSource | TreeDirectory | TreeMultiSource;
 
+/** A single source file node */
 export type TreeSource = {
   type: "source";
   name: string;
@@ -17,6 +18,15 @@ export type TreeSource = {
   contents: SourceDetails;
 };
 
+/** Parent node when there are multiple versions of the same file URL */
+export type TreeMultiSource = {
+  type: "multiSource";
+  name: string;
+  path: string;
+  contents: TreeSource[];
+};
+
+/** A directory in the source tree */
 export type TreeDirectory = {
   type: "directory";
   name: string;

--- a/src/devtools/client/debugger/src/utils/sources-tree/updateTree.ts
+++ b/src/devtools/client/debugger/src/utils/sources-tree/updateTree.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-//
+import { createNextState } from "@reduxjs/toolkit";
 
 import { SourceDetails } from "ui/reducers/sources";
 
@@ -58,11 +58,15 @@ export function updateTree({ newSources, prevSources, uncollapsedTree }: UpdateT
   // @ts-expect-error This used to be nested records - somehow it still works?
   const sourcesToAdd = getSourcesToAdd(Object.values(newSources), Object.values(prevSources));
 
-  for (const source of sourcesToAdd) {
-    addToTree(uncollapsedTree, source, debuggeeHost!);
-  }
+  // Since the logic here is mutative, wrap the updates with Immer to
+  // produce a fully immutable update.
+  const newUncollapsedTree = createNextState(uncollapsedTree, draft => {
+    for (const source of sourcesToAdd) {
+      addToTree(draft, source, debuggeeHost!);
+    }
+  });
 
-  const newSourceTree = collapseTree(uncollapsedTree);
+  const newSourceTree = collapseTree(newUncollapsedTree);
 
   return {
     uncollapsedTree,

--- a/src/devtools/client/debugger/src/utils/sources-tree/utils.ts
+++ b/src/devtools/client/debugger/src/utils/sources-tree/utils.ts
@@ -14,7 +14,7 @@ import type { ParentMap, TreeDirectory, TreeNode, TreeSource } from "./types";
 export type SourcesMap = Record<string, SourceDetails>;
 
 export function nodeHasChildren(item: TreeNode) {
-  return item.type == "directory" && Array.isArray(item.contents);
+  return Array.isArray(item.contents);
 }
 
 export function isExactUrlMatch(pathPart: string, debuggeeUrl: string) {
@@ -63,14 +63,17 @@ export function isDirectory(item: TreeNode) {
 }
 
 export function getSourceFromNode(item: TreeNode) {
-  const { contents } = item;
-  if (!isDirectory(item) && !Array.isArray(contents)) {
-    return contents;
+  if (item.type === "source") {
+    return item.contents;
+  } else if (item.type === "multiSource") {
+    // All items should have the same filename, so use the first one.
+    // That way we get an icon.
+    return item.contents[0]?.contents;
   }
 }
 
 export function isSource(item: TreeNode) {
-  return item.type === "source";
+  return !isDirectory(item);
 }
 
 export function partIsFile(index: number, parts: string[], url: TreeNode) {
@@ -104,7 +107,7 @@ export function createParentMap(tree: TreeNode) {
   const map = new WeakMap();
 
   function _traverse(subtree: TreeNode) {
-    if (subtree.type === "directory") {
+    if (subtree.type !== "source") {
       for (const child of subtree.contents) {
         map.set(child, subtree);
         _traverse(child);


### PR DESCRIPTION
- Fixed a broken lookup for sources that caused file tree nodes to not have icons (the record is keyed by URL, not source ID)
- Cleaned up some `$FixTypeLater` types and used the proper `TreeNode` types
- Rewrote source tree construction logic to better handle multiple versions of the same file:
  - added a new `"multiSource"` tree node type that acts as an expandable parent to the actual source entries
  - Rewrote checks for node types to handle this case
  - Improved React key selection for tree node components to use URLs+IDs for source entries instead of path
  - Added checks for existing files by content hash to prevent showing full duplicates
  - Multiple-version tree nodes are prefixed with a number to distinguish them, like `(1) App.tsx`
  - Ensured "find file node" logic works for these duplicates, allowing "Reveal in Tree" and highlighting based on selected source tab to work right
- Tweaked tree node CSS to shrink whitespace between icon and text from 10px to 3px per Jon's direction

Note that the source tabs do not show the same `(N) ` prefix, because that's internal to the source tree construction logic for now.

To see an example of this behavior, open up https://devtools-git-feature-fe-162-source-tree-duplicates-recordreplay.vercel.app/recording/vite-hmr-multi-file-test-with-duplicates--3ed2de41-1d87-4b53-8c7f-e1016d48547f on the preview branch.  I edited both `src/App.tsx` and `src/main.tsx` several times, including flipping back and forth between identical contents.  There should be 8 total versions of each file, but only 4 will show up in the tree because of the duplication.  (Currently, the "Quick Open" dialog will still show all 8 versions of each file.)

Visual:

![image](https://user-images.githubusercontent.com/1128784/203658105-034762c7-2c38-48d0-a27e-4a6fedf235e0.png)
