### PR TITLE
Add navigation events to test step side bar

### DIFF
--- a/src/devtools/client/debugger/src/components/TestInfo/NetworkEvent.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/NetworkEvent.tsx
@@ -2,11 +2,7 @@ import React from "react";
 
 import { setSelectedPanel, setViewMode } from "ui/actions/layout";
 import { selectAndFetchRequest } from "ui/actions/network";
-import { RequestSummary } from "ui/components/NetworkMonitor/utils";
 import { useAppDispatch } from "ui/setup/hooks";
-import { AnnotatedTestStep } from "ui/types";
-
-import { XHR_TYPE } from "./TestSteps";
 
 export function NetworkEvent({
   method,
@@ -32,28 +28,3 @@ export function NetworkEvent({
     </button>
   );
 }
-export const getDisplayedEvents = (
-  step: AnnotatedTestStep,
-  steps: AnnotatedTestStep[],
-  data: RequestSummary[],
-  startTime: number
-) => {
-  return data.filter(r => {
-    if (!r.end) {
-      return false;
-    }
-
-    const isDuringStep = (time: number, start: number, end: number) => time >= start && time < end;
-    const applicableSteps = steps.filter(s =>
-      isDuringStep(
-        r.end!,
-        startTime + s.relativeStartTime,
-        startTime + s.relativeStartTime + s.duration
-      )
-    );
-
-    return (
-      applicableSteps[applicableSteps.length - 1]?.id === step.id && r.documentType === XHR_TYPE
-    );
-  });
-};

--- a/src/ui/reducers/reporter.ts
+++ b/src/ui/reducers/reporter.ts
@@ -48,3 +48,11 @@ export const getReporterAnnotationsForTitleEnd = (title: string) =>
         a.message.event === "step:end"
     )
   );
+export const getReporterAnnotationsForTitleNavigation = (title: string) =>
+  createSelector(getReporterAnnotations, (annotations: Annotation[]) =>
+    annotations.filter(
+      a =>
+        a.message.titlePath[a.message.titlePath.length - 1] === title &&
+        a.message.event === "event:navigation"
+    )
+  );

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -186,7 +186,7 @@ type TestItemError = {
   column?: number;
 };
 
-type TestEvents = "test:start" | "step:end" | "step:enqueue" | "step:start";
+type TestEvents = "test:start" | "step:end" | "step:enqueue" | "step:start" | "event:navigation";
 
 export type CypressAnnotationMessage = {
   event: TestEvents;
@@ -194,6 +194,7 @@ export type CypressAnnotationMessage = {
   commandVariable?: "cmd" | "log";
   logVariable?: "cmd" | "log";
   id?: string;
+  url?: string;
 };
 export interface Annotation {
   point: ExecutionPoint;


### PR DESCRIPTION
* Refactors the step/network/nav sorting into a single, cross-test-hook runner to sort and group everything at once
* Adds navigation events to the side bar

> **Note**
> Requires new navigation annoations like those in `d7aa40cd-fb8e-4b18-8495-5d9a90852cf4`