### PR TITLE
Preload `useIndexedDB` values

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -5,3 +5,4 @@ node_modules
 src/devtools/client/shared/vendor/
 src/devtools/client/shared/sourceeditor/codemirror
 src/test/harness.js
+packages/bvaughn-architecture-demo/src/hooks/useIndexedDB.ts

--- a/packages/bvaughn-architecture-demo/components/Initializer.tsx
+++ b/packages/bvaughn-architecture-demo/components/Initializer.tsx
@@ -6,7 +6,7 @@ import { ReactNode, useContext, useEffect, useRef, useState } from "react";
 
 import { CONSOLE_SETTINGS_DATABASE } from "bvaughn-architecture-demo/src/contexts/ConsoleFiltersContext";
 import { POINTS_DATABASE } from "bvaughn-architecture-demo/src/contexts/PointsContext";
-import { getInitialIDBValueAsync } from "bvaughn-architecture-demo/src/hooks/useIndexedDB";
+import { preloadIDBInitialValues } from "bvaughn-architecture-demo/src/hooks/useIndexedDB";
 import { preCacheExecutionPointForTime } from "bvaughn-architecture-demo/src/suspense/PointsCache";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
@@ -58,18 +58,7 @@ export default function Initializer({
           }
         }
 
-        const idbPrefsPromises: Promise<any>[] = [];
-
-        if (recordingId) {
-          // Preload
-          for (let dbOptions of IDB_PREFS_DATABASES) {
-            for (let storeName of dbOptions.storeNames) {
-              idbPrefsPromises.push(getInitialIDBValueAsync(dbOptions, storeName, recordingId));
-            }
-          }
-
-          await Promise.all(idbPrefsPromises);
-        }
+        await preloadIDBInitialValues(IDB_PREFS_DATABASES, recordingId!);
 
         const sessionId = await client.initialize(activeRecordingId, activeAccessToken);
         const endpoint = await client.getSessionEndpoint(sessionId);

--- a/packages/bvaughn-architecture-demo/src/contexts/ConsoleFiltersContext.tsx
+++ b/packages/bvaughn-architecture-demo/src/contexts/ConsoleFiltersContext.tsx
@@ -82,7 +82,6 @@ export function ConsoleFiltersContextRoot({ children }: PropsWithChildren<{}>) {
     },
     recordName: recordingId,
     storeName: "filterToggles",
-    suspend: true,
   });
 
   // Filter input changes quickly while a user types, but re-filtering can be slow.

--- a/packages/bvaughn-architecture-demo/src/contexts/ConsoleFiltersContext.tsx
+++ b/packages/bvaughn-architecture-demo/src/contexts/ConsoleFiltersContext.tsx
@@ -82,6 +82,7 @@ export function ConsoleFiltersContextRoot({ children }: PropsWithChildren<{}>) {
     },
     recordName: recordingId,
     storeName: "filterToggles",
+    suspend: true,
   });
 
   // Filter input changes quickly while a user types, but re-filtering can be slow.

--- a/src/ui/setup/index.ts
+++ b/src/ui/setup/index.ts
@@ -2,7 +2,7 @@ import { loadedRegions as LoadedRegions, Location, SourceId } from "@replayio/pr
 
 import { CONSOLE_SETTINGS_DATABASE } from "bvaughn-architecture-demo/src/contexts/ConsoleFiltersContext";
 import { POINTS_DATABASE } from "bvaughn-architecture-demo/src/contexts/PointsContext";
-import { getInitialIDBValueAsync } from "bvaughn-architecture-demo/src/hooks/useIndexedDB";
+import { preloadIDBInitialValues } from "bvaughn-architecture-demo/src/hooks/useIndexedDB";
 import { preCacheExecutionPointForTime } from "bvaughn-architecture-demo/src/suspense/PointsCache";
 import type { TabsState } from "devtools/client/debugger/src/reducers/tabs";
 import { EMPTY_TABS } from "devtools/client/debugger/src/reducers/tabs";
@@ -128,15 +128,6 @@ const IDB_PREFS_DATABASES = [CONSOLE_SETTINGS_DATABASE, POINTS_DATABASE];
 
 export async function bootstrapApp() {
   const recordingId = getRecordingId();
-  const idbPrefsPromises: Promise<any>[] = [];
-
-  if (recordingId) {
-    for (let dbOptions of IDB_PREFS_DATABASES) {
-      for (let storeName of dbOptions.storeNames) {
-        idbPrefsPromises.push(getInitialIDBValueAsync(dbOptions, storeName, recordingId));
-      }
-    }
-  }
 
   // Load all async/IDB prefs in parallel before we continue.
   // We don't actively use the `idbPrefsPromises` data here,
@@ -145,7 +136,7 @@ export async function bootstrapApp() {
     getInitialLayoutState(),
     getInitialTabsState(),
     getInitialSourcesState(),
-    ...idbPrefsPromises,
+    preloadIDBInitialValues(IDB_PREFS_DATABASES, recordingId!),
   ] as const);
 
   const initialState = {


### PR DESCRIPTION
- Added Suspense caches to `useIndexedDB` to cache the DB instance itself for a given database, and the _initial_ value read for a given store + record.  
- Updated `bootstrapApp()` to know about all of our IDB database definitions, and preload the _initial_ value for each store during the setup process so that we can read it synchronously later
- Updated `useIndexedDB` to synchronously read that initial value if available so that we avoid flashes during rendering (such as applying console filters)