### PR TITLE
Fix stepping when the selected frame is not the top frame (FE-1082)

### DIFF
--- a/packages/e2e-tests/examples.json
+++ b/packages/e2e-tests/examples.json
@@ -14,7 +14,7 @@
   "doc_navigate.html": "768b3f13-0635-4dbc-8b8e-e3f53a70e405",
   "doc_prod_bundle.html": "07d4015d-bcf5-497d-b9bd-989692e38238",
   "doc_recursion.html": "419f4491-9860-428e-b6bc-1fe3df359844",
-  "doc_rr_basic.html": "8b0b7c1c-d909-423a-a5d1-84bda4dcd532",
+  "doc_rr_basic.html": "f744e2cf-7d26-4236-b7d6-d07e3759aeea",
   "doc_rr_blackbox.html": "3faddf0d-facb-40f7-91f1-f6c800803b64",
   "doc_rr_console.html": "13ba34c5-c4b2-4f44-a592-18b7fa83a940",
   "doc_rr_error.html": "15c145a7-8969-4385-aaed-f084f9c0141d",

--- a/packages/e2e-tests/tests/stepping-04.test.ts
+++ b/packages/e2e-tests/tests/stepping-04.test.ts
@@ -1,0 +1,29 @@
+import test from "@playwright/test";
+
+import { openDevToolsTab, startTest } from "../helpers";
+import { warpToMessage } from "../helpers/console-panel";
+import { selectFrame, stepOutToLine, stepOverToLine } from "../helpers/pause-information-panel";
+import { clickSourceTreeNode } from "../helpers/source-explorer-panel";
+import { addLogpoint } from "../helpers/source-panel";
+
+const url = "doc_rr_basic.html";
+
+test("stepping-04: Test stepping in a frame other than the top frame", async ({ page }) => {
+  await startTest(page, url);
+  await openDevToolsTab(page);
+
+  // Open doc_rr_basic.html
+  await clickSourceTreeNode(page, "test");
+  await clickSourceTreeNode(page, "examples");
+  await clickSourceTreeNode(page, url);
+
+  await addLogpoint(page, { lineNumber: 24, url, content: "'logpoint', number" });
+
+  await warpToMessage(page, "logpoint 5");
+  await selectFrame(page, 1);
+  await stepOverToLine(page, 22);
+
+  await warpToMessage(page, "logpoint 5");
+  await selectFrame(page, 1);
+  await stepOutToLine(page, 12);
+});

--- a/public/test/examples/doc_rr_basic.html
+++ b/public/test/examples/doc_rr_basic.html
@@ -18,7 +18,7 @@ function f() {
 function updateNumber() {
   number++;
   document.getElementById("maindiv").innerHTML = "Number: " + number;
-  testStepping();
+  return testStepping();
 }
 function testStepping() {
   var a = 0;

--- a/src/devtools/client/debugger/src/reducers/pause.ts
+++ b/src/devtools/client/debugger/src/reducers/pause.ts
@@ -304,7 +304,7 @@ async function getResumePoint(replayClient: ReplayClientInterface, state: UIStat
     selectedFrameId.pauseId,
     selectedFrameId.frameId
   );
-  if (!frameSteps) {
+  if (!frameSteps?.length) {
     return;
   }
 
@@ -312,8 +312,12 @@ async function getResumePoint(replayClient: ReplayClientInterface, state: UIStat
     return findLast(frameSteps, p => compareNumericStrings(p.point, executionPoint) < 0)?.point;
   }
 
-  if (type == "stepOver" || type == "resume" || type == "stepIn" || type == "stepUp") {
-    return frameSteps.find(p => compareNumericStrings(p.point, executionPoint) > 0)?.point;
+  if (type == "stepOver" || type == "resume" || type == "stepIn" || type == "stepOut") {
+    let index = frameSteps.findIndex(p => compareNumericStrings(p.point, executionPoint) > 0);
+    if (index < 0) {
+      index = frameSteps.length - 1;
+    }
+    return frameSteps[index].point;
   }
 }
 


### PR DESCRIPTION
Before: https://app.replay.io/recording/broken-stepout--0ef0a398-6f72-4d8b-8725-9ef6bf4a54ba
After: https://app.replay.io/recording/fixed-stepout--ddf04b03-bece-4ea3-86af-f3f8002ed546

This happened because the current execution point was after the last frame step in the selected frame, so we didn't step over or out from any of the frame steps but from the current execution point instead. Furthermore we never chose a frame step when stepping out because the operation type is called `stepOut` but we were looking for `stepUp`.
