### PR TITLE
Fix broken replaySessions definition and improve TS types

### DIFF
--- a/src/devtools/client/shared/prefs.d.ts
+++ b/src/devtools/client/shared/prefs.d.ts
@@ -3,14 +3,16 @@ export type PrefsType = "Bool" | "Char" | "String" | "Int" | "Float" | "Json";
 export type PrefsBlueprint = Record<string, [PrefsType, string]>;
 
 /** Convert from the string names to the appropriate TS type */
-export type PrefsTypeToTSType<T extends PrefsType> = T extends "Bool"
+export type PrefsTypeToTSType<T extends PrefsType, DefaultValueType = never> = T extends "Bool"
   ? boolean
   : T extends "Char" | "String"
   ? string
   : T extends "Int" | "Float"
   ? number
   : T extends "Json"
-  ? Record<string, unknown>
+  ? DefaultValueType extends never
+    ? Record<string, unknown>
+    : DefaultValueType
   : never;
 
 export declare type Prefs<BP extends PrefsBlueprint<K>> = {

--- a/src/devtools/shared/async-store-helper.d.ts
+++ b/src/devtools/shared/async-store-helper.d.ts
@@ -1,8 +1,14 @@
-import { Prefs, PrefsBlueprint } from "devtools/client/shared/prefs";
+import { PrefsType, PrefsTypeToTSType } from "devtools/client/shared/prefs";
 
-export function asyncStoreHelper<BP extends PrefsBlueprint>(
+export type AsyncPrefsBlueprint = Record<string, [PrefsType, string, any]>;
+
+export declare type AsyncPrefs<BP extends AsyncPrefsBlueprint<K>> = {
+  [key in keyof BP]: PrefsTypeToTSType<BP[key][0], BP[key][2]>;
+};
+
+export function asyncStoreHelper<BP extends AsyncPrefsBlueprint>(
   prefsRoot?: string,
   prefsBlueprint?: BP
-): Prefs<BP> & {
-  toJSON(): Prefs<BP>;
+): AsyncPrefs<BP> & {
+  toJSON(): AsyncPrefs<BP>;
 };

--- a/src/devtools/shared/async-store-helper.js
+++ b/src/devtools/shared/async-store-helper.js
@@ -21,11 +21,11 @@ export function asyncStoreHelper(root, mappings) {
   let store = {};
 
   function getMappingKey(key) {
-    return Array.isArray(mappings[key]) ? mappings[key][0] : mappings[key];
+    return Array.isArray(mappings[key]) ? mappings[key][1] : mappings[key];
   }
 
   function getMappingDefaultValue(key) {
-    return Array.isArray(mappings[key]) ? mappings[key][1] : null;
+    return Array.isArray(mappings[key]) ? mappings[key][2] : null;
   }
 
   Object.keys(mappings).map(key =>

--- a/src/ui/setup/prefs.ts
+++ b/src/ui/setup/prefs.ts
@@ -101,14 +101,14 @@ async function getReplaySessions() {
   if (replaySessions) {
     return replaySessions;
   }
-  replaySessions = (await asyncStore.replaySessions) as ReplaySessions;
+  replaySessions = await asyncStore.replaySessions;
   return replaySessions;
 }
 
 export async function getReplaySession(
   recordingId: RecordingId
 ): Promise<ReplaySession | undefined> {
-  return ((await asyncStore.replaySessions) as ReplaySessions)[recordingId];
+  return (await asyncStore.replaySessions)[recordingId];
 }
 
 export enum LocalNag {

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -1,6 +1,7 @@
 import { PrefsHelper } from "devtools/client/shared/prefs";
 import { asyncStoreHelper } from "devtools/shared/async-store-helper";
 import { pref } from "devtools/shared/services";
+import { ReplaySession } from "ui/setup/prefs";
 
 // Note: additional preferences are defined in other files,
 // including uses of `pref()`, `useLocalStorage`, and `useIndexedDB`.
@@ -75,5 +76,5 @@ export const features = new PrefsHelper("devtools.features", {
 });
 
 export const asyncStore = asyncStoreHelper("devtools", {
-  replaySessions: ["Json", "replay-sessions"],
+  replaySessions: ["Json", "replay-sessions", {} as Record<string, ReplaySession>],
 });


### PR DESCRIPTION
- Fixed an incorrect change to the `replay-sessions` key definition in `asyncStoreHelper`
- Improved the TS types for `asyncStoreHelper` to correctly capture the type of `"Json"` fields

There was a mismatch between how `PrefsHelper` and `asyncStoreHelper` define their string lookup keys and default values.  I had made a change to the one `asyncStoreHelper` usage thinking they were the _same_, but that was incorrect, and resulted in the field being incorrectly saved in IDB.