### PR TITLE
Suppress test step preview for the current step

### DIFF
--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -171,6 +171,10 @@ export function TestStepItem({ step, argString, index, id }: TestStepItemProps) 
     }
   };
   const onMouseEnter = () => {
+    if (isPaused) {
+      return;
+    }
+
     dispatch(setTimelineToTime(step.absoluteStartTime));
     if (localPauseData?.startPauseId) {
       dispatch(
@@ -186,6 +190,10 @@ export function TestStepItem({ step, argString, index, id }: TestStepItemProps) 
     }
   };
   const onMouseLeave = () => {
+    if (isPaused) {
+      return;
+    }
+
     dispatch(setTimelineToTime(null));
     dispatch(unhighlightNode());
   };


### PR DESCRIPTION
Blocked by #8258 and effectively by #8247 because the before/after screenshots are generally incorrect until that lands
