### PR TITLE
Fix log point panel white-space collapsing behavior in Firefox

### DIFF
--- a/packages/bvaughn-architecture-demo/components/lexical/CodeEditor.tsx
+++ b/packages/bvaughn-architecture-demo/components/lexical/CodeEditor.tsx
@@ -8,7 +8,9 @@ import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
 import { $rootTextContent } from "@lexical/text";
 import {
   $getRoot,
+  COMMAND_PRIORITY_CRITICAL,
   EditorState,
+  KEY_ENTER_COMMAND,
   Klass,
   LexicalEditor,
   LexicalNode,
@@ -31,6 +33,7 @@ import styles from "./styles.module.css";
 const NODES: Array<Klass<LexicalNode>> = [LineBreakNode, CodeNode, TextNode];
 
 export default function CodeEditor({
+  allowWrapping = true,
   autoFocus = false,
   dataTestId,
   dataTestName,
@@ -41,6 +44,7 @@ export default function CodeEditor({
   onSave,
   placeholder = "",
 }: {
+  allowWrapping?: boolean;
   autoFocus?: boolean;
   dataTestId?: string;
   dataTestName?: string;
@@ -106,6 +110,24 @@ export default function CodeEditor({
       }
     }
   };
+
+  useEffect(() => {
+    if (!allowWrapping) {
+      const editor = editorRef.current;
+      if (editor) {
+        const onEnter = (event: KeyboardEvent) => {
+          if (event.shiftKey) {
+            event.preventDefault();
+            return true;
+          }
+
+          return false;
+        };
+
+        return editor.registerCommand(KEY_ENTER_COMMAND, onEnter, COMMAND_PRIORITY_CRITICAL);
+      }
+    }
+  }, [allowWrapping, editorRef]);
 
   const onFormSubmit = (editorState: EditorState) => {
     const editor = editorRef.current;

--- a/packages/bvaughn-architecture-demo/components/sources/PointPanel.module.css
+++ b/packages/bvaughn-architecture-demo/components/sources/PointPanel.module.css
@@ -97,7 +97,7 @@
   height: 0.5rem;
 }
 .Content [data-test-name="PointPanel-ContentInput"] {
-  white-space: nowrap !important;
+  white-space: pre !important;
 }
 
 .AddConditionButton,

--- a/packages/bvaughn-architecture-demo/components/sources/PointPanel.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/PointPanel.tsx
@@ -146,6 +146,7 @@ function PointPanel({ className, point }: { className: string; point: Point }) {
                       }
                     >
                       <CodeEditor
+                        allowWrapping={false}
                         autoFocus={editReason === "condition"}
                         dataTestId={`PointPanel-ConditionInput-${lineNumber}`}
                         dataTestName="PointPanel-ConditionInput"
@@ -173,6 +174,7 @@ function PointPanel({ className, point }: { className: string; point: Point }) {
                     }
                   >
                     <CodeEditor
+                      allowWrapping={false}
                       autoFocus={showEditBreakpointNag || editReason === "content"}
                       dataTestId={`PointPanel-ContentInput-${lineNumber}`}
                       dataTestName="PointPanel-ContentInput"


### PR DESCRIPTION
Referencing the [docs](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space) for `white-space`, it seems like `"pre"` is the only value that doesn't collapse spaces _or_ wrap implicitly. It _does_ wrap explicitly though, so we need to disable that programmatically.