### PR TITLE
Fix selectLocation() to not open a source unless requested (FE-1010)

### DIFF
--- a/src/devtools/client/debugger/src/actions/sources/select.ts
+++ b/src/devtools/client/debugger/src/actions/sources/select.ts
@@ -154,11 +154,11 @@ export function selectLocation(
       dispatch(closeActiveSearch());
     }
 
-    dispatch(locationSelected({ location, source }));
-
     if (!openSource) {
       return;
     }
+
+    dispatch(locationSelected({ location, source }));
 
     if (!getTabExists(getState(), source.id)) {
       dispatch(addTab(source));


### PR DESCRIPTION
Dispatching the `locationSelected` redux action is enough to open a source and is not necessary if we don't want to open it.