### PR TITLE
Add auth telemetry

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -26,6 +26,7 @@ import { InstallRouteListener } from "ui/utils/routeListener";
 import tokenManager from "ui/utils/tokenManager";
 
 import "../src/base.css";
+import useAuthTelemetry from "ui/hooks/useAuthTelemetry";
 
 if (isMock()) {
   // If this is an end to end test, bootstrap the mock environment.
@@ -118,6 +119,7 @@ function Routing({ Component, pageProps }: AppProps) {
 }
 
 const App = ({ apiKey, ...props }: AppProps & AuthProps) => {
+  useAuthTelemetry();
   const router = useRouter();
   let head: React.ReactNode;
 

--- a/src/ui/hooks/useAuthTelemetry.ts
+++ b/src/ui/hooks/useAuthTelemetry.ts
@@ -1,0 +1,38 @@
+import { useEffect } from "react";
+
+import { pingTelemetry } from "ui/utils/replay-telemetry";
+
+export default function useAuthTelemetry() {
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    try {
+      const isAuthenticated = document.cookie
+        .split(";")
+        .filter(s => s.includes("auth0.is.authenticated"))
+        .map(s => s.split("=")?.[1])
+        .every(s => s === "true");
+
+      let auth0Obj: Record<string, any> | null = null;
+
+      for (let key in localStorage) {
+        if (key.includes("auth0spajs")) {
+          const value = localStorage.getItem(key);
+          auth0Obj = value && JSON.parse(value);
+        }
+      }
+
+      pingTelemetry("auth-initial-state", {
+        isAuthenticated,
+        authId: auth0Obj?.body?.decodedToken?.user?.sub,
+        hasRefreshToken: !!auth0Obj?.body?.refresh_token,
+        expiresAt: auth0Obj?.expiresAt ? new Date(auth0Obj.expiresAt * 1000).toISOString() : null,
+        expiresIn: auth0Obj?.body?.expires_in,
+      });
+    } catch {
+      // no-op
+    }
+  }, []);
+}


### PR DESCRIPTION
Adding some telemetry to grab the current auth state from cookies and local storage to track if we're somehow dropping state for users.