### PR TITLE
Highlight search results within a line

### DIFF
--- a/packages/bvaughn-architecture-demo/components/sources/SearchResultHighlight.module.css
+++ b/packages/bvaughn-architecture-demo/components/sources/SearchResultHighlight.module.css
@@ -1,0 +1,16 @@
+.Highlight {
+  position: absolute;
+  left: 0;
+  z-index: 2;
+
+  display: flex;
+}
+
+.ActiveMark {
+  background-color: var(--search-result-active-background-color);
+  color: var(--search-result-active-color);
+}
+.InactiveMark {
+  background-color: var(--search-result-inactive-background-color);
+  color: var(--search-result-inactive-color);
+}

--- a/packages/bvaughn-architecture-demo/components/sources/SearchResultHighlight.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/SearchResultHighlight.tsx
@@ -1,0 +1,24 @@
+import styles from "./SearchResultHighlight.module.css";
+
+export default function SearchResultHighlight({
+  columnIndex,
+  isActive,
+  text,
+}: {
+  columnIndex: number;
+  isActive: boolean;
+  text: string;
+}) {
+  return (
+    <pre className={styles.Highlight}>
+      <span
+        className={isActive ? styles.ActiveMark : styles.InactiveMark}
+        style={{
+          marginLeft: `${columnIndex + 1}ch`,
+        }}
+      >
+        {text}
+      </span>
+    </pre>
+  );
+}

--- a/packages/bvaughn-architecture-demo/components/sources/SourceListRow.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/SourceListRow.tsx
@@ -12,6 +12,8 @@ import {
 import { areEqual } from "react-window";
 
 import Icon from "bvaughn-architecture-demo/components/Icon";
+import SearchResultHighlight from "bvaughn-architecture-demo/components/sources/SearchResultHighlight";
+import { SourceSearchContext } from "bvaughn-architecture-demo/components/sources/SourceSearchContext";
 import useSourceContextMenu from "bvaughn-architecture-demo/components/sources/useSourceContextMenu";
 import { FocusContext } from "bvaughn-architecture-demo/src/contexts/FocusContext";
 import {
@@ -50,6 +52,7 @@ export type ItemData = {
 const SourceListRow = memo(
   ({ data, index, style }: { data: ItemData; index: number; style: CSSProperties }) => {
     const { isTransitionPending: isFocusRangePending } = useContext(FocusContext);
+    const [searchState] = useContext(SourceSearchContext);
 
     const [isHovered, setIsHovered] = useState(false);
 
@@ -245,6 +248,12 @@ const SourceListRow = memo(
       sourceUrl: source.url ?? null,
     });
 
+    const currentSearchResult = searchState.results[searchState.index] || null;
+    const searchResultsForLine = useMemo(
+      () => searchState.results.filter(result => result.lineIndex === index),
+      [index, searchState.results]
+    );
+
     return (
       <div
         className={styles.Row}
@@ -287,6 +296,15 @@ const SourceListRow = memo(
           )}
 
           <div className={styles.LineSegmentsAndPointPanel}>
+            {searchResultsForLine.map((result, resultIndex) => (
+              <SearchResultHighlight
+                key={resultIndex}
+                columnIndex={result.columnIndex}
+                isActive={result === currentSearchResult}
+                text={result.text}
+              />
+            ))}
+
             {lineSegments}
 
             {/* Workaround for FE-1025 */}

--- a/packages/bvaughn-architecture-demo/components/sources/SourceSearchContext.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/SourceSearchContext.tsx
@@ -22,10 +22,10 @@ export function SourceSearchContextRoot({ children }: { children: ReactNode }) {
 
   const focusedSourceId = focusedSource?.sourceId ?? null;
 
-  const [state, dispatch] = useSourceSearch(lineIndex => {
-    if (focusedSourceId !== null && lineIndex !== null) {
+  const [state, dispatch] = useSourceSearch(result => {
+    if (focusedSourceId != null && result != null) {
       // Update the highlighted line when the current search result changes.
-      openSource("search-result", focusedSourceId, lineIndex, lineIndex);
+      openSource("search-result", focusedSourceId, result.lineIndex, result.lineIndex);
     }
   });
 

--- a/packages/bvaughn-architecture-demo/pages/variables.css
+++ b/packages/bvaughn-architecture-demo/pages/variables.css
@@ -45,7 +45,7 @@
   --background-color-disabled-button: #454950;
   --background-color-high-contrast-button: #081120;
   --background-color-current-execution-point: #25364e;
-  --background-color-current-search-result: #42381f;
+  --background-color-current-search-result: #25364e;
   --background-color-warning: #42381f;
   --background-color-inputs: #0e1119;
   --background-color-source-search: #25364e;
@@ -169,6 +169,11 @@
   --region-unfocused-color: var(--background-color-contrast-3);
   --region-loaded-color: #939395;
   --region-loading-color: #69e261;
+
+  --search-result-active-background-color: #fffd03;
+  --search-result-active-color: #000000;
+  --search-result-inactive-background-color: #ff9632;
+  --search-result-inactive-color: #000000;
 }
 
 :root.theme-light {
@@ -196,7 +201,7 @@
   --background-color-disabled-button: #666666;
   --background-color-high-contrast-button: #f2f2f2;
   --background-color-current-execution-point: #eaf3ff;
-  --background-color-current-search-result: #fffac8;
+  --background-color-current-search-result: #eaf3ff;
   --background-color-warning: #fffac8;
   --background-color-inputs: #e6e6e6;
   --background-color-source-search: #eaf3ff;
@@ -320,4 +325,9 @@
   --region-unfocused-color: var(--background-color-contrast-1);
   --region-loaded-color: #ff0000;
   --region-loading-color: #73cc6d;
+
+  --search-result-active-background-color: #fffd03;
+  --search-result-active-color: #000000;
+  --search-result-inactive-background-color: #ff9632;
+  --search-result-inactive-color: #000000;
 }


### PR DESCRIPTION
Changed Source search to highlight column-level results _and_ to account for more than one match per line. This looks and feels more like the browser's built-in search feature now. (For search result highlighting, I just copied Chrome's colors.)

![Kapture 2022-12-07 at 15 01 57](https://user-images.githubusercontent.com/29597/206283806-e3f712c8-14c8-47d8-9ff4-b3400d457e5e.gif)

cc @jonbell-lot23 