### PR TITLE
Don't wrap parens around expressions sent to Pause.evaluateInGlobal

### DIFF
--- a/packages/shared/client/ReplayClient.ts
+++ b/packages/shared/client/ReplayClient.ts
@@ -176,7 +176,7 @@ export class ReplayClient implements ReplayClientInterface {
     if (frameId === null) {
       const response = await client.Pause.evaluateInGlobal(
         {
-          expression: `(${expression})`,
+          expression,
           pure: false,
         },
         sessionId,
@@ -187,7 +187,7 @@ export class ReplayClient implements ReplayClientInterface {
       const response = await client.Pause.evaluateInFrame(
         {
           frameId,
-          expression: `(${expression})`,
+          expression,
           pure: false,
           useOriginalScopes: true,
         },


### PR DESCRIPTION
We were wrapping expressions in parens (e.g. `a + 1` was modified to `(a + 1)` before being sent to `Pause.evaluateInGlobal`). This operation could cause a _valid expression_ to become _invalid_.

I'm not sure why we were doing this, but it doesn't seem to be necessary based on some limited testing, so this commit removes the parens.

### Before

https://user-images.githubusercontent.com/29597/208111550-bf445d0d-b15b-4cdf-b4ed-056aae49fc9c.mp4

### After

https://user-images.githubusercontent.com/29597/208111656-8c037d8b-ff66-4ac1-8d8a-993d3fd206b9.mp4
