### PR TITLE
AnalysisCache experiment

### DIFF
--- a/packages/replay-next/components/console/LoggablesContext.tsx
+++ b/packages/replay-next/components/console/LoggablesContext.tsx
@@ -13,7 +13,7 @@ import { FocusContext } from "replay-next/src/contexts/FocusContext";
 import { PointInstance, PointsContext } from "replay-next/src/contexts/PointsContext";
 import { TerminalContext, TerminalExpression } from "replay-next/src/contexts/TerminalContext";
 import { EventLog, getEventTypeEntryPointsSuspense } from "replay-next/src/suspense/EventsCache";
-import { UncaughtException, getExceptionsSuspense } from "replay-next/src/suspense/ExceptionsCache";
+import { UncaughtException, getExceptionPointsSuspense } from "replay-next/src/suspense/ExceptionsCache";
 import { ProtocolMessage, getMessagesSuspense } from "replay-next/src/suspense/MessagesCache";
 import { getHitPointsForLocationSuspense } from "replay-next/src/suspense/PointsCache";
 import { loggableSort } from "replay-next/src/utils/loggables";
@@ -59,7 +59,14 @@ export function LoggablesContextRoot({
     showWarnings,
   } = useContext(ConsoleFiltersContext);
 
-  const { range: focusRange } = useContext(FocusContext);
+  const { range: focusRange, endPoint } = useContext(FocusContext);
+  const range = useMemo(
+    () =>
+      focusRange
+        ? { begin: focusRange.begin.point, end: focusRange.end.point }
+        : { begin: "0", end: endPoint!.point },
+    [endPoint, focusRange]
+  );
 
   // Find the set of event type handlers we should be displaying in the console.
   const eventTypesToLoad = useMemo<EventHandlerType[]>(() => {
@@ -123,7 +130,7 @@ export function LoggablesContextRoot({
   // We may suspend based on this value, so let's this value changes at sync priority,
   let exceptions: UncaughtException[] = EMPTY_ARRAY;
   if (showExceptions) {
-    exceptions = getExceptionsSuspense(client, focusRange);
+    exceptions = getExceptionPointsSuspense(client, range);
   }
 
   // Trim eventLogs and logPoints by focusRange.

--- a/packages/replay-next/components/console/renderers/EventLogRenderer.tsx
+++ b/packages/replay-next/components/console/renderers/EventLogRenderer.tsx
@@ -8,7 +8,7 @@ import Loader from "replay-next/components/Loader";
 import { ConsoleFiltersContext } from "replay-next/src/contexts/ConsoleFiltersContext";
 import { InspectableTimestampedPointContext } from "replay-next/src/contexts/InspectorContext";
 import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
-import { EventLog } from "replay-next/src/suspense/EventsCache";
+import { EventLog, getEventSuspense } from "replay-next/src/suspense/EventsCache";
 import { formatTimestamp } from "replay-next/src/utils/time";
 
 import MessageHoverButton from "../MessageHoverButton";
@@ -24,14 +24,13 @@ function EventLogRenderer({
   index: number;
   isFocused: boolean;
 }) {
-  const { showTimestamps } = useContext(ConsoleFiltersContext);
   const { executionPoint: currentExecutionPoint } = useContext(TimelineContext);
 
   const ref = useRef<HTMLDivElement>(null);
 
   const [isHovered, setIsHovered] = useState(false);
 
-  const { point, pauseId, time, values } = eventLog;
+  const { point, time } = eventLog;
 
   const context = useMemo(
     () => ({
@@ -52,34 +51,7 @@ function EventLogRenderer({
     className = `${className} ${styles.Focused}`;
   }
 
-  const content =
-    values.length > 0
-      ? values.map((value, index) => (
-          <Fragment key={index}>
-            <Inspector context="console" pauseId={pauseId} protocolValue={value} />
-            {index < values.length - 1 && " "}
-          </Fragment>
-        ))
-      : null;
-
   const { contextMenu, onContextMenu } = useConsoleContextMenu(eventLog);
-
-  const primaryContent = (
-    <>
-      {showTimestamps && (
-        <span className={styles.TimeStamp}>{formatTimestamp(eventLog.time, true)} </span>
-      )}
-      {content ? (
-        <span className={styles.LogContents} data-test-name="LogContents">
-          {content}
-        </span>
-      ) : (
-        <span className={styles.LogContentsEmpty} data-test-name="LogContents">
-          No data to display.
-        </span>
-      )}
-    </>
-  );
 
   return (
     <>
@@ -98,14 +70,16 @@ function EventLogRenderer({
         >
           <span className={styles.Source}>
             <Suspense fallback={<Loader />}>
-              <Source locations={eventLog.location} />
+              <Source locations={eventLog.frame!} />
             </Suspense>
           </span>
-          {primaryContent}
+          <Suspense fallback={<Loader />}>
+            <AnalyzedContent eventLog={eventLog} />
+          </Suspense>
           {isHovered && (
             <MessageHoverButton
               executionPoint={eventLog.point}
-              locations={eventLog.location}
+              locations={eventLog.frame!}
               showAddCommentButton={true}
               time={eventLog.time}
             />
@@ -113,6 +87,40 @@ function EventLogRenderer({
         </div>
       </InspectableTimestampedPointContext.Provider>
       {contextMenu}
+    </>
+  );
+}
+
+
+function AnalyzedContent({ eventLog }: { eventLog: EventLog }) {
+  const { showTimestamps } = useContext(ConsoleFiltersContext);
+
+  const { pauseId, values } = getEventSuspense(eventLog.eventType, eventLog.point);
+
+  const content =
+    values.length > 0
+      ? values.map((value, index) => (
+          <Fragment key={index}>
+            <Inspector context="console" pauseId={pauseId} protocolValue={value} />
+            {index < values.length - 1 && " "}
+          </Fragment>
+        ))
+      : null;
+
+  return (
+    <>
+      {showTimestamps && (
+        <span className={styles.TimeStamp}>{formatTimestamp(eventLog.time, true)} </span>
+      )}
+      {content ? (
+        <span className={styles.LogContents} data-test-name="LogContents">
+          {content}
+        </span>
+      ) : (
+        <span className={styles.LogContentsEmpty} data-test-name="LogContents">
+          No data to display.
+        </span>
+      )}
     </>
   );
 }

--- a/packages/replay-next/components/console/renderers/UncaughtExceptionRenderer.tsx
+++ b/packages/replay-next/components/console/renderers/UncaughtExceptionRenderer.tsx
@@ -1,5 +1,5 @@
 import { Value as ProtocolValue } from "@replayio/protocol";
-import { Fragment, MouseEvent, useMemo, useRef, useState } from "react";
+import { Fragment, useMemo, useRef, useState } from "react";
 import { useLayoutEffect } from "react";
 import { Suspense, memo, useContext } from "react";
 
@@ -10,7 +10,7 @@ import Inspector from "replay-next/components/inspector";
 import Loader from "replay-next/components/Loader";
 import { ConsoleFiltersContext } from "replay-next/src/contexts/ConsoleFiltersContext";
 import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
-import { UncaughtException } from "replay-next/src/suspense/ExceptionsCache";
+import { getExceptionSuspense, UncaughtException } from "replay-next/src/suspense/ExceptionsCache";
 import { formatTimestamp } from "replay-next/src/utils/time";
 
 import MessageHoverButton from "../MessageHoverButton";
@@ -34,12 +34,6 @@ function UncaughtExceptionRenderer({
 
   const { contextMenu, onContextMenu } = useConsoleContextMenu(uncaughtException);
 
-  const locations = useMemo(() => {
-    return Array.isArray(uncaughtException.location)
-      ? uncaughtException.location
-      : [uncaughtException.location];
-  }, [uncaughtException.location]);
-
   const ref = useRef<HTMLDivElement>(null);
 
   const [isHovered, setIsHovered] = useState(false);
@@ -55,29 +49,7 @@ function UncaughtExceptionRenderer({
     className = `${className} ${styles.Focused}`;
   }
 
-  const frames = uncaughtException.data.frames || EMPTY_ARRAY;
-  const showExpandable = frames.length > 0;
-
-  const argumentValues = uncaughtException.values || EMPTY_ARRAY;
-  const primaryContent =
-    argumentValues.length > 0 ? (
-      <span className={styles.LogContents} data-test-name="LogContents">
-        <Suspense fallback={<Loader />}>
-          {argumentValues.map((argumentValue: ProtocolValue, index: number) => (
-            <Fragment key={index}>
-              <Inspector
-                context="console"
-                pauseId={uncaughtException.pauseId}
-                protocolValue={argumentValue}
-              />
-              {index < argumentValues.length - 1 && " "}
-            </Fragment>
-          ))}
-        </Suspense>
-      </span>
-    ) : (
-      " "
-    );
+  const locations = uncaughtException.frame!;
 
   return (
     <>
@@ -102,18 +74,9 @@ function UncaughtExceptionRenderer({
             {locations.length > 0 && <Source locations={locations} />}
           </Suspense>
         </span>
-        {showExpandable ? (
-          <Expandable
-            children={
-              <StackRenderer frames={frames} stack={frames.map(({ frameId }) => frameId)} />
-            }
-            className={styles.Expandable}
-            header={primaryContent}
-            useBlockLayoutWhenExpanded={false}
-          />
-        ) : (
-          primaryContent
-        )}
+        <Suspense fallback={<Loader />}>
+          <AnalyzedContent uncaughtException={uncaughtException} />
+        </Suspense>
         {isHovered && (
           <MessageHoverButton
             executionPoint={uncaughtException.point}
@@ -125,6 +88,45 @@ function UncaughtExceptionRenderer({
       </div>
       {contextMenu}
     </>
+  );
+}
+
+function AnalyzedContent({ uncaughtException }: { uncaughtException: UncaughtException }) {
+  const uncaughtExceptionResult = getExceptionSuspense(uncaughtException.point);
+
+  const frames = uncaughtExceptionResult.data.frames || EMPTY_ARRAY;
+  const showExpandable = frames.length > 0;
+
+  const argumentValues = uncaughtExceptionResult.values || EMPTY_ARRAY;
+  const primaryContent =
+    argumentValues.length > 0 ? (
+      <span className={styles.LogContents} data-test-name="LogContents">
+        <Suspense fallback={<Loader />}>
+          {argumentValues.map((argumentValue: ProtocolValue, index: number) => (
+            <Fragment key={index}>
+              <Inspector
+                context="console"
+                pauseId={uncaughtExceptionResult.pauseId}
+                protocolValue={argumentValue}
+              />
+              {index < argumentValues.length - 1 && " "}
+            </Fragment>
+          ))}
+        </Suspense>
+      </span>
+    ) : (
+      <>" "</>
+    );
+
+  return showExpandable ? (
+    <Expandable
+      children={<StackRenderer frames={frames} stack={frames.map(({ frameId }) => frameId)} />}
+      className={styles.Expandable}
+      header={primaryContent}
+      useBlockLayoutWhenExpanded={false}
+    />
+  ) : (
+    primaryContent
   );
 }
 

--- a/packages/replay-next/src/contexts/FocusContext.tsx
+++ b/packages/replay-next/src/contexts/FocusContext.tsx
@@ -1,4 +1,4 @@
-import { TimeStampedPointRange } from "@replayio/protocol";
+import { TimeStampedPoint, TimeStampedPointRange } from "@replayio/protocol";
 import {
   PropsWithChildren,
   createContext,
@@ -31,6 +31,7 @@ export type FocusContextType = {
   range: TimeStampedPointRange | null;
   rangeForDisplay: TimeStampedPointRange | null;
   update: (value: Range | null, debounce: boolean) => void;
+  endPoint?: TimeStampedPoint;
 };
 
 export const FocusContext = createContext<FocusContextType>(null as any);

--- a/packages/replay-next/src/suspense/AnalysisCache.ts
+++ b/packages/replay-next/src/suspense/AnalysisCache.ts
@@ -260,7 +260,7 @@ function createMapperForCondition(condition: string): string {
   `;
 }
 
-function createMapperForAnalysis(code: string, condition: string | null): string {
+export function createMapperForAnalysis(code: string, condition: string | null): string {
   const escapedCode = code.replace(/"/g, '\\"');
   return `
     const finalData = { frames: [], scopes: [], objects: [] };

--- a/packages/replay-next/src/suspense/ExceptionsCache.ts
+++ b/packages/replay-next/src/suspense/ExceptionsCache.ts
@@ -1,43 +1,18 @@
-import { TimeStampedPointRange } from "@replayio/protocol";
+import { PointDescription } from "@replayio/protocol";
 
-import { ReplayClientInterface } from "shared/client/types";
-import { ProtocolError, isCommandError } from "shared/utils/error";
+import { getAnalysisCache } from "./NewAnalysisCache";
 
-import { createWakeable } from "../utils/suspense";
-import { isRangeEqual, isRangeSubset } from "../utils/time";
-import { RemoteAnalysisResult } from "./AnalysisCache";
-import { cachePauseData } from "./PauseCache";
-import { Wakeable } from "./types";
-
-export type UncaughtException = RemoteAnalysisResult & {
+export type UncaughtException = PointDescription & {
   type: "UncaughtException";
 };
 
 type Callback = () => void;
 export type Status = "failed-too-many-points" | "fetched" | "request-in-progress" | "uninitialized";
 
-const EMPTY_ARRAY: any[] = [];
-
-let inFlightFocusRange: TimeStampedPointRange | null = null;
-let inFlightWakeable: Wakeable<RemoteAnalysisResult[]> | null = null;
-let lastFetchDidFailTooManyPoints: boolean = false;
-let lastFetchedFocusRange: TimeStampedPointRange | null = null;
-let lastFetchedExceptions: UncaughtException[] | null = null;
-let lastFilteredExceptions: UncaughtException[] | null = null;
-let lastFilteredFocusRange: TimeStampedPointRange | null = null;
-
 const tooManyPointsListeners: Set<Callback> = new Set();
 
 export function getStatus(): Status {
-  if (inFlightWakeable !== null) {
-    return "request-in-progress";
-  } else if (lastFetchDidFailTooManyPoints) {
-    return "failed-too-many-points";
-  } else if (lastFetchedExceptions !== null) {
-    return "fetched";
-  } else {
-    return "uninitialized";
-  }
+  return "uninitialized"; //TODO
 }
 
 export function subscribeForStatus(callback: Callback): Callback {
@@ -45,129 +20,6 @@ export function subscribeForStatus(callback: Callback): Callback {
   return function unsubscribeFromStatus() {
     tooManyPointsListeners.delete(callback);
   };
-}
-
-function notifyStatusSubscribers(): void {
-  tooManyPointsListeners.forEach(callback => callback());
-}
-
-export function getExceptionsSuspense(
-  client: ReplayClientInterface,
-  focusRange: TimeStampedPointRange | null
-): UncaughtException[] {
-  if (focusRange !== null && focusRange.begin.point === focusRange.end.point) {
-    // Edge case scenario handling.
-    lastFetchedExceptions = lastFilteredExceptions = EMPTY_ARRAY;
-    lastFetchedFocusRange = lastFilteredFocusRange = focusRange;
-
-    notifyStatusSubscribers();
-
-    return EMPTY_ARRAY;
-  }
-
-  if (inFlightWakeable !== null && isRangeEqual(inFlightFocusRange, focusRange)) {
-    // If we're already fetching this data, rethrow the same Wakeable (for Suspense reasons).
-    throw inFlightWakeable;
-  }
-
-  let shouldFetch = false;
-  if (lastFetchedExceptions === null) {
-    // This is the first time we're fetching data.
-    shouldFetch = true;
-  } else {
-    if (!isRangeSubset(lastFetchedFocusRange, focusRange)) {
-      // The new range is bigger than the old range so we need to fetch again.
-      shouldFetch = true;
-    } else {
-      if (!isRangeEqual(lastFetchedFocusRange, focusRange)) {
-        // The new range is smaller than the old one
-        if (lastFetchDidFailTooManyPoints) {
-          // The last time we tried to fetch overflowed, so we should try again.
-          shouldFetch = true;
-        }
-      }
-    }
-  }
-
-  if (shouldFetch) {
-    inFlightFocusRange = focusRange;
-    inFlightWakeable = createWakeable(
-      `getExceptionsSuspense: ${
-        focusRange ? `${focusRange.begin.point}-${focusRange.end.point}` : "-"
-      }`
-    );
-
-    fetchExceptions(client);
-
-    notifyStatusSubscribers();
-
-    throw inFlightWakeable;
-  }
-
-  if (focusRange === null) {
-    lastFilteredExceptions = lastFetchedExceptions;
-    lastFilteredFocusRange = focusRange;
-  } else if (!isRangeEqual(lastFilteredFocusRange, focusRange)) {
-    lastFilteredExceptions = lastFetchedExceptions!.filter(exception => {
-      return exception.point >= focusRange.begin.point && exception.point <= focusRange.end.point;
-    });
-    lastFilteredFocusRange = focusRange;
-  }
-
-  return lastFilteredExceptions!;
-}
-
-async function fetchExceptions(client: ReplayClientInterface) {
-  const wakeable = inFlightWakeable!;
-
-  try {
-    const results = await client.runAnalysis<RemoteAnalysisResult>({
-      effectful: false,
-      exceptionPoints: true,
-      mapper: EXCEPTIONS_MAPPER,
-      range: inFlightFocusRange
-        ? { begin: inFlightFocusRange.begin.point, end: inFlightFocusRange.end.point }
-        : undefined,
-    });
-
-    // Cache Object preview data since we have it.
-    // This may save us from making unnecessary requests later.
-    results.forEach(result => {
-      if (result.data) {
-        cachePauseData(client, result.pauseId, result.data);
-      }
-    });
-
-    if (wakeable === inFlightWakeable) {
-      lastFetchDidFailTooManyPoints = false;
-      lastFetchedExceptions = results.map(result => ({
-        ...result,
-        type: "UncaughtException",
-      }));
-      lastFetchedFocusRange = inFlightFocusRange;
-    }
-
-    // React doesn't use the resolved value.
-    wakeable.resolve(null as any);
-  } catch (error) {
-    if (wakeable === inFlightWakeable && isCommandError(error, ProtocolError.TooManyPoints)) {
-      lastFetchDidFailTooManyPoints = true;
-      lastFetchedExceptions = EMPTY_ARRAY;
-      lastFetchedFocusRange = inFlightFocusRange;
-    } else {
-      console.error(error);
-    }
-
-    // React doesn't use the resolved value.
-    wakeable.resolve(null as any);
-  } finally {
-    if (wakeable === inFlightWakeable) {
-      inFlightFocusRange = null;
-      inFlightWakeable = null;
-
-      notifyStatusSubscribers();
-    }
-  }
 }
 
 const EXCEPTIONS_MAPPER = `
@@ -210,3 +62,18 @@ const EXCEPTIONS_MAPPER = `
     },
   ];
 `;
+
+export const {
+  getPointsSuspense: getExceptionPointsSuspense,
+  getPointsAsync: getExceptionPointsAsync,
+  getCachedPoints: getCachedExceptionPoints,
+  getResultSuspense: getExceptionSuspense,
+  getResultAsync: getExceptionAsync,
+  getResultIfCached: getExceptionIfCached,
+} = getAnalysisCache<UncaughtException>(
+  {
+    exceptions: true,
+    mapper: EXCEPTIONS_MAPPER,
+  },
+  point => ({ ...point, type: "UncaughtException" })
+);

--- a/packages/replay-next/src/suspense/NewAnalysisCache.ts
+++ b/packages/replay-next/src/suspense/NewAnalysisCache.ts
@@ -1,0 +1,163 @@
+import { ExecutionPoint, Location, PointDescription, PointRange } from "@replayio/protocol";
+
+import { ReplayClientInterface } from "shared/client/types";
+
+import { createWakeable } from "../utils/suspense";
+import { RemoteAnalysisResult, createMapperForAnalysis } from "./AnalysisCache";
+import { createGenericRangeCache } from "./createGenericRangeCache";
+import { cachePauseData } from "./PauseCache";
+import { Record, STATUS_PENDING, STATUS_REJECTED, STATUS_RESOLVED, Thennable } from "./types";
+
+export interface AnalysisCache<T extends { point: ExecutionPoint }> {
+  getPointsSuspense(client: ReplayClientInterface, range: PointRange): T[];
+  getPointsAsync(client: ReplayClientInterface, range: PointRange): Thennable<T[]> | T[];
+  getCachedPoints(range: PointRange): T[];
+  getResultSuspense(point: ExecutionPoint): RemoteAnalysisResult;
+  getResultAsync(point: ExecutionPoint): Thennable<RemoteAnalysisResult> | RemoteAnalysisResult;
+  getResultIfCached(point: ExecutionPoint): RemoteAnalysisResult | undefined;
+}
+
+const cachesByLocationAndMapper = new Map<string, AnalysisCache<any>>();
+
+export interface AnalysisParams {
+  location?: Location;
+  eventTypes?: string[];
+  exceptions?: true;
+  mapper: string;
+}
+
+function getCacheKey(params: AnalysisParams) {
+  let cacheKey = "";
+  if (params.location) {
+    cacheKey += `${params.location.sourceId}:${params.location.line}:${params.location.column}:`;
+  }
+  if (params.eventTypes) {
+    cacheKey += `${params.eventTypes.join(",")}:`;
+  }
+  if (params.exceptions) {
+    cacheKey += "exceptions:";
+  }
+  return cacheKey + params.mapper;
+}
+
+export function getAnalysisCache<T extends { point: ExecutionPoint }>(
+  params: AnalysisParams,
+  transformPoint: (point: PointDescription) => T
+): AnalysisCache<T> {
+  const key = getCacheKey(params);
+  if (!cachesByLocationAndMapper.has(key)) {
+    cachesByLocationAndMapper.set(key, createCache(params, transformPoint));
+  }
+  return cachesByLocationAndMapper.get(key)!;
+}
+
+function createCache<T extends { point: ExecutionPoint }>(
+  params: AnalysisParams,
+  transformPoint: (point: PointDescription) => T
+): AnalysisCache<T> {
+  const results = new Map<ExecutionPoint, Record<RemoteAnalysisResult>>();
+
+  const {
+    getValuesSuspense: getPointsSuspense,
+    getValuesAsync: getPointsAsync,
+    getCachedValues: getCachedPoints,
+  } = createGenericRangeCache<T>(
+    async (client, range, cacheValues) => {
+      await client.streamAnalysis(
+        {
+          locations: params.location ? [{ location: params.location }] : undefined,
+          eventHandlerEntryPoints: params.eventTypes?.map(eventType => ({ eventType })),
+          exceptionPoints: params.exceptions,
+          mapper: params.mapper,
+          effectful: false,
+          range,
+        },
+        points => cacheValues(points.map(transformPoint)),
+        analysisEntries => {
+          for (const analysisEntry of analysisEntries) {
+            const result = analysisEntry.value;
+            cachePauseData(client, result.pauseId, result.data);
+            const record = results.get(result.point);
+            if (record) {
+              record.value.resolve(result);
+              record.status = STATUS_RESOLVED;
+              record.value = result;
+            } else {
+              results.set(result.point, {
+                status: STATUS_RESOLVED,
+                value: result,
+              });
+            }
+          }
+        }
+      ).pointsReceived;
+    },
+    pointDescription => pointDescription.point
+  );
+
+  function getOrCreateRecord(point: ExecutionPoint) {
+    let record = results.get(point);
+    if (!record) {
+      const wakeable = createWakeable<RemoteAnalysisResult>("AnalysisCache.getResultSuspense");
+      record = {
+        status: STATUS_PENDING,
+        value: wakeable,
+      };
+      results.set(point, record);
+    }
+    return record;
+  }
+
+  function getResultSuspense(point: ExecutionPoint) {
+    const record = getOrCreateRecord(point);
+    if (record.status === STATUS_RESOLVED) {
+      return record.value;
+    } else {
+      throw record.value;
+    }
+  }
+
+  function getResultAsync(point: ExecutionPoint) {
+    const record = getOrCreateRecord(point);
+    if (record.status !== STATUS_REJECTED) {
+      return record.value;
+    } else {
+      throw record.value;
+    }
+  }
+
+  function getResultIfCached(point: ExecutionPoint) {
+    const record = results.get(point);
+    if (record?.status === STATUS_RESOLVED) {
+      return record.value;
+    }
+  }
+
+  return {
+    getPointsSuspense,
+    getPointsAsync,
+    getCachedPoints,
+    getResultSuspense,
+    getResultAsync,
+    getResultIfCached,
+  };
+}
+
+export function getAnalysisResultSuspense(
+  client: ReplayClientInterface,
+  range: PointRange,
+  point: ExecutionPoint,
+  location: Location,
+  content: string,
+  condition: string | null
+) {
+  const cache = getAnalysisCache<PointDescription>(
+    {
+      mapper: createMapperForAnalysis(content, condition),
+      location,
+    },
+    point => point
+  );
+  cache.getPointsAsync(client, range);
+  return cache.getResultSuspense(point);
+}

--- a/packages/replay-next/src/suspense/createGenericRangeCache.ts
+++ b/packages/replay-next/src/suspense/createGenericRangeCache.ts
@@ -1,0 +1,208 @@
+import { ExecutionPoint, PointRange } from "@replayio/protocol";
+
+import { ReplayClientInterface } from "shared/client/types";
+
+import { Range, getMissingRanges, isInRange, mergeRanges } from "../utils/range-list";
+import { Subscriber, UnsubscribeFunction } from "./SearchCache";
+import { Thennable } from "./types";
+
+interface RangeStore<T> {
+  cachedRanges: Range[];
+  valuesFromCachedRanges: T[];
+  pendingRanges: Range[];
+  valuesFromPendingRanges: T[];
+  subscribe(subscriber: Subscriber): UnsubscribeFunction;
+  notifySubscribers(): void;
+  fetchMissingRanges(client: ReplayClientInterface, range: PointRange): Promise<void>;
+  getExecutionPoint: (value: T) => ExecutionPoint;
+}
+
+export interface RangeCache<T> {
+  getValuesSuspense(client: ReplayClientInterface, range: PointRange): T[];
+  getValuesAsync(client: ReplayClientInterface, range: PointRange): Thennable<T[]> | T[];
+  getCachedValues(range: PointRange): T[];
+}
+
+interface PendingRange<T> {
+  range: Range;
+  values: T[];
+  promise?: Promise<void>;
+}
+
+export function createGenericRangeCache<T>(
+  fetchRange: (
+    client: ReplayClientInterface,
+    range: PointRange,
+    cacheValues: (values: T[]) => void
+  ) => Promise<void>,
+  getExecutionPoint: (value: T) => ExecutionPoint
+): RangeCache<T> {
+  const pendingRanges: PendingRange<T>[] = [];
+  const subscribers: Set<Subscriber> = new Set();
+  const store: RangeStore<T> = {
+    cachedRanges: [],
+    valuesFromCachedRanges: [],
+    pendingRanges: [],
+    valuesFromPendingRanges: [],
+    subscribe(subscriber: Subscriber) {
+      subscribers.add(subscriber);
+      return () => {
+        subscribers.delete(subscriber);
+      };
+    },
+    notifySubscribers() {
+      subscribers.forEach(subscriber => subscriber());
+    },
+    async fetchMissingRanges(client: ReplayClientInterface, pointRange: PointRange) {
+      const requestedRange = pointRangeToRange(pointRange);
+      const missingRanges = getMissingRanges(
+        requestedRange,
+        mergeRanges(store.cachedRanges, store.pendingRanges)
+      );
+
+      missingRanges.forEach(missingRange => {
+        const pendingRange: PendingRange<T> = {
+          range: missingRange,
+          values: [],
+        };
+
+        async function doFetch() {
+          insertPendingRange(pendingRanges, pendingRange);
+          store.pendingRanges = mergeRanges(store.pendingRanges, [missingRange]);
+
+          await fetchRange(client, rangeToPointRange(missingRange), (values: T[]) => {
+            pendingRange.values = mergeValues(pendingRange.values, values, getExecutionPoint);
+            store.valuesFromPendingRanges = mergeValues(
+              store.valuesFromPendingRanges,
+              values,
+              getExecutionPoint
+            );
+            store.notifySubscribers();
+          });
+
+          removePendingRange(pendingRanges, pendingRange);
+          store.pendingRanges = pendingRanges.reduce<Range[]>(
+            (previous, current) => mergeRanges(previous, [current.range]),
+            []
+          );
+          store.valuesFromPendingRanges = pendingRanges.reduce<T[]>(
+            (previous, current) => mergeValues(previous, current.values, getExecutionPoint),
+            []
+          );
+          store.cachedRanges = mergeRanges(store.cachedRanges, [pendingRange.range]);
+          store.valuesFromCachedRanges = mergeValues(
+            store.valuesFromCachedRanges,
+            pendingRange.values,
+            getExecutionPoint
+          );
+          store.notifySubscribers();
+        }
+
+        pendingRange.promise = doFetch();
+      });
+
+      store.notifySubscribers();
+
+      await Promise.all(
+        pendingRanges
+          .filter(pending => rangesOverlap(pending.range, requestedRange))
+          .map(pending => pending.promise)
+      );
+    },
+    getExecutionPoint,
+  };
+
+  function getValuesSuspense(client: ReplayClientInterface, pointRange: PointRange): T[] {
+    const range = pointRangeToRange(pointRange);
+    if (getMissingRanges(range, store.cachedRanges).length > 0) {
+      throw store.fetchMissingRanges(client, pointRange);
+    }
+    return store.valuesFromCachedRanges.filter(value =>
+      isInRange(BigInt(store.getExecutionPoint(value)), range)
+    );
+  }
+
+  function getValuesAsync(
+    client: ReplayClientInterface,
+    pointRange: PointRange
+  ): T[] | Promise<T[]> {
+    const range = pointRangeToRange(pointRange);
+    if (getMissingRanges(range, store.cachedRanges).length > 0) {
+      return store
+        .fetchMissingRanges(client, pointRange)
+        .then(() =>
+          store.valuesFromCachedRanges.filter(value =>
+            isInRange(BigInt(store.getExecutionPoint(value)), range)
+          )
+        );
+    }
+    return store.valuesFromCachedRanges.filter(value =>
+      isInRange(BigInt(store.getExecutionPoint(value)), range)
+    );
+  }
+
+  function getCachedValues(pointRange: PointRange) {
+    const range = pointRange ? pointRangeToRange(pointRange) : undefined;
+    const cachedValues = store.valuesFromCachedRanges;
+    if (!range) {
+      return cachedValues;
+    }
+    return cachedValues.filter(value => isInRange(BigInt(store.getExecutionPoint(value)), range));
+  }
+
+  return { getValuesSuspense, getValuesAsync, getCachedValues };
+}
+
+function insertPendingRange<T>(existing: PendingRange<T>[], toInsert: PendingRange<T>) {
+  let index = existing.findIndex(ra => ra.range.begin > toInsert.range.begin);
+  if (index < 0) {
+    index = existing.length;
+  }
+  existing.splice(index, 0, toInsert);
+}
+
+function removePendingRange<T>(existing: PendingRange<T>[], toRemove: PendingRange<T>) {
+  const index = existing.indexOf(toRemove);
+  if (index >= 0) {
+    existing.splice(index, 1);
+  }
+}
+
+export function mergeValues<T>(
+  values1: T[],
+  values2: T[],
+  getExecutionPoint: (value: T) => ExecutionPoint
+) {
+  const result: T[] = [];
+  let index1 = 0;
+  let index2 = 0;
+  while (index1 < values1.length && index2 < values2.length) {
+    if (BigInt(getExecutionPoint(values1[index1])) < BigInt(getExecutionPoint(values2[index2]))) {
+      result.push(values1[index1]);
+      index1++;
+    } else {
+      result.push(values2[index2]);
+      index2++;
+    }
+  }
+
+  if (index1 < values1.length) {
+    result.push(...values1.slice(index1));
+  } else if (index2 < values2.length) {
+    result.push(...values2.slice(index2));
+  }
+
+  return result;
+}
+
+function pointRangeToRange(pointRange: PointRange): Range {
+  return { begin: BigInt(pointRange.begin), end: BigInt(pointRange.end) };
+}
+
+function rangeToPointRange(range: Range): PointRange {
+  return { begin: String(range.begin), end: String(range.end) };
+}
+
+function rangesOverlap(range1: Range, range2: Range) {
+  return range1.end > range2.begin && range1.begin < range2.end;
+}

--- a/packages/replay-next/src/utils/range-list.ts
+++ b/packages/replay-next/src/utils/range-list.ts
@@ -1,0 +1,88 @@
+export interface Range {
+  begin: bigint;
+  end: bigint;
+}
+
+function min(b1: bigint, b2: bigint) {
+  return b1 < b2 ? b1 : b2;
+}
+
+function max(b1: bigint, b2: bigint) {
+  return b1 > b2 ? b1 : b2;
+}
+
+export function isInRange(b: bigint, range: Range) {
+  return b >= range.begin && b < range.end;
+}
+
+export function getMissingRanges(requested: Range, cached: Range[]): Range[] {
+  let index = cached.findIndex(range => BigInt(range.end) > BigInt(requested.begin));
+  if (index < 0) {
+    return [requested];
+  }
+  let point: bigint;
+  if (cached[index].begin <= requested.begin) {
+    point = min(cached[index].end, requested.end);
+    index++;
+  } else {
+    point = requested.begin;
+  }
+  const missing = [];
+  while (point < requested.end && index <= cached.length) {
+    if (index === cached.length) {
+      missing.push({ begin: point, end: requested.end });
+      break;
+    }
+    missing.push({
+      begin: point,
+      end: min(cached[index].begin, requested.end),
+    });
+    point = cached[index].end;
+    index++;
+  }
+  return missing;
+}
+
+export function mergeRanges(ranges1: Range[], ranges2: Range[]): Range[] {
+  if (ranges1.length === 0) {
+    return ranges2;
+  } else if (ranges2.length === 0) {
+    return ranges1;
+  }
+
+  const merged: Range[] = [];
+  let point = BigInt(0);
+  let index1 = 0;
+  let index2 = 0;
+  while (index1 < ranges1.length && index2 < ranges2.length) {
+    point = min(ranges1[index1].begin, ranges2[index2].begin);
+    const begin = point;
+
+    while (true) {
+      if (index1 < ranges1.length && BigInt(ranges1[index1].begin) <= BigInt(point)) {
+        point = ranges1[index1].end;
+      } else if (index2 < ranges2.length && BigInt(ranges2[index2].begin) <= BigInt(point)) {
+        point = ranges2[index2].end;
+      } else {
+        break;
+      }
+      while (index1 < ranges1.length && BigInt(ranges1[index1].end) <= BigInt(point)) {
+        index1++;
+      }
+      while (index2 < ranges2.length && BigInt(ranges2[index2].end) <= BigInt(point)) {
+        index2++;
+      }
+    }
+
+    const end = point;
+    merged.push({ begin, end });
+  }
+
+  if (index1 < ranges1.length) {
+    merged.push(...ranges1.slice(index1));
+  } else if (index2 < ranges2.length) {
+    merged.push(...ranges2.slice(index2));
+  }
+
+  return merged;
+}

--- a/packages/replay-next/src/utils/testing.tsx
+++ b/packages/replay-next/src/utils/testing.tsx
@@ -223,6 +223,7 @@ export function createMockReplayClient() {
     runAnalysis: jest.fn().mockImplementation(async () => []),
     searchFunctions: jest.fn().mockImplementation(async () => {}),
     searchSources: jest.fn().mockImplementation(async () => {}),
+    streamAnalysis: jest.fn().mockImplementation(async () => undefined),
     streamSourceContents: jest.fn().mockImplementation(async () => {}),
     waitForLoadedSources: jest.fn().mockImplementation(async () => undefined),
     waitForTimeToBeLoaded: jest.fn().mockImplementation(async () => undefined),

--- a/packages/shared/client/types.ts
+++ b/packages/shared/client/types.ts
@@ -1,4 +1,5 @@
 import {
+  AnalysisEntry,
   BreakpointId,
   ContentType,
   Result as EvaluationResult,
@@ -185,6 +186,11 @@ export interface ReplayClientInterface {
     },
     onMatches: (matches: SearchSourceContentsMatch[], didOverflow: boolean) => void
   ): Promise<void>;
+  streamAnalysis(
+    params: AnalysisParams,
+    onPoints: (points: PointDescription[]) => void,
+    onResults: (results: AnalysisEntry[]) => void
+  ): { pointsReceived: Promise<void>; resultsReceived: Promise<void> };
   streamSourceContents(
     sourceId: SourceId,
     onSourceContentsInfo: ({

--- a/src/ui/components/FocusContextReduxAdapter.tsx
+++ b/src/ui/components/FocusContextReduxAdapter.tsx
@@ -1,10 +1,10 @@
 import { PropsWithChildren, useCallback, useEffect, useMemo, useState, useTransition } from "react";
 
-import { FocusContext, FocusContextType } from "replay-next/src/contexts/FocusContext";
+import { FocusContext } from "replay-next/src/contexts/FocusContext";
 import { Range } from "replay-next/src/types";
 import { enterFocusMode, setFocusRegionFromTimeRange } from "ui/actions/timeline";
 import { getLoadedRegions } from "ui/reducers/app";
-import { getFocusRegion } from "ui/reducers/timeline";
+import { getFocusRegion, getPoints } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { FocusRegion } from "ui/state/timeline";
 import { rangeForFocusRegion } from "ui/utils/timeline";
@@ -14,6 +14,8 @@ export default function FocusContextReduxAdapter({ children }: PropsWithChildren
   const dispatch = useAppDispatch();
   const loadedRegions = useAppSelector(getLoadedRegions);
   const focusRegion = useAppSelector(getFocusRegion);
+  const receivedPoints = useAppSelector(getPoints);
+  const endPoint = receivedPoints[receivedPoints.length - 1];
 
   const [isPending, startTransition] = useTransition();
   const [deferredFocusRegion, setDeferredFocusRegion] = useState<FocusRegion | null>(null);
@@ -45,12 +47,13 @@ export default function FocusContextReduxAdapter({ children }: PropsWithChildren
       enterFocusMode: () => {
         dispatch(enterFocusMode());
       },
+      endPoint,
       isTransitionPending: isPending,
       range: deferredFocusRegion ? rangeForFocusRegion(deferredFocusRegion) : null,
       rangeForDisplay: focusRegion ? rangeForFocusRegion(focusRegion) : null,
       update,
     };
-  }, [deferredFocusRegion, dispatch, isPending, focusRegion, update]);
+  }, [deferredFocusRegion, dispatch, endPoint, isPending, focusRegion, update]);
 
   return <FocusContext.Provider value={context}>{children}</FocusContext.Provider>;
 }


### PR DESCRIPTION
This is (mostly) the code that I showed yesterday in our architecture sync but I have moved the hooks out of the cache now because that is just one possible API that we could put on top of the cache and probably not the one we want to use in the `LoggablesContext` (or whatever we want to replace it with).
In particular I realized that having a hook that accesses a single analysis is useless for the `LoggablesContext`: we have a dynamic number of analyses whose results we want to combine but we can't call a dynamic number of hooks.