### PR TITLE
Fix repainting (FE-1031)

### DIFF
--- a/packages/protocol/graphics.ts
+++ b/packages/protocol/graphics.ts
@@ -287,7 +287,7 @@ async function fetchScreenshotForPause(pauseId: string, force = false) {
 export async function repaint(force = false) {
   repaintAtPause(
     ThreadFront.currentTime,
-    ThreadFront.currentPause.pauseId!,
+    await ThreadFront.getCurrentPauseId(replayClient),
     (_time, pauseId) => {
       return pauseId !== ThreadFront.currentPause.pauseId;
     },


### PR DESCRIPTION
When we seek to an execution point for which no pause has been created yet, `ThreadFront.currentPause.pauseId` will initially be `null`, so the Typescript error should not be suppressed.