### PR TITLE
Skip framesteps that point to the beginning of a function body (SCS-172)

### DIFF
--- a/src/devtools/client/debugger/src/reducers/ast.ts
+++ b/src/devtools/client/debugger/src/reducers/ast.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 import { EntityState, createAsyncThunk, createEntityAdapter, createSlice } from "@reduxjs/toolkit";
+import { SourceLocation } from "@replayio/protocol";
 
 import { getSourceIDsToSearch } from "devtools/client/debugger/src/utils/sourceVisualizations";
 import { MiniSource, SourceDetails, getSourceDetailsEntities } from "ui/reducers/sources";
@@ -69,6 +70,7 @@ export type SymbolDeclarations = {
   hasJsx: boolean;
   hasTypes: boolean;
   framework?: string;
+  functionBodyLocations: SourceLocation[];
 };
 
 export interface SymbolEntry {

--- a/src/devtools/client/debugger/src/workers/parser/getSymbols.js
+++ b/src/devtools/client/debugger/src/workers/parser/getSymbols.js
@@ -17,6 +17,14 @@ let symbolDeclarations = new Map();
 // eslint-disable-next-line complexity
 function extractSymbol(path, symbols, state) {
   if (isFunction(path)) {
+    const start = path.node.body?.loc?.start;
+    if (start) {
+      symbols.functionBodyLocations.push({
+        line: start.line,
+        column: start.column,
+      });
+    }
+
     const name = getFunctionName(path.node, path.parent);
 
     if (!state.fnCounts[name]) {
@@ -80,6 +88,7 @@ function extractSymbols(sourceId) {
   const symbols = {
     functions: [],
     classes: [],
+    functionBodyLocations: [],
     hasJsx: false,
     hasTypes: false,
     loading: false,


### PR DESCRIPTION
This is a minimal experiment for SCS-172: the FrameTimeline ignores steps that point to the beginning of a function body (but the stepping buttons don't).
This fixes the example in SCS-172 but we still need to check if we're ignoring too many steps in some places.