### PR TITLE
Source viewer context menu changes

### DIFF
--- a/packages/bvaughn-architecture-demo/components/context-menu/ContextMenuContext.ts
+++ b/packages/bvaughn-architecture-demo/components/context-menu/ContextMenuContext.ts
@@ -1,0 +1,9 @@
+import { MouseEvent, createContext } from "react";
+
+export type ContextMenuContextType = {
+  contextMenuEvent: MouseEvent | null;
+};
+
+export const ContextMenuContext = createContext<ContextMenuContextType>({
+  contextMenuEvent: null,
+});

--- a/packages/bvaughn-architecture-demo/components/context-menu/useContextMenu.tsx
+++ b/packages/bvaughn-architecture-demo/components/context-menu/useContextMenu.tsx
@@ -1,11 +1,7 @@
-import { MouseEvent, ReactNode, useState } from "react";
+import { MouseEvent, ReactNode, useMemo, useState } from "react";
 
 import ContextMenu from "./ContextMenu";
-
-type Coordinates = {
-  pageX: number;
-  pageY: number;
-};
+import { ContextMenuContext, ContextMenuContextType } from "./ContextMenuContext";
 
 export default function useContextMenu(
   contextMenuItems: ReactNode,
@@ -19,28 +15,31 @@ export default function useContextMenu(
 } {
   const { dataTestId, dataTestName } = options;
 
-  const [coordinates, setCoordinates] = useState<Coordinates | null>(null);
+  const [contextMenuEvent, setContextMenuEvent] = useState<MouseEvent | null>(null);
+  const context = useMemo<ContextMenuContextType>(() => ({ contextMenuEvent }), [contextMenuEvent]);
 
   const onContextMenu = (event: MouseEvent) => {
     event.preventDefault();
 
-    setCoordinates({ pageX: event.pageX, pageY: event.pageY });
+    setContextMenuEvent(event);
   };
 
-  const hideContextMenu = () => setCoordinates(null);
+  const hideContextMenu = () => setContextMenuEvent(null);
 
   let contextMenu = null;
-  if (coordinates) {
+  if (contextMenuEvent) {
     contextMenu = (
-      <ContextMenu
-        dataTestId={dataTestId}
-        dataTestName={dataTestName}
-        hide={hideContextMenu}
-        pageX={coordinates.pageX}
-        pageY={coordinates.pageY}
-      >
-        {contextMenuItems}
-      </ContextMenu>
+      <ContextMenuContext.Provider value={context}>
+        <ContextMenu
+          dataTestId={dataTestId}
+          dataTestName={dataTestName}
+          hide={hideContextMenu}
+          pageX={contextMenuEvent.pageX}
+          pageY={contextMenuEvent.pageY}
+        >
+          {contextMenuItems}
+        </ContextMenu>
+      </ContextMenuContext.Provider>
     );
   }
 

--- a/packages/bvaughn-architecture-demo/components/sources/SearchResultHighlight.module.css
+++ b/packages/bvaughn-architecture-demo/components/sources/SearchResultHighlight.module.css
@@ -2,8 +2,8 @@
   position: absolute;
   left: 0;
   z-index: 2;
-
   display: flex;
+  pointer-events: none;
 }
 
 .ActiveMark {

--- a/packages/bvaughn-architecture-demo/components/sources/Source.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/Source.tsx
@@ -129,11 +129,7 @@ function SourceRenderer({
           return;
         }
       } else {
-        // HACK
-        // This is kind of a janky way to differentiate tokens from non-tokens but it works for now.
-        const className = htmlElement.className;
-        const isToken = typeof className === "string" && className.startsWith("tok-");
-
+        const isToken = htmlElement.hasAttribute("data-parsed-token");
         if (isToken) {
           // Debounce hover event to avoid showing the popup (or requesting data) in response to normal mouse movements.
           setHoverStateDebounced(htmlElement, null, null, null, setHoveredState);

--- a/packages/bvaughn-architecture-demo/src/suspense/SyntaxParsingCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/SyntaxParsingCache.ts
@@ -342,6 +342,7 @@ function processSection(
 
       cachedElement.className = className;
       cachedElement.textContent = subsection;
+      cachedElement.setAttribute("data-parsed-token", "");
       cachedElement.setAttribute("data-column-index", "" + htmlString.rawString.length);
 
       htmlString.htmlString += cachedElement.outerHTML;
@@ -354,6 +355,7 @@ function processSection(
 
       cachedElement.className = className;
       cachedElement.textContent = subsection;
+      cachedElement.setAttribute("data-parsed-token", "");
       cachedElement.setAttribute("data-column-index", "" + htmlString.rawString.length);
 
       htmlString.htmlString += cachedElement.outerHTML;


### PR DESCRIPTION
Includes several incremental changes being made in support of issues FE-932 and FE-1059:
- [x] Expose context menu `target` element via new `ContextMenuContext`. This could be used by the source viewer to associated a context menu operation with a source code column
  - [x] Disable pointer events for search result highlight overlay (since they might interfere with `event.target`)
- [x] Add `data-column-index` attribute to markup generated for syntax highlighted code. This can be used to quickly determine the position of the token in the source code line
- [x] Add `data-parsed-token` attribute as a more reliable way of detecting an HTML element containing a source token than the previous `className` based approach