### PR TITLE
Test flakiness

### DIFF
--- a/packages/e2e-tests/tests/breakpoints-07.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-07.test.ts
@@ -14,6 +14,8 @@ import {
   closeSource,
   getSourceTab,
   verifyLogpointStep,
+  waitForBreakpoint,
+  waitForLogpoint,
 } from "../helpers/source-panel";
 
 test(`breakpoints-07: rewind and seek using command bar and console messages`, async ({ page }) => {
@@ -51,9 +53,9 @@ test(`breakpoints-07: rewind and seek using command bar and console messages`, a
 
   // Verify that the active source and breakpoints/logpoints are restored after a reload.
   await page.reload();
+  await openDevToolsTab(page); // Should be unnecessary but sometimes "Viewer" tab is selected
   await sourceTab.waitFor({ state: "visible" });
 
-  // TODO [FE-757] Re-enable these once both breakpoints and log points are reliably restored after reloading
-  // await waitForBreakpoint(page, { lineNumber: 5, url: "bundle_input.js" });
-  // await waitForLogpoint(page, { lineNumber: 5, url: "bundle_input.js" });
+  await waitForBreakpoint(page, { lineNumber: 5, url: "bundle_input.js" });
+  await waitForLogpoint(page, { lineNumber: 5, url: "bundle_input.js" });
 });

--- a/packages/e2e-tests/tests/object_preview-05.test.ts
+++ b/packages/e2e-tests/tests/object_preview-05.test.ts
@@ -1,0 +1,20 @@
+import test from "@playwright/test";
+
+import { openDevToolsTab, startTest } from "../helpers";
+import {
+  executeTerminalExpression,
+  verifyConsoleMessage,
+  warpToMessage,
+} from "../helpers/console-panel";
+
+const url = "doc_prod_bundle.html";
+
+test(`object_preview-05: Should support logging objects as values`, async ({ page }) => {
+  await startTest(page, url);
+  await openDevToolsTab(page);
+
+  await warpToMessage(page, "ExampleFinished");
+
+  await executeTerminalExpression(page, "{foo: 'abc', bar: 123}");
+  await verifyConsoleMessage(page, '{foo: "abc", bar: 123}');
+});

--- a/packages/shared/client/ReplayClient.ts
+++ b/packages/shared/client/ReplayClient.ts
@@ -173,6 +173,13 @@ export class ReplayClient implements ReplayClientInterface {
   ): Promise<EvaluationResult> {
     const sessionId = this.getSessionIdThrows();
 
+    // Edge case handling:
+    // User is logging a plan object (e.g. "{...}")
+    // This expression will not evaluate correctly unless we wrap parens around it
+    if (expression.startsWith("{") && expression.endsWith("}")) {
+      expression = `(${expression})`;
+    }
+
     if (frameId === null) {
       const response = await client.Pause.evaluateInGlobal(
         {


### PR DESCRIPTION
Detailed findings in this [FE-1075 comment](https://linear.app/replay/issue/FE-1075/recent-e2e-regression#comment-e5deaf33).

- [x] Make `breakpoints-07` test more robust
  - [x] Re-enable a commented out portion of the test that should be safe to enable now
- [x] Auto-wrap naked object expressions in parens (follow up for #8386)