### PR TITLE
Show hook headers where they exist

### DIFF
--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -190,6 +190,7 @@ export type TestStep = {
   relativeStartTime: number;
   parentId?: string;
   error?: TestItemError;
+  hook?: "beforeEach" | "afterEach";
 };
 
 // https://github.com/Replayio/replay-cli/blob/main/packages/replay/metadata/source.ts


### PR DESCRIPTION
* Shows headers for test sections (before each / body / after each)
* If there's only a test body, no headers are shown

<img width="460" alt="image" src="https://user-images.githubusercontent.com/788456/203669500-7f52f879-bca5-46d8-9b00-384eaa9de6d3.png">

Can do more in the future (e.g. make them collapsible) but this is the minimum for those replays that have the data.
