### PR TITLE
Link to the correct location for test steps

### DIFF
--- a/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
@@ -12,12 +12,10 @@ import { TestSteps } from "./TestSteps";
 
 export function TestCase({
   test,
-  location,
   setHighlightedTest,
   isHighlighted,
 }: {
   test: TestItem;
-  location?: Location;
   setHighlightedTest: () => void;
   isHighlighted: boolean;
 }) {
@@ -95,9 +93,7 @@ export function TestCase({
           </div>
         </button>
       </div>
-      {expandSteps ? (
-        <TestSteps test={test} startTime={test.relativeStartTime} location={location} />
-      ) : null}
+      {expandSteps ? <TestSteps test={test} startTime={test.relativeStartTime} /> : null}
     </div>
   );
 }

--- a/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
@@ -10,7 +10,6 @@ import { TestItem } from "ui/types";
 import { TestCase } from "./TestCase";
 
 function maybeCorrectTestTimes(testCases: TestItem[], annotations: Annotation[]) {
-  console.log({ testCases, annotations });
   return testCases.map((t, i) => ({
     ...t,
     relativeStartTime: annotations?.[i]?.time ? annotations?.[i]?.time : t.relativeStartTime,

--- a/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
@@ -1,16 +1,16 @@
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 
 import { getRecordingDuration } from "ui/actions/app";
 import { setFocusRegion } from "ui/actions/timeline";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
-import { useFetchCypressSpec } from "ui/hooks/useFetchCypressSpec";
-import { Annotation, getReporterAnnotations } from "ui/reducers/reporter";
+import { Annotation, getReporterAnnotationsForTests } from "ui/reducers/reporter";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { TestItem } from "ui/types";
 
 import { TestCase } from "./TestCase";
 
 function maybeCorrectTestTimes(testCases: TestItem[], annotations: Annotation[]) {
+  console.log({ testCases, annotations });
   return testCases.map((t, i) => ({
     ...t,
     relativeStartTime: annotations?.[i]?.time ? annotations?.[i]?.time : t.relativeStartTime,
@@ -27,8 +27,7 @@ export default function TestInfo({
   setHighlightedTest: (test: number | null) => void;
 }) {
   const dispatch = useAppDispatch();
-  const annotations = useAppSelector(getReporterAnnotations);
-  const cypressResults = useFetchCypressSpec();
+  const annotations = useAppSelector(getReporterAnnotationsForTests);
   const duration = useAppSelector(getRecordingDuration);
 
   // The test start times in metadata may be incorrect. If we have the reporter annotations,
@@ -66,7 +65,6 @@ export default function TestInfo({
             <TestCase
               test={t}
               key={i}
-              location={cypressResults?.[i]?.location}
               setHighlightedTest={() => setHighlightedTest(i)}
               isHighlighted={i === highlightedTest}
             />

--- a/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
@@ -77,7 +77,7 @@ export function TestSteps({
     dispatch(startPlayback({ beginTime: testStart, endTime: testEnd - 1 }));
   };
   const onPlayFromHere = (beginTime: number) => {
-    dispatch(startPlayback({ beginTime: startTime, endTime: testEnd - 1 }));
+    dispatch(startPlayback({ beginTime, endTime: testEnd - 1 }));
   };
 
   const [beforeEachSteps, testBodySteps, afterEachSteps] = (test.steps || []).reduce<TestStep[][]>(

--- a/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
@@ -1,16 +1,16 @@
-import { Location } from "@replayio/protocol";
-import React, { useState } from "react";
+import React from "react";
 
 import { setViewMode } from "ui/actions/layout";
 import { seekToTime, setTimelineToTime, startPlayback } from "ui/actions/timeline";
 import Icon from "ui/components/shared/Icon";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
 import { getViewMode } from "ui/reducers/layout";
+import { getReporterAnnotationsForTitle } from "ui/reducers/reporter";
 import { getCurrentTime, getPlayback } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { TestItem, TestStep } from "ui/types";
 
-import { selectLocation } from "../../actions/sources";
+import { selectLocation, selectSource } from "../../actions/sources";
 import { getThreadContext } from "../../selectors";
 import { ProgressBar } from "./ProgressBar";
 
@@ -18,15 +18,15 @@ function TestSection({
   steps,
   startTime,
   header,
-  onGoToLocation,
+  testTitle,
   onPlayFromHere,
   onReplay,
 }: {
-  onGoToLocation: () => void;
   onPlayFromHere: (time: number) => void;
   onReplay: () => void;
   startTime: number;
   steps: TestStep[];
+  testTitle: string;
   header?: string;
 }) {
   if (steps.length === 0) {
@@ -38,7 +38,8 @@ function TestSection({
       {header ? <div className="py-2">{header}</div> : null}
       {steps.map((s, i) => (
         <TestStepItem
-          testName={s.name}
+          stepName={s.name}
+          testTitle={testTitle}
           key={i}
           index={i}
           startTime={startTime + s.relativeStartTime}
@@ -49,7 +50,6 @@ function TestSection({
           isLastStep={steps.length - 1 === i}
           onReplay={onReplay}
           onPlayFromHere={() => onPlayFromHere(startTime + s.relativeStartTime)}
-          onGoToLocation={onGoToLocation}
         />
       ))}
     </>
@@ -79,11 +79,6 @@ export function TestSteps({
   const onPlayFromHere = (beginTime: number) => {
     dispatch(startPlayback({ beginTime: startTime, endTime: testEnd - 1 }));
   };
-  const onGoToLocation = () => {
-    if (location) {
-      dispatch(selectLocation(cx, location));
-    }
-  };
 
   const [beforeEachSteps, testBodySteps, afterEachSteps] = (test.steps || []).reduce<TestStep[][]>(
     (acc, step) => {
@@ -107,24 +102,24 @@ export function TestSteps({
   return (
     <div className="flex flex-col rounded-lg py-2 pl-11">
       <TestSection
+        testTitle={test.title}
         onReplay={onReplay}
-        onGoToLocation={onGoToLocation}
         onPlayFromHere={onPlayFromHere}
         steps={beforeEachSteps}
         startTime={startTime}
         header="Before Each"
       />
       <TestSection
+        testTitle={test.title}
         onReplay={onReplay}
-        onGoToLocation={onGoToLocation}
         onPlayFromHere={onPlayFromHere}
         steps={testBodySteps}
         startTime={startTime}
         header={beforeEachSteps.length + afterEachSteps.length > 0 ? "Test Body" : undefined}
       />
       <TestSection
+        testTitle={test.title}
         onReplay={onReplay}
-        onGoToLocation={onGoToLocation}
         onPlayFromHere={onPlayFromHere}
         steps={afterEachSteps}
         startTime={startTime}
@@ -146,7 +141,8 @@ export function TestSteps({
 }
 
 function TestStepItem({
-  testName,
+  testTitle,
+  stepName,
   startTime,
   duration,
   argString,
@@ -156,9 +152,9 @@ function TestStepItem({
   isLastStep,
   onReplay,
   onPlayFromHere,
-  onGoToLocation,
 }: {
-  testName: string;
+  testTitle: string;
+  stepName: string;
   startTime: number;
   duration: number;
   argString: string;
@@ -168,8 +164,9 @@ function TestStepItem({
   isLastStep: boolean;
   onReplay: () => void;
   onPlayFromHere: () => void;
-  onGoToLocation: () => void;
 }) {
+  const cx = useAppSelector(getThreadContext);
+  const annotations = useAppSelector(getReporterAnnotationsForTitle(testTitle));
   const currentTime = useAppSelector(getCurrentTime);
   const dispatch = useAppDispatch();
   const isPast = currentTime > startTime;
@@ -183,6 +180,29 @@ function TestStepItem({
   const onJumpToBefore = () => dispatch(seekToTime(startTime));
   const onJumpToAfter = () => {
     dispatch(seekToTime(startTime + adjustedDuration - 1));
+  };
+  const onGoToLocation = async () => {
+    const { point } = annotations[index];
+
+    const frame = await (async point => {
+      const {
+        data: { frames },
+      } = await window.app.sendMessage("Session.createPause", {
+        point,
+      });
+      const returnFirst = (list: any, fn: any) =>
+        list.reduce((acc: any, v: any, i: any) => acc ?? fn(v, i, list), null);
+
+      return returnFirst(frames, (f: any, i: any, l: any) =>
+        l[i + 1]?.functionName === "__stackReplacementMarker" ? f : null
+      );
+    })(point);
+
+    const location = frame.location[frame.location.length - 1];
+
+    if (location) {
+      dispatch(selectLocation(cx, location));
+    }
   };
 
   // This math is bananas don't look here until this is cleaned up :)
@@ -211,7 +231,7 @@ function TestStepItem({
         <div className="opacity-70">{index + 1}</div>
         <div className={`whitespace-pre font-medium text-bodyColor ${isPaused ? "font-bold" : ""}`}>
           {parentId ? "- " : ""}
-          {testName}
+          {stepName}
         </div>
         <div className="opacity-70">{argString}</div>
       </button>

--- a/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useContext } from "react";
+import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
 import { setViewMode } from "ui/actions/layout";
 import { seekToTime, setTimelineToTime, startPlayback } from "ui/actions/timeline";
@@ -164,6 +165,7 @@ function TestStepItem({
   const currentTime = useAppSelector(getCurrentTime);
   const dispatch = useAppDispatch();
   const isPast = currentTime > startTime;
+  const client = useContext(ReplayClientContext);
   // some chainers (`then`) don't have a duration, so let's bump it here (+1) so that it shows something in the UI
   const adjustedDuration = duration || 1;
   const isPaused = currentTime >= startTime && currentTime < startTime + adjustedDuration;
@@ -183,9 +185,8 @@ function TestStepItem({
     const frame = await (async point => {
       const {
         data: { frames },
-      } = await window.app.sendMessage("Session.createPause", {
-        point,
-      });
+      } = await client.createPause(point);
+      
       const returnFirst = (list: any, fn: any) =>
         list.reduce((acc: any, v: any, i: any) => acc ?? fn(v, i, list), null);
 

--- a/src/ui/actions/reporter.ts
+++ b/src/ui/actions/reporter.ts
@@ -35,7 +35,7 @@ export async function setupReporter(store: UIStore, ThreadFront: typeof TF) {
         filtered.map(({ point, time, contents }) => ({
           point,
           time,
-          message: parseContents(contents),
+          message: JSON.parse(parseContents(contents)),
         }))
       )
     );

--- a/src/ui/reducers/reporter.ts
+++ b/src/ui/reducers/reporter.ts
@@ -42,7 +42,8 @@ const reporterSlice = createSlice({
 export default reporterSlice.reducer;
 export const { addReporterAnnotations } = reporterSlice.actions;
 export const getReporterAnnotations = (state: UIState) => state.reporter.annotations;
-export const getReporterAnnotationsForTests = (state: UIState) =>  state.reporter.annotations.filter(a => a.message.event === "test:start");
+export const getReporterAnnotationsForTests = (state: UIState) =>
+  state.reporter.annotations.filter(a => a.message.event === "test:start");
 export const getReporterAnnotationsForTitle = (title: string) => (state: UIState) =>
   state.reporter.annotations.filter(
     a =>

--- a/src/ui/reducers/reporter.ts
+++ b/src/ui/reducers/reporter.ts
@@ -4,9 +4,13 @@ import { ExecutionPoint } from "@replayio/protocol";
 import { compareNumericStrings } from "protocol/utils";
 import { UIState } from "ui/state";
 
+type TestEvents = "test:start" | "step:end" | "step:enqueue" | "step:start";
+
 type CypressAnnotationMessage = {
-  event: "test:start";
+  event: TestEvents;
   titlePath: string[];
+  commandVariable?: "cmd" | "log";
+  id?: string;
 };
 export interface Annotation {
   point: ExecutionPoint;
@@ -38,3 +42,10 @@ const reporterSlice = createSlice({
 export default reporterSlice.reducer;
 export const { addReporterAnnotations } = reporterSlice.actions;
 export const getReporterAnnotations = (state: UIState) => state.reporter.annotations;
+export const getReporterAnnotationsForTests = (state: UIState) =>  state.reporter.annotations.filter(a => a.message.event === "test:start");
+export const getReporterAnnotationsForTitle = (title: string) => (state: UIState) =>
+  state.reporter.annotations.filter(
+    a =>
+      a.message.titlePath[a.message.titlePath.length - 1] === title &&
+      a.message.event === "step:enqueue"
+  );

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -188,6 +188,7 @@ export type TestStep = {
   name: string;
   duration: number;
   relativeStartTime: number;
+  point?: string;
   parentId?: string;
   error?: TestItemError;
   hook?: "beforeEach" | "afterEach";


### PR DESCRIPTION
This:
- links to a more accurate location by working up from a step's enqueue event to find the corresponding caller. That means we have a working link to the step's source, whether that function call was in a spec file or not.
- fixes the play from here and jump to step actions so it lands/starts in the right place