### PR TITLE
Polish test steps

### DIFF
--- a/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
@@ -70,29 +70,29 @@ export function TestCase({
 
   return (
     <div className="flex flex-col">
-      <div className="flex flex-row items-center justify-between gap-1 rounded-lg p-1 transition hover:cursor-pointer">
-        <button
-          onClick={toggleExpand}
-          disabled={!expandable}
-          className="group flex flex-grow flex-row gap-1 overflow-hidden"
-        >
-          <Status result={test.result} />
-          <div className="flex flex-col items-start text-bodyColor">
-            <div
-              className={`overflow-hidden overflow-ellipsis whitespace-pre ${
-                !isHighlighted ? "group-hover:underline" : ""
-              }`}
-            >
-              {test.title}
-            </div>
-            {test.error ? (
-              <div className="mt-1 overflow-hidden rounded-lg bg-testsuitesErrorBgcolor px-2 py-1 text-left font-mono ">
-                {test.error.message}
+      {!isHighlighted && (
+        <div className="flex flex-row items-center justify-between gap-1 rounded-lg p-1 transition hover:cursor-pointer">
+          <button
+            onClick={toggleExpand}
+            disabled={!expandable}
+            className="group flex flex-grow flex-row gap-1 overflow-hidden"
+          >
+            <Status result={test.result} />
+            <div className="flex flex-col items-start text-bodyColor">
+              <div
+                className={`overflow-hidden overflow-ellipsis whitespace-pre ${"group-hover:underline"}`}
+              >
+                {test.title}
               </div>
-            ) : null}
-          </div>
-        </button>
-      </div>
+              {test.error ? (
+                <div className="mt-1 overflow-hidden rounded-lg bg-testsuitesErrorBgcolor px-2 py-1 text-left font-mono ">
+                  {test.error.message}
+                </div>
+              ) : null}
+            </div>
+          </button>
+        </div>
+      )}
       {expandSteps ? <TestSteps test={test} startTime={test.relativeStartTime} /> : null}
     </div>
   );

--- a/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
@@ -74,11 +74,15 @@ export default function TestInfo({
       value={{ selectedId, setSelectedId, consoleProps, setConsoleProps, pauseId, setPauseId }}
     >
       <div className="flex flex-grow flex-col overflow-hidden">
-        <div className="flex flex-grow flex-col space-y-1 overflow-scroll px-4 py-2">
+        <div className="flex flex-grow flex-col space-y-1 overflow-auto px-2 py-2">
           {highlightedTest !== null && (
-            <button onClick={onReset} className="flex flex-row items-center hover:underline">
+            <button
+              onClick={onReset}
+              className="flex flex-row items-center hover:underline"
+              style={{ fontSize: "15px" }}
+            >
               <MaterialIcon>chevron_left</MaterialIcon>
-              <div>Back</div>
+              <div>{correctedTestCases[highlightedTest].title}</div>
             </button>
           )}
           {correctedTestCases.map(
@@ -104,11 +108,23 @@ function Console() {
   const hideProps = !pauseId || !consoleProps;
 
   return (
-    <div className="h-100 flex h-64 flex-shrink-0 flex-col overflow-auto p-2">
-      <div>Console Props</div>
+    <div
+      className="h-100 flex h-64 flex-shrink-0 flex-col overflow-auto p-4"
+      style={{
+        borderTop: "2px solid var(--chrome)",
+        fontSize: "15px",
+      }}
+    >
+      <div className="text-md">Console Props</div>
       <ErrorBoundary>
         <div className="flex flex-grow flex-col gap-1 p-2 pl-8 font-mono">
-          {!hideProps && <PropertiesRenderer pauseId={pauseId} object={consoleProps} />}
+          {hideProps ? (
+            <div className="flex flex-grow items-center justify-center align-middle text-xs opacity-50">
+              Nothing Selected...
+            </div>
+          ) : (
+            <PropertiesRenderer pauseId={pauseId} object={consoleProps} />
+          )}
         </div>
       </ErrorBoundary>
     </div>

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -199,34 +199,35 @@ export function TestStepItem({
   const bump = isPaused || isPast ? 10 : 0;
   const actualProgress = bump + 90 * ((currentTime - startTime) / adjustedDuration);
   const progress = actualProgress > 100 ? 100 : actualProgress;
-  const displayedProgress = adjustedDuration === 1 && isPaused ? 100 : progress;
+  const displayedProgress =
+    adjustedDuration === 1 && isPaused ? 100 : progress == 100 ? 0 : progress;
 
   const color = error ? "border-l-red-500" : "border-l-primaryAccent";
 
   return (
     <>
       <div
-        className={`group/step relative flex items-start gap-1 overflow-hidden border-b border-l-2 border-themeBase-90 pl-1 pr-3 font-mono hover:bg-gray-100 ${
+        className={`group/step relative flex items-start gap-1 border-b border-l-2 border-themeBase-90 pl-1 pr-3 font-mono hover:bg-gray-100 ${
           isPaused || isPast ? color : "border-l-transparent"
-        } ${isPaused ? "bg-gray-100" : "bg-testsuitesStepsBgcolor"}`}
+        } ${
+          progress > 0 && error
+            ? "bg-testsuitesErrorBgcolor text-testsuitesErrorColor hover:bg-testsuitesErrorBgcolorHover"
+            : isPaused
+            ? "bg-gray-100"
+            : "bg-testsuitesStepsBgcolor"
+        }`}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
       >
-        <button
-          onClick={onClick}
-          className="flex flex-grow items-start space-x-2 overflow-hidden py-2 text-start"
-        >
+        <button onClick={onClick} className="flex flex-grow items-start space-x-2  py-2 text-start">
           <div title={"" + displayedProgress} className="flex h-4 items-center">
             <ProgressBar progress={displayedProgress} error={error} />
           </div>
           <div className="opacity-70">{index + 1}</div>
-          <div
-            className={`whitespace-pre font-medium text-bodyColor ${isPaused ? "font-bold" : ""}`}
-          >
+          <div className={` font-medium ${isPaused ? "font-bold" : ""}`}>
             {parentId ? "- " : ""}
-            {stepName}
+            {stepName} <span className="opacity-70">{argString}</span>
           </div>
-          <div className="opacity-70">{argString}</div>
         </button>
         <TestStepActions
           onReplay={onReplay}

--- a/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
@@ -93,7 +93,7 @@ export function TestSteps({ test, startTime }: { test: TestItem; startTime: numb
   };
 
   return (
-    <div className="flex flex-col rounded-lg py-2 pl-11">
+    <div className="flex flex-col rounded-lg py-2 px-2">
       <TestSection
         onReplay={onReplay}
         onPlayFromHere={onPlayFromHere}
@@ -127,9 +127,7 @@ export function TestSteps({ test, startTime }: { test: TestItem; startTime: numb
             <Icon filename="warning" size="small" className="bg-testsuitesErrorColor" />
             <div className="font-bold">Error</div>
           </div>
-          <div className="wrap space-y-1 overflow-hidden bg-testsuitesErrorBgcolor p-2 font-mono">
-            {test.error.message}
-          </div>
+          <div className="wrap space-y-1 overflow-hidden p-2 font-mono">{test.error.message}</div>
         </div>
       ) : null}
     </div>
@@ -167,36 +165,52 @@ function TestSection({
 
   return (
     <>
-      {header ? <div className="py-2">{header}</div> : null}
-      {steps.map((s, i) => (
-        <>
-          <TestStepItem
-            stepName={s.name}
-            messageEnqueue={s.annotations.enqueue?.message}
-            messageEnd={s.annotations.end?.message}
-            point={s.annotations.enqueue?.point}
-            pointEnd={s.annotations.end?.point}
-            key={i}
-            index={i}
-            startTime={startTime + s.relativeStartTime}
-            duration={s.duration}
-            argString={s.args?.toString()}
-            parentId={s.parentId}
-            error={!!s.error}
-            isLastStep={steps.length - 1 === i}
-            onReplay={onReplay}
-            onPlayFromHere={() => onPlayFromHere(startTime + s.relativeStartTime)}
-            selectedIndex={selectedIndex}
-            setSelectedIndex={setSelectedIndex}
-            id={s.id}
-          />
-          <div className="flex flex-col">
-            {getDisplayedEvents(s, steps, data, startTime).map(r => (
-              <NetworkEvent key={r.id} method={r.method} status={r.status} url={r.url} id={r.id} />
-            ))}
-          </div>
-        </>
-      ))}
+      {header ? (
+        <div
+          className="pt-6 pb-2 pl-2  font-semibold uppercase opacity-50"
+          style={{ fontSize: "10px" }}
+        >
+          {header}
+        </div>
+      ) : null}
+      {steps
+
+        .filter((step, i) => !steps.slice(0, i).some(s => !!s.error))
+        .map((s, i) => (
+          <>
+            <TestStepItem
+              stepName={s.name}
+              messageEnqueue={s.annotations.enqueue?.message}
+              messageEnd={s.annotations.end?.message}
+              point={s.annotations.enqueue?.point}
+              pointEnd={s.annotations.end?.point}
+              key={i}
+              index={i}
+              startTime={startTime + s.relativeStartTime}
+              duration={s.duration}
+              argString={s.args?.toString()}
+              parentId={s.parentId}
+              error={!!s.error}
+              isLastStep={steps.length - 1 === i}
+              onReplay={onReplay}
+              onPlayFromHere={() => onPlayFromHere(startTime + s.relativeStartTime)}
+              selectedIndex={selectedIndex}
+              setSelectedIndex={setSelectedIndex}
+              id={s.id}
+            />
+            <div className="flex flex-col">
+              {getDisplayedEvents(s, steps, data, startTime).map(r => (
+                <NetworkEvent
+                  key={r.id}
+                  method={r.method}
+                  status={r.status}
+                  url={r.url}
+                  id={r.id}
+                />
+              ))}
+            </div>
+          </>
+        ))}
     </>
   );
 }

--- a/src/devtools/client/themes/variables.css
+++ b/src/devtools/client/themes/variables.css
@@ -220,6 +220,7 @@
 
   /* Testsuites (Light) */
   --testsuites-error-bgcolor: #ffe9e9;
+  --testsuites-error-bgcolor-hover: #fce2e2;
   --testsuites-error-color: red;
   --testsuites-steps-bgcolor: #fafafa;
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -51,6 +51,7 @@ module.exports = {
         textFieldBorder: "var(--text-field-border)",
         bodyBgcolor: "var(--body-bgcolor)",
         testsuitesErrorBgcolor: "var(--testsuites-error-bgcolor)",
+        testsuitesErrorBgcolorHover: "var(--testsuites-error-bgcolor-hover)",
         testsuitesErrorColor: "var(--testsuites-error-color)",
         testsuitesStepsBgcolor: "var(--testsuites-steps-bgcolor)",
         themeBorder: "var(--theme-border)",


### PR DESCRIPTION
- [x] Wrap error messages inline with the step
- [x] Use test title as the back button to be more hub/spokey
- [x] Update layout hierarchy
  - [x] remove indendation
  - [x] use capitalization and smaller fonts for before/after each
  - [x] add mergin between sections
  - [x] add clearer divide for console props
- [x] Console props
  - [x]  Add a not selected state
- [x] only show blue progress circle when in progress (cypess parity)
- [x] Use red background treatment for failed messages (cypess parity)
- [x] Hide steps after a failure (cypress parity)
- [x] Don't show error at the top (both similar to cypress and an attempt at avoiding an error sandwich. It should be fine to read the test from top to bottom)


### Before
<img width="1440" alt="Screen Shot 2022-11-30 at 1 58 13 PM" src="https://user-images.githubusercontent.com/254562/204916982-11c0ef22-7cf0-478c-bf56-610b61fe7acd.png">



### After
<img width="1437" alt="Screen Shot 2022-11-30 at 2 09 49 PM" src="https://user-images.githubusercontent.com/254562/204918969-2bcf6752-3f73-47ca-b1c0-56fcddaae523.png">


### Cypress

<img width="1439" alt="Screen Shot 2022-11-30 at 1 27 36 PM" src="https://user-images.githubusercontent.com/254562/204917539-114905ca-4717-4080-b73a-0e10a92fda63.png">

