### PR TITLE
Fix showing console props

### DIFF
--- a/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
@@ -63,6 +63,9 @@ function Console() {
       sanitized.preview.properties = sanitized.preview.properties.filter(
         p => p.name !== "Snapshot"
       );
+
+      // suppress the prototype entry in the properties output
+      sanitized.preview.prototypeId = undefined;
     }
 
     return sanitized;

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -1,4 +1,4 @@
-import { Object, createPauseResult } from "@replayio/protocol";
+import { Object as ProtocolObject, createPauseResult } from "@replayio/protocol";
 import React, { useContext, useEffect, useState } from "react";
 
 import { highlightNodes, unhighlightNode } from "devtools/client/inspector/markup/actions/markup";
@@ -68,7 +68,7 @@ export function TestStepItem({ step, argString, index, id }: TestStepItemProps) 
 
     (async () => {
       try {
-        let consoleProps: Object | undefined;
+        let consoleProps: ProtocolObject | undefined;
 
         endPauseResult = pointEnd ? await client.createPause(pointEnd) : undefined;
         startPauseResult = pointStart ? await client.createPause(pointStart) : undefined;
@@ -120,14 +120,9 @@ export function TestStepItem({ step, argString, index, id }: TestStepItemProps) 
                 consolePropsProperty.object,
                 endPauseResult.pauseId
               );
-              const consoleProps = consolePropsPauseData.objects?.find(
+              consoleProps = consolePropsPauseData.objects?.find(
                 o => o.objectId === consolePropsProperty.object
               );
-
-              if (consoleProps?.preview) {
-                // suppress the prototype entry in the properties output
-                consoleProps.preview.prototypeId = undefined;
-              }
             }
           }
 


### PR DESCRIPTION
Variable shadowing strikes again!

Also moved mutating the console props object for prototype into the sanitizer so we don't mutate the possibly cached object ref.