### PR TITLE
Re-implement "hit counts" preference

### DIFF
--- a/packages/bvaughn-architecture-demo/src/hooks/useLocalStorage.ts
+++ b/packages/bvaughn-architecture-demo/src/hooks/useLocalStorage.ts
@@ -1,6 +1,20 @@
-import { SetStateAction, useCallback, useLayoutEffect, useState, useTransition } from "react";
+import {
+  SetStateAction,
+  useCallback,
+  useLayoutEffect,
+  useReducer,
+  useRef,
+  useState,
+  useTransition,
+} from "react";
 
 import { localStorageGetItem, localStorageSetItem } from "../utils/storage";
+
+function manuallyTriggerStorageEvent() {
+  // Apparently the "storage" event only fires across tabs, and setting a value
+  // in the _same_ tab won't trigger it. Do that manually:
+  window.dispatchEvent(new Event("storage"));
+}
 
 // Stores value in localStorage and synchronizes it between sessions and tabs.
 // The API mirrors useState.
@@ -15,6 +29,7 @@ export default function useLocalStorage<T>(
   scheduleUpdatesAsTransitions: boolean = false
 ): [value: T, setValue: (value: T | ((prevValue: T) => T)) => void, isPending: boolean] {
   const [isPending, startTransition] = useTransition();
+  const [updateCounter, dispatchUpdate] = useReducer(c => c + 1, 0);
 
   const [value, setValue] = useState<T>(() => {
     const storedValue = localStorageGetItem(key);
@@ -30,9 +45,11 @@ export default function useLocalStorage<T>(
       if (scheduleUpdatesAsTransitions) {
         startTransition(() => {
           setValue(action);
+          dispatchUpdate();
         });
       } else {
         setValue(action);
+        dispatchUpdate();
       }
     },
     [scheduleUpdatesAsTransitions]
@@ -62,6 +79,15 @@ export default function useLocalStorage<T>(
 
     localStorageSetItem(key, string);
   }, [key, value]);
+
+  // Order of effects matters here. Don't trigger this until _after_ we've updated `localStorage`.
+  useLayoutEffect(() => {
+    // Only notify if this hook has had its setter run
+    if (updateCounter > 0) {
+      // Notify any other components subscribed to this value that it has changed
+      manuallyTriggerStorageEvent();
+    }
+  }, [updateCounter]);
 
   return [value, setValueWrapper, isPending];
 }

--- a/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
+++ b/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
@@ -21,11 +21,6 @@ const EXPERIMENTAL_SETTINGS: ExperimentalSetting[] = [
     key: "enableColumnBreakpoints",
   },
   {
-    label: "Inline hit counts",
-    description: "Show line hit counts in the source view",
-    key: "hitCounts",
-  },
-  {
     label: "Profile Source Worker",
     description:
       "Record a performance profile of the source worker and send it to Replay to help diagnose performance issues",
@@ -92,7 +87,6 @@ export default function ExperimentalSettings({}) {
     value: consoleFilterDrawerDefaultsToOpen,
     update: updateConsoleFilterDrawerDefaultsToOpen,
   } = useFeature("consoleFilterDrawerDefaultsToOpen");
-  const { value: hitCounts, update: updateHitCounts } = useFeature("hitCounts");
   const { value: profileWorkerThreads, update: updateProfileWorkerThreads } =
     useFeature("profileWorkerThreads");
   const { value: enableQueryCache, update: updateEnableQueryCache } =
@@ -104,8 +98,6 @@ export default function ExperimentalSettings({}) {
   const onChange = (key: ExperimentalKey, value: any) => {
     if (key == "enableColumnBreakpoints") {
       updateEnableColumnBreakpoints(!enableColumnBreakpoints);
-    } else if (key === "hitCounts") {
-      updateHitCounts(!hitCounts);
     } else if (key === "profileWorkerThreads") {
       updateProfileWorkerThreads(!profileWorkerThreads);
     } else if (key === "enableQueryCache") {
@@ -125,7 +117,6 @@ export default function ExperimentalSettings({}) {
     disableScanDataCache,
     enableColumnBreakpoints,
     enableQueryCache,
-    hitCounts,
     profileWorkerThreads,
   };
 

--- a/src/ui/components/shared/UserSettingsModal/PreferencesSettings.tsx
+++ b/src/ui/components/shared/UserSettingsModal/PreferencesSettings.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 
+import useLocalStorage from "bvaughn-architecture-demo/src/hooks/useLocalStorage";
 import hooks from "ui/hooks";
 import { useFeature, useStringPref } from "ui/hooks/settings";
 import { EmailSubscription } from "ui/hooks/users";
@@ -107,15 +108,12 @@ function PrivacyPreferences() {
     </div>
   );
 }
-type HitCountMode = "hide-counts" | "show-counts" | "disabled";
 
 function UiPreferences() {
   const dispatch = useAppDispatch();
   const theme = useAppSelector(getThemePreference);
   const { value: defaultMode, update: updateDefaultMode } = useStringPref("defaultMode");
-  // TODO [FE-1011] Hit count settings is broken and disabled for now
-  // const { value: hitCountsMode, update: updateHitCounts } = useStringPref("hitCounts");
-  // const hitCountsEnabled = useFeature("hitCounts");
+  const [showHitCounts, setShowHitCounts] = useLocalStorage<boolean>(`Replay:ShowHitCounts`, true);
   const { value: enableLargeText, update: updateEnableLargeText } = useFeature("enableLargeText");
 
   const setSelected = (value: AppTheme) => {
@@ -152,22 +150,18 @@ function UiPreferences() {
           />
         </div>
       </div>
-      {/* {hitCountsEnabled && (
-        <div className="flex flex-row justify-between">
-          <div>Heat Maps</div>
-          <div className="w-1/2">
-            <SelectMenu
-              options={[
-                { name: "Hide Counts", id: "hide-counts" },
-                { name: "Show Counts", id: "show-counts" },
-                { name: "Hidden", id: "disabled" },
-              ]}
-              selected={hitCountsMode}
-              setSelected={mode => updateHitCounts(mode as HitCountMode)}
-            />
-          </div>
-        </div>
-      )} */}
+      <label
+        className="flex cursor-pointer items-center space-x-2 p-1"
+        data-private
+        htmlFor="show-hit-counts"
+      >
+        <Checkbox
+          id="show-hit-counts"
+          checked={showHitCounts}
+          onChange={() => setShowHitCounts(!showHitCounts)}
+        />
+        <div>Show hit count numbers for each source line</div>
+      </label>
       <label
         className="flex cursor-pointer items-center space-x-2 p-1"
         data-private

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -21,7 +21,6 @@ export type LocalExperimentalUserSettings = {
   consoleFilterDrawerDefaultsToOpen: boolean;
   enableQueryCache: boolean;
   enableColumnBreakpoints: boolean;
-  hitCounts: boolean;
   profileWorkerThreads: boolean;
 };
 

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -2,6 +2,9 @@ import { PrefsHelper } from "devtools/client/shared/prefs";
 import { asyncStoreHelper } from "devtools/shared/async-store-helper";
 import { pref } from "devtools/shared/services";
 
+// Note: additional preferences are defined in other files,
+// including uses of `pref()`, `useLocalStorage`, and `useIndexedDB`.
+
 // app prefs.
 pref("devtools.defaultMode", "non-dev");
 pref("devtools.dev-secondary-panel-height", "375px");
@@ -15,7 +18,6 @@ pref("devtools.sidePanelSize", "240px");
 pref("devtools.theme", "system");
 pref("devtools.toolbox-size", "50%");
 pref("devtools.consoleFilterDrawerExpanded", true);
-pref("devtools.hitCounts", "hide-counts");
 
 // app features
 pref("devtools.features.basicProcessingLoadingBar", false);
@@ -50,7 +52,6 @@ export const prefs = new PrefsHelper("devtools", {
   theme: ["String", "theme"],
   toolboxSize: ["String", "toolbox-size"],
   consoleFilterDrawerExpanded: ["Bool", "consoleFilterDrawerExpanded"],
-  hitCounts: ["String", "hitCounts"],
 });
 
 export const features = new PrefsHelper("devtools.features", {
@@ -62,7 +63,6 @@ export const features = new PrefsHelper("devtools.features", {
   enableQueryCache: ["Bool", "enableQueryCache"],
   disableUnHitLines: ["Bool", "disableUnHitLines"],
   enableLargeText: ["Bool", "enableLargeText"],
-  hitCounts: ["Bool", "hitCounts"],
   logProtocol: ["Bool", "logProtocol"],
   logProtocolEvents: ["Bool", "logProtocolEvents"],
   newControllerOnRefresh: ["Bool", "newControllerOnRefresh"],


### PR DESCRIPTION
- Removed dead "experimental setting" option
- Updated `useLocalStorage` hook to force updates in the same tab
- Replaced tri-state "hide/color only/show numbers" hit counts pref with a boolean that is either "color only/show numbers".

Confirmed that this neatly toggles the behavior in the source viewer as soon as you click the checkbox.