### PR TITLE
Consolidate test step actions into a hook

### DIFF
--- a/src/devtools/client/debugger/src/components/TestInfo/CypressToggler.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/CypressToggler.tsx
@@ -1,35 +1,27 @@
 import React from "react";
 
-import { seekToTime } from "ui/actions/timeline";
+import { useTestStepActions } from "ui/hooks/useTestStepActions";
 import { getSelectedStep } from "ui/reducers/reporter";
-import { getCurrentTime } from "ui/reducers/timeline";
-import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
+import { useAppSelector } from "ui/setup/hooks";
 
 import styles from "./CypressToggler.module.css";
 
 export function CypressToggler() {
-  const currentTime = useAppSelector(getCurrentTime);
-  const dispatch = useAppDispatch();
   const selectedStep = useAppSelector(getSelectedStep);
+  const { isAtStepStart, isAtStepEnd, seekToStepEnd, seekToStepStart } =
+    useTestStepActions(selectedStep);
 
-  if (!selectedStep || selectedStep.startTime === selectedStep.endTime) {
+  if (!selectedStep || (isAtStepStart && isAtStepEnd)) {
     return null;
   }
-
-  const onBefore = () => {
-    dispatch(seekToTime(selectedStep.startTime));
-  };
-  const onAfter = () => {
-    dispatch(seekToTime(selectedStep.endTime));
-  };
 
   return (
     <div className={styles.ToggleWrapper}>
       <div className={styles.ToggleContainer}>
-        <Button onClick={onBefore} active={currentTime === selectedStep.startTime}>
+        <Button onClick={seekToStepStart} active={isAtStepStart}>
           Before
         </Button>
-        <Button onClick={onAfter} active={currentTime === selectedStep.endTime}>
+        <Button onClick={seekToStepEnd} active={isAtStepEnd}>
           After
         </Button>
       </div>

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -157,13 +157,7 @@ export function TestStepItem({ step, argString, index, id }: TestStepItemProps) 
         setPauseId(localPauseData.endPauseId);
       }
       dispatch(seek(pointStart!, step.absoluteStartTime, false, localPauseData?.startPauseId));
-      dispatch(
-        setSelectedStep({
-          id,
-          startTime: step.absoluteStartTime,
-          endTime: step.absoluteEndTime - 1,
-        })
-      );
+      dispatch(setSelectedStep(step));
     }
   };
   const onMouseEnter = () => {

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -22,7 +22,7 @@ import { ThreadFront } from "protocol/thread";
 import { PauseEventArgs } from "protocol/thread/thread";
 import { waitForTime } from "protocol/utils";
 import { getFirstComment } from "ui/hooks/comments/comments";
-import { selectedStepCleared } from "ui/reducers/reporter";
+import { mayClearSelectedStep } from "ui/reducers/reporter";
 import {
   getCurrentTime,
   getFocusRegion,
@@ -243,7 +243,7 @@ export function seek(
   pauseId?: PauseId
 ): UIThunkAction<boolean> {
   return (dispatch, getState, { ThreadFront }) => {
-    dispatch(selectedStepCleared());
+    dispatch(mayClearSelectedStep({ point, time }));
     dispatch(framePositionsCleared());
     if (pauseId) {
       ThreadFront.timeWarpToPause({ point, time, pauseId }, openSource);

--- a/src/ui/hooks/useTestStepActions.ts
+++ b/src/ui/hooks/useTestStepActions.ts
@@ -1,0 +1,131 @@
+import { useContext } from "react";
+
+import { selectLocation } from "devtools/client/debugger/src/actions/sources";
+import { returnFirst } from "devtools/client/debugger/src/components/TestInfo/TestStepItem";
+import { getContext } from "devtools/client/debugger/src/selectors";
+import { ReplayClientContext } from "shared/client/ReplayClientContext";
+import { getCurrentPoint } from "ui/actions/app";
+import { seek, seekToTime, startPlayback } from "ui/actions/timeline";
+import { getCurrentTime } from "ui/reducers/timeline";
+import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
+import { AnnotatedTestStep, TestItem } from "ui/types";
+
+export const useTestStepActions = (testStep: AnnotatedTestStep | null) => {
+  const dispatch = useAppDispatch();
+  const currentTime = useAppSelector(getCurrentTime);
+  const currentPoint = useAppSelector(getCurrentPoint);
+  const cx = useAppSelector(getContext);
+  const client = useContext(ReplayClientContext);
+
+  const isAtStepStart =
+    currentPoint && testStep?.annotations.start
+      ? BigInt(currentPoint) === BigInt(testStep.annotations.start.point)
+      : !!testStep && currentTime === testStep.absoluteStartTime;
+  const canJumpToBefore = !isAtStepStart;
+
+  const isAtStepEnd =
+    currentPoint && testStep?.annotations.end
+      ? BigInt(currentPoint) === BigInt(testStep.annotations.end.point)
+      : !!testStep && currentTime === testStep.absoluteEndTime;
+  const canJumpToAfter = !isAtStepEnd;
+
+  const playFromStep = (test: TestItem) => {
+    if (!testStep) {
+      return;
+    }
+
+    dispatch(
+      startPlayback({
+        beginTime: testStep.absoluteStartTime,
+        endTime: test.relativeStartTime + test.duration,
+      })
+    );
+  };
+
+  const playToStep = (test: TestItem) => {
+    if (!testStep) {
+      return;
+    }
+    dispatch(
+      startPlayback({
+        beginTime: test.relativeStartTime,
+        endTime: testStep.absoluteStartTime,
+      })
+    );
+  };
+
+  const seekToStepStart = () => {
+    if (!canJumpToBefore || !testStep) {
+      return;
+    }
+
+    const start = testStep.annotations.start;
+    if (start) {
+      dispatch(seek(start.point, start.time, false));
+    } else {
+      dispatch(seekToTime(testStep.absoluteStartTime));
+    }
+  };
+
+  const seekToStepEnd = () => {
+    if (!canJumpToAfter || !testStep) {
+      return;
+    }
+
+    const end = testStep.annotations.end;
+    if (end) {
+      dispatch(seek(end.point, end.time, false));
+    } else {
+      dispatch(seekToTime(testStep.absoluteEndTime - 1));
+    }
+  };
+
+  const showStepSource = async () => {
+    if (!testStep?.annotations.enqueue) {
+      return;
+    }
+
+    const point = testStep.annotations.enqueue.point;
+
+    const {
+      data: { frames },
+    } = await client.createPause(point);
+
+    if (frames) {
+      // find the cypress marker frame
+      const markerFrameIndex = returnFirst(frames, (f: any, i: any, l: any) =>
+        f.functionName === "__stackReplacementMarker" ? i : null
+      );
+
+      // and extract its sourceId
+      const markerSourceId = frames[markerFrameIndex]?.functionLocation?.[0].sourceId;
+      if (markerSourceId) {
+        // slice the frames from the current to the marker frame and reverse
+        // it so the user frames are on top
+        const userFrames = frames?.slice(0, markerFrameIndex).reverse();
+
+        // then search from the top for the first frame from the same source
+        // as the marker (which should be cypress_runner.js) and return it
+        const frame = returnFirst(userFrames, (f, i, l) => {
+          return l[i + 1]?.functionLocation?.some(fl => fl.sourceId === markerSourceId) ? f : null;
+        });
+
+        const location = frame?.location[frame.location.length - 1];
+
+        if (location) {
+          dispatch(selectLocation(cx, location));
+        }
+      }
+    }
+  };
+
+  return {
+    isAtStepEnd,
+    isAtStepStart,
+    playFromStep,
+    playToStep,
+    seekToStepEnd,
+    seekToStepStart,
+    showStepSource,
+  };
+};


### PR DESCRIPTION
* Consolidate the seek and source actions for a step into a new hook
* Change the selected step redux state to use `AnnotatedTestStep` so we have the complete details for a step
* Change the selected step clear logic to only clear if the target point/time isn't the start or end of the selected step so we can jump between before/after without losing the selection