### PR TITLE
Updated useSearch reducer to fix potential infinite update loop

### DIFF
--- a/packages/bvaughn-architecture-demo/components/sources/hooks/useSearch.ts
+++ b/packages/bvaughn-architecture-demo/components/sources/hooks/useSearch.ts
@@ -175,21 +175,27 @@ function reducer<Item, Result, QueryData = never>(
       const cachedScopes = state.cachedScopes;
       if (currentScopeId !== null) {
         const currentScope = cachedScopes[currentScopeId];
-        if (currentScope != null && currentScope.results !== results) {
-          return {
-            ...state,
-            cachedScopes: {
-              ...cachedScopes,
-              [currentScopeId]: {
-                ...currentScope,
-                query,
-                queryData,
-                results,
+        if (currentScope != null) {
+          if (
+            currentScope.query !== query ||
+            currentScope.queryData !== queryData ||
+            currentScope.results !== results
+          ) {
+            return {
+              ...state,
+              cachedScopes: {
+                ...cachedScopes,
+                [currentScopeId]: {
+                  ...currentScope,
+                  query,
+                  queryData,
+                  results,
+                },
               },
-            },
-            index,
-            results,
-          };
+              index,
+              results,
+            };
+          }
         }
       }
 


### PR DESCRIPTION
See comment trail on [a30cdfaf-5342-42dc-9688-cae2bc336a9a](https://app.replay.io/recording/fe-1043-too-many-re-renders--a30cdfaf-5342-42dc-9688-cae2bc336a9a) for why this change was needed.

This error wasn't the easiest to repro, but I _think_ I verified the fix afterward.