### PR TITLE
Fix selecting a test step when annotations failed to load

### DIFF
--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -4,7 +4,7 @@ import React, { useContext, useEffect, useState } from "react";
 import { highlightNodes, unhighlightNode } from "devtools/client/inspector/markup/actions/markup";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { getCurrentPoint } from "ui/actions/app";
-import { seek, setTimelineToPauseTime, setTimelineToTime } from "ui/actions/timeline";
+import { seek, seekToTime, setTimelineToPauseTime, setTimelineToTime } from "ui/actions/timeline";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
 import { getSelectedStep, setSelectedStep } from "ui/reducers/reporter";
 import {
@@ -147,12 +147,17 @@ export function TestStepItem({ step, argString, index, id }: TestStepItemProps) 
   }, [client, messageEnd, pointEnd, pointStart]);
 
   const onClick = () => {
-    if (id && pointStart) {
-      if (localPauseData?.endPauseId && localPauseData.consoleProps) {
-        setConsoleProps(localPauseData.consoleProps);
-        setPauseId(localPauseData.endPauseId);
+    if (id) {
+      if (pointStart) {
+        if (localPauseData?.endPauseId && localPauseData.consoleProps) {
+          setConsoleProps(localPauseData.consoleProps);
+          setPauseId(localPauseData.endPauseId);
+        }
+        dispatch(seek(pointStart!, step.absoluteStartTime, false, localPauseData?.startPauseId));
+      } else {
+        dispatch(seekToTime(step.absoluteStartTime, false));
       }
-      dispatch(seek(pointStart!, step.absoluteStartTime, false, localPauseData?.startPauseId));
+
       dispatch(setSelectedStep(step));
     }
   };


### PR DESCRIPTION
## Issue

When annotations fail to load, we don't have start and end points so the `onClick` handler was bailing early.

## Resolution

Fall back to start time to navigate the timeline on click.

## Notes

I didn't update the hover handlers in the same way because our experience has been that the screenshots available are off enough that I think it's more confusing to show the wrong thing on hover than not change the video at all.