### PR TITLE
Push remaining non step events into last section with content

### DIFF
--- a/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
@@ -150,6 +150,16 @@ function useGetTestSections(
       }
     }
 
+    if (nonStepStack.length) {
+      if (afterEach.length) {
+        afterEach.push(...nonStepStack);
+      } else if (testBody.length) {
+        testBody.push(...nonStepStack);
+      } else if (beforeEach.length) {
+        beforeEach.push(...nonStepStack);
+      }
+    }
+
     return { beforeEach, testBody, afterEach };
   }, [
     steps,


### PR DESCRIPTION
Some network / navigation events can come in after the last step / assert and should be logged for cypress parity