### PR TITLE
Add cypress test suite test

### DIFF
--- a/packages/e2e-tests/examples.json
+++ b/packages/e2e-tests/examples.json
@@ -32,5 +32,6 @@
   "node/objects.js": "6ea2837c-386e-483a-8ec9-94c7a51a07e4",
   "node/run_worker.js": "b41107df-8d0e-488f-bad3-a7d26c183043",
   "node/spawn.js": "c9d0539d-fde0-4949-a9f7-acdb5b56d4a6",
-  "log_points_and_block_scope.html": "ad8f5490-0b9f-4488-bd3c-4f2824bc21ce"
+  "log_points_and_block_scope.html": "ad8f5490-0b9f-4488-bd3c-4f2824bc21ce",
+  "cypress/basic": "f8f0a8ac-7f93-4eb3-afd8-0220e1260015"
 }

--- a/packages/e2e-tests/helpers/testsuites.ts
+++ b/packages/e2e-tests/helpers/testsuites.ts
@@ -1,0 +1,25 @@
+import { Locator, Page } from "@playwright/test";
+
+export async function getTestRows(page: Page) {
+  return page.locator('[data-test-id="TestSuite-TestCaseRow"]');
+}
+
+export async function getCypressLogo(page: Page) {
+  return page.locator('[data-test-name="ToolbarButton-CypressPanel"]');
+}
+
+export async function getTestRowChevron(row: Locator) {
+  return row.locator(":scope", { hasText: "chevron_right" });
+}
+
+export async function getTestRowError(row: Locator) {
+  return row.locator('[data-test-id="TestSuite-TestCaseRow-Error"]');
+}
+
+export async function getTestCaseSections(row: Locator) {
+  return row.locator('[data-test-id="TestSuites-TestCase-SectionHeader"]');
+}
+
+export async function getTestCaseSteps(row: Locator) {
+  return row.locator('[data-test-id="TestSuites-TestCase-TestStepRow"]');
+}

--- a/packages/e2e-tests/tests/cypress-01.test.ts
+++ b/packages/e2e-tests/tests/cypress-01.test.ts
@@ -1,0 +1,54 @@
+import test, { expect } from "@playwright/test";
+
+import { openDevToolsTab, startTest } from "../helpers";
+import { executeAndVerifyTerminalExpression } from "../helpers/console-panel";
+import { resumeToLine, rewindToLine } from "../helpers/pause-information-panel";
+import { addBreakpoint } from "../helpers/source-panel";
+import {
+  getCypressLogo,
+  getTestCaseSections,
+  getTestCaseSteps,
+  getTestRowChevron,
+  getTestRowError,
+  getTestRows,
+} from "../helpers/testsuites";
+
+const url = "cypress/basic";
+
+test(`cypress-01: Test basic cypress reporter functionality`, async ({ page }) => {
+  await startTest(page, url);
+
+  // shows the cypress logo
+  const logo = await getCypressLogo(page);
+  await logo.waitFor({ state: "attached" });
+
+  // has 9 tests
+  const rows = await getTestRows(page);
+  await expect(rows).toHaveCount(9);
+
+  const firstTest = rows.first();
+
+  // displays the nav chevron on hover
+  const chevron = await getTestRowChevron(firstTest);
+  await chevron.isHidden();
+  await firstTest.hover();
+  await chevron.isVisible();
+
+  // shows the error icon and message
+  const failedRow = rows.nth(7);
+  await failedRow.locator(".testsuites-fail").isVisible();
+  const failedRowError = await getTestRowError(failedRow);
+  await expect(failedRowError).toContainText("Error");
+
+  // can open tests
+  await failedRow.locator("button").click();
+  const selectedRow = await getTestRows(page);
+  expect(selectedRow).toHaveCount(1);
+  const sections = await getTestCaseSections(selectedRow);
+  await expect(sections).toHaveCount(2);
+  const steps = await getTestCaseSteps(selectedRow);
+  await expect(steps).toHaveCount(5);
+
+  // failed test should be visible
+  await steps.nth(4).isVisible();
+});

--- a/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
@@ -119,7 +119,7 @@ export function TestCase({ test, index }: { test: TestItem; index: number }) {
     <TestCaseContext.Provider
       value={{ startTime: testStartTime, endTime: testEndTime, onReplay, onPlayFromHere, test }}
     >
-      <div className="flex flex-col">
+      <div className="flex flex-col" data-test-id="TestSuite-TestCaseRow">
         {!isSelected && (
           <button
             className={classnames(
@@ -140,7 +140,10 @@ export function TestCase({ test, index }: { test: TestItem; index: number }) {
                   {test.title}
                 </div>
                 {test.error ? (
-                  <div className="mt-2 overflow-hidden rounded-lg bg-testsuitesErrorBgcolor px-3 py-2 text-left font-mono ">
+                  <div
+                    className="mt-2 overflow-hidden rounded-lg bg-testsuitesErrorBgcolor px-3 py-2 text-left font-mono"
+                    data-test-id="TestSuite-TestCaseRow-Error"
+                  >
                     {formatStepError(test.steps?.find(s => s.error)) || test.error.message}
                   </div>
                 ) : null}

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -260,6 +260,7 @@ export function TestStepItem({ step, argString, index, id }: TestStepItemProps) 
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       ref={ref}
+      data-test-id="TestSuites-TestCase-TestStepRow"
     >
       <button onClick={onClick} className="flex flex-grow items-start space-x-2 text-start">
         <div title={"" + displayedProgress} className="flex h-4 items-center">

--- a/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
@@ -236,6 +236,7 @@ function TestSection({ events, header }: { events: CompositeTestEvent[]; header?
     <>
       {header ? (
         <div
+          data-test-id="TestSuites-TestCase-SectionHeader"
           className="pt-6 pb-2 pl-2  font-semibold uppercase opacity-50"
           style={{ fontSize: "10px" }}
         >


### PR DESCRIPTION
Adds a test case for cypress to verify:
* Uses the cypress logo
* Has 9 tests
* Shows the chevron on hover
* Shows error for a failed test
* Can open a test
* Scrolls the failed step into view