### PR TITLE
Fix error dialog text wrapping and only show request args in dev

### DIFF
--- a/packages/protocol/socket.ts
+++ b/packages/protocol/socket.ts
@@ -216,9 +216,12 @@ export async function sendMessage<M extends CommandMethods>(
 
     console.warn("Message failed", method, { code, id, message }, data);
 
-    // Include details on the method and params in the error string so that we get more than
-    // _just_ "Internal Error" or similar
-    const finalMessage = `${message} (request: ${method}, ${JSON.stringify(params)})`;
+    let finalMessage = message;
+    if (process.env.NODE_ENV === "development") {
+      // Include details on the method and params in the error string so that we get more than
+      // _just_ "Internal Error" or similar
+      finalMessage = `${message} (request: ${method}, ${JSON.stringify(params)})`;
+    }
     throw commandError(finalMessage, code);
   }
 

--- a/src/ui/components/shared/Dialog.tsx
+++ b/src/ui/components/shared/Dialog.tsx
@@ -68,7 +68,10 @@ export const DialogDescription = ({
   ...props
 }: HTMLProps<HTMLParagraphElement>) => {
   return (
-    <p {...props} className="mb-2 whitespace-pre-wrap text-center text-sm text-themeBase-70">
+    <p
+      {...props}
+      className="mb-2 whitespace-pre-wrap break-all text-center text-sm text-themeBase-70"
+    >
       {children}
     </p>
   );


### PR DESCRIPTION
- Updated `socket.ts` to only include protocol method name and args in error messages in dev
- Added `break-all` styling to the `<Error>` component to allow long unbroken text to wrap correctly:

![image](https://user-images.githubusercontent.com/1128784/205742981-452724ca-b519-469e-a3ee-9c0066116e43.png)
