### PR TITLE
Add stable/unstable query cache flags

### DIFF
--- a/packages/protocol/socket.ts
+++ b/packages/protocol/socket.ts
@@ -96,6 +96,8 @@ export type ExperimentalSettings = {
   disableCache?: boolean;
   disableScanDataCache?: boolean;
   disableQueryCache?: boolean;
+  disableStableQueryCache?: boolean;
+  disableUnstableQueryCache?: boolean;
   profileWorkerThreads?: boolean;
 };
 

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -198,7 +198,8 @@ export function createSocket(
       const experimentalSettings: ExperimentalSettings = {
         disableScanDataCache: !!features.disableScanDataCache,
         disableCache: !!prefs.disableCache,
-        disableQueryCache: !features.enableQueryCache,
+        disableStableQueryCache: !!features.disableStableQueryCache,
+        disableUnstableQueryCache: !features.enableUnstableQueryCache,
         listenForMetrics: !!prefs.listenForMetrics,
         profileWorkerThreads: !!features.profileWorkerThreads,
       };

--- a/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
+++ b/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
@@ -27,10 +27,15 @@ const EXPERIMENTAL_SETTINGS: ExperimentalSetting[] = [
     key: "profileWorkerThreads",
   },
   {
-    label: "Enable query-level caching",
+    label: "Enable query-level caching for unstable request types",
     description:
       "Allow the backend to return previously generated responses without re-running the request",
-    key: "enableQueryCache",
+    key: "enableUnstableQueryCache",
+  },
+  {
+    label: "Disable query-level caching for stable request types",
+    description: "Disable caching of previously generated responses",
+    key: "disableStableQueryCache",
   },
   {
     label: "Detailed loading bar",
@@ -89,8 +94,11 @@ export default function ExperimentalSettings({}) {
   } = useFeature("consoleFilterDrawerDefaultsToOpen");
   const { value: profileWorkerThreads, update: updateProfileWorkerThreads } =
     useFeature("profileWorkerThreads");
-  const { value: enableQueryCache, update: updateEnableQueryCache } =
-    useFeature("enableQueryCache");
+  const { value: enableUnstableQueryCache, update: updateEnableUnstableQueryCache } = useFeature(
+    "enableUnstableQueryCache"
+  );
+  const { value: disableStableQueryCache, update: updateDisableStableQueryCache } =
+    useFeature("disableStableQueryCache");
   const { value: basicProcessingLoadingBar, update: updateBasicProcessingLoadingBar } = useFeature(
     "basicProcessingLoadingBar"
   );
@@ -100,8 +108,10 @@ export default function ExperimentalSettings({}) {
       updateEnableColumnBreakpoints(!enableColumnBreakpoints);
     } else if (key === "profileWorkerThreads") {
       updateProfileWorkerThreads(!profileWorkerThreads);
-    } else if (key === "enableQueryCache") {
-      updateEnableQueryCache(!enableQueryCache);
+    } else if (key === "enableUnstableQueryCache") {
+      updateEnableUnstableQueryCache(!enableUnstableQueryCache);
+    } else if (key === "disableStableQueryCache") {
+      updateDisableStableQueryCache(!disableStableQueryCache);
     } else if (key === "basicProcessingLoadingBar") {
       updateBasicProcessingLoadingBar(!basicProcessingLoadingBar);
     } else if (key === "consoleFilterDrawerDefaultsToOpen") {
@@ -115,8 +125,9 @@ export default function ExperimentalSettings({}) {
     basicProcessingLoadingBar,
     consoleFilterDrawerDefaultsToOpen,
     disableScanDataCache,
+    disableStableQueryCache,
     enableColumnBreakpoints,
-    enableQueryCache,
+    enableUnstableQueryCache,
     profileWorkerThreads,
   };
 

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -19,8 +19,9 @@ export type LocalExperimentalUserSettings = {
   basicProcessingLoadingBar: boolean;
   disableScanDataCache: boolean;
   consoleFilterDrawerDefaultsToOpen: boolean;
-  enableQueryCache: boolean;
+  disableStableQueryCache: boolean;
   enableColumnBreakpoints: boolean;
+  enableUnstableQueryCache: boolean;
   profileWorkerThreads: boolean;
 };
 

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -27,8 +27,9 @@ pref("devtools.features.commentAttachments", false);
 pref("devtools.features.consoleFilterDrawerDefaultsToOpen", false);
 pref("devtools.features.disableScanDataCache", false);
 pref("devtools.features.disableUnHitLines", false);
+pref("devtools.features.disableStableQueryCache", false);
+pref("devtools.features.enableUnstableQueryCache", false);
 pref("devtools.features.enableLargeText", false);
-pref("devtools.features.enableQueryCache", false);
 pref("devtools.features.hitCounts", true);
 pref("devtools.features.logProtocol", false);
 pref("devtools.features.logProtocolEvents", false);
@@ -61,9 +62,10 @@ export const features = new PrefsHelper("devtools.features", {
   commentAttachments: ["Bool", "commentAttachments"],
   consoleFilterDrawerDefaultsToOpen: ["Bool", "consoleFilterDrawerDefaultsToOpen"],
   disableScanDataCache: ["Bool", "disableScanDataCache"],
-  enableQueryCache: ["Bool", "enableQueryCache"],
+  disableStableQueryCache: ["Bool", "disableStableQueryCache"],
   disableUnHitLines: ["Bool", "disableUnHitLines"],
   enableLargeText: ["Bool", "enableLargeText"],
+  enableUnstableQueryCache: ["Bool", "enableUnstableQueryCache"],
   logProtocol: ["Bool", "logProtocol"],
   logProtocolEvents: ["Bool", "logProtocolEvents"],
   newControllerOnRefresh: ["Bool", "newControllerOnRefresh"],


### PR DESCRIPTION
I kind of don't like how complicated this is getting, but I *do* want the ability to toggle these things on/off separately.



Pairs with https://github.com/replayio/backend/pull/6698/