### PR TITLE
Fix Quick Open duplicate content entries and query strings

### DIFF
--- a/src/devtools/client/debugger/src/utils/quick-open.ts
+++ b/src/devtools/client/debugger/src/utils/quick-open.ts
@@ -63,9 +63,9 @@ export function parseLineColumn(query: string) {
 
 function formatSourceForList(source: SourceDetails, tabUrls: Set<string>) {
   const title = getTruncatedFileName(source);
-  const relativeUrlWithQuery = `${source.url}${getSourceQueryString(source) || ""}`;
-  const subtitle = endTruncateStr(relativeUrlWithQuery, 100);
-  const value = relativeUrlWithQuery;
+  // `source.url` now includes query strings already
+  const subtitle = endTruncateStr(source.url!, 100);
+  const value = source.url!;
   return {
     value,
     title,
@@ -153,6 +153,8 @@ export function formatSources(
 ) {
   const formattedSources = [];
 
+  const seenContentHashes = new Set<string>();
+
   for (const url in sourcesToDisplayByUrl) {
     if (onlySourcesInTabs && !tabUrls.has(url)) {
       continue;
@@ -161,6 +163,11 @@ export function formatSources(
       continue;
     }
     const sourceToDisplay = sourcesToDisplayByUrl[url]!;
+
+    if (seenContentHashes.has(sourceToDisplay.contentHash!)) {
+      continue;
+    }
+    seenContentHashes.add(sourceToDisplay.contentHash!);
     formattedSources.push(formatSourceForList(sourceToDisplay, tabUrls));
   }
 


### PR DESCRIPTION
We weren't filtering duplicate Quick Open file list entries by content hash, and some change to `source.url` to include query params meant that they were getting duplicated into the list item subtitles.

Before (in a recording where I edited `App.tsx` 8 times, 4 of them with duplicate content):

![image](https://user-images.githubusercontent.com/1128784/204033813-d68ad187-0ca7-432a-91dd-0cf2bdb3e029.png)

After:

![image](https://user-images.githubusercontent.com/1128784/204033822-7bd5942b-4bf8-4d82-9229-9fdb07632568.png)
