### PR TITLE
Remove apparently-broken positioning for "after last request" line

### DIFF
--- a/src/ui/components/NetworkMonitor/RequestTable.module.css
+++ b/src/ui/components/NetworkMonitor/RequestTable.module.css
@@ -53,8 +53,6 @@ table.requests {
   background: var(--secondary-accent);
   height: 2px;
   width: 100%;
-  position: absolute;
-  bottom: 0;
 }
 
 .resizer {


### PR DESCRIPTION
- Updated styles for the "after last network request" red line to keep it relatively positioned

This seems like it has been broken for a while, and the code around this hasn't meaningfully changed.  With the absolute positioning, the line can end up in a very wrong position (in this case, it was at the bottom of the initially visible scroll area, and when I scrolled further down the line stayed over the same request row):

![image](https://user-images.githubusercontent.com/1128784/206296428-0c1c7086-76c4-4686-94b0-e88d7b10b27a.png)

whereas without the absolute positioning it appears to slot into place after the last request row:

![image](https://user-images.githubusercontent.com/1128784/206296627-d58086cd-1114-4edb-8cba-09731238b128.png)
