### PR TITLE
Move test step actions into a context menu

### DIFF
--- a/src/devtools/client/debugger/src/components/TestInfo/ContextMenu.module.css
+++ b/src/devtools/client/debugger/src/components/TestInfo/ContextMenu.module.css
@@ -5,10 +5,9 @@
   border-radius: 0.5em;
   overflow: hidden;
   white-space: nowrap;
-  transform: translateX(-100%);
 
   /* Ensure the context menu is always above console rows and the current time indicator */
-  z-index: 4;
+  z-index: 11;
 }
 
 .ContextMenuItem {

--- a/src/devtools/client/debugger/src/components/TestInfo/ContextMenu.module.css
+++ b/src/devtools/client/debugger/src/components/TestInfo/ContextMenu.module.css
@@ -1,0 +1,42 @@
+.ContextMenu {
+  position: absolute;
+  flex-direction: column;
+  display: flex;
+  border-radius: 0.5em;
+  overflow: hidden;
+  white-space: nowrap;
+  transform: translateX(-100%);
+
+  /* Ensure the context menu is always above console rows and the current time indicator */
+  z-index: 4;
+}
+
+.ContextMenuItem {
+  background-color: var(--context-menu-background-color);
+  color: var(--color-default);
+  padding: 0.5em 1em;
+  user-select: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 1ch;
+}
+.ContextMenuItem:hover {
+  background-color: var(--context-menu-background-color-hover);
+}
+
+.ColorBadge,
+.ColorBadgeClear,
+.UnicornBadge {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  border-radius: 1em;
+}
+.ColorBadge {
+  background-color: var(--badge-color);
+}
+.ColorBadgeClear {
+  border: 0.25em solid var(--background-color-contrast-5);
+}
+

--- a/src/devtools/client/debugger/src/components/TestInfo/ContextMenu.module.css
+++ b/src/devtools/client/debugger/src/components/TestInfo/ContextMenu.module.css
@@ -2,7 +2,7 @@
   position: absolute;
   flex-direction: column;
   display: flex;
-  border-radius: 0.5em;
+  border-radius: 0.5rem;
   overflow: hidden;
   white-space: nowrap;
 
@@ -13,7 +13,7 @@
 .ContextMenuItem {
   background-color: var(--context-menu-background-color);
   color: var(--color-default);
-  padding: 0.5em 1em;
+  padding: 0.5rem 1rem;
   user-select: none;
   cursor: pointer;
   display: flex;
@@ -28,13 +28,13 @@
 .ColorBadgeClear,
 .UnicornBadge {
   display: inline-block;
-  width: 1em;
-  height: 1em;
-  border-radius: 1em;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 1rem;
 }
 .ColorBadge {
   background-color: var(--badge-color);
 }
 .ColorBadgeClear {
-  border: 0.25em solid var(--background-color-contrast-5);
+  border: 0.25rem solid var(--background-color-contrast-5);
 }

--- a/src/devtools/client/debugger/src/components/TestInfo/ContextMenu.module.css
+++ b/src/devtools/client/debugger/src/components/TestInfo/ContextMenu.module.css
@@ -39,4 +39,3 @@
 .ColorBadgeClear {
   border: 0.25em solid var(--background-color-contrast-5);
 }
-

--- a/src/devtools/client/debugger/src/components/TestInfo/ContextMenu.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/ContextMenu.tsx
@@ -52,20 +52,20 @@ function ContextMenu({
       return;
     }
 
-    const frame = await (async point => {
-      const {
-        data: { frames },
-      } = await client.createPause(point);
+    const point = testStep.enqueuePoint;
 
-      const returnFirst = (list: any, fn: any) =>
-        list.reduce((acc: any, v: any, i: any) => acc ?? fn(v, i, list), null);
+    const {
+      data: { frames },
+    } = await client.createPause(point);
 
-      return returnFirst(frames, (f: any, i: any, l: any) =>
-        l[i + 1]?.functionName === "__stackReplacementMarker" ? f : null
-      );
-    })(testStep.enqueuePoint);
+    const returnFirst = (list: any, fn: any) =>
+      list.reduce((acc: any, v: any, i: any) => acc ?? fn(v, i, list), null);
 
-    const location = frame.location[frame.location.length - 1];
+    const firstFrame = returnFirst(frames, (f: any, i: any, l: any) =>
+      l[i + 1]?.functionName === "__stackReplacementMarker" ? f : null
+    );
+
+    const location = firstFrame.location[firstFrame.location.length - 1];
 
     if (location) {
       dispatch(selectLocation(cx, location));

--- a/src/devtools/client/debugger/src/components/TestInfo/ContextMenu.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/ContextMenu.tsx
@@ -1,23 +1,74 @@
 import { useContext, useRef } from "react";
+
 import useModalDismissSignal from "bvaughn-architecture-demo/src/hooks/useModalDismissSignal";
-import { TestInfoContextMenuContext, Coordinates } from "./TestInfoContextMenuContext";
+import { seekToTime, startPlayback } from "ui/actions/timeline";
+
+import {
+  Coordinates,
+  TestCaseType,
+  TestInfoContextMenuContext,
+  TestStepType,
+} from "./TestInfoContextMenuContext";
 import styles from "./ContextMenu.module.css";
+import { selectLocation } from "../../actions/sources";
+import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
+import { getContext } from "../../selectors";
 
 function ContextMenu({
   hide,
   mouseCoordinates,
+  testStep,
+  testCase,
 }: {
   hide: () => void;
   mouseCoordinates: Coordinates;
+  testStep: TestStepType;
+  testCase: TestCaseType;
 }) {
+  const dispatch = useAppDispatch();
   const ref = useRef<HTMLDivElement>(null);
+  const cx = useAppSelector(getContext);
 
   useModalDismissSignal(ref, hide, true);
 
-  const onClick = () => {
+  const onPlayFromHere = () => {
     hide();
+    dispatch(startPlayback({ beginTime: testStep.startTime, endTime: testCase.endTime }));
+    console.log("on play from here", { testStep, testCase });
   };
-  
+  const onJumpToBefore = () => {
+    hide();
+    dispatch(seekToTime(testStep.startTime));
+  };
+  const onJumpToAfter = () => {
+    hide();
+    dispatch(seekToTime(testStep.endTime - 1));
+  };
+  const onGoToLocation = async () => {
+    if (!testStep.enqueuePoint) {
+      return;
+    }
+
+    const frame = await (async point => {
+      const {
+        data: { frames },
+      } = await client.createPause(point);
+
+      const returnFirst = (list: any, fn: any) =>
+        list.reduce((acc: any, v: any, i: any) => acc ?? fn(v, i, list), null);
+
+      return returnFirst(frames, (f: any, i: any, l: any) =>
+        l[i + 1]?.functionName === "__stackReplacementMarker" ? f : null
+      );
+    })(testStep.enqueuePoint);
+
+    const location = frame.location[frame.location.length - 1];
+
+    if (location) {
+      dispatch(selectLocation(cx, location));
+    }
+  };
+
   return (
     <div
       className={styles.ContextMenu}
@@ -31,41 +82,48 @@ function ContextMenu({
       <div
         className={styles.ContextMenuItem}
         data-test-id="ConsoleContextMenu-SetFocusStartButton"
-        onClick={onClick}
+        onClick={onPlayFromHere}
       >
         Play from here
       </div>
       <div
         className={styles.ContextMenuItem}
         data-test-id="ConsoleContextMenu-SetFocusStartButton"
-        onClick={onClick}
+        onClick={onJumpToBefore}
       >
         Show before
       </div>
       <div
         className={styles.ContextMenuItem}
         data-test-id="ConsoleContextMenu-SetFocusStartButton"
-        onClick={onClick}
+        onClick={onJumpToAfter}
       >
         Show after
       </div>
-      <div
+      {/* <div
         className={styles.ContextMenuItem}
         data-test-id="ConsoleContextMenu-SetFocusStartButton"
         onClick={onClick}
       >
         Jump to source code
-      </div>
+      </div> */}
     </div>
   );
 }
 
 export default function ContextMenuWrapper() {
-  const { hide, mouseCoordinates } = useContext(TestInfoContextMenuContext);
+  const { hide, mouseCoordinates, testStep, testCase } = useContext(TestInfoContextMenuContext);
 
-  if (mouseCoordinates === null) {
+  if (mouseCoordinates === null || testStep === null || testCase === null) {
     return null;
   } else {
-    return <ContextMenu hide={hide} mouseCoordinates={mouseCoordinates} />;
+    return (
+      <ContextMenu
+        hide={hide}
+        mouseCoordinates={mouseCoordinates}
+        testStep={testStep}
+        testCase={testCase}
+      />
+    );
   }
 }

--- a/src/devtools/client/debugger/src/components/TestInfo/ContextMenu.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/ContextMenu.tsx
@@ -37,7 +37,6 @@ function ContextMenu({
   const onPlayFromHere = () => {
     hide();
     dispatch(startPlayback({ beginTime: testStep.startTime, endTime: testCase.endTime }));
-    console.log("on play from here", { testStep, testCase });
   };
   const onJumpToBefore = () => {
     hide();

--- a/src/devtools/client/debugger/src/components/TestInfo/ContextMenu.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/ContextMenu.tsx
@@ -1,0 +1,71 @@
+import { useContext, useRef } from "react";
+import useModalDismissSignal from "bvaughn-architecture-demo/src/hooks/useModalDismissSignal";
+import { TestInfoContextMenuContext, Coordinates } from "./TestInfoContextMenuContext";
+import styles from "./ContextMenu.module.css";
+
+function ContextMenu({
+  hide,
+  mouseCoordinates,
+}: {
+  hide: () => void;
+  mouseCoordinates: Coordinates;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useModalDismissSignal(ref, hide, true);
+
+  const onClick = () => {
+    hide();
+  };
+  
+  return (
+    <div
+      className={styles.ContextMenu}
+      data-test-id="ConsoleContextMenu"
+      ref={ref}
+      style={{
+        left: mouseCoordinates.x,
+        top: mouseCoordinates.y,
+      }}
+    >
+      <div
+        className={styles.ContextMenuItem}
+        data-test-id="ConsoleContextMenu-SetFocusStartButton"
+        onClick={onClick}
+      >
+        Play from here
+      </div>
+      <div
+        className={styles.ContextMenuItem}
+        data-test-id="ConsoleContextMenu-SetFocusStartButton"
+        onClick={onClick}
+      >
+        Show before
+      </div>
+      <div
+        className={styles.ContextMenuItem}
+        data-test-id="ConsoleContextMenu-SetFocusStartButton"
+        onClick={onClick}
+      >
+        Show after
+      </div>
+      <div
+        className={styles.ContextMenuItem}
+        data-test-id="ConsoleContextMenu-SetFocusStartButton"
+        onClick={onClick}
+      >
+        Jump to source code
+      </div>
+    </div>
+  );
+}
+
+export default function ContextMenuWrapper() {
+  const { hide, mouseCoordinates } = useContext(TestInfoContextMenuContext);
+
+  if (mouseCoordinates === null) {
+    return null;
+  } else {
+    return <ContextMenu hide={hide} mouseCoordinates={mouseCoordinates} />;
+  }
+}

--- a/src/devtools/client/debugger/src/components/TestInfo/ContextMenu.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/ContextMenu.tsx
@@ -1,8 +1,13 @@
 import { useContext, useRef } from "react";
 
 import useModalDismissSignal from "bvaughn-architecture-demo/src/hooks/useModalDismissSignal";
+import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { seekToTime, startPlayback } from "ui/actions/timeline";
+import MaterialIcon from "ui/components/shared/MaterialIcon";
+import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 
+import { selectLocation } from "../../actions/sources";
+import { getContext } from "../../selectors";
 import {
   Coordinates,
   TestCaseType,
@@ -10,9 +15,6 @@ import {
   TestStepType,
 } from "./TestInfoContextMenuContext";
 import styles from "./ContextMenu.module.css";
-import { selectLocation } from "../../actions/sources";
-import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
-import { getContext } from "../../selectors";
 
 function ContextMenu({
   hide,
@@ -28,6 +30,7 @@ function ContextMenu({
   const dispatch = useAppDispatch();
   const ref = useRef<HTMLDivElement>(null);
   const cx = useAppSelector(getContext);
+  const client = useContext(ReplayClientContext);
 
   useModalDismissSignal(ref, hide, true);
 
@@ -45,6 +48,7 @@ function ContextMenu({
     dispatch(seekToTime(testStep.endTime - 1));
   };
   const onGoToLocation = async () => {
+    hide();
     if (!testStep.enqueuePoint) {
       return;
     }
@@ -72,41 +76,28 @@ function ContextMenu({
   return (
     <div
       className={styles.ContextMenu}
-      data-test-id="ConsoleContextMenu"
       ref={ref}
       style={{
         left: mouseCoordinates.x,
         top: mouseCoordinates.y,
       }}
     >
-      <div
-        className={styles.ContextMenuItem}
-        data-test-id="ConsoleContextMenu-SetFocusStartButton"
-        onClick={onPlayFromHere}
-      >
+      <div className={styles.ContextMenuItem} onClick={onPlayFromHere}>
+        <MaterialIcon>play_circle</MaterialIcon>
         Play from here
       </div>
-      <div
-        className={styles.ContextMenuItem}
-        data-test-id="ConsoleContextMenu-SetFocusStartButton"
-        onClick={onJumpToBefore}
-      >
+      <div className={styles.ContextMenuItem} onClick={onJumpToBefore}>
+        <MaterialIcon>arrow_back</MaterialIcon>
         Show before
       </div>
-      <div
-        className={styles.ContextMenuItem}
-        data-test-id="ConsoleContextMenu-SetFocusStartButton"
-        onClick={onJumpToAfter}
-      >
+      <div className={styles.ContextMenuItem} onClick={onJumpToAfter}>
+        <MaterialIcon>arrow_forward</MaterialIcon>
         Show after
       </div>
-      {/* <div
-        className={styles.ContextMenuItem}
-        data-test-id="ConsoleContextMenu-SetFocusStartButton"
-        onClick={onClick}
-      >
-        Jump to source code
-      </div> */}
+      <div className={styles.ContextMenuItem} onClick={onGoToLocation}>
+        <MaterialIcon>code</MaterialIcon>
+        Show source code
+      </div>
     </div>
   );
 }

--- a/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
@@ -111,7 +111,7 @@ export function TestCase({
             </button>
           </div>
         )}
-        {expandSteps ? <TestSteps test={test} startTime={test.relativeStartTime} /> : null}
+        {expandSteps ? <TestSteps test={test} /> : null}
       </div>
     </TestCaseContext.Provider>
   );

--- a/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
@@ -84,7 +84,9 @@ export function TestCase({
   };
 
   return (
-    <TestCaseContext.Provider value={{startTime: testStartTime, endTime: testEndTime, onReplay, onPlayFromHere}}>
+    <TestCaseContext.Provider
+      value={{ startTime: testStartTime, endTime: testEndTime, onReplay, onPlayFromHere }}
+    >
       <div className="flex flex-col">
         {!isHighlighted && (
           <div className="flex flex-row items-center justify-between gap-1 rounded-lg p-1 transition hover:cursor-pointer">

--- a/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
@@ -1,14 +1,22 @@
-import { Location } from "@replayio/protocol";
-import { useEffect, useState } from "react";
+import { createContext, useEffect, useState } from "react";
 
 import { getRecordingDuration } from "ui/actions/app";
-import { seekToTime, setFocusRegion } from "ui/actions/timeline";
+import { seekToTime, setFocusRegion, startPlayback } from "ui/actions/timeline";
 import Icon from "ui/components/shared/Icon";
 import { getFocusRegion } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { TestItem, TestResult } from "ui/types";
 
 import { TestSteps } from "./TestSteps";
+
+export type TestCaseContextType = {
+  startTime: number;
+  endTime: number;
+  onReplay: () => void;
+  onPlayFromHere: (startTime: number) => void;
+};
+
+export const TestCaseContext = createContext<TestCaseContextType>(null as any);
 
 export function TestCase({
   test,
@@ -68,33 +76,42 @@ export function TestCase({
     }
   }, [isHighlighted]);
 
+  const onReplay = () => {
+    dispatch(startPlayback({ beginTime: testStartTime, endTime: testEndTime - 1 }));
+  };
+  const onPlayFromHere = (beginTime: number) => {
+    dispatch(startPlayback({ beginTime, endTime: testEndTime - 1 }));
+  };
+
   return (
-    <div className="flex flex-col">
-      {!isHighlighted && (
-        <div className="flex flex-row items-center justify-between gap-1 rounded-lg p-1 transition hover:cursor-pointer">
-          <button
-            onClick={toggleExpand}
-            disabled={!expandable}
-            className="group flex flex-grow flex-row gap-1 overflow-hidden"
-          >
-            <Status result={test.result} />
-            <div className="flex flex-col items-start text-bodyColor">
-              <div
-                className={`overflow-hidden overflow-ellipsis whitespace-pre ${"group-hover:underline"}`}
-              >
-                {test.title}
-              </div>
-              {test.error ? (
-                <div className="mt-1 overflow-hidden rounded-lg bg-testsuitesErrorBgcolor px-2 py-1 text-left font-mono ">
-                  {test.error.message}
+    <TestCaseContext.Provider value={{startTime: testStartTime, endTime: testEndTime, onReplay, onPlayFromHere}}>
+      <div className="flex flex-col">
+        {!isHighlighted && (
+          <div className="flex flex-row items-center justify-between gap-1 rounded-lg p-1 transition hover:cursor-pointer">
+            <button
+              onClick={toggleExpand}
+              disabled={!expandable}
+              className="group flex flex-grow flex-row gap-1 overflow-hidden"
+            >
+              <Status result={test.result} />
+              <div className="flex flex-col items-start text-bodyColor">
+                <div
+                  className={`overflow-hidden overflow-ellipsis whitespace-pre ${"group-hover:underline"}`}
+                >
+                  {test.title}
                 </div>
-              ) : null}
-            </div>
-          </button>
-        </div>
-      )}
-      {expandSteps ? <TestSteps test={test} startTime={test.relativeStartTime} /> : null}
-    </div>
+                {test.error ? (
+                  <div className="mt-1 overflow-hidden rounded-lg bg-testsuitesErrorBgcolor px-2 py-1 text-left font-mono ">
+                    {test.error.message}
+                  </div>
+                ) : null}
+              </div>
+            </button>
+          </div>
+        )}
+        {expandSteps ? <TestSteps test={test} startTime={test.relativeStartTime} /> : null}
+      </div>
+    </TestCaseContext.Provider>
   );
 }
 

--- a/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
@@ -10,8 +10,8 @@ import { getReporterAnnotationsForTests } from "ui/reducers/reporter";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { Annotation, TestItem } from "ui/types";
 
-import { TestCase } from "./TestCase";
 import ContextMenuWrapper from "./ContextMenu";
+import { TestCase } from "./TestCase";
 import { TestInfoContextMenuContextRoot } from "./TestInfoContextMenuContext";
 
 type TestInfoContextType = {

--- a/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
@@ -11,6 +11,8 @@ import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { Annotation, TestItem } from "ui/types";
 
 import { TestCase } from "./TestCase";
+import ContextMenuWrapper from "./ContextMenu";
+import { TestInfoContextMenuContextRoot } from "./TestInfoContextMenuContext";
 
 type TestInfoContextType = {
   selectedId: string | null;
@@ -73,32 +75,35 @@ export default function TestInfo({
     <TestInfoContext.Provider
       value={{ selectedId, setSelectedId, consoleProps, setConsoleProps, pauseId, setPauseId }}
     >
-      <div className="flex flex-grow flex-col overflow-hidden">
-        <div className="flex flex-grow flex-col space-y-1 overflow-auto px-2 py-2">
-          {highlightedTest !== null && (
-            <button
-              onClick={onReset}
-              className="flex flex-row items-center hover:underline"
-              style={{ fontSize: "15px" }}
-            >
-              <MaterialIcon>chevron_left</MaterialIcon>
-              <div>{correctedTestCases[highlightedTest].title}</div>
-            </button>
-          )}
-          {correctedTestCases.map(
-            (t, i) =>
-              showTest(i) && (
-                <TestCase
-                  test={t}
-                  key={i}
-                  setHighlightedTest={() => setHighlightedTest(i)}
-                  isHighlighted={i === highlightedTest}
-                />
-              )
-          )}
+      <TestInfoContextMenuContextRoot>
+        <div className="flex flex-grow flex-col overflow-hidden">
+          <div className="flex flex-grow flex-col space-y-1 overflow-auto px-2 py-2">
+            {highlightedTest !== null && (
+              <button
+                onClick={onReset}
+                className="flex flex-row items-center hover:underline"
+                style={{ fontSize: "15px" }}
+              >
+                <MaterialIcon>chevron_left</MaterialIcon>
+                <div>{correctedTestCases[highlightedTest].title}</div>
+              </button>
+            )}
+            {correctedTestCases.map(
+              (t, i) =>
+                showTest(i) && (
+                  <TestCase
+                    test={t}
+                    key={i}
+                    setHighlightedTest={() => setHighlightedTest(i)}
+                    isHighlighted={i === highlightedTest}
+                  />
+                )
+            )}
+          </div>
+          {highlightedTest ? <Console /> : null}
+          <ContextMenuWrapper />
         </div>
-        {highlightedTest ? <Console /> : null}
-      </div>
+      </TestInfoContextMenuContextRoot>
     </TestInfoContext.Provider>
   );
 }

--- a/src/devtools/client/debugger/src/components/TestInfo/TestInfoContextMenuContext.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestInfoContextMenuContext.tsx
@@ -1,0 +1,42 @@
+import { PropsWithChildren, createContext, useCallback, useMemo, useState } from "react";
+
+export type Coordinates = {
+  x: number;
+  y: number;
+};
+
+export type TestInfoContextMenuContextType = {
+  hide: () => void;
+  mouseCoordinates: Coordinates | null;
+  show: (mouseCoordinates: Coordinates) => void;
+};
+
+export const TestInfoContextMenuContext = createContext<TestInfoContextMenuContextType>(null as any);
+
+export function TestInfoContextMenuContextRoot({ children }: PropsWithChildren) {
+  const [mouseCoordinates, setMouseCoordinates] = useState<Coordinates | null>(null);
+
+  const hide = useCallback(() => {
+    setMouseCoordinates(null);
+  }, []);
+
+  const show = useCallback((mouseCoordinates: Coordinates) => {
+    console.log("hi");
+    setMouseCoordinates(mouseCoordinates);
+  }, []);
+
+  const context = useMemo(
+    () => ({
+      hide,
+      mouseCoordinates,
+      show,
+    }),
+    [hide, mouseCoordinates, show]
+  );
+
+  return (
+    <TestInfoContextMenuContext.Provider value={context}>
+      {children}
+    </TestInfoContextMenuContext.Provider>
+  );
+}

--- a/src/devtools/client/debugger/src/components/TestInfo/TestInfoContextMenuContext.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestInfoContextMenuContext.tsx
@@ -5,33 +5,55 @@ export type Coordinates = {
   y: number;
 };
 
-export type TestInfoContextMenuContextType = {
-  hide: () => void;
-  mouseCoordinates: Coordinates | null;
-  show: (mouseCoordinates: Coordinates) => void;
+export type TestCaseType = {
+  startTime: number;
+  endTime: number;
+};
+export type TestStepType = TestCaseType & {
+  enqueuePoint?: string;
 };
 
-export const TestInfoContextMenuContext = createContext<TestInfoContextMenuContextType>(null as any);
+export type TestInfoContextMenuContextType = {
+  hide: () => void;
+  show: (mouseCoordinates: Coordinates, testCase: TestCaseType, testStep: TestStepType) => void;
+  mouseCoordinates: Coordinates | null;
+  testStep: TestStepType | null;
+  testCase: TestCaseType | null;
+};
+
+export const TestInfoContextMenuContext = createContext<TestInfoContextMenuContextType>(
+  null as any
+);
 
 export function TestInfoContextMenuContextRoot({ children }: PropsWithChildren) {
   const [mouseCoordinates, setMouseCoordinates] = useState<Coordinates | null>(null);
+  const [testStep, setTestStep] = useState<TestStepType | null>(null);
+  const [testCase, setTestCase] = useState<TestCaseType | null>(null);
 
   const hide = useCallback(() => {
     setMouseCoordinates(null);
+    setTestStep(null);
+    setTestCase(null);
   }, []);
 
-  const show = useCallback((mouseCoordinates: Coordinates) => {
-    console.log("hi");
-    setMouseCoordinates(mouseCoordinates);
-  }, []);
+  const show = useCallback(
+    (mouseCoordinates: Coordinates, testCase: TestCaseType, testStep: TestStepType) => {
+      setMouseCoordinates(mouseCoordinates);
+      setTestStep(testStep);
+      setTestCase(testCase);
+    },
+    []
+  );
 
   const context = useMemo(
     () => ({
       hide,
       mouseCoordinates,
       show,
+      testStep,
+      testCase,
     }),
-    [hide, mouseCoordinates, show]
+    [hide, mouseCoordinates, show, testStep, testCase]
   );
 
   return (

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -8,10 +8,10 @@ import { getCurrentTime } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 
 import { ProgressBar } from "./ProgressBar";
+import { TestCaseContext } from "./TestCase";
 import { TestInfoContext } from "./TestInfo";
 import { TestInfoContextMenuContext } from "./TestInfoContextMenuContext";
 import { TestStepContext } from "./TestStepRoot";
-import { TestCaseContext } from "./TestCase";
 
 function returnFirst<T, R>(list: T[] | undefined, fn: (v: T) => R | null) {
   return list ? list.reduce<R | null>((acc, v) => acc ?? fn(v), null) : null;
@@ -23,12 +23,12 @@ export interface TestStepItemProps {
   id: string | null;
 }
 
-export function TestStepItem({
-  argString,
-  index,
-  id,
-}: TestStepItemProps) {
-  const { setConsoleProps, setPauseId, setSelectedId: setSelectedIndex } = useContext(TestInfoContext);
+export function TestStepItem({ argString, index, id }: TestStepItemProps) {
+  const {
+    setConsoleProps,
+    setPauseId,
+    setSelectedId: setSelectedIndex,
+  } = useContext(TestInfoContext);
   const [subjectNodePauseData, setSubjectNodePauseData] = useState<{
     pauseId: string;
     nodeIds: string[];
@@ -179,33 +179,21 @@ export function TestStepItem({
 
 function Actions() {
   const { startTime: stepStartTime, duration, point } = useContext(TestStepContext);
-  const { startTime: caseStartTime, endTime: caseEndTime} = useContext(TestCaseContext);
+  const { startTime: caseStartTime, endTime: caseEndTime } = useContext(TestCaseContext);
   const { show } = useContext(TestInfoContextMenuContext);
-
 
   const onClick = (e: React.MouseEvent) => {
     const testStep = {
       startTime: stepStartTime,
       endTime: stepStartTime + duration,
-      enqueuePoint: point
-    }
+      enqueuePoint: point,
+    };
     const testCase = {
       startTime: caseStartTime,
       endTime: caseEndTime,
-    }
+    };
     show({ x: e.pageX, y: e.pageY }, testCase, testStep);
   };
-
-  {/* <TestStepActions
-    onReplay={onReplay}
-    onPlayFromHere={onPlayFromHere}
-    isLastStep={isLastStep}
-    isPaused={isPaused}
-    onGoToLocation={onGoToLocation}
-    onJumpToBefore={onJumpToBefore}
-    onJumpToAfter={onJumpToAfter}
-    duration={adjustedDuration}
-  /> */}
 
   return (
     <button onClick={onClick} className="py-2">

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -11,6 +11,7 @@ import { ProgressBar } from "./ProgressBar";
 import { TestInfoContext } from "./TestInfo";
 import { TestInfoContextMenuContext } from "./TestInfoContextMenuContext";
 import { TestStepContext } from "./TestStepRoot";
+import { TestCaseContext } from "./TestCase";
 
 function returnFirst<T, R>(list: T[] | undefined, fn: (v: T) => R | null) {
   return list ? list.reduce<R | null>((acc, v) => acc ?? fn(v), null) : null;
@@ -138,35 +139,6 @@ export function TestStepItem({
     dispatch(setTimelineToTime(currentTime));
     dispatch(unhighlightNode());
   };
-  // const onJumpToBefore = () => dispatch(seekToTime(startTime));
-  // const onJumpToAfter = () => {
-  //   dispatch(seekToTime(startTime + adjustedDuration - 1));
-  // };
-  // // const onPlayFromHere = () => onPlayFromHere(startTime);
-  // const onGoToLocation = async () => {
-  //   if (!point) {
-  //     return;
-  //   }
-
-  //   const frame = await (async point => {
-  //     const {
-  //       data: { frames },
-  //     } = await client.createPause(point);
-
-  //     const returnFirst = (list: any, fn: any) =>
-  //       list.reduce((acc: any, v: any, i: any) => acc ?? fn(v, i, list), null);
-
-  //     return returnFirst(frames, (f: any, i: any, l: any) =>
-  //       l[i + 1]?.functionName === "__stackReplacementMarker" ? f : null
-  //     );
-  //   })(point);
-
-  //   const location = frame.location[frame.location.length - 1];
-
-  //   if (location) {
-  //     dispatch(selectLocation(cx, location));
-  //   }
-  // };
 
   // This math is bananas don't look here until this is cleaned up :)
   const bump = isPaused || isPast ? 10 : 0;
@@ -177,40 +149,64 @@ export function TestStepItem({
   const color = error ? "border-l-red-500" : "border-l-primaryAccent";
 
   return (
-      <div
-        className={`group/step relative flex items-start gap-1 border-b border-l-2 border-themeBase-90 pl-1 pr-3 font-mono hover:bg-toolbarBackground ${
-          isPaused || isPast ? color : "border-l-transparent"
-        } ${
-          progress > 0 && error
-            ? "bg-testsuitesErrorBgcolor text-testsuitesErrorColor hover:bg-testsuitesErrorBgcolorHover"
-            : isPaused
-            ? "bg-gray-100"
-            : "bg-testsuitesStepsBgcolor"
-        }`}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
-      >
-        <button onClick={onClick} className="flex flex-grow items-start space-x-2  py-2 text-start">
-          <div title={"" + displayedProgress} className="flex h-4 items-center">
-            <ProgressBar progress={displayedProgress} error={error} />
-          </div>
-          <div className="opacity-70">{index + 1}</div>
-          <div className={` font-medium ${isPaused ? "font-bold" : ""}`}>
-            {parentId ? "- " : ""}
-            {stepName} <span className="opacity-70">{argString}</span>
-          </div>
-        </button>
+    <div
+      className={`group/step relative flex items-start gap-1 border-b border-l-2 border-themeBase-90 pl-1 pr-3 font-mono hover:bg-toolbarBackground ${
+        isPaused || isPast ? color : "border-l-transparent"
+      } ${
+        progress > 0 && error
+          ? "bg-testsuitesErrorBgcolor text-testsuitesErrorColor hover:bg-testsuitesErrorBgcolorHover"
+          : isPaused
+          ? "bg-gray-100"
+          : "bg-testsuitesStepsBgcolor"
+      }`}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
+      <button onClick={onClick} className="flex flex-grow items-start space-x-2  py-2 text-start">
+        <div title={"" + displayedProgress} className="flex h-4 items-center">
+          <ProgressBar progress={displayedProgress} error={error} />
+        </div>
+        <div className="opacity-70">{index + 1}</div>
+        <div className={` font-medium ${isPaused ? "font-bold" : ""}`}>
+          {parentId ? "- " : ""}
+          {stepName} <span className="opacity-70">{argString}</span>
+        </div>
+      </button>
       <Actions />
     </div>
   );
 }
 
 function Actions() {
+  const { startTime: stepStartTime, duration, point } = useContext(TestStepContext);
+  const { startTime: caseStartTime, endTime: caseEndTime} = useContext(TestCaseContext);
   const { show } = useContext(TestInfoContextMenuContext);
+
+
   const onClick = (e: React.MouseEvent) => {
-    console.log("click1");
-    show({ x: e.pageX, y: e.pageY });
+    const testStep = {
+      startTime: stepStartTime,
+      endTime: stepStartTime + duration,
+      enqueuePoint: point
+    }
+    const testCase = {
+      startTime: caseStartTime,
+      endTime: caseEndTime,
+    }
+    show({ x: e.pageX, y: e.pageY }, testCase, testStep);
   };
+
+  {/* <TestStepActions
+    onReplay={onReplay}
+    onPlayFromHere={onPlayFromHere}
+    isLastStep={isLastStep}
+    isPaused={isPaused}
+    onGoToLocation={onGoToLocation}
+    onJumpToBefore={onJumpToBefore}
+    onJumpToAfter={onJumpToAfter}
+    duration={adjustedDuration}
+  /> */}
+
   return (
     <button onClick={onClick} className="py-2">
       <div className="flex items-center">

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -12,6 +12,8 @@ import { getThreadContext } from "../../selectors";
 import { ProgressBar } from "./ProgressBar";
 import { TestInfoContext } from "./TestInfo";
 import { TestStepActions } from "./TestStepActions";
+import { TestInfoContextMenuContext } from "./TestInfoContextMenuContext";
+import MaterialIcon from "ui/components/shared/MaterialIcon";
 
 function returnFirst<T, R>(list: T[] | undefined, fn: (v: T) => R | null) {
   return list ? list.reduce<R | null>((acc, v) => acc ?? fn(v), null) : null;
@@ -229,7 +231,7 @@ export function TestStepItem({
             {stepName} <span className="opacity-70">{argString}</span>
           </div>
         </button>
-        <TestStepActions
+        {/* <TestStepActions
           onReplay={onReplay}
           onPlayFromHere={onPlayFromHere}
           isLastStep={isLastStep}
@@ -238,8 +240,24 @@ export function TestStepItem({
           onJumpToBefore={onJumpToBefore}
           onJumpToAfter={onJumpToAfter}
           duration={adjustedDuration}
-        />
+        /> */}
+        <ContextMenuIcon />
       </div>
     </>
   );
+}
+
+function ContextMenuIcon() {
+  const { show } = useContext(TestInfoContextMenuContext);
+  const onClick = (e: React.MouseEvent) => {
+    console.log("click1");
+    show({ x: e.pageX, y: e.pageY });
+  };
+  return (
+    <button onClick={onClick} className="py-2">
+      <div className="flex items-center">
+        <MaterialIcon>more_vert</MaterialIcon>
+      </div>
+    </button>
+  )
 }

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -196,7 +196,7 @@ function Actions() {
   };
 
   return (
-    <button onClick={onClick} className={`group-hover/step:visible py-2 invisible`}>
+    <button onClick={onClick} className={`invisible py-2 group-hover/step:visible`}>
       <div className="flex items-center">
         <MaterialIcon>more_vert</MaterialIcon>
       </div>

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -196,7 +196,7 @@ function Actions() {
   };
 
   return (
-    <button onClick={onClick} className="py-2">
+    <button onClick={onClick} className={`group-hover/step:visible py-2 invisible`}>
       <div className="flex items-center">
         <MaterialIcon>more_vert</MaterialIcon>
       </div>

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -144,7 +144,7 @@ export function TestStepItem({ argString, index, id }: TestStepItemProps) {
   const bump = isPaused || isPast ? 10 : 0;
   const actualProgress = bump + 90 * ((currentTime - startTime) / duration);
   const progress = actualProgress > 100 ? 100 : actualProgress;
-  const displayedProgress = duration === 1 && isPaused ? 100 : progress == 100 ? 0 : progress;
+  const displayedProgress = duration === 1 && isPaused ? 100 : progress;
 
   const color = error ? "border-l-red-500" : "border-l-primaryAccent";
 

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepRoot.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepRoot.tsx
@@ -1,0 +1,47 @@
+import { createContext, useContext } from "react";
+import { AnnotatedTestStep, CypressAnnotationMessage } from "ui/types";
+import { TestCaseContext } from "./TestCase";
+import { TestStepItem, TestStepItemProps } from "./TestStepItem";
+
+export type TestStepContextType = {
+  stepName: string;
+  messageEnqueue?: CypressAnnotationMessage;
+  messageEnd?: CypressAnnotationMessage;
+  point?: string;
+  pointEnd?: string;
+  startTime: number;
+  duration: number;
+  parentId?: string;
+  error: boolean;
+};
+
+export const TestStepContext = createContext<TestStepContextType>(null as any);
+
+type TestStepRootProps = TestStepItemProps & {
+  step: AnnotatedTestStep
+}
+
+export function TestStepRoot({ step, ...props }: TestStepRootProps) {
+  const {startTime: testStartTime} =useContext(TestCaseContext);
+
+  // some chainers (`then`) don't have a duration, so let's bump it here (+1) so that it shows something in the UI
+  const adjustedDuration = step.duration || 1;
+
+  const value = {
+    stepName: step.name,
+    messageEnqueue: step.annotations.enqueue?.message,
+    startTime: testStartTime + step.relativeStartTime,
+    messageEnd: step.annotations.end?.message,
+    point: step.annotations.enqueue?.point,
+    pointEnd: step.annotations.end?.point,
+    duration: adjustedDuration,
+    parentId: step.parentId,
+    error: !!step.error
+  }
+
+  return (
+  <TestStepContext.Provider value={value}>
+    <TestStepItem {...props} />
+  </TestStepContext.Provider>
+  )
+}

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepRoot.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepRoot.tsx
@@ -36,7 +36,7 @@ export function TestStepRoot({ step, ...props }: TestStepRootProps) {
     messageEnd: step.annotations.end?.message,
     point: step.annotations.enqueue?.point,
     pointEnd: step.annotations.end?.point,
-    duration: adjustedDuration,
+    duration: step.name === "assert" ? 1 : adjustedDuration,
     parentId: step.parentId,
     error: !!step.error,
   };

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepRoot.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepRoot.tsx
@@ -1,5 +1,7 @@
 import { createContext, useContext } from "react";
+
 import { AnnotatedTestStep, CypressAnnotationMessage } from "ui/types";
+
 import { TestCaseContext } from "./TestCase";
 import { TestStepItem, TestStepItemProps } from "./TestStepItem";
 
@@ -18,11 +20,11 @@ export type TestStepContextType = {
 export const TestStepContext = createContext<TestStepContextType>(null as any);
 
 type TestStepRootProps = TestStepItemProps & {
-  step: AnnotatedTestStep
-}
+  step: AnnotatedTestStep;
+};
 
 export function TestStepRoot({ step, ...props }: TestStepRootProps) {
-  const {startTime: testStartTime} =useContext(TestCaseContext);
+  const { startTime: testStartTime } = useContext(TestCaseContext);
 
   // some chainers (`then`) don't have a duration, so let's bump it here (+1) so that it shows something in the UI
   const adjustedDuration = step.duration || 1;
@@ -36,12 +38,12 @@ export function TestStepRoot({ step, ...props }: TestStepRootProps) {
     pointEnd: step.annotations.end?.point,
     duration: adjustedDuration,
     parentId: step.parentId,
-    error: !!step.error
-  }
+    error: !!step.error,
+  };
 
   return (
-  <TestStepContext.Provider value={value}>
-    <TestStepItem {...props} />
-  </TestStepContext.Provider>
-  )
+    <TestStepContext.Provider value={value}>
+      <TestStepItem {...props} />
+    </TestStepContext.Provider>
+  );
 }

--- a/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useContext, useMemo } from "react";
 
 import {
   RequestSummary,
@@ -15,6 +15,7 @@ import { useAppSelector } from "ui/setup/hooks";
 import { AnnotatedTestStep, CypressAnnotationMessage, TestItem, TestStep } from "ui/types";
 
 import { NetworkEvent } from "./NetworkEvent";
+import { TestCase, TestCaseContext } from "./TestCase";
 import { TestStepRoot } from "./TestStepRoot";
 
 type StepEvent = {
@@ -73,7 +74,7 @@ function useGetTestSections(
       .map<NetworkEvent>(n => ({ time: n.end!, type: "network", event: n }));
 
     const stepsByTime = steps.map<StepEvent>(s => ({
-      time: startTime + s.relativeStartTime + s.duration,
+      time: startTime + s.relativeStartTime,
       type: "step",
       event: {
         ...s,
@@ -141,8 +142,13 @@ function useGetTestSections(
   }, [steps, annotationsEnd, annotationsEnqueue, requests, events, startTime, navigationEvents]);
 }
 
-export function TestSteps({ test, startTime }: { test: TestItem; startTime: number }) {
-  const { beforeEach, testBody, afterEach } = useGetTestSections(startTime, test.steps, test.title);
+export function TestSteps({ test }: { test: TestItem }) {
+  const { startTime: testCaseStartTime } = useContext(TestCaseContext);
+  const { beforeEach, testBody, afterEach } = useGetTestSections(
+    testCaseStartTime,
+    test.steps,
+    test.title
+  );
 
   return (
     <div className="flex flex-col rounded-lg py-2 px-2">

--- a/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
@@ -146,18 +146,12 @@ export function TestSteps({ test, startTime }: { test: TestItem; startTime: numb
 
   return (
     <div className="flex flex-col rounded-lg py-2 px-2">
-      <TestSection
-        events={beforeEach}
-        header="Before Each"
-      />
+      <TestSection events={beforeEach} header="Before Each" />
       <TestSection
         events={testBody}
         header={beforeEach.length + afterEach.length > 0 ? "Test Body" : undefined}
       />
-      <TestSection
-        events={afterEach}
-        header="After Each"
-      />
+      <TestSection events={afterEach} header="After Each" />
       {test.error ? (
         <div className="border-l-2 border-red-500 bg-testsuitesErrorBgcolor text-testsuitesErrorColor">
           <div className="flex flex-row items-center space-x-1 p-2">
@@ -171,13 +165,7 @@ export function TestSteps({ test, startTime }: { test: TestItem; startTime: numb
   );
 }
 
-function TestSection({
-  events,
-  header,
-}: {
-  events: CompositeTestEvent[];
-  header?: string;
-}) {
+function TestSection({ events, header }: { events: CompositeTestEvent[]; header?: string }) {
   if (events.length === 0) {
     return null;
   }
@@ -194,13 +182,7 @@ function TestSection({
       ) : null}
       {events.map(({ event: s, type }, i) =>
         type === "step" ? (
-          <TestStepRoot
-            step={s}
-            key={i}
-            index={i}
-            argString={s.args?.toString()}
-            id={s.id}
-          />
+          <TestStepRoot step={s} key={i} index={i} argString={s.args?.toString()} id={s.id} />
         ) : type === "network" ? (
           <NetworkEvent key={s.id} method={s.method} status={s.status} url={s.url} id={s.id} />
         ) : (

--- a/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
@@ -17,6 +17,7 @@ import { AnnotatedTestStep, CypressAnnotationMessage, TestItem, TestStep } from 
 
 import { NetworkEvent } from "./NetworkEvent";
 import { TestInfoContext } from "./TestInfo";
+import { TestInfoContextMenuContext } from "./TestInfoContextMenuContext";
 import { TestStepItem } from "./TestStepItem";
 
 type StepEvent = {


### PR DESCRIPTION
Fix SCS-302, Fix SCS-356.

https://www.loom.com/share/ca62c04777e845a5a542d43fb141e176

This moves the actions into a context menu. And makes it so that assertions are considered as 0 duration events.