### PR TITLE
Refactor focus region UI (FE-1040, FE-1041)

### DIFF
--- a/packages/bvaughn-architecture-demo/src/utils/testing.tsx
+++ b/packages/bvaughn-architecture-demo/src/utils/testing.tsx
@@ -194,9 +194,9 @@ export function createMockReplayClient() {
     getObjectWithPreview: jest.fn().mockImplementation(async () => ({})),
     getObjectProperty: jest.fn().mockImplementation(async () => ({})),
     getPointNearTime: jest.fn().mockImplementation(async () => ({ point: "0", time: 0 })),
-    getPointsBoundingTime: jest.fn().mockImplementation(async () => ({
-      before: { point: "0", time: 0 },
-      after: { point: "0", time: 0 },
+    getPointsBoundingTime: jest.fn().mockImplementation(async time => ({
+      before: { point: String(time), time },
+      after: { point: String(time), time },
     })),
     getPreferredLocation: jest.fn().mockImplementation(async () => ({})),
     getRecordingCapabilities: jest.fn().mockImplementation(async () => ({

--- a/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
@@ -1,11 +1,10 @@
 import classnames from "classnames";
 import { createContext, useEffect, useState } from "react";
 
-import { getRecordingDuration } from "ui/actions/app";
 import {
   seek,
   seekToTime,
-  setFocusRegion,
+  setFocusRegionFromTimeRange,
   startPlayback,
   syncFocusedRegion,
   updateFocusRegionParam,
@@ -17,7 +16,6 @@ import {
   getSelectedTest,
   setSelectedTest,
 } from "ui/reducers/reporter";
-import { getFocusRegion } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { TestItem, TestResult, TestStep } from "ui/types";
 
@@ -54,26 +52,15 @@ export function TestCase({ test, index }: { test: TestItem; index: number }) {
   const isSelected = selectedTest === index;
   const annotationsStart = useAppSelector(getReporterAnnotationsForTitleEnd);
 
-  const duration = useAppSelector(getRecordingDuration);
   const testStartTime = test.relativeStartTime || 0;
   const testEndTime = testStartTime + (test.duration || 0);
-  const focusRegion = useAppSelector(getFocusRegion);
-  const isFocused =
-    focusRegion?.beginTime === testStartTime && focusRegion?.endTime === testEndTime;
 
   const onFocus = () => {
-    if (isFocused) {
+    if (testEndTime > testStartTime) {
       dispatch(
-        setFocusRegion({
-          beginTime: 0,
-          endTime: duration,
-        })
-      );
-    } else if (testEndTime > testStartTime) {
-      dispatch(
-        setFocusRegion({
-          beginTime: testStartTime,
-          endTime: testEndTime,
+        setFocusRegionFromTimeRange({
+          begin: testStartTime,
+          end: testEndTime,
         })
       );
     }

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -1,7 +1,8 @@
-import { ExecutionPoint, PauseId, ScreenShot } from "@replayio/protocol";
-import sortedIndexBy from "lodash/sortedIndexBy";
-import sortedLastIndexBy from "lodash/sortedLastIndexBy";
+import { AnyAction, ThunkDispatch } from "@reduxjs/toolkit";
+import { ExecutionPoint, PauseId, ScreenShot, TimeRange } from "@replayio/protocol";
+import throttle from "lodash/throttle";
 
+import { getPointsBoundingTimeAsync } from "bvaughn-architecture-demo/src/suspense/PointsCache";
 import { framePositionsCleared, resumed } from "devtools/client/debugger/src/reducers/pause";
 import {
   addLastScreen,
@@ -27,6 +28,7 @@ import { getFirstComment } from "ui/hooks/comments/comments";
 import { mayClearSelectedStep } from "ui/reducers/reporter";
 import {
   getCurrentTime,
+  getDisplayedFocusRegion,
   getFocusRegion,
   getHoverTime,
   getHoveredItem,
@@ -35,9 +37,11 @@ import {
   getRecordingDuration,
   getShowFocusModeControls,
   getZoomRegion,
-  pointsReceivedThunk,
+  pointsReceived,
+  setDisplayedFocusRegion,
   setPlaybackPrecachedTime,
 } from "ui/reducers/timeline";
+import { UIState } from "ui/state";
 import { FocusRegion, HoveredItem, PlaybackOptions } from "ui/state/timeline";
 import {
   encodeObjectToURL,
@@ -48,12 +52,8 @@ import {
 import KeyShortcuts, { isEditableElement } from "ui/utils/key-shortcuts";
 import { features } from "ui/utils/prefs";
 import { trackEvent } from "ui/utils/telemetry";
-import {
-  displayedBeginForFocusRegion,
-  displayedEndForFocusRegion,
-  isTimeInRegions,
-  rangeForFocusRegion,
-} from "ui/utils/timeline";
+import { ThunkExtraArgs } from "ui/utils/thunk";
+import { isTimeInRegions, rangeForFocusRegion } from "ui/utils/timeline";
 
 import {
   setFocusRegion as newFocusRegion,
@@ -96,7 +96,7 @@ export async function setupTimeline(store: UIStore) {
 export function jumpToInitialPausePoint(): UIThunkAction {
   return async (dispatch, getState, { ThreadFront, replayClient }) => {
     const endpoint = await replayClient.getSessionEndpoint(replayClient.getSessionId()!);
-    dispatch(pointsReceivedThunk([endpoint]));
+    dispatch(pointsReceived([endpoint]));
     let { point, time } = endpoint;
 
     const state = getState();
@@ -112,13 +112,7 @@ export function jumpToInitialPausePoint(): UIThunkAction {
       const focusRegion =
         "focusRegion" in initialPausePoint ? initialPausePoint.focusRegion : undefined;
       if (focusRegion) {
-        dispatch(
-          newFocusRegion({
-            ...focusRegion,
-            beginTime: focusRegion.begin.time,
-            endTime: focusRegion.end.time,
-          })
-        );
+        dispatch(newFocusRegion(focusRegion));
         dispatch(syncFocusedRegion());
       }
       point = initialPausePoint.point;
@@ -533,10 +527,38 @@ export function clearHoveredItem(): UIThunkAction {
   };
 }
 
-export function setFocusRegion(
-  focusRegion: { beginTime: number; endTime: number } | null
-): UIThunkAction {
-  return (dispatch, getState) => {
+export function setFocusRegionFromTimeRange(
+  timeRange: TimeRange | null
+): UIThunkAction<Promise<void>> {
+  return async (dispatch, getState, { replayClient }) => {
+    if (timeRange === null) {
+      dispatch(newFocusRegion(null));
+      return;
+    }
+
+    const [pointsBoundingBegin, pointsBoundingEnd] = await Promise.all([
+      getPointsBoundingTimeAsync(replayClient, timeRange.begin),
+      getPointsBoundingTimeAsync(replayClient, timeRange.end),
+    ]);
+    const begin = pointsBoundingBegin.before;
+    const end = pointsBoundingEnd.after;
+
+    dispatch(newFocusRegion({ begin, end }));
+  };
+}
+
+export const setFocusRegionFromTimeRangeThrottled = throttle(
+  (dispatch: ThunkDispatch<UIState, ThunkExtraArgs, AnyAction>, timeRange: TimeRange) =>
+    dispatch(setFocusRegionFromTimeRange(timeRange)),
+  200,
+  { leading: false, trailing: true }
+);
+
+export function updateDisplayedFocusRegion(
+  displayedFocusRegion: { begin: number; end: number },
+  throttle = false
+): UIThunkAction<Promise<void>> {
+  return async (dispatch, getState) => {
     const state = getState();
     const currentTime = getCurrentTime(state);
 
@@ -546,120 +568,87 @@ export function setFocusRegion(
       dispatch(stopPlayback());
     }
 
-    if (focusRegion !== null) {
-      const zoomRegion = getZoomRegion(state);
-      const previousFocusRegion = getFocusRegion(state);
-      const prevBeginTime = previousFocusRegion
-        ? displayedBeginForFocusRegion(previousFocusRegion)
-        : undefined;
-      const prevEndTime = previousFocusRegion
-        ? displayedEndForFocusRegion(previousFocusRegion)
-        : undefined;
+    if (displayedFocusRegion === null) {
+      dispatch(setTimelineState({ focusRegion: null, displayedFocusRegion: null }));
+      return;
+    }
 
-      let { endTime, beginTime } = focusRegion;
+    const zoomRegion = getZoomRegion(state);
+    const previousDisplayedFocusRegion = getDisplayedFocusRegion(state);
+    const prevBeginTime = previousDisplayedFocusRegion?.begin;
+    const prevEndTime = previousDisplayedFocusRegion?.end;
 
-      // Basic bounds check.
-      if (beginTime < zoomRegion.beginTime) {
-        beginTime = zoomRegion.beginTime;
-      }
-      if (endTime > zoomRegion.endTime) {
-        endTime = zoomRegion.endTime;
-      }
+    let { begin: beginTime, end: endTime } = displayedFocusRegion;
 
-      // Make sure our region is valid.
+    // Basic bounds check.
+    if (beginTime < zoomRegion.beginTime) {
+      beginTime = zoomRegion.beginTime;
       if (endTime < beginTime) {
-        // If we need to adjust a dimension, it's the most intuitive to adjust the one that's being updated.
-        if (prevEndTime === endTime) {
-          beginTime = endTime;
-        } else {
-          endTime = beginTime;
-        }
+        endTime = beginTime;
       }
+    }
+    if (endTime > zoomRegion.endTime) {
+      endTime = zoomRegion.endTime;
+      if (beginTime > endTime) {
+        beginTime = endTime;
+      }
+    }
 
-      // Cap time to fit within max focus region size.
-      if (endTime === prevEndTime) {
-        endTime = Math.min(endTime, beginTime + MAX_FOCUS_REGION_DURATION);
+    // Make sure our region is valid.
+    if (endTime < beginTime) {
+      // If we need to adjust a dimension, it's the most intuitive to adjust the one that's being updated.
+      if (prevEndTime === endTime) {
+        beginTime = endTime;
       } else {
-        beginTime = Math.max(beginTime, endTime - MAX_FOCUS_REGION_DURATION);
+        endTime = beginTime;
       }
+    }
 
-      // Update the previous to match the handle that's being dragged.
-      if (beginTime !== prevBeginTime && endTime === prevEndTime) {
-        dispatch(setTimelineToTime(beginTime));
-      } else if (beginTime === prevBeginTime && endTime !== prevEndTime) {
-        dispatch(setTimelineToTime(endTime));
-      } else {
-        // Else just make sure the preview time stays within the moving window.
-        const hoverTime = getHoverTime(state);
-        if (hoverTime !== null) {
-          if (hoverTime < beginTime) {
-            dispatch(setTimelineToTime(beginTime));
-          } else if (hoverTime > endTime) {
-            dispatch(setTimelineToTime(endTime));
-          }
-        } else {
-          dispatch(setTimelineToTime(currentTime));
-        }
-      }
-
-      // We now try and create a focus region with a time and a point, from just a
-      // time. In the future, it would be better if this were something like
-      // "setFocusRegionByTime" and we had another method which accepted
-      // TimeStampedPoints, because setting via context menu will often happen on
-      // resources where we already know the time *and* point. Also, we probably
-      // should *not* do this on every mouse movement in focus mode. This is
-      // actually foregoing most of the `getPointNearTime`, and instead relying on
-      // points that we mostly have already. I think often this will be OK, but
-      // probably we should also run "getPointNearTime", store that, and take the
-      // closest thing we can find of the points we have (assuming we don't have
-      // an exact match.)
-      const beginIndex = sortedLastIndexBy(
-        state.timeline.points,
-        { time: beginTime, point: "" },
-        p => p.time
-      );
-      const begin =
-        beginIndex > 0 ? state.timeline.points[beginIndex - 1] : { point: "0", time: 0 };
-
-      const endIndex = sortedIndexBy(
-        state.timeline.points,
-        { time: endTime, point: "" },
-        p => p.time
-      );
-      const end =
-        endIndex > 0 && endIndex < state.timeline.points.length
-          ? state.timeline.points[endIndex]
-          : { point: "", time: endTime };
-
-      dispatch(
-        newFocusRegion({
-          begin,
-          beginTime,
-          end,
-          endTime,
-        })
-      );
+    // Cap time to fit within max focus region size.
+    if (endTime === prevEndTime) {
+      endTime = Math.min(endTime, beginTime + MAX_FOCUS_REGION_DURATION);
     } else {
-      dispatch(newFocusRegion(null));
+      beginTime = Math.max(beginTime, endTime - MAX_FOCUS_REGION_DURATION);
+    }
+
+    // Update the previous to match the handle that's being dragged.
+    if (beginTime !== prevBeginTime && endTime === prevEndTime) {
+      dispatch(setTimelineToTime(beginTime));
+    } else if (beginTime === prevBeginTime && endTime !== prevEndTime) {
+      dispatch(setTimelineToTime(endTime));
+    } else {
+      // Else just make sure the preview time stays within the moving window.
+      const hoverTime = getHoverTime(state);
+      if (hoverTime !== null) {
+        if (hoverTime < beginTime) {
+          dispatch(setTimelineToTime(beginTime));
+        } else if (hoverTime > endTime) {
+          dispatch(setTimelineToTime(endTime));
+        }
+      } else {
+        dispatch(setTimelineToTime(currentTime));
+      }
+    }
+
+    dispatch(setDisplayedFocusRegion({ begin: beginTime, end: endTime }));
+    if (throttle) {
+      setFocusRegionFromTimeRangeThrottled(dispatch, { begin: beginTime, end: endTime });
+    } else {
+      await dispatch(setFocusRegionFromTimeRange({ begin: beginTime, end: endTime }));
     }
   };
 }
 
-export function setFocusRegionEndTime(endTime: number, sync: boolean): UIThunkAction {
-  return (dispatch, getState) => {
+export function setFocusRegionEndTime(end: number, sync: boolean): UIThunkAction<Promise<void>> {
+  return async (dispatch, getState) => {
     const state = getState();
     const focusRegion = getFocusRegion(state);
 
     // If this is the first time the user is focusing, begin at the beginning of the recording (or zoom region).
     // Let the focus action/reducer will handle cropping for us.
-    const beginTime = focusRegion ? displayedBeginForFocusRegion(focusRegion) : 0;
+    const begin = focusRegion?.begin.time || 0;
 
-    dispatch(
-      setFocusRegion({
-        endTime,
-        beginTime,
-      })
-    );
+    await dispatch(updateDisplayedFocusRegion({ begin, end }));
 
     if (sync) {
       dispatch(syncFocusedRegion());
@@ -668,23 +657,19 @@ export function setFocusRegionEndTime(endTime: number, sync: boolean): UIThunkAc
   };
 }
 
-export function setFocusRegionBeginTime(beginTime: number, sync: boolean): UIThunkAction {
-  return (dispatch, getState) => {
+export function setFocusRegionBeginTime(
+  begin: number,
+  sync: boolean
+): UIThunkAction<Promise<void>> {
+  return async (dispatch, getState) => {
     const state = getState();
     const focusRegion = getFocusRegion(state);
 
     // If this is the first time the user is focusing, extend to the end of the recording (or zoom region).
     // Let the focus action/reducer will handle cropping for us.
-    const endTime = focusRegion
-      ? displayedEndForFocusRegion(focusRegion)
-      : Number.POSITIVE_INFINITY;
+    const end = focusRegion?.end.time || Number.POSITIVE_INFINITY;
 
-    dispatch(
-      setFocusRegion({
-        endTime,
-        beginTime,
-      })
-    );
+    await dispatch(updateDisplayedFocusRegion({ begin, end }));
 
     if (sync) {
       dispatch(syncFocusedRegion());
@@ -696,17 +681,13 @@ export function setFocusRegionBeginTime(beginTime: number, sync: boolean): UIThu
 export function syncFocusedRegion(): UIThunkAction {
   return async (dispatch, getState, { replayClient }) => {
     const state = getState();
-    const focusRegion = getFocusRegion(state) as FocusRegion;
+    const focusRegion = getFocusRegion(state);
     const zoomTime = getZoomRegion(state);
-
-    if (!focusRegion) {
-      return;
-    }
 
     replayClient.loadRegion(
       {
-        begin: displayedBeginForFocusRegion(focusRegion),
-        end: displayedEndForFocusRegion(focusRegion),
+        begin: focusRegion ? focusRegion.begin.time : zoomTime.beginTime,
+        end: focusRegion ? focusRegion.end.time : zoomTime.endTime,
       },
       zoomTime.endTime
     );
@@ -721,14 +702,10 @@ export function enterFocusMode(): UIThunkAction {
     const currentTime = getCurrentTime(state);
     const focusRegion = getFocusRegion(state);
 
-    dispatch(
-      setTimelineState({
-        focusRegionBackup: focusRegion,
-        showFocusModeControls: true,
-      })
-    );
-
-    if (!focusRegion) {
+    let displayedFocusRegion: TimeRange;
+    if (focusRegion) {
+      displayedFocusRegion = { begin: focusRegion.begin.time, end: focusRegion.end.time };
+    } else {
       const zoomRegion = getZoomRegion(state);
 
       const focusWindowSize = Math.min(
@@ -736,11 +713,19 @@ export function enterFocusMode(): UIThunkAction {
         DEFAULT_FOCUS_WINDOW_MAX_LENGTH
       );
 
-      const beginTime = Math.max(zoomRegion.beginTime, currentTime - focusWindowSize / 2);
-      const endTime = Math.min(zoomRegion.endTime, currentTime + focusWindowSize / 2);
-
-      dispatch(setFocusRegion({ endTime, beginTime }));
+      displayedFocusRegion = {
+        begin: Math.max(zoomRegion.beginTime, currentTime - focusWindowSize / 2),
+        end: Math.min(zoomRegion.endTime, currentTime + focusWindowSize / 2),
+      };
     }
+
+    dispatch(updateDisplayedFocusRegion(displayedFocusRegion));
+    dispatch(
+      setTimelineState({
+        focusRegionBackup: focusRegion,
+        showFocusModeControls: true,
+      })
+    );
   };
 }
 
@@ -750,6 +735,7 @@ export function exitFocusMode(): UIThunkAction {
     dispatch(
       setTimelineState({
         showFocusModeControls: false,
+        displayedFocusRegion: null,
       })
     );
   };

--- a/src/ui/components/FocusContextReduxAdapter.tsx
+++ b/src/ui/components/FocusContextReduxAdapter.tsx
@@ -2,7 +2,7 @@ import { PropsWithChildren, useCallback, useEffect, useMemo, useState, useTransi
 
 import { FocusContext } from "bvaughn-architecture-demo/src/contexts/FocusContext";
 import { Range } from "bvaughn-architecture-demo/src/types";
-import { setFocusRegion } from "ui/actions/timeline";
+import { setFocusRegionFromTimeRange } from "ui/actions/timeline";
 import { getLoadedRegions } from "ui/reducers/app";
 import { getFocusRegion } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
@@ -27,11 +27,11 @@ export default function FocusContextReduxAdapter({ children }: PropsWithChildren
   const update = useCallback(
     (value: Range | null, _: boolean) => {
       dispatch(
-        setFocusRegion(
+        setFocusRegionFromTimeRange(
           value !== null
             ? {
-                beginTime: value[0],
-                endTime: value[1],
+                begin: value[0],
+                end: value[1],
               }
             : null
         )

--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -4,8 +4,11 @@ import PrimaryPanes from "devtools/client/debugger/src/components/PrimaryPanes";
 import SecondaryPanes from "devtools/client/debugger/src/components/SecondaryPanes";
 import Accordion from "devtools/client/debugger/src/components/shared/Accordion";
 import TestInfo from "devtools/client/debugger/src/components/TestInfo/TestInfo";
-import { getRecordingDuration } from "ui/actions/app";
-import { setFocusRegion, syncFocusedRegion, updateFocusRegionParam } from "ui/actions/timeline";
+import {
+  setFocusRegionFromTimeRange,
+  syncFocusedRegion,
+  updateFocusRegionParam,
+} from "ui/actions/timeline";
 import Events from "ui/components/Events";
 import SearchFilesReduxAdapter from "ui/components/SearchFilesReduxAdapter";
 import Icon from "ui/components/shared/Icon";
@@ -115,7 +118,6 @@ function EventsPane({ items }: { items: any[] }) {
   const annotations = useAppSelector(getReporterAnnotationsForTests);
   const selectedTest = useAppSelector(getSelectedTest);
   const dispatch = useAppDispatch();
-  const duration = useAppSelector(getRecordingDuration);
 
   const testCases = useMemo(
     () => maybeCorrectTestTimes(recording, annotations),
@@ -125,12 +127,7 @@ function EventsPane({ items }: { items: any[] }) {
   const onReset = () => {
     dispatch(setSelectedTest(null));
     dispatch(setSelectedStep(null));
-    dispatch(
-      setFocusRegion({
-        beginTime: 0,
-        endTime: duration,
-      })
-    );
+    dispatch(setFocusRegionFromTimeRange(null));
     dispatch(syncFocusedRegion());
     dispatch(updateFocusRegionParam());
   };

--- a/src/ui/components/Timeline/EditableTimeInput.tsx
+++ b/src/ui/components/Timeline/EditableTimeInput.tsx
@@ -89,6 +89,8 @@ function EditableTimeInput({
         setPendingValue(defaultValue);
         break;
       case "Enter":
+        // we don't want this event to reach the handler in FocusModePopout
+        event.nativeEvent.cancelBubble = true;
         // Always save on Enter, even if the value has not been modified.
         // Enter is a strong signal of intent.
         validateAndSave(pendingValue, true);

--- a/src/ui/components/Timeline/FocusModePopout.tsx
+++ b/src/ui/components/Timeline/FocusModePopout.tsx
@@ -1,15 +1,11 @@
 import React, { useEffect } from "react";
 
-import {
-  exitFocusMode,
-  setFocusRegion,
-  syncFocusedRegion,
-  updateFocusRegionParam,
-} from "ui/actions/timeline";
+import { exitFocusMode, syncFocusedRegion, updateFocusRegionParam } from "ui/actions/timeline";
 import {
   getFocusRegionBackup,
   getShowFocusModeControls,
   isMaximumFocusRegion,
+  setFocusRegion,
 } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { trackEvent } from "ui/utils/telemetry";

--- a/src/ui/components/Timeline/PlaybackControls.tsx
+++ b/src/ui/components/Timeline/PlaybackControls.tsx
@@ -2,17 +2,16 @@ import { replayPlayback, startPlayback, stopPlayback } from "ui/actions/timeline
 import { selectors } from "ui/reducers";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { trackEvent } from "ui/utils/telemetry";
-import { displayedEndForFocusRegion } from "ui/utils/timeline";
 
 export default function PlayPauseButton() {
   const dispatch = useAppDispatch();
   const currentTime = useAppSelector(selectors.getCurrentTime);
-  const focusRegion = useAppSelector(selectors.getFocusRegion);
+  const displayedFocusRegion = useAppSelector(selectors.getDisplayedFocusRegion);
   const playback = useAppSelector(selectors.getPlayback);
   const recordingDuration = useAppSelector(selectors.getRecordingDuration);
 
-  const isAtEnd = focusRegion
-    ? currentTime === displayedEndForFocusRegion(focusRegion)
+  const isAtEnd = displayedFocusRegion
+    ? currentTime === displayedFocusRegion.end
     : currentTime == recordingDuration;
 
   let onClick;

--- a/src/ui/components/Timeline/Tooltip.tsx
+++ b/src/ui/components/Timeline/Tooltip.tsx
@@ -2,17 +2,13 @@ import React from "react";
 
 import { getNonLoadingTimeRanges } from "ui/reducers/app";
 import {
-  getFocusRegion,
+  getDisplayedFocusRegion,
   getHoverTime,
   getShowFocusModeControls,
   getZoomRegion,
 } from "ui/reducers/timeline";
 import { useAppSelector } from "ui/setup/hooks";
-import {
-  displayedBeginForFocusRegion,
-  displayedEndForFocusRegion,
-  getVisiblePosition,
-} from "ui/utils/timeline";
+import { getVisiblePosition } from "ui/utils/timeline";
 
 const getTimestamp = (time?: number) => {
   const date = new Date(time || 0);
@@ -27,7 +23,7 @@ export default function Tooltip({ timelineWidth }: { timelineWidth: number }) {
   const zoomRegion = useAppSelector(getZoomRegion);
   const showFocusModeControls = useAppSelector(getShowFocusModeControls);
   const nonLoadingRegion = useAppSelector(getNonLoadingTimeRanges);
-  const focusRegion = useAppSelector(getFocusRegion);
+  const displayedFocusRegion = useAppSelector(getDisplayedFocusRegion);
 
   if (!hoverTime || showFocusModeControls) {
     return null;
@@ -40,9 +36,8 @@ export default function Tooltip({ timelineWidth }: { timelineWidth: number }) {
   );
 
   const isHoveredOnUnFocusedRegion =
-    focusRegion &&
-    (displayedBeginForFocusRegion(focusRegion) > hoverTime ||
-      displayedEndForFocusRegion(focusRegion) < hoverTime);
+    displayedFocusRegion &&
+    (displayedFocusRegion.begin > hoverTime || displayedFocusRegion.end < hoverTime);
 
   const timestamp = getTimestamp(hoverTime);
   const message =

--- a/src/ui/components/Timeline/UnfocusedRegion.tsx
+++ b/src/ui/components/Timeline/UnfocusedRegion.tsx
@@ -2,23 +2,19 @@ import clamp from "lodash/clamp";
 
 import { selectors } from "ui/reducers";
 import { useAppSelector } from "ui/setup/hooks";
-import { trackEvent } from "ui/utils/telemetry";
-import {
-  displayedBeginForFocusRegion,
-  displayedEndForFocusRegion,
-  getVisiblePosition,
-} from "ui/utils/timeline";
+import { getVisiblePosition } from "ui/utils/timeline";
 
 export default function UnfocusedRegion() {
+  const displayedFocusRegion = useAppSelector(selectors.getDisplayedFocusRegion);
   const focusRegion = useAppSelector(selectors.getFocusRegion);
   const zoomRegion = useAppSelector(selectors.getZoomRegion);
 
-  if (!focusRegion) {
+  if (!displayedFocusRegion && !focusRegion) {
     return null;
   }
 
-  const beginTime = displayedBeginForFocusRegion(focusRegion);
-  const endTime = displayedEndForFocusRegion(focusRegion);
+  const beginTime = displayedFocusRegion?.begin ?? focusRegion!.begin.time;
+  const endTime = displayedFocusRegion?.end ?? focusRegion!.end.time;
   const duration = zoomRegion.endTime - zoomRegion.beginTime;
 
   const start = getVisiblePosition({ time: beginTime, zoom: zoomRegion }) * 100;

--- a/src/ui/components/Timeline/UnloadedRegions.tsx
+++ b/src/ui/components/Timeline/UnloadedRegions.tsx
@@ -27,20 +27,7 @@ export const UnloadedRegions: FC = () => {
   let beginTime = begin.time;
   let endTime = end.time;
   if (focusRegion) {
-    // Even though we technically focus on the nearest points,
-    // We should only show the user a range defining their specified times.
-    const userVisibleTimeStampedPointRange: TimeStampedPointRange = {
-      begin: {
-        point: focusRegion.begin.point,
-        time: focusRegion.beginTime,
-      },
-      end: {
-        point: focusRegion.end.point,
-        time: focusRegion.endTime,
-      },
-    };
-
-    const overlappingRegions = overlap([userVisibleTimeStampedPointRange], loadedRegions.loading);
+    const overlappingRegions = overlap([focusRegion], loadedRegions.loading);
     if (overlappingRegions.length > 0) {
       const focusedAndLoaded = overlappingRegions[0];
       beginTime = focusedAndLoaded.begin.time;

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -23,13 +23,7 @@ import { getNonLoadingRegionTimeRanges } from "ui/utils/app";
 import { getSystemColorSchemePreference } from "ui/utils/environment";
 import { compareBigInt } from "ui/utils/helpers";
 import { prefs } from "ui/utils/prefs";
-import {
-  displayedBeginForFocusRegion,
-  displayedEndForFocusRegion,
-  isPointInRegions,
-  isTimeInRegions,
-  overlap,
-} from "ui/utils/timeline";
+import { isPointInRegions, isTimeInRegions, overlap } from "ui/utils/timeline";
 
 export const initialAppState: AppState = {
   // analysisPoints: {},
@@ -309,9 +303,7 @@ export const getFlatEvents = (state: UIState) => {
   // Only show the events in the current focused region
   return focusRegion
     ? filteredEvents.filter(
-        e =>
-          e.time > displayedBeginForFocusRegion(focusRegion) &&
-          e.time < displayedEndForFocusRegion(focusRegion)
+        e => e.point >= focusRegion.begin.point && e.point < focusRegion.end.point
       )
     : filteredEvents;
 };

--- a/src/ui/reducers/network.ts
+++ b/src/ui/reducers/network.ts
@@ -8,15 +8,10 @@ import sortBy from "lodash/sortBy";
 import sortedUniqBy from "lodash/sortedUniqBy";
 import { createSelector } from "reselect";
 
-import { isPointInRegions } from "shared/utils/time";
 import { NetworkAction } from "ui/actions/network";
 import { partialRequestsToCompleteSummaries } from "ui/components/NetworkMonitor/utils";
 import { UIState } from "ui/state";
-import {
-  displayedBeginForFocusRegion,
-  displayedEndForFocusRegion,
-  filterToFocusRegion,
-} from "ui/utils/timeline";
+import { filterToFocusRegion } from "ui/utils/timeline";
 
 import { getFocusRegion } from "./timeline";
 
@@ -102,9 +97,7 @@ export const getFocusedEvents = createSelector(getEvents, getFocusRegion, (event
   if (!focusRegion) {
     return events;
   }
-  const beginTime = displayedBeginForFocusRegion(focusRegion);
-  const endTime = displayedEndForFocusRegion(focusRegion);
-  return events.filter(e => e.time > beginTime && e.time <= endTime);
+  return events.filter(e => e.time > focusRegion.begin.time && e.time <= focusRegion.end.time);
 });
 
 type GetFocusedRequestsReturn = [

--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -55,7 +55,7 @@ import reporter from "ui/reducers/reporter";
 import timeline, {
   allPaintsReceived,
   paintsReceived,
-  pointsReceivedThunk,
+  pointsReceived,
   setPlaybackStalled,
 } from "ui/reducers/timeline";
 import { UIState } from "ui/state";
@@ -262,7 +262,7 @@ export default async function setupDevtools(store: AppStore, replayClient: Repla
   let points: TimeStampedPoint[] = [];
 
   const onPointsReceived = debounce(() => {
-    store.dispatch(pointsReceivedThunk(points.map(({ point, time }) => ({ point, time }))));
+    store.dispatch(pointsReceived(points.map(({ point, time }) => ({ point, time }))));
     store.dispatch(paintsReceived(points.filter(p => "screenShots" in p)));
     points = [];
   }, 1_000);

--- a/src/ui/state/timeline.ts
+++ b/src/ui/state/timeline.ts
@@ -8,9 +8,7 @@ export interface ZoomRegion {
 
 export interface FocusRegion {
   end: TimeStampedPoint;
-  endTime: number;
   begin: TimeStampedPoint;
-  beginTime: number;
 }
 
 export interface TimelineState {
@@ -20,6 +18,7 @@ export interface TimelineState {
   hoverTime: number | null;
   focusRegion: FocusRegion | null;
   focusRegionBackup: FocusRegion | null;
+  displayedFocusRegion: TimeRange | null;
   playback: {
     beginTime: number;
     beginDate: number;

--- a/src/ui/utils/timeline.test.ts
+++ b/src/ui/utils/timeline.test.ts
@@ -14,9 +14,7 @@ import {
 const point = (time: number) => ({ time, point: `${time}` });
 const focusRegion = (from: number, to: number): FocusRegion => ({
   begin: point(from),
-  beginTime: from,
   end: point(to),
-  endTime: to,
 });
 
 describe("getFormattedTime", () => {

--- a/src/ui/utils/timeline.ts
+++ b/src/ui/utils/timeline.ts
@@ -26,14 +26,6 @@ export function getPixelDistance({
   return Math.abs((toPos - fromPos) * overlayWidth);
 }
 
-export function displayedBeginForFocusRegion(focusRegion: FocusRegion) {
-  return focusRegion.beginTime;
-}
-
-export function displayedEndForFocusRegion(focusRegion: FocusRegion) {
-  return focusRegion.endTime;
-}
-
 // Get the position of a time on the visible part of the timeline,
 // in the range [0, 1] if the timeline is fully zommed out.
 export function getVisiblePosition({ time, zoom }: { time: number | null; zoom: ZoomRegion }) {
@@ -219,10 +211,7 @@ export function isSameTimeStampedPointRange(
 }
 
 export function isInFocusSpan(time: number, focusRegion: FocusRegion) {
-  const beginTime = displayedBeginForFocusRegion(focusRegion);
-  const endTime = displayedEndForFocusRegion(focusRegion);
-
-  return time >= beginTime && time <= endTime;
+  return time >= focusRegion.begin.time && time <= focusRegion.end.time;
 }
 
 export function isPointInRegions(regions: TimeStampedPointRange[], point: string) {
@@ -286,9 +275,8 @@ export function isFocusRegionSubset(
     return false;
   } else {
     return (
-      displayedBeginForFocusRegion(nextFocusRegion) >=
-        displayedBeginForFocusRegion(prevFocusRegion) &&
-      displayedEndForFocusRegion(nextFocusRegion) <= displayedEndForFocusRegion(prevFocusRegion)
+      nextFocusRegion.begin.time >= prevFocusRegion.begin.time &&
+      nextFocusRegion.end.time <= prevFocusRegion.end.time
     );
   }
 }


### PR DESCRIPTION
- replaced `focusRegion.beginTime`/`focusRegion.endTime` (the times for the `Focuser` component) by `displayedFocusRegion` to avoid the kind of mistakes we were running into
- changes to `displayedFocusRegion` will be synced to `focusRegion` using `getPointsBoundingTime()` (instead of trying to find nearby points from those collected from backend messages)
- these updates will be throttled if they come from dragging the `Focuser`
- removed the thunk that tried to "improve" the focus region begin/end points when new points were received
- added `PointsBoundingTimeCache`
