### PR TITLE
Fix auto scrolling behavior

### DIFF
--- a/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
@@ -52,7 +52,7 @@ export function TestCase({ test, index }: { test: TestItem; index: number }) {
   const expandable = typeof test.relativeStartTime === "number" && (test.steps || test.error);
   const selectedTest = useAppSelector(getSelectedTest);
   const isSelected = selectedTest === index;
-  const annotationsStart = useAppSelector(getReporterAnnotationsForTitleEnd(test.title));
+  const annotationsStart = useAppSelector(getReporterAnnotationsForTitleEnd);
 
   const duration = useAppSelector(getRecordingDuration);
   const testStartTime = test.relativeStartTime;
@@ -90,7 +90,7 @@ export function TestCase({ test, index }: { test: TestItem; index: number }) {
         dispatch(seek(pointStart, time, false));
       }
 
-      dispatch(setSelectedTest(index));
+      dispatch(setSelectedTest({ index, title: test.title }));
     } else if (typeof test.relativeStartTime === "number") {
       dispatch(seekToTime(test.relativeStartTime, false));
     }

--- a/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
@@ -34,7 +34,7 @@ export default function TestInfo({ testCases }: { testCases: TestItem[] }) {
     <TestInfoContext.Provider value={{ consoleProps, setConsoleProps, pauseId, setPauseId }}>
       <TestInfoContextMenuContextRoot>
         <div className="flex flex-grow flex-col overflow-hidden">
-          <div className="flex flex-grow flex-col space-y-1 overflow-auto px-2 ">
+          <div className="relative flex flex-grow flex-col space-y-1 overflow-auto px-2">
             {testCases.map((t, i) => showTest(i) && <TestCase test={t} key={i} index={i} />)}
           </div>
           {selectedTest !== null ? <Console /> : null}

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -1,5 +1,5 @@
 import { Object as ProtocolObject, createPauseResult } from "@replayio/protocol";
-import React, { createRef, useCallback, useContext, useEffect, useState } from "react";
+import React, { useCallback, useContext, useEffect, useRef, useState } from "react";
 
 import { highlightNodes, unhighlightNode } from "devtools/client/inspector/markup/actions/markup";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
@@ -28,6 +28,20 @@ export function returnFirst<T, R>(
   return list ? list.reduce<R | null>((acc, v, i, l) => acc ?? fn(v, i, l), null) : null;
 }
 
+// relies on the scrolling parent to be the nearest positioning context
+function scrollIntoView(node: HTMLDivElement) {
+  if (!node.offsetParent) {
+    return;
+  }
+
+  const parentBounds = node.offsetParent.getBoundingClientRect();
+  const nodeBounds = node.getBoundingClientRect();
+
+  if (nodeBounds.top < parentBounds.top || nodeBounds.bottom > parentBounds.bottom) {
+    node.scrollIntoView();
+  }
+}
+
 export interface TestStepItemProps {
   step: AnnotatedTestStep;
   argString: string;
@@ -36,7 +50,7 @@ export interface TestStepItemProps {
 }
 
 export function TestStepItem({ step, argString, index, id }: TestStepItemProps) {
-  const ref = createRef<HTMLDivElement>();
+  const ref = useRef<HTMLDivElement>(null);
   const [localPauseData, setLocalPauseData] = useState<{
     startPauseId?: string;
     endPauseId?: string;
@@ -191,24 +205,23 @@ export function TestStepItem({ step, argString, index, id }: TestStepItemProps) 
     dispatch(unhighlightNode());
   };
 
-  // TODO [ryanjduffy]: Reverting
-  // useEffect(() => {
-  //   if (
-  //     !isPlaying &&
-  //     ref.current &&
-  //     currentTime >= step.absoluteStartTime &&
-  //     currentTime <= step.absoluteEndTime
-  //   ) {
-  //     ref.current.scrollIntoView();
-  //   }
-  // }, [isPlaying, ref, currentTime, step]);
+  useEffect(() => {
+    if (
+      !isPlaying &&
+      ref.current &&
+      currentTime >= step.absoluteStartTime &&
+      currentTime <= step.absoluteEndTime
+    ) {
+      scrollIntoView(ref.current);
+    }
+  }, [isPlaying, ref, currentTime, step]);
 
-  // useEffect(() => {
-  //   if (step.error && ref.current) {
-  //     ref.current.scrollIntoView();
-  //     onClick();
-  //   }
-  // }, [step, ref, onClick]);
+  useEffect(() => {
+    if (step.error && ref.current) {
+      scrollIntoView(ref.current);
+      onClick();
+    }
+  }, [step, ref, onClick]);
 
   // This math is bananas don't look here until this is cleaned up :)
   const bump = isPaused || isPast ? 10 : 0;

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -191,23 +191,24 @@ export function TestStepItem({ step, argString, index, id }: TestStepItemProps) 
     dispatch(unhighlightNode());
   };
 
-  useEffect(() => {
-    if (
-      !isPlaying &&
-      ref.current &&
-      currentTime >= step.absoluteStartTime &&
-      currentTime <= step.absoluteEndTime
-    ) {
-      ref.current.scrollIntoView();
-    }
-  }, [isPlaying, ref, currentTime, step]);
+  // TODO [ryanjduffy]: Reverting
+  // useEffect(() => {
+  //   if (
+  //     !isPlaying &&
+  //     ref.current &&
+  //     currentTime >= step.absoluteStartTime &&
+  //     currentTime <= step.absoluteEndTime
+  //   ) {
+  //     ref.current.scrollIntoView();
+  //   }
+  // }, [isPlaying, ref, currentTime, step]);
 
-  useEffect(() => {
-    if (step.error && ref.current) {
-      ref.current.scrollIntoView();
-      onClick();
-    }
-  }, [step, ref, onClick]);
+  // useEffect(() => {
+  //   if (step.error && ref.current) {
+  //     ref.current.scrollIntoView();
+  //     onClick();
+  //   }
+  // }, [step, ref, onClick]);
 
   // This math is bananas don't look here until this is cleaned up :)
   const bump = isPaused || isPast ? 10 : 0;

--- a/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
@@ -41,17 +41,16 @@ type CompositeTestEvent = StepEvent | NetworkEvent | NavigationEvent;
 
 function useGetTestSections(
   startTime: number,
-  steps: TestStep[],
-  testTitle: string
+  steps: TestStep[]
 ): {
   beforeEach: CompositeTestEvent[];
   testBody: CompositeTestEvent[];
   afterEach: CompositeTestEvent[];
 } {
-  const navigationEvents = useAppSelector(getReporterAnnotationsForTitleNavigation(testTitle));
-  const annotationsEnqueue = useAppSelector(getReporterAnnotationsForTitle(testTitle));
-  const annotationsEnd = useAppSelector(getReporterAnnotationsForTitleEnd(testTitle));
-  const annotationsStart = useAppSelector(getReporterAnnotationsForTitleStart(testTitle));
+  const navigationEvents = useAppSelector(getReporterAnnotationsForTitleNavigation);
+  const annotationsEnqueue = useAppSelector(getReporterAnnotationsForTitle);
+  const annotationsEnd = useAppSelector(getReporterAnnotationsForTitleEnd);
+  const annotationsStart = useAppSelector(getReporterAnnotationsForTitleStart);
   const requests = useAppSelector(getRequests);
   const events = useAppSelector(getEvents);
 
@@ -190,11 +189,7 @@ function useGetTestSections(
 
 export function TestSteps({ test }: { test: TestItem }) {
   const { startTime: testCaseStartTime } = useContext(TestCaseContext);
-  const { beforeEach, testBody, afterEach } = useGetTestSections(
-    testCaseStartTime,
-    test.steps,
-    test.title
-  );
+  const { beforeEach, testBody, afterEach } = useGetTestSections(testCaseStartTime, test.steps);
 
   return (
     <div className="flex flex-col rounded-lg px-2">
@@ -219,8 +214,19 @@ export function TestSteps({ test }: { test: TestItem }) {
   );
 }
 
-function TestSection({ events, header }: { events: CompositeTestEvent[]; header?: string }) {
+function NewUrlRow({ time, message }: { time: number; message: CypressAnnotationMessage }) {
   const currentTime = useAppSelector(getCurrentTime);
+
+  return (
+    <TestStepRow pending={time > currentTime} key={(message.url || "url") + time}>
+      <div className="truncate italic opacity-70" title={message.url}>
+        new url {message.url}
+      </div>
+    </TestStepRow>
+  );
+}
+
+function TestSection({ events, header }: { events: CompositeTestEvent[]; header?: string }) {
   if (events.length === 0) {
     return null;
   }
@@ -237,15 +243,17 @@ function TestSection({ events, header }: { events: CompositeTestEvent[]; header?
       ) : null}
       {events.map(({ event: s, type, time }, i) =>
         type === "step" ? (
-          <TestStepItem step={s} key={i} index={s.index} argString={s.args?.toString()} id={s.id} />
+          <TestStepItem
+            step={s}
+            key={s.id}
+            index={s.index}
+            argString={s.args?.toString()}
+            id={s.id}
+          />
         ) : type === "network" ? (
           <NetworkEvent key={s.id} request={s} />
         ) : (
-          <TestStepRow pending={time > currentTime}>
-            <div className="truncate italic opacity-70" title={s.url}>
-              new url {s.url}
-            </div>
-          </TestStepRow>
+          <NewUrlRow message={s} time={time} key={s.id} />
         )
       )}
     </>

--- a/src/ui/reducers/reporter.ts
+++ b/src/ui/reducers/reporter.ts
@@ -8,12 +8,14 @@ export interface ReporterState {
   annotations: Annotation[];
   selectedStep: AnnotatedTestStep | null;
   selectedTest: number | null;
+  selectedTestTitle: string | null;
 }
 
 const initialState: ReporterState = {
   annotations: [],
   selectedStep: null,
   selectedTest: null,
+  selectedTestTitle: null,
 };
 
 const reporterSlice = createSlice({
@@ -32,8 +34,9 @@ const reporterSlice = createSlice({
       // data instead.
       state.selectedStep = action.payload;
     },
-    setSelectedTest(state, action: PayloadAction<number | null>) {
-      state.selectedTest = action.payload;
+    setSelectedTest(state, action: PayloadAction<{ index: number; title: string } | null>) {
+      state.selectedTest = action.payload?.index || null;
+      state.selectedTestTitle = action.payload?.title || null;
     },
     mayClearSelectedStep(state, action: PayloadAction<{ point?: string; time?: number }>) {
       const { point, time } = action.payload;
@@ -62,39 +65,56 @@ export const { addReporterAnnotations, setSelectedStep, setSelectedTest, mayClea
 export const getReporterAnnotations = (state: UIState) => state.reporter.annotations;
 export const getSelectedStep = (state: UIState) => state.reporter.selectedStep;
 export const getSelectedTest = (state: UIState) => state.reporter.selectedTest;
+export const getSelectedTestTitle = (state: UIState) => state.reporter.selectedTestTitle;
 export const getReporterAnnotationsForTests = createSelector(
   getReporterAnnotations,
   (annotations: Annotation[]) => annotations.filter(a => a.message.event === "test:start")
 );
-export const getReporterAnnotationsForTitle = (title: string) =>
-  createSelector(getReporterAnnotations, (annotations: Annotation[]) =>
-    annotations.filter(
-      a =>
-        a.message.titlePath[a.message.titlePath.length - 1] === title &&
-        a.message.event === "step:enqueue"
-    )
-  );
-export const getReporterAnnotationsForTitleEnd = (title: string) =>
-  createSelector(getReporterAnnotations, (annotations: Annotation[]) =>
-    annotations.filter(
-      a =>
-        a.message.titlePath[a.message.titlePath.length - 1] === title &&
-        a.message.event === "step:end"
-    )
-  );
-export const getReporterAnnotationsForTitleStart = (title: string) =>
-  createSelector(getReporterAnnotations, (annotations: Annotation[]) =>
-    annotations.filter(
-      a =>
-        a.message.titlePath[a.message.titlePath.length - 1] === title &&
-        a.message.event === "step:start"
-    )
-  );
-export const getReporterAnnotationsForTitleNavigation = (title: string) =>
-  createSelector(getReporterAnnotations, (annotations: Annotation[]) =>
-    annotations.filter(
-      a =>
-        a.message.titlePath[a.message.titlePath.length - 1] === title &&
-        a.message.event === "event:navigation"
-    )
-  );
+export const getReporterAnnotationsForTitle = createSelector(
+  getSelectedTestTitle,
+  getReporterAnnotations,
+  (title, annotations) =>
+    title
+      ? annotations.filter(
+          a =>
+            a.message.titlePath[a.message.titlePath.length - 1] === title &&
+            a.message.event === "step:enqueue"
+        )
+      : []
+);
+export const getReporterAnnotationsForTitleEnd = createSelector(
+  getSelectedTestTitle,
+  getReporterAnnotations,
+  (title, annotations) =>
+    title
+      ? annotations.filter(
+          a =>
+            a.message.titlePath[a.message.titlePath.length - 1] === title &&
+            a.message.event === "step:end"
+        )
+      : []
+);
+export const getReporterAnnotationsForTitleStart = createSelector(
+  getSelectedTestTitle,
+  getReporterAnnotations,
+  (title, annotations) =>
+    title
+      ? annotations.filter(
+          a =>
+            a.message.titlePath[a.message.titlePath.length - 1] === title &&
+            a.message.event === "step:start"
+        )
+      : []
+);
+export const getReporterAnnotationsForTitleNavigation = createSelector(
+  getSelectedTestTitle,
+  getReporterAnnotations,
+  (title, annotations) =>
+    title
+      ? annotations.filter(
+          a =>
+            a.message.titlePath[a.message.titlePath.length - 1] === title &&
+            a.message.event === "event:navigation"
+        )
+      : []
+);


### PR DESCRIPTION
## Issue

Two things were breaking auto-scrolling:
* We were regenerating the test step objects because our selectors for annotations and navigation events were not memoized so they were producing new arrays for each call which in turn retriggered the `useMemo` for test steps which retriggered the `useEffect` for scrolling
* I accidentally used `createRef` instead of `useRef` so the ref was changing on every render which (along with `currentTime` changing) would invoke the error scrolling any time a seek occurred.

## Resolution

* Add the selected test title to redux and fix the annotation and navigation events selectors
* Use `useRef`
* Add some calculations to avoid scrolling a step that is already in view