### PR TITLE
Fix the logic for matching annotations to steps

### DIFF
--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -226,7 +226,7 @@ function ConsoleProps({
   }
 
   return (
-    <div className="flex flex-col gap-1 p-2 pl-8">
+    <div className="flex flex-col gap-1 p-2 pl-8 font-mono">
       <div>Console Props</div>
       <PropertiesRenderer pauseId={pauseId} object={consoleProps} />
     </div>

--- a/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
@@ -29,8 +29,8 @@ function useGetTestSections(
           acc[0].push({
             ...step,
             annotations: {
-              end: annotationsEnd[i],
-              enqueue: annotationsEnqueue[i],
+              end: annotationsEnd.find(a => a.message.id === step.id),
+              enqueue: annotationsEnqueue.find(a => a.message.id === step.id),
             },
           });
           break;
@@ -38,8 +38,8 @@ function useGetTestSections(
           acc[2].push({
             ...step,
             annotations: {
-              end: annotationsEnd[i],
-              enqueue: annotationsEnqueue[i],
+              end: annotationsEnd.find(a => a.message.id === step.id),
+              enqueue: annotationsEnqueue.find(a => a.message.id === step.id),
             },
           });
           break;
@@ -47,8 +47,8 @@ function useGetTestSections(
           acc[1].push({
             ...step,
             annotations: {
-              end: annotationsEnd[i],
-              enqueue: annotationsEnqueue[i],
+              end: annotationsEnd.find(a => a.message.id === step.id),
+              enqueue: annotationsEnqueue.find(a => a.message.id === step.id),
             },
           });
           break;


### PR DESCRIPTION
We were using indices before, which was unreliable.