### PR TITLE
Use times for test step status when playing or dragging

### DIFF
--- a/src/ui/components/Timeline/index.tsx
+++ b/src/ui/components/Timeline/index.tsx
@@ -2,7 +2,11 @@ import { MouseEvent, useLayoutEffect, useRef, useState } from "react";
 
 import { seekToTime, setTimelineToTime, stopPlayback } from "ui/actions/timeline";
 import { selectors } from "ui/reducers";
-import { isPlaying as isPlayingSelector, setTimelineState } from "ui/reducers/timeline";
+import {
+  isPlaying as isPlayingSelector,
+  setDragging,
+  setTimelineState,
+} from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { getTimeFromPosition } from "ui/utils/timeline";
 
@@ -86,6 +90,8 @@ export default function Timeline() {
     );
     const isDragging = event.buttons === 1;
 
+    dispatch(setDragging(isDragging));
+
     if (hoverTime != mouseTime) {
       dispatch(setTimelineToTime(mouseTime, isDragging));
     }
@@ -102,6 +108,7 @@ export default function Timeline() {
       zoomRegion
     );
 
+    dispatch(setDragging(false));
     dispatch(seekToTime(mouseTime, resumePlaybackOnMouseUp));
 
     if (resumePlaybackOnMouseUp) {

--- a/src/ui/reducers/timeline.ts
+++ b/src/ui/reducers/timeline.ts
@@ -32,6 +32,7 @@ function initialTimelineState(): TimelineState {
     unprocessedRegions: [],
     /** @deprecated This appears to be obsolete for now? */
     zoomRegion: { beginTime: 0, endTime: 0, scale: 1 },
+    dragging: false,
   };
 }
 
@@ -39,6 +40,9 @@ const timelineSlice = createSlice({
   name: "timeline",
   initialState: initialTimelineState,
   reducers: {
+    setDragging(state, action: PayloadAction<boolean>) {
+      state.dragging = action.payload;
+    },
     setTimelineState(state, action: PayloadAction<Partial<TimelineState>>) {
       // This is poor action design and we should avoid this :(
       Object.assign(state, action.payload);
@@ -83,6 +87,7 @@ const lessThan = (a: number, b: number) => b - a > EPSILON;
 
 export const {
   allPaintsReceived,
+  setDragging,
   setHoveredItem,
   setPlaybackPrecachedTime,
   setPlaybackStalled,
@@ -134,6 +139,7 @@ export const getCurrentTime = (state: UIState) => state.timeline.currentTime;
 export const getHoverTime = (state: UIState) => state.timeline.hoverTime;
 export const getPlayback = (state: UIState) => state.timeline.playback;
 export const getShowFocusModeControls = (state: UIState) => state.timeline.showFocusModeControls;
+export const isDragging = (state: UIState) => state.timeline.dragging;
 export const isPlaying = (state: UIState) => state.timeline.playback !== null;
 export const isPlaybackStalled = (state: UIState) => state.timeline.stalled;
 export const getUnprocessedRegions = (state: UIState) => state.timeline.unprocessedRegions;

--- a/src/ui/state/timeline.ts
+++ b/src/ui/state/timeline.ts
@@ -35,6 +35,7 @@ export interface TimelineState {
   timelineDimensions: { width: number; left: number; top: number };
   unprocessedRegions: TimeRange[];
   zoomRegion: ZoomRegion;
+  dragging: boolean;
 }
 
 export interface HoveredItem {


### PR DESCRIPTION
When playing or dragging the timeline, we should use the times instead of points to determine the active state. This will introduce a little variation in behavior because times are less precise but I don't expect it to be noticeable to the user.