### PR TITLE
Be defensive about URL parsing

### DIFF
--- a/src/ui/utils/environment.ts
+++ b/src/ui/utils/environment.ts
@@ -179,9 +179,13 @@ export function getDisplayedUrl(url: string | undefined) {
     return "";
   }
 
-  const urlObj = new URL(url);
-  const { hostname, pathname } = urlObj;
-  return `${hostname}${pathname}`;
+  try {
+    const urlObj = new URL(url);
+    const { hostname, pathname } = urlObj;
+    return `${hostname}${pathname}`;
+  } catch (e) {
+    return "";
+  }
 }
 
 export function getSystemColorSchemePreference() {


### PR DESCRIPTION
I just hit this on a recording where I manually changed the URL to `foobar`. That's probably not a common case, but we *do* have an API where users can set the recording metadata to whatever they want. Given that, we should probably be careful when parsing that info to not throw.