### PR TITLE
Fix broken Redux logo in grouped stack frames

### DIFF
--- a/src/devtools/client/debugger/src/utils/pause/frames/getLibraryFromUrl.ts
+++ b/src/devtools/client/debugger/src/utils/pause/frames/getLibraryFromUrl.ts
@@ -87,7 +87,7 @@ const libraryMap = [
     contextPattern: /zone\.js/,
   },
   {
-    label: "@reduxjs/toolkit",
+    label: "Redux",
     pattern: /redux/i,
   },
   {


### PR DESCRIPTION
Apparently when I changed the text label name from "redux" to "@reduxjs/toolkit" a few months ago, that broke the logo because it's looking for `.img .redux` (and it lower-cases the library name to get the classname).  So, reverting it back:

![image](https://user-images.githubusercontent.com/1128784/206308626-4649ff43-a808-477f-b9da-e56684bc48a0.png)
