### PR TITLE
Add preview images to visual comments

### DIFF
--- a/packages/bvaughn-architecture-demo/components/Icon.tsx
+++ b/packages/bvaughn-architecture-demo/components/Icon.tsx
@@ -1,9 +1,10 @@
-import { ReactNode } from "react";
+import { CSSProperties, ReactNode } from "react";
 
 import styles from "./Icon.module.css";
 
 export default function Icon({
   className = styles.DefaultIcon,
+  style,
   type,
 }: {
   className?: string;
@@ -55,6 +56,7 @@ export default function Icon({
     | "view-html-element"
     | "visible"
     | "warning";
+  style?: CSSProperties;
 }) {
   let path: ReactNode = null;
   switch (type) {
@@ -273,7 +275,7 @@ export default function Icon({
   }
 
   return (
-    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+    <svg className={className} style={style} viewBox="0 0 24 24" fill="currentColor">
       <path d="M0 0h24v24H0z" fill="none" />
       {path}
     </svg>

--- a/packages/bvaughn-architecture-demo/components/Icon.tsx
+++ b/packages/bvaughn-architecture-demo/components/Icon.tsx
@@ -36,6 +36,7 @@ export default function Icon({
     | "menu-closed"
     | "menu-open"
     | "pause"
+    | "preview"
     | "print"
     | "prompt"
     | "protocol"
@@ -161,6 +162,10 @@ export default function Icon({
     case "pause":
       path =
         "M12,2C6.48,2,2,6.48,2,12s4.48,10,10,10s10-4.48,10-10S17.52,2,12,2z M11,16H9V8h2V16z M15,16h-2V8h2V16z";
+      break;
+    case "preview":
+      path =
+        "M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z";
       break;
     case "print":
       path =

--- a/packages/bvaughn-architecture-demo/components/comments/Comment.module.css
+++ b/packages/bvaughn-architecture-demo/components/comments/Comment.module.css
@@ -127,12 +127,12 @@
 }
 
 .PrimaryLabel {
-  font-size: var(--font-size-small);
+  font-size: var(--font-size-tiny);
   padding: 0.25rem 0.5rem;
 }
 
 .SecondaryLabel {
-  font-size: var(--font-size-regular);
+  font-size: var(--font-size-small);
   padding: 0.25rem 0.5rem;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/packages/bvaughn-architecture-demo/components/comments/Comment.module.css
+++ b/packages/bvaughn-architecture-demo/components/comments/Comment.module.css
@@ -138,3 +138,31 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+.OuterImageContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0.25rem;
+  padding: 0.25rem;
+  border-radius: 0.25rem;
+  background-color: var(--comment-card-source-preview-background-color);
+}
+
+.InnerImageContainer {
+  position: relative;
+}
+
+.PositionIndicator {
+  position: absolute;
+  width: 1.5rem;
+  height: 1.5rem;
+  margin-left: -0.75rem;
+  margin-top: -0.75rem;
+  fill: var(--color-current);
+}
+
+.Image {
+  max-width: 100%;
+  height: auto;
+}

--- a/packages/bvaughn-architecture-demo/src/utils/canvas.ts
+++ b/packages/bvaughn-architecture-demo/src/utils/canvas.ts
@@ -1,0 +1,58 @@
+export async function getBase64Png(
+  canvas: HTMLCanvasElement,
+  options: {
+    maxWidth?: number;
+    maxHeight?: number;
+  } = {}
+): Promise<string | null> {
+  const base64PNG = canvas.toDataURL();
+  if (!base64PNG) {
+    return null;
+  }
+
+  const { maxHeight, maxWidth } = options;
+  if (maxHeight == null && maxWidth == null) {
+    return base64PNG;
+  }
+
+  return new Promise(resolve => {
+    const image = new Image();
+    image.src = base64PNG;
+    image.onload = () => {
+      const tempCanvas = document.createElement("canvas");
+
+      let width = image.width;
+      let height = image.height;
+
+      if ((maxWidth == null || width < maxWidth) && (maxHeight == null || height < maxHeight)) {
+        resolve(base64PNG);
+        return;
+      }
+
+      if (maxWidth != null) {
+        if (width > maxWidth) {
+          height *= maxWidth / width;
+          width = maxWidth;
+        }
+      }
+
+      if (maxHeight != null) {
+        if (height > maxHeight) {
+          width *= maxHeight / height;
+          height = maxHeight;
+        }
+      }
+
+      tempCanvas.width = width;
+      tempCanvas.height = height;
+
+      const context = tempCanvas.getContext("2d");
+      if (context) {
+        context.drawImage(image, 0, 0, width, height);
+        resolve(tempCanvas.toDataURL());
+      } else {
+        resolve(null);
+      }
+    };
+  });
+}

--- a/src/ui/components/Comments/CommentPreview.tsx
+++ b/src/ui/components/Comments/CommentPreview.tsx
@@ -3,6 +3,7 @@ import { MouseEvent } from "react";
 import { Comment } from "ui/state/comments";
 
 import CommentSource from "./TranscriptComments/CommentSource";
+import CommentThumbnail from "./TranscriptComments/CommentThumbnail";
 import NetworkRequestPreview from "./TranscriptComments/NetworkRequestPreview";
 import styles from "./CommentPreview.module.css";
 
@@ -26,6 +27,15 @@ export default function CommentPreview({
       </div>
     );
   } else {
+    const { primaryLabel, secondaryLabel } = comment;
+    if (typeof secondaryLabel === "string" && secondaryLabel.startsWith("data:image")) {
+      return (
+        <div className={styles.Preview}>
+          <CommentThumbnail primaryLabel={primaryLabel ?? null} secondaryLabel={secondaryLabel} />
+        </div>
+      );
+    }
+
     return null;
   }
 }

--- a/src/ui/components/Comments/TranscriptComments/CommentThumbnail.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentThumbnail.tsx
@@ -2,8 +2,6 @@ import { ChatAltIcon } from "@heroicons/react/solid";
 import { useState } from "react";
 
 import Icon from "bvaughn-architecture-demo/components/Icon";
-import { setViewMode } from "ui/actions/layout";
-import { useAppDispatch } from "ui/setup/hooks";
 
 import styles from "./styles.module.css";
 
@@ -14,8 +12,6 @@ export default function CommentThumbnail({
   primaryLabel: string | null;
   secondaryLabel: string;
 }) {
-  const dispatch = useAppDispatch();
-
   const [showPreview, setShowPreview] = useState(false);
 
   let indicatorLeft: string | null = null;
@@ -28,16 +24,14 @@ export default function CommentThumbnail({
     } catch (error) {}
   }
 
-  const onClick = () => {
-    if (showPreview) {
-      dispatch(setViewMode("non-dev"));
-    } else {
-      setShowPreview(true);
-    }
-  };
+  const onClick = () => setShowPreview(!showPreview);
 
   return (
-    <div className={styles.OuterImageContainer} onClick={onClick}>
+    <div
+      className={styles.OuterImageContainer}
+      onClick={onClick}
+      title={showPreview ? "Hide preview" : "Show preview"}
+    >
       {showPreview ? (
         <div className={styles.InnerImageContainer}>
           <img className={styles.Image} src={secondaryLabel} />

--- a/src/ui/components/Comments/TranscriptComments/CommentThumbnail.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentThumbnail.tsx
@@ -1,5 +1,7 @@
 import { ChatAltIcon } from "@heroicons/react/solid";
+import { useState } from "react";
 
+import Icon from "bvaughn-architecture-demo/components/Icon";
 import { setViewMode } from "ui/actions/layout";
 import { useAppDispatch } from "ui/setup/hooks";
 
@@ -14,6 +16,8 @@ export default function CommentThumbnail({
 }) {
   const dispatch = useAppDispatch();
 
+  const [showPreview, setShowPreview] = useState(false);
+
   let indicatorLeft: string | null = null;
   let indicatorTop: string | null = null;
   if (typeof primaryLabel === "string") {
@@ -25,20 +29,34 @@ export default function CommentThumbnail({
   }
 
   const onClick = () => {
-    dispatch(setViewMode("non-dev"));
+    if (showPreview) {
+      dispatch(setViewMode("non-dev"));
+    } else {
+      setShowPreview(true);
+    }
   };
 
   return (
     <div className={styles.OuterImageContainer} onClick={onClick}>
-      <div className={styles.InnerImageContainer}>
-        <img className={styles.Image} src={secondaryLabel} />
+      {showPreview ? (
+        <div className={styles.InnerImageContainer}>
+          <img className={styles.Image} src={secondaryLabel} />
 
-        {indicatorLeft !== null && indicatorTop !== null && (
-          <div className={styles.MarkerWrapper} style={{ left: indicatorLeft, top: indicatorTop }}>
-            <ChatAltIcon className={styles.MarkerIcon} />
-          </div>
-        )}
-      </div>
+          {indicatorLeft !== null && indicatorTop !== null && (
+            <div
+              className={styles.MarkerWrapper}
+              style={{ left: indicatorLeft, top: indicatorTop }}
+            >
+              <ChatAltIcon className={styles.MarkerIcon} />
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className={styles.ShowPreviewPrompt}>
+          <Icon className={styles.PreviewIcon} type="preview" />
+          Show preview
+        </div>
+      )}
     </div>
   );
 }

--- a/src/ui/components/Comments/TranscriptComments/CommentThumbnail.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentThumbnail.tsx
@@ -1,0 +1,44 @@
+import { ChatAltIcon } from "@heroicons/react/solid";
+
+import { setViewMode } from "ui/actions/layout";
+import { useAppDispatch } from "ui/setup/hooks";
+
+import styles from "./styles.module.css";
+
+export default function CommentThumbnail({
+  primaryLabel,
+  secondaryLabel,
+}: {
+  primaryLabel: string | null;
+  secondaryLabel: string;
+}) {
+  const dispatch = useAppDispatch();
+
+  let indicatorLeft: string | null = null;
+  let indicatorTop: string | null = null;
+  if (typeof primaryLabel === "string") {
+    try {
+      const coordinates = JSON.parse(primaryLabel);
+      indicatorLeft = `${coordinates.x * 100}%`;
+      indicatorTop = `${coordinates.y * 100}%`;
+    } catch (error) {}
+  }
+
+  const onClick = () => {
+    dispatch(setViewMode("non-dev"));
+  };
+
+  return (
+    <div className={styles.OuterImageContainer} onClick={onClick}>
+      <div className={styles.InnerImageContainer}>
+        <img className={styles.Image} src={secondaryLabel} />
+
+        {indicatorLeft !== null && indicatorTop !== null && (
+          <div className={styles.MarkerWrapper} style={{ left: indicatorLeft, top: indicatorTop }}>
+            <ChatAltIcon className={styles.MarkerIcon} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/Comments/TranscriptComments/NetworkRequestPreview.tsx
+++ b/src/ui/components/Comments/TranscriptComments/NetworkRequestPreview.tsx
@@ -38,7 +38,7 @@ export default function NetworkRequestPreview({ networkRequestId }: { networkReq
       title={isSeekEnabled ? "Show in the Network Monitor" : undefined}
     >
       <div className={styles.Labels}>
-        <div className={styles.PrimaryLabel}>
+        <div className={styles.NetworkRequestLabel}>
           <span className={styles.NetworkRequestMethod}>{`[${method}]`}</span> {name}
         </div>
       </div>

--- a/src/ui/components/Comments/TranscriptComments/styles.module.css
+++ b/src/ui/components/Comments/TranscriptComments/styles.module.css
@@ -102,3 +102,14 @@
   width: 1rem;
   height: 1rem;
 }
+
+.ShowPreviewPrompt {
+  display: flex;
+  gap: 1ch;
+}
+
+.PreviewIcon {
+  width: 1rem;
+  height: 1rem;
+  color: var(--color-dimmer);
+}

--- a/src/ui/components/Comments/TranscriptComments/styles.module.css
+++ b/src/ui/components/Comments/TranscriptComments/styles.module.css
@@ -26,8 +26,8 @@
   flex-direction: column;
   flex: 1 1 auto;
   overflow: hidden;
-  padding: 0.25rem 0.5rem;
-  gap: 0.25rem;
+  padding: 0.125rem 0.5rem;
+  gap: 0.125rem;
 }
 
 .PrimaryLabel,
@@ -42,8 +42,12 @@
 }
 .SecondaryLabel {
   margin: 0;
-  font-size: var(--font-size-regular);
+  font-size: var(--font-size-small);
   color: var(--color-dim);
+}
+
+.NetworkRequestLabel {
+  font-size: var(--font-size-small);
 }
 
 .Icon {

--- a/src/ui/components/Comments/TranscriptComments/styles.module.css
+++ b/src/ui/components/Comments/TranscriptComments/styles.module.css
@@ -57,3 +57,44 @@
   font-weight: bold;
   color: var(--color-dim);
 }
+
+.OuterImageContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0.25rem;
+  padding: 0.25rem;
+  border-radius: 0.25rem;
+  background-color: var(--comment-card-source-preview-background-color);
+}
+.OuterImageContainer:hover {
+  background-color: var(--comment-card-source-preview-background-color-hover);
+}
+
+.InnerImageContainer {
+  position: relative;
+}
+
+.Image {
+  max-width: 100%;
+  height: auto;
+}
+
+.MarkerWrapper {
+  position: absolute;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  margin-left: -0.75rem;
+  margin-top: -0.75rem;
+  border-radius: 1.5rem;
+  background-color: var(--secondary-accent);
+}
+
+.MarkerIcon {
+  fill: var(--color-default);
+  width: 1rem;
+  height: 1rem;
+}

--- a/src/ui/components/KeyboardShortcuts.tsx
+++ b/src/ui/components/KeyboardShortcuts.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo } from "react";
 import { ConnectedProps, connect } from "react-redux";
 
 import { SHOW_GLOBAL_SEARCH_EVENT_TYPE } from "bvaughn-architecture-demo/components/search-files/SearchFiles";
+import { getBase64Png } from "bvaughn-architecture-demo/src/utils/canvas";
 import { closeQuickOpen, toggleQuickOpen } from "devtools/client/debugger/src/actions/quick-open";
 import * as dbgActions from "devtools/client/debugger/src/actions/ui";
 import { getActiveSearch, getQuickOpenEnabled } from "devtools/client/debugger/src/selectors";
@@ -111,7 +112,7 @@ function KeyboardShortcuts({
       toggleQuickOpen(query, project);
     };
 
-    const addComment = (e: KeyboardEvent) => {
+    const addComment = async (e: KeyboardEvent) => {
       // Un-authenticated users can't comment on Replays.
       if (!isAuthenticated) {
         return;
@@ -119,7 +120,17 @@ function KeyboardShortcuts({
 
       if (!e.target || !isEditableElement(e.target)) {
         e.preventDefault();
-        createFrameComment(null, recordingId);
+
+        let base64PNG: string | null = null;
+        const canvas = document.querySelector("canvas#graphics");
+        if (canvas) {
+          base64PNG = await getBase64Png(canvas as HTMLCanvasElement, {
+            maxWidth: 200,
+            maxHeight: 200,
+          });
+        }
+
+        createFrameComment(null, recordingId, base64PNG ?? null, null);
       }
     };
 

--- a/src/ui/components/KeyboardShortcuts.tsx
+++ b/src/ui/components/KeyboardShortcuts.tsx
@@ -125,8 +125,8 @@ function KeyboardShortcuts({
         const canvas = document.querySelector("canvas#graphics");
         if (canvas) {
           base64PNG = await getBase64Png(canvas as HTMLCanvasElement, {
-            maxWidth: 200,
-            maxHeight: 200,
+            maxWidth: 300,
+            maxHeight: 300,
           });
         }
 

--- a/src/ui/components/shared/CommentTool.tsx
+++ b/src/ui/components/shared/CommentTool.tsx
@@ -91,8 +91,8 @@ export default function CommentTool({ comments }: { comments: (Comment | Reply)[
           const canvas = document.querySelector("canvas#graphics");
           if (canvas) {
             base64PNG = await getBase64Png(canvas as HTMLCanvasElement, {
-              maxWidth: 200,
-              maxHeight: 200,
+              maxWidth: 300,
+              maxHeight: 300,
             });
 
             const rect = canvas.getBoundingClientRect();

--- a/src/ui/state/comments.ts
+++ b/src/ui/state/comments.ts
@@ -19,6 +19,8 @@ export type CommentOptions = {
   hasFrames: boolean;
   sourceLocation: SourceLocation | null;
   networkRequestId?: string;
+  primaryLabel?: string | null;
+  secondaryLabel?: string | null;
 };
 
 export interface Remark {


### PR DESCRIPTION
### [Loom overview](https://www.loom.com/share/33b6a1b48cc645b4be3cc087354e22d3)

This change makes use of the generic `primaryLabel` and `secondaryLabel` attributes to encode base-64 image data for visual comments. I've filed FE-1058 for some cleanup work around comments in general.
