### PR TITLE
Use inspector component for console props

### DIFF
--- a/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
@@ -3,9 +3,9 @@ import { useMemo } from "react";
 import { getRecordingDuration } from "ui/actions/app";
 import { setFocusRegion } from "ui/actions/timeline";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
-import { Annotation, getReporterAnnotationsForTests } from "ui/reducers/reporter";
+import { getReporterAnnotationsForTests } from "ui/reducers/reporter";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
-import { TestItem } from "ui/types";
+import { Annotation, TestItem } from "ui/types";
 
 import { TestCase } from "./TestCase";
 

--- a/src/ui/reducers/reporter.ts
+++ b/src/ui/reducers/reporter.ts
@@ -1,23 +1,8 @@
-import { PayloadAction, createSlice } from "@reduxjs/toolkit";
-import { ExecutionPoint } from "@replayio/protocol";
+import { PayloadAction, createSelector, createSlice } from "@reduxjs/toolkit";
 
 import { compareNumericStrings } from "protocol/utils";
 import { UIState } from "ui/state";
-
-type TestEvents = "test:start" | "step:end" | "step:enqueue" | "step:start";
-
-export type CypressAnnotationMessage = {
-  event: TestEvents;
-  titlePath: string[];
-  commandVariable?: "cmd" | "log";
-  logVariable?: "cmd" | "log";
-  id?: string;
-};
-export interface Annotation {
-  point: ExecutionPoint;
-  time: number;
-  message: CypressAnnotationMessage;
-}
+import { Annotation } from "ui/types";
 
 export interface ReporterState {
   annotations: Annotation[];
@@ -43,17 +28,23 @@ const reporterSlice = createSlice({
 export default reporterSlice.reducer;
 export const { addReporterAnnotations } = reporterSlice.actions;
 export const getReporterAnnotations = (state: UIState) => state.reporter.annotations;
-export const getReporterAnnotationsForTests = (state: UIState) =>
-  state.reporter.annotations.filter(a => a.message.event === "test:start");
-export const getReporterAnnotationsForTitle = (title: string) => (state: UIState) =>
-  state.reporter.annotations.filter(
-    a =>
-      a.message.titlePath[a.message.titlePath.length - 1] === title &&
-      a.message.event === "step:enqueue"
+export const getReporterAnnotationsForTests = createSelector(
+  getReporterAnnotations,
+  (annotations: Annotation[]) => annotations.filter(a => a.message.event === "test:start")
+);
+export const getReporterAnnotationsForTitle = (title: string) =>
+  createSelector(getReporterAnnotations, (annotations: Annotation[]) =>
+    annotations.filter(
+      a =>
+        a.message.titlePath[a.message.titlePath.length - 1] === title &&
+        a.message.event === "step:enqueue"
+    )
   );
-export const getReporterAnnotationsForTitleEnd = (title: string) => (state: UIState) =>
-  state.reporter.annotations.filter(
-    a =>
-      a.message.titlePath[a.message.titlePath.length - 1] === title &&
-      a.message.event === "step:end"
+export const getReporterAnnotationsForTitleEnd = (title: string) =>
+  createSelector(getReporterAnnotations, (annotations: Annotation[]) =>
+    annotations.filter(
+      a =>
+        a.message.titlePath[a.message.titlePath.length - 1] === title &&
+        a.message.event === "step:end"
+    )
   );

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -1,4 +1,4 @@
-import { Annotation, CypressAnnotationMessage } from "ui/reducers/reporter";
+import { ExecutionPoint } from "@replayio/protocol";
 
 export interface User {
   name?: string | null;
@@ -184,6 +184,22 @@ type TestItemError = {
   line?: number;
   column?: number;
 };
+
+type TestEvents = "test:start" | "step:end" | "step:enqueue" | "step:start";
+
+export type CypressAnnotationMessage = {
+  event: TestEvents;
+  titlePath: string[];
+  commandVariable?: "cmd" | "log";
+  logVariable?: "cmd" | "log";
+  id?: string;
+};
+
+export interface Annotation {
+  point: ExecutionPoint;
+  time: number;
+  message: CypressAnnotationMessage;
+}
 
 export type TestStep = {
   args: string[];


### PR DESCRIPTION
I'd like to get rid of the prototype entry but this'll be a lot better than building a custom inspector for test suites.

<img width="355" alt="image" src="https://user-images.githubusercontent.com/788456/204196123-af818b42-f8d9-4663-91f3-e0ec11b78dfe.png">
