### PR TITLE
Workaround for the source viewer flickering in the Replay browser (FE-1025)

### DIFF
--- a/packages/bvaughn-architecture-demo/components/sources/SourceListRow.module.css
+++ b/packages/bvaughn-architecture-demo/components/sources/SourceListRow.module.css
@@ -53,6 +53,13 @@
   width: 1.5rem;
   height: 1.5rem;
 }
+.HoverButtonCompanion {
+  position: absolute;
+  width: 1px;
+  height: 1rem;
+  background-color: white;
+  opacity: 0.0001;
+}
 
 .BreakpointIcon,
 .DisabledBreakpointIcon,

--- a/packages/bvaughn-architecture-demo/components/sources/SourceListRow.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/SourceListRow.tsx
@@ -278,6 +278,9 @@ const SourceListRow = memo(
           <div className={styles.LineSegmentsAndPointPanel}>
             {lineSegments}
 
+            {/* Workaround for FE-1025 */}
+            <div className={styles.HoverButtonCompanion}></div>
+
             {isHovered && (
               <Suspense>
                 <HoverButton


### PR DESCRIPTION
This is a pretty weird workaround for a pretty weird rendering issue in the Replay browser (see FE-1025).
Don't ask me how I came up with it :laughing: