### PR TITLE
Show "Loading..." indicators for comment source snippets

### DIFF
--- a/src/ui/components/Comments/TranscriptComments/CommentSource.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentSource.tsx
@@ -8,6 +8,8 @@ import { selectors } from "ui/reducers";
 import { UIState } from "ui/state";
 import { trackEvent } from "ui/utils/telemetry";
 
+import LoadingLabelPlaceholder from "./LoadingLabelPlaceholder";
+
 type PropsFromParent = {
   comment: any;
 };
@@ -45,21 +47,6 @@ function CommentSource({
     return null;
   }
 
-  let sourceContent: React.ReactNode = null;
-  // We may not have sources yet, and once we have sources we still have to calculate
-  // the "labels" from the source texts.  Show loading indicators until ready.
-  if (labels) {
-    sourceContent = (
-      <div
-        className="cm-s-mozilla overflow-hidden whitespace-pre font-mono text-xs"
-        style={{ fontSize: "11px" }}
-        dangerouslySetInnerHTML={{ __html: labels?.secondary || "" }}
-      />
-    );
-  } else {
-    sourceContent = <div className="whitespace-pre font-mono text-xs italic">Loading...</div>;
-  }
-
   return (
     <div
       onClick={onSelectSource}
@@ -67,7 +54,16 @@ function CommentSource({
     >
       <div className="mono flex flex-col font-medium">
         <div className="flex w-full flex-row justify-between space-x-1">
-          {sourceContent}
+          <div
+            className="cm-s-mozilla overflow-hidden whitespace-pre font-mono text-xs"
+            style={{ fontSize: "11px" }}
+          >
+            {labels ? (
+              <span dangerouslySetInnerHTML={{ __html: labels?.secondary || "" }} />
+            ) : (
+              <LoadingLabelPlaceholder />
+            )}
+          </div>
           <div
             className="flex flex-shrink-0 opacity-0 transition group-hover:opacity-100"
             title="Show in the Editor"

--- a/src/ui/components/Comments/TranscriptComments/CommentSource.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentSource.tsx
@@ -41,6 +41,25 @@ function CommentSource({
     selectLocation(context, sourceLocation);
   };
 
+  if (!sourceLocation) {
+    return null;
+  }
+
+  let sourceContent: React.ReactNode = null;
+  // We may not have sources yet, and once we have sources we still have to calculate
+  // the "labels" from the source texts.  Show loading indicators until ready.
+  if (labels) {
+    sourceContent = (
+      <div
+        className="cm-s-mozilla overflow-hidden whitespace-pre font-mono text-xs"
+        style={{ fontSize: "11px" }}
+        dangerouslySetInnerHTML={{ __html: labels?.secondary || "" }}
+      />
+    );
+  } else {
+    sourceContent = <div className="whitespace-pre font-mono text-xs italic">Loading...</div>;
+  }
+
   return (
     <div
       onClick={onSelectSource}
@@ -48,14 +67,9 @@ function CommentSource({
     >
       <div className="mono flex flex-col font-medium">
         <div className="flex w-full flex-row justify-between space-x-1">
-          <div
-            className="cm-s-mozilla overflow-hidden whitespace-pre font-mono text-xs"
-            style={{ fontSize: "11px" }}
-            dangerouslySetInnerHTML={{ __html: labels?.secondary || "" }}
-          />
+          {sourceContent}
           <div
             className="flex flex-shrink-0 opacity-0 transition group-hover:opacity-100"
-            // className="flex-shrink-0 p-px w-4 h-4 opacity-0 group-hover:opacity-100"
             title="Show in the Editor"
           >
             <MaterialIcon iconSize="sm">keyboard_arrow_right</MaterialIcon>

--- a/src/ui/components/Comments/TranscriptComments/LoadingLabelPlaceholder.tsx
+++ b/src/ui/components/Comments/TranscriptComments/LoadingLabelPlaceholder.tsx
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+
+export default function LoadingLabelPlaceholder({
+  interval = 250,
+  maxDots = 3,
+}: {
+  interval?: number;
+  maxDots?: number;
+}) {
+  const [count, setCount] = useState(1);
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      setCount(prevCount => prevCount + 1);
+    }, interval);
+
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, [interval]);
+
+  const dots = ".".repeat(count % (maxDots + 1));
+
+  return <span className="tok-comment">{`// Loading ${dots}`}</span>;
+}


### PR DESCRIPTION
- Updates the `<CommentSource>` component to show "Loading..." text in the source snippet line until we actually have the source labels available

![image](https://user-images.githubusercontent.com/1128784/205751779-3cffe1c9-89d2-4579-a2c0-06b4b04f2811.png)
