### PR TITLE
Fix little badge position in side nav

### DIFF
--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -79,7 +79,13 @@ function ToolbarButton({
         />
       </div>
       {showBadge ? (
-        <div className="absolute top-1 left-3 mr-2 mb-1 h-2 w-2 rounded-full bg-secondaryAccent" />
+        <div
+          className="absolute h-2 w-2 rounded-full bg-secondaryAccent"
+          style={{
+            left: "1em",
+            top: "0.5em",
+          }}
+        />
       ) : null}
     </div>
   );


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/29597/205174829-2f295cc9-c3e5-4847-85f7-5228ebe2f0bc.png)

After:
![Screen Shot 2022-12-01 at 5 43 37 PM](https://user-images.githubusercontent.com/29597/205174850-40e75aee-e50e-4dd6-ba5a-8a72f4b9601b.png)

To ensure it lines up _right_ I made it partially opaque:
![Screen Shot 2022-12-01 at 5 43 34 PM](https://user-images.githubusercontent.com/29597/205174848-0ac4a467-7b2b-4736-809e-a40a4909f1cf.png)