### PR TITLE
E2e tests

### DIFF
--- a/packages/bvaughn-architecture-demo/components/sources/useSourceContextMenu.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/useSourceContextMenu.tsx
@@ -38,10 +38,6 @@ export default function useSourceContextMenu({
   const invalidateCache = useCacheRefresh();
 
   const addComment = () => {
-    if (accessToken === null) {
-      return;
-    }
-
     startTransition(async () => {
       if (showCommentsPanel !== null) {
         showCommentsPanel();
@@ -55,7 +51,7 @@ export default function useSourceContextMenu({
         firstBreakableColumnIndex
       );
 
-      await addCommentGraphQL(graphQLClient, accessToken, recordingId, {
+      await addCommentGraphQL(graphQLClient, accessToken!, recordingId, {
         content: "",
         hasFrames: true,
         isPublished: false,
@@ -82,10 +78,14 @@ export default function useSourceContextMenu({
 
   return useContextMenu(
     <>
-      <ContextMenuItem disabled={isPending} onClick={addComment}>
-        Add comment to line {lineNumber}
-      </ContextMenuItem>
-      <ContextMenuDivider />
+      {accessToken !== null && (
+        <>
+          <ContextMenuItem disabled={isPending} onClick={addComment}>
+            Add comment to line {lineNumber}
+          </ContextMenuItem>
+          <ContextMenuDivider />
+        </>
+      )}
       <ContextMenuItem disabled={disableCopySourceUri} onClick={copySourceUri}>
         Copy source URI
       </ContextMenuItem>

--- a/packages/bvaughn-architecture-demo/pages/_app.tsx
+++ b/packages/bvaughn-architecture-demo/pages/_app.tsx
@@ -27,10 +27,11 @@ function Routing({ Component, pageProps }: AppProps) {
   );
 }
 
-const App = ({ apiKey, ...props }: AppProps & AuthProps) => {
+const App = (props: AppProps & AuthProps) => {
   return <Routing {...props} />;
 };
 
+// Forked verbatim from /pages/_app.tsx
 App.getInitialProps = (appContext: AppContext) => {
   const props = NextApp.getInitialProps(appContext);
   const authHeader = appContext.ctx.req?.headers.authorization;

--- a/packages/bvaughn-architecture-demo/pages/index.tsx
+++ b/packages/bvaughn-architecture-demo/pages/index.tsx
@@ -42,7 +42,7 @@ const recordData = hasFlag("record");
 
 type Panel = "comments" | "protocol-viewer" | "search" | "sources";
 
-export default function HomePage() {
+export default function HomePage({ apiKey }: { apiKey?: string }) {
   // TODO As we finalize the client implementation to interface with Replay backend,
   // we can inject a wrapper here that also reports cache hits and misses to this UI in a debug panel.
 
@@ -71,7 +71,7 @@ export default function HomePage() {
   usePreferredColorScheme();
 
   const content = (
-    <Initializer>
+    <Initializer accessToken={apiKey || null}>
       <KeyboardModifiersContextRoot>
         <SourcesContextRoot>
           <InspectorContextRoot

--- a/pages/recording/[[...id]].tsx
+++ b/pages/recording/[[...id]].tsx
@@ -121,10 +121,11 @@ function useRecordingSlug(recordingId: string) {
 }
 
 function RecordingPage({
+  apiKey,
   getAccessibleRecording,
   setExpectedError,
   head,
-}: PropsFromRedux & { head?: React.ReactNode }) {
+}: PropsFromRedux & { apiKey?: string; head?: React.ReactNode }) {
   const token = useToken();
   const store = useAppStore();
   const { query } = useRouter();
@@ -200,7 +201,7 @@ function RecordingPage({
     return (
       <>
         {head}
-        <DevTools uploadComplete={uploadComplete} />
+        <DevTools apiKey={apiKey} uploadComplete={uploadComplete} />
       </>
     );
   }
@@ -220,14 +221,14 @@ export const getServerSideProps: GetServerSideProps = async function ({ params }
   };
 };
 
-type SSRProps = MetadataProps & { headOnly?: boolean };
+type SSRProps = MetadataProps & { apiKey?: string; headOnly?: boolean };
 
-export default function SSRRecordingPage({ headOnly, metadata }: SSRProps) {
+export default function SSRRecordingPage({ apiKey, headOnly, metadata }: SSRProps) {
   let head: React.ReactNode = <RecordingHead metadata={metadata} />;
 
   if (headOnly) {
     return head;
   }
 
-  return <ConnectedRecordingPage head={head} />;
+  return <ConnectedRecordingPage apiKey={apiKey} head={head} />;
 }

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -47,7 +47,7 @@ import Video from "./Video";
 
 const Viewer = React.lazy(() => import("./Viewer"));
 
-type DevToolsProps = PropsFromRedux & { uploadComplete: boolean };
+type DevToolsProps = PropsFromRedux & { apiKey?: string; uploadComplete: boolean };
 
 function ViewLoader() {
   const [showLoader, setShowLoader] = useState(false);
@@ -107,6 +107,7 @@ function Body() {
 }
 
 function _DevTools({
+  apiKey,
   clearTrialExpired,
   createSocket,
   loadedRegions,
@@ -203,7 +204,7 @@ function _DevTools({
   }
 
   return (
-    <SessionContextAdapter>
+    <SessionContextAdapter apiKey={apiKey ?? null}>
       <SourcesContextAdapter>
         <FocusContextReduxAdapter>
           <PointsContextRoot>

--- a/src/ui/components/SessionContextAdapter.tsx
+++ b/src/ui/components/SessionContextAdapter.tsx
@@ -13,7 +13,13 @@ import { useAppSelector } from "ui/setup/hooks";
 import { trackEventOnce } from "ui/utils/mixpanel";
 import { trackEvent } from "ui/utils/telemetry";
 
-export default function SessionContextAdapter({ children }: { children: ReactNode }) {
+export default function SessionContextAdapter({
+  apiKey,
+  children,
+}: {
+  apiKey: string | null;
+  children: ReactNode;
+}) {
   const recordingId = useGetRecordingId();
   const currentUserInfo = useGetUserInfo();
   const apolloClient = useApolloClient();
@@ -28,7 +34,7 @@ export default function SessionContextAdapter({ children }: { children: ReactNod
 
   const sessionContext = useMemo<SessionContextType>(
     () => ({
-      accessToken: ThreadFront.getAccessToken(),
+      accessToken: apiKey || ThreadFront.getAccessToken(),
       currentUserInfo,
       duration,
       recordingId,
@@ -39,7 +45,7 @@ export default function SessionContextAdapter({ children }: { children: ReactNod
       trackEvent: trackEvent as SessionContextType["trackEvent"],
       trackEventOnce: trackEventOnce as SessionContextType["trackEventOnce"],
     }),
-    [currentUserInfo, duration, recordingId, refetchUser]
+    [apiKey, currentUserInfo, duration, recordingId, refetchUser]
   );
 
   return <SessionContext.Provider value={sessionContext}>{children}</SessionContext.Provider>;


### PR DESCRIPTION
- [x] Don't render "Add comment" button in Source context menu unless user is authenticated
- [x] Pass `apiKey` prop through to `SessionContext` (this will unblock future work on e2e tests that require authorization via an API key)