### PR TITLE
Add debug label to wakeable to help track circular chains

### DIFF
--- a/packages/bvaughn-architecture-demo/src/hooks/useIndexedDB.ts
+++ b/packages/bvaughn-architecture-demo/src/hooks/useIndexedDB.ts
@@ -46,6 +46,7 @@ export const {
   getValueAsync: getIDBInstanceAsync,
   getValueIfCached: getIDBInstanceIfCached,
 } = createGenericCache<[dbOptions: IDBOptions], IDBPDatabase>(
+  "useIndexedDB: getIDBInstance",
   async dbOptions => {
     const { databaseName, databaseVersion, storeNames } = dbOptions;
     // Create a single shared IDB instance for this DB definition
@@ -71,6 +72,7 @@ export const {
   getValueIfCached: getLatestIDBValueIfCached,
   addValue: setLatestIDBValue,
 } = createGenericCache<[dbOptions: IDBOptions, storeName: string, recordName: string], any>(
+  "MappedLocationCache: getLatestIDBValue",
   async (dbOptions, storeName, recordName) => {
     // Only look up this initial stored value once
     const dbInstance = await getIDBInstanceAsync(dbOptions);

--- a/packages/bvaughn-architecture-demo/src/suspense/AnalysisCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/AnalysisCache.ts
@@ -65,7 +65,7 @@ export function runAnalysisSuspense(
 
   let record = locationAndTimeToValueMap.get(key);
   if (record == null) {
-    const wakeable = createWakeable<AnalysisResults>();
+    const wakeable = createWakeable<AnalysisResults>(`runAnalysisSuspense: ${key}`);
 
     record = {
       status: STATUS_PENDING,

--- a/packages/bvaughn-architecture-demo/src/suspense/CommentsCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/CommentsCache.ts
@@ -24,7 +24,7 @@ export function getCommentListSuspense(
 ): Comment[] {
   const commentRecord = getCacheForType(createCommentRecord);
   if (commentRecord.record === null) {
-    const wakeable = createWakeable<Comment[]>();
+    const wakeable = createWakeable<Comment[]>("getCommentListSuspense");
 
     commentRecord.record = {
       status: STATUS_PENDING,

--- a/packages/bvaughn-architecture-demo/src/suspense/EventsCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/EventsCache.ts
@@ -48,7 +48,9 @@ export function getEventCategoryCountsSuspense(client: ReplayClientInterface): E
   }
 
   if (inProgressEventCategoryCountsWakeable === null) {
-    inProgressEventCategoryCountsWakeable = createWakeable<EventCategory[]>();
+    inProgressEventCategoryCountsWakeable = createWakeable<EventCategory[]>(
+      "getEventCategoryCountsSuspense"
+    );
 
     fetchEventCategoryCounts(client);
   }
@@ -64,7 +66,7 @@ export function getEventTypeEntryPointsSuspense(
   if (record == null) {
     record = {
       status: STATUS_PENDING,
-      value: createWakeable<EventLog[]>(),
+      value: createWakeable<EventLog[]>("getEventTypeEntryPointsSuspense"),
     };
 
     eventTypeToEntryPointMap.set(eventType, record);

--- a/packages/bvaughn-architecture-demo/src/suspense/ExceptionsCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/ExceptionsCache.ts
@@ -91,7 +91,11 @@ export function getExceptionsSuspense(
 
   if (shouldFetch) {
     inFlightFocusRange = focusRange;
-    inFlightWakeable = createWakeable();
+    inFlightWakeable = createWakeable(
+      `getExceptionsSuspense: ${
+        focusRange ? `${focusRange.begin.point}-${focusRange.end.point}` : "-"
+      }`
+    );
 
     fetchExceptions(client);
 

--- a/packages/bvaughn-architecture-demo/src/suspense/FrameCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/FrameCache.ts
@@ -12,6 +12,7 @@ export const {
   getValueIfCached: getFramesIfCached,
   addValue: cacheFrames,
 } = createGenericCache2<ReplayClientInterface, [pauseId: PauseId], Frame[] | undefined>(
+  "FrameCache: getFrames",
   async (client, pauseId) => {
     const framesResult = await client.getAllFrames(pauseId);
     await client.waitForLoadedSources();

--- a/packages/bvaughn-architecture-demo/src/suspense/FrameStepsCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/FrameStepsCache.ts
@@ -15,6 +15,7 @@ export const {
   [pauseId: PauseId, frameId: FrameId],
   PointDescription[] | undefined
 >(
+  "FrameStepsCache: getFrameSteps",
   async (client, pauseId, frameId) => {
     try {
       const frameSteps = await client.getFrameSteps(pauseId, frameId);

--- a/packages/bvaughn-architecture-demo/src/suspense/MappedLocationCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/MappedLocationCache.ts
@@ -15,6 +15,7 @@ export const {
   [replayClient: ReplayClientInterface, location: ProtocolLocation],
   ProtocolMappedLocation
 >(
+  "MappedLocationCache: getMappedLocation",
   (client, location) => client.getMappedLocation(location),
   (client, location) => `${location.sourceId}:${location.line}:${location.column}`
 );

--- a/packages/bvaughn-architecture-demo/src/suspense/MessagesCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/MessagesCache.ts
@@ -118,7 +118,11 @@ export function getMessagesSuspense(
   if (shouldFetch) {
     inFlightFocusRange = focusRange;
 
-    const wakeable = (inFlightWakeable = createWakeable());
+    const wakeable = (inFlightWakeable = createWakeable(
+      `getMessagesSuspense: ${
+        focusRange ? `${focusRange.begin.point}-${focusRange.end.point}` : "-"
+      }`
+    ));
 
     fetchMessages(client, focusRange, wakeable);
 

--- a/packages/bvaughn-architecture-demo/src/suspense/ObjectPreviews.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/ObjectPreviews.ts
@@ -123,7 +123,9 @@ export function getObjectWithPreviewSuspense(
 
   let record = recordMap.get(objectId);
   if (record == null) {
-    const wakeable = createWakeable<Object>();
+    const wakeable = createWakeable<Object>(
+      `getObjectWithPreviewSuspense objectId: ${objectId} and pauseId: ${pauseId}`
+    );
 
     record = {
       status: STATUS_PENDING,
@@ -178,7 +180,9 @@ export function getObjectPropertySuspense(
 
   let record = recordMap.get(key);
   if (record == null) {
-    const wakeable = createWakeable<ProtocolValue>();
+    const wakeable = createWakeable<ProtocolValue>(
+      `getObjectProperty objectId: ${objectId} and pauseId: ${pauseId} and propertyName: ${propertyName}`
+    );
 
     record = {
       status: STATUS_PENDING,

--- a/packages/bvaughn-architecture-demo/src/suspense/PauseCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/PauseCache.ts
@@ -22,6 +22,7 @@ const {
   getValueAsync: getPauseIdForExecutionPointAsync,
   getValueIfCached: getPauseIdForExecutionPointIfCached,
 } = createGenericCache2<ReplayClientInterface, [executionPoint: ExecutionPoint], PauseId>(
+  "PauseCache: getPauseIdForExecutionPoint",
   async (client, executionPoint) => {
     const createPauseResult = await client.createPause(executionPoint);
     await client.waitForLoadedSources();
@@ -73,6 +74,7 @@ export const {
   [pauseId: PauseId, frameId: FrameId | null, expression: string],
   Omit<Result, "data">
 >(
+  "PauseCache: evaluate",
   async (client, pauseId, frameId, expression) => {
     const result = await client.evaluateExpression(pauseId, expression, frameId);
     await client.waitForLoadedSources();

--- a/packages/bvaughn-architecture-demo/src/suspense/PointsCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/PointsCache.ts
@@ -254,7 +254,7 @@ export function getClosestPointForTimeSuspense(
   // Otherwise let's fetch the closest points for this time.
   let wakeable = timeToInFlightRequestMap.get(time);
   if (wakeable == null) {
-    wakeable = createWakeable<ExecutionPoint>();
+    wakeable = createWakeable<ExecutionPoint>(`getClosestPointForTimeSuspense time: ${time}`);
 
     timeToInFlightRequestMap.set(time, wakeable);
 
@@ -287,7 +287,9 @@ export function getHitPointsForLocationSuspense(
   const key = getKey(location, condition, focusRange);
   let record = locationToHitPointsMap.get(key);
   if (record == null) {
-    const wakeable = createWakeable<HitPointsAndStatusTuple>();
+    const wakeable = createWakeable<HitPointsAndStatusTuple>(
+      `getHitPointsForLocationSuspense: ${key}`
+    );
 
     record = {
       status: STATUS_PENDING,
@@ -341,7 +343,12 @@ export async function imperativelyGetClosestPointForTime(
   // Next try asking the backend for a match and cache it.
   // Note that the backend may throw an error if this time isn't within a loaded region.
   try {
-    await fetchPointsBoundingTime(client, time, createWakeable<ExecutionPoint>(), true);
+    await fetchPointsBoundingTime(
+      client,
+      time,
+      createWakeable<ExecutionPoint>(`imperativelyGetClosestPointForTime time: ${time}`),
+      true
+    );
     return cachedPointsForTime.get(time)!;
   } catch (error) {
     if (!isCommandError(error, ProtocolError.RecordingUnloaded)) {
@@ -385,6 +392,7 @@ export const {
   getValueAsync: getPointsBoundingTimeAsync,
   getValueIfCached: getPointsBoundingTimeIfCached,
 } = createGenericCache2<ReplayClientInterface, [time: number], PointsBoundingTime>(
+  "PointsCache: getPointsBoundingTime",
   async (client, time) => client.getPointsBoundingTime(time),
   time => `${time}`
 );

--- a/packages/bvaughn-architecture-demo/src/suspense/ScopeCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/ScopeCache.ts
@@ -19,6 +19,7 @@ export const {
   getValueIfCached: getScopeIfCached,
   addValue: cacheScope,
 } = createGenericCache2<ReplayClientInterface, [pauseId: PauseId, scopeId: ScopeId], Scope>(
+  "ScopeCache: getScope",
   async (client, pauseId, scopeId) => {
     const result = await client.getScope(pauseId, scopeId);
     await client.waitForLoadedSources();
@@ -35,6 +36,7 @@ export const {
   getValueAsync: getFrameScopesAsync,
   getValueIfCached: getFrameScopesIfCached,
 } = createGenericCache2<ReplayClientInterface, [pauseId: PauseId, frameId: FrameId], FrameScopes>(
+  "ScopeCache: getFrameScopes",
   async (client, pauseId, frameId) => {
     const frame = (await getFramesAsync(client, pauseId))?.find(
       frame => frame.frameId === frameId

--- a/packages/bvaughn-architecture-demo/src/suspense/SearchCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/SearchCache.ts
@@ -60,6 +60,7 @@ export const {
   [query: string, includeNodeModules: boolean, limit?: number],
   StreamingSourceSearchResults
 >(
+  "SearchCache: searchSources",
   async (
     client: ReplayClientInterface,
     query: string,

--- a/packages/bvaughn-architecture-demo/src/suspense/SourcesCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/SourcesCache.ts
@@ -75,7 +75,7 @@ export function getSourcesSuspense(client: ReplayClientInterface) {
   }
 
   if (inProgressSourcesWakeable === null) {
-    inProgressSourcesWakeable = createWakeable();
+    inProgressSourcesWakeable = createWakeable("getSourcesSuspense");
 
     // Suspense caches fire and forget; errors will be handled within the fetch function.
     fetchSources(client);
@@ -160,7 +160,9 @@ export function getStreamingSourceContentsSuspense(
   if (record == null) {
     record = {
       status: STATUS_PENDING,
-      value: createWakeable<StreamingSourceContents>(),
+      value: createWakeable<StreamingSourceContents>(
+        `getStreamingSourceContentsSuspense sourceId: ${sourceId}`
+      ),
     };
 
     sourceIdToStreamingSourceContentsMap.set(sourceId, record);
@@ -227,7 +229,7 @@ export function getSourceHitCountsSuspense(
   if (record == null) {
     record = {
       status: STATUS_PENDING,
-      value: createWakeable<LineNumberToHitCountMap>(),
+      value: createWakeable<LineNumberToHitCountMap>(`getSourceHitCountsSuspense ${key}`),
     };
 
     hitCountRecordsMap.set(key, record);
@@ -254,6 +256,7 @@ export const {
     breakablePositionsByLine: Map<number, ProtocolSameLineSourceLocations>
   ]
 >(
+  "SourcesCache: getBreakpointPositions",
   async (client, sourceId) => {
     const breakablePositions = await client.getBreakpointPositions(sourceId, null);
 

--- a/packages/bvaughn-architecture-demo/src/suspense/SyntaxParsingCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/SyntaxParsingCache.ts
@@ -48,13 +48,14 @@ export const DEFAULT_MAX_TIME = 5_000;
 export const { getValueSuspense: parse } = createGenericCache<
   [code: string, fileName: string],
   Array<ParsedToken[]> | null
->(highlighter, identity);
+>("SyntaxParsingCache: parse", highlighter, identity);
 
 export const {
   getValueAsync: parseStreamingAsync,
   getValueSuspense: parseStreaming,
   getValueIfCached: getParsedValueIfCached,
 } = createGenericCache<[source: StreamingSourceContents, maxTime?: number], StreamingParser | null>(
+  "SyntaxParsingCache: parseStreaming",
   streamingSourceContentsToStreamingParser,
   identity
 );

--- a/packages/bvaughn-architecture-demo/src/suspense/createGenericCache.test.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/createGenericCache.test.ts
@@ -35,6 +35,7 @@ describe("Generic suspense cache", () => {
 
 function createTestCache() {
   return createGenericCache<[number], number>(
+    "test",
     n => (n % 2 === 0 ? n : Promise.resolve(n)),
     n => `${n}`
   );

--- a/packages/bvaughn-architecture-demo/src/suspense/createGenericCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/createGenericCache.ts
@@ -34,10 +34,12 @@ interface HookState<TValue> {
 }
 
 export function createGenericCache<TParams extends Array<any>, TValue>(
+  debugLabel: string,
   fetchValue: (...args: TParams) => Thennable<TValue> | TValue,
   getCacheKey: (...args: TParams) => string
 ): GenericCache<TParams, TValue> {
   const cache = createGenericCache2<undefined, TParams, TValue>(
+    debugLabel,
     (_, ...args) => fetchValue(...args),
     (...args) => getCacheKey(...args)
   );
@@ -50,6 +52,7 @@ export function createGenericCache<TParams extends Array<any>, TValue>(
 }
 
 export function createGenericCache2<TExtra, TParams extends Array<any>, TValue>(
+  debugLabel: string,
   fetchValue: (extra: TExtra, ...args: TParams) => Thennable<TValue> | TValue,
   getCacheKey: (...args: TParams) => string
 ): GenericCache2<TExtra, TParams, TValue> {
@@ -60,7 +63,7 @@ export function createGenericCache2<TExtra, TParams extends Array<any>, TValue>(
 
     let record = recordMap.get(cacheKey);
     if (!record) {
-      const wakeable = createWakeable<TValue>();
+      const wakeable = createWakeable<TValue>(`${debugLabel} ${cacheKey}}`);
       record = {
         status: STATUS_PENDING,
         value: wakeable,

--- a/packages/bvaughn-architecture-demo/src/utils/suspense.test.ts
+++ b/packages/bvaughn-architecture-demo/src/utils/suspense.test.ts
@@ -12,7 +12,7 @@ describe("Suspense util", () => {
       const onRejectA = jest.fn();
       const onRejectB = jest.fn();
 
-      const wakeable = createWakeable();
+      const wakeable = createWakeable("test");
       wakeable.then(onFulfillA, onRejectA);
       wakeable.then(onFulfillB, onRejectB);
 
@@ -35,7 +35,7 @@ describe("Suspense util", () => {
       const onRejectA = jest.fn();
       const onRejectB = jest.fn();
 
-      const wakeable = createWakeable();
+      const wakeable = createWakeable("test");
       wakeable.then(onFulfillA, onRejectA);
       wakeable.then(onFulfillB, onRejectB);
 
@@ -60,7 +60,7 @@ describe("Suspense util", () => {
         throw Error("Should not be called");
       };
 
-      const wakeable = createWakeable();
+      const wakeable = createWakeable("test");
       wakeable.then(throwsIfCalled, rejectedInitially);
       wakeable.reject(error);
       expect(rejectedInitially).toHaveBeenCalledWith(error);
@@ -80,7 +80,7 @@ describe("Suspense util", () => {
         throw Error("Should not be called");
       };
 
-      const wakeable = createWakeable();
+      const wakeable = createWakeable("test");
       wakeable.then(resolvedInitially, throwsIfCalled);
 
       wakeable.resolve(123);
@@ -98,10 +98,10 @@ describe("Suspense util", () => {
     it("should not allow rejecting or resolving the same wakeable more than once", () => {
       const error = new Error("This is an error");
 
-      const alreadyRejected = createWakeable();
+      const alreadyRejected = createWakeable("test");
       alreadyRejected.reject(error);
 
-      const alreadyResolved = createWakeable();
+      const alreadyResolved = createWakeable("test");
       alreadyResolved.resolve(123);
 
       expect(() => {
@@ -143,26 +143,26 @@ describe("Suspense util", () => {
     });
 
     it("should not throw if count is not exceeded", () => {
-      const wakeable = createWakeable<number>();
+      const wakeable = createWakeable<number>("test");
       wakeable.resolve(123);
       registerSyncListeners(wakeable, 5);
     });
 
     it("should throw if count is exceeded", () => {
-      const wakeable = createWakeable<number>();
+      const wakeable = createWakeable<number>("test");
       wakeable.resolve(123);
       verifyThrows(wakeable, 6);
     });
 
     it("should re-throw if count is exceeded multiple times", () => {
-      const wakeable = createWakeable<number>();
+      const wakeable = createWakeable<number>("test");
       wakeable.resolve(123);
       verifyThrows(wakeable, 6);
       verifyThrows(wakeable, 1);
     });
 
     it("should detect loops that span ticks", async () => {
-      const wakeable = createWakeable<number>();
+      const wakeable = createWakeable<number>("test");
       wakeable.resolve(123);
       registerSyncListeners(wakeable, 3);
       await new Promise(resolve => setTimeout(resolve, 0));
@@ -170,7 +170,7 @@ describe("Suspense util", () => {
     });
 
     it("should detect loops that span ticks variant", async () => {
-      const wakeable = createWakeable<number>();
+      const wakeable = createWakeable<number>("test");
       wakeable.resolve(123);
 
       let caught = null;
@@ -190,10 +190,10 @@ describe("Suspense util", () => {
     });
 
     it("should track loops separately per wakeable", async () => {
-      const wakeableA = createWakeable<number>();
+      const wakeableA = createWakeable<number>("test");
       wakeableA.resolve(123);
 
-      const wakeableB = createWakeable<number>();
+      const wakeableB = createWakeable<number>("test");
       wakeableB.resolve(456);
 
       // Total count exceeds loop but not individually

--- a/packages/bvaughn-architecture-demo/src/utils/suspense.ts
+++ b/packages/bvaughn-architecture-demo/src/utils/suspense.ts
@@ -7,7 +7,7 @@ let CIRCULAR_THENABLE_CHECK_MAX_COUNT = 1_000;
 // An advantage to creating a custom thennable is synchronous resolution (or rejection).
 //
 // A "wakeable" is a "thennable" that has convenience resolve/reject methods.
-export function createWakeable<T>(): Wakeable<T> {
+export function createWakeable<T>(debugLabel: string): Wakeable<T> {
   const resolveCallbacks: Set<(value: T) => void> = new Set();
   const rejectCallbacks: Set<(error: Error) => void> = new Set();
 
@@ -22,7 +22,7 @@ export function createWakeable<T>(): Wakeable<T> {
   // It is a legitimate use-case to register handlers after a wakeable has been resolved or rejected.
   const checkCircularThenableChain = () => {
     if (++callbacksRegisteredAfterResolutionCount > CIRCULAR_THENABLE_CHECK_MAX_COUNT) {
-      throw Error("Circular thenable chain detected (infinite loop?)");
+      throw Error(`Circular thenable chain detected (infinite loop) for resource:\n${debugLabel}`);
     }
   };
 

--- a/packages/shared/utils/client.ts
+++ b/packages/shared/utils/client.ts
@@ -51,7 +51,7 @@ function getEncodedSuspense(host: string, fixtureDataPath: string): string {
     if (caughtError !== null) {
       throw caughtError;
     } else if (wakeable === null) {
-      wakeable = createWakeable<string>();
+      wakeable = createWakeable<string>(`getEncodedSuspense`);
       fetch(`http://${host}:3000/api/data?fixtureDataPath=${fixtureDataPath}`)
         .then(async response => {
           encoded = await response.text();

--- a/src/ui/suspense/nodeCaches.ts
+++ b/src/ui/suspense/nodeCaches.ts
@@ -56,6 +56,7 @@ export const {
   ],
   ProtocolObject[]
 >(
+  "nodeCaches: getNodeData",
   async (client, replayClient, sessionId, pauseId, options) => {
     let nodeIds: string[] = [];
     let pauseData = null as PauseData | null;
@@ -181,6 +182,7 @@ export const {
   ],
   EventListener[] | undefined
 >(
+  "nodeCaches: getNodeEventListeners",
   async (client, replayClient, sessionId, pauseId, nodeId) => {
     const { listeners, data } = await client.DOM.getEventListeners(
       {
@@ -201,6 +203,7 @@ export const {
   getValueAsync: getBoundingRectsAsync,
   getValueIfCached: getBoundingRectsIfCached,
 } = createGenericCache<[client: ProtocolClient, sessionId: string, pauseId: PauseId], NodeBounds[]>(
+  "nodeCaches: getBoundingRects",
   async (client, sessionId, pauseId) => {
     const { elements } = await client.DOM.getAllBoundingClientRects({}, sessionId, pauseId);
     return elements;
@@ -216,6 +219,7 @@ export const {
   [client: ProtocolClient, sessionId: string, pauseId: PauseId, nodeId: string],
   BoxModel
 >(
+  "nodeCaches: getBoxModel",
   async (client, sessionId, pauseId, nodeId) => {
     const { model: nodeBoxModel } = await client.DOM.getBoxModel(
       {

--- a/src/ui/suspense/styleCaches.ts
+++ b/src/ui/suspense/styleCaches.ts
@@ -26,6 +26,7 @@ export const {
   ],
   WiredAppliedRule[]
 >(
+  "styleCaches: getAppliedRules",
   async (client, replayClient, sessionId, pauseId, nodeId) => {
     const { rules, data } = await client.CSS.getAppliedRules({ node: nodeId }, sessionId, pauseId);
 
@@ -82,6 +83,7 @@ export const {
   [client: ProtocolClient, sessionId: string, pauseId: PauseId, nodeId: string],
   Map<string, string> | undefined
 >(
+  "styleCaches: getComputedStyle",
   async (client, sessionId, pauseId, nodeId) => {
     try {
       const { computedStyle } = await client.CSS.getComputedStyle(
@@ -113,6 +115,8 @@ export const {
   [client: ProtocolClient, sessionId: string, pauseId: PauseId, nodeId: string],
   DOMRect | undefined
 >(
+  "styleCaches: getBoundingRect",
+
   async (client, sessionId, pauseId, nodeId) => {
     try {
       const { rect } = await client.DOM.getBoundingClientRect(


### PR DESCRIPTION
Sentry error [3825236237](https://sentry.io/organizations/replay/issues/3825236237) doesn't have enough information to help uniquely identify **where** it happens in the React tree or **what** it hangs while loading. This commit adds some additional debug metadata to help with that.

It's not great and I'm open for alternate suggestions.