### PR TITLE
Fix console props using the wrong pause id

### DIFF
--- a/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
@@ -1,4 +1,5 @@
 import { Object as ProtocolObject } from "@replayio/protocol";
+import cloneDeep from "lodash/cloneDeep";
 import React, { createContext, useContext, useMemo, useState } from "react";
 
 import ErrorBoundary from "bvaughn-architecture-demo/components/ErrorBoundary";
@@ -106,7 +107,19 @@ export default function TestInfo({
 
 function Console() {
   const { pauseId, consoleProps } = useContext(TestInfoContext);
-  const hideProps = !pauseId || !consoleProps;
+
+  const sanitizedConsoleProps = useMemo(() => {
+    const sanitized = cloneDeep(consoleProps);
+    if (sanitized?.preview?.properties) {
+      sanitized.preview.properties = sanitized.preview.properties.filter(
+        p => p.name !== "Snapshot"
+      );
+    }
+
+    return sanitized;
+  }, [consoleProps]);
+
+  const hideProps = !pauseId || !sanitizedConsoleProps;
 
   return (
     <div
@@ -114,6 +127,7 @@ function Console() {
       style={{
         borderTop: "2px solid var(--chrome)",
       }}
+      key={pauseId}
     >
       <div
         className="text-md"
@@ -130,7 +144,7 @@ function Console() {
               Nothing Selected...
             </div>
           ) : (
-            <PropertiesRenderer pauseId={pauseId} object={consoleProps} />
+            <PropertiesRenderer pauseId={pauseId} object={sanitizedConsoleProps} />
           )}
         </div>
       </ErrorBoundary>

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -25,6 +25,7 @@ export interface TestStepItemProps {
 }
 
 export function TestStepItem({ argString, index, id }: TestStepItemProps) {
+  const [localPauseData, setLocalPauseData] = useState<{ pauseId: string; consoleProps: any }>();
   const { setConsoleProps, setPauseId } = useContext(TestInfoContext);
   const [subjectNodePauseData, setSubjectNodePauseData] = useState<{
     pauseId: string;
@@ -52,8 +53,6 @@ export function TestStepItem({ argString, index, id }: TestStepItemProps) {
         if (!frames) {
           return null;
         }
-
-        setPauseId(pauseResult.pauseId);
 
         const callerFrame = frames[1];
 
@@ -109,12 +108,11 @@ export function TestStepItem({ argString, index, id }: TestStepItemProps) {
               consoleProps.preview.prototypeId = undefined;
             }
 
-            setConsoleProps(consoleProps);
+            setLocalPauseData({ pauseId: pauseResult.pauseId, consoleProps });
           }
         }
       } catch {
-        setPauseId(null);
-        setConsoleProps(undefined);
+        setLocalPauseData(undefined);
       }
 
       return null;
@@ -123,6 +121,10 @@ export function TestStepItem({ argString, index, id }: TestStepItemProps) {
 
   const onClick = () => {
     if (id) {
+      if (localPauseData) {
+        setConsoleProps(localPauseData.consoleProps);
+        setPauseId(localPauseData.pauseId);
+      }
       dispatch(seekToTime(startTime));
       dispatch(setSelectedStep({ id, startTime, endTime: startTime + duration - 1 }));
     }


### PR DESCRIPTION
We were setting the pause id and console props in an effect on mount so (generally) we using the wrong values.

This sets those values in local state and pushes them to context on click. Also fixes `Snapshot` reappearing in the console