### PR TITLE
Add support to play from/to a point

### DIFF
--- a/src/ui/hooks/useTestStepActions.ts
+++ b/src/ui/hooks/useTestStepActions.ts
@@ -49,7 +49,8 @@ export const useTestStepActions = (testStep: AnnotatedTestStep | null) => {
     dispatch(
       startPlayback({
         beginTime: test.relativeStartTime,
-        endTime: testStep.absoluteStartTime,
+        endTime: testStep.annotations.end?.time || testStep.absoluteEndTime,
+        endPoint: testStep.annotations.end?.point,
       })
     );
   };

--- a/src/ui/state/timeline.ts
+++ b/src/ui/state/timeline.ts
@@ -56,6 +56,8 @@ export enum FocusOperation {
 }
 
 export type PlaybackOptions = {
+  beginPoint?: string;
+  endPoint?: string;
   beginTime: number | null;
   endTime: number | null;
 };


### PR DESCRIPTION
## Summary

* Adds support for starting and ending points to playback via new `playbackPoints` action
* Move the feature check into `fetchScreenshotForPause` since it already returns `undefined` for a failed fetch to unlock using that method here without duplicating the feature check. The existing call site already had to account for the method returning `undefined`.
* Adds a new method to add a screenshot to `gPaintPoints` for a particular point so we can accurately start and stop where we want with the correct paint.