### PR TITLE
inspector-02 test: reduce flakiness

### DIFF
--- a/packages/e2e-tests/helpers/console-panel.ts
+++ b/packages/e2e-tests/helpers/console-panel.ts
@@ -355,6 +355,7 @@ export async function verifyTrimmedConsoleMessages(
 }
 
 export async function warpToMessage(page: Page, text: string, line?: number) {
+  await openConsolePanel(page);
   const messages = await findConsoleMessage(page, text);
   const message = messages.first();
   await seekToConsoleMessage(page, message, line);

--- a/packages/e2e-tests/tests/inspector-02.test.ts
+++ b/packages/e2e-tests/tests/inspector-02.test.ts
@@ -1,7 +1,7 @@
 import test, { expect } from "@playwright/test";
 
 import { openDevToolsTab, startTest } from "../helpers";
-import { openConsolePanel, warpToMessage } from "../helpers/console-panel";
+import { warpToMessage } from "../helpers/console-panel";
 import {
   activateInspectorTool,
   getElementsPanelSelection,

--- a/packages/e2e-tests/tests/inspector-02.test.ts
+++ b/packages/e2e-tests/tests/inspector-02.test.ts
@@ -1,6 +1,7 @@
 import test, { expect } from "@playwright/test";
 
 import { openDevToolsTab, startTest } from "../helpers";
+import { openConsolePanel, warpToMessage } from "../helpers/console-panel";
 import {
   activateInspectorTool,
   getElementsPanelSelection,
@@ -14,7 +15,13 @@ const url = "doc_inspector_basic.html";
 test(`inspector-02: element picker and iframe behavior`, async ({ page }) => {
   await startTest(page, url);
   await openDevToolsTab(page);
+
+  // DOM/document may not be available at the end of the recording;
+  // to avoid getting stuck waiting on it to load, seek to a known safe point.
+  await warpToMessage(page, "ExampleFinished");
+
   await openElementsPanel(page);
+
   await waitForElementsToLoad(page);
 
   await activateInspectorTool(page);


### PR DESCRIPTION
In FE-1075, Logan pointed out that the `inspector-02` test sometimes gets stuck waiting for the Elements panel to load because the test loads at the _end_ of the recording, and document may not still be available at that time.

This commit changes the test to seek to an earlier point in time before waiting for the Elements panel to load.