### PR TITLE
Revert "Adjust testsuites color and layout (#8408)"

### DIFF
--- a/packages/bvaughn-architecture-demo/pages/variables.css
+++ b/packages/bvaughn-architecture-demo/pages/variables.css
@@ -94,9 +94,9 @@
 
   --collapsible-toggle-color: #9ba0a5;
 
-  --context-menu-background-color: var(--theme-base-95);
+  --context-menu-background-color: var(--background-color-contrast-3);
   --context-menu-background-color-divider: var(--background-color-contrast-2);
-  --context-menu-background-color-hover: var(--theme-base-90);
+  --context-menu-background-color-hover: var(--background-color-contrast-2);
 
   --comment-card-source-preview-background-color: #081221;
   --comment-card-source-preview-background-color-hover: #3e434a;
@@ -253,9 +253,9 @@
 
   --collapsible-toggle-color: #868688;
 
-  --context-menu-background-color: var(--theme-base-100);
+  --context-menu-background-color: var(--background-color-default);
   --context-menu-background-color-divider: var(--background-color-contrast-1);
-  --context-menu-background-color-hover: var(--theme-base-95);
+  --context-menu-background-color-hover: var(--background-color-contrast-1);
 
   --comment-card-source-preview-background-color: #f2f3f2;
   --comment-card-source-preview-background-color-hover: #e6e6e6;

--- a/src/devtools/client/debugger/src/components/TestInfo/ContextMenu.module.css
+++ b/src/devtools/client/debugger/src/components/TestInfo/ContextMenu.module.css
@@ -8,13 +8,12 @@
 
   /* Ensure the context menu is always above console rows and the current time indicator */
   z-index: 11;
-  box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
 }
 
 .ContextMenuItem {
   background-color: var(--context-menu-background-color);
   color: var(--color-default);
-  padding: 0.5rem 1rem 0.5rem 0.5rem;
+  padding: 0.5rem 1rem;
   user-select: none;
   cursor: pointer;
   display: flex;

--- a/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
@@ -34,7 +34,7 @@ export default function TestInfo({ testCases }: { testCases: TestItem[] }) {
     <TestInfoContext.Provider value={{ consoleProps, setConsoleProps, pauseId, setPauseId }}>
       <TestInfoContextMenuContextRoot>
         <div className="flex flex-grow flex-col overflow-hidden">
-          <div className="relative flex flex-grow flex-col space-y-1 overflow-auto px-2 pt-3">
+          <div className="relative flex flex-grow flex-col space-y-1 overflow-auto px-2">
             {testCases.map((t, i) => showTest(i) && <TestCase test={t} key={i} index={i} />)}
           </div>
           {selectedTest !== null ? <Console /> : null}

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -295,7 +295,7 @@ function Actions({ step, isSelected }: { step: AnnotatedTestStep; isSelected: bo
       onClick={onClick}
       className={`${isSelected ? "" : "invisible"} group-hover/step:visible`}
     >
-      <div className="flex items-center text-themeBase-85">
+      <div className="flex items-center">
         <MaterialIcon>more_vert</MaterialIcon>
       </div>
     </button>

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepRow.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepRow.tsx
@@ -33,7 +33,7 @@ export function TestStepRowBase({
           "bg-testsuitesErrorBgcolor hover:bg-testsuitesErrorBgcolorHover": error && pending,
           "bg-testsuitesErrorBgcolorHover": error && active,
           "bg-toolbarBackgroundHover": active && !error,
-          "bg-testsuitesStepsBgcolor hover:bg-testsuitesStepsBgcolorHover": pending && !error,
+          "bg-testsuitesStepsBgcolor hover:bg-toolbarBackgroundHover": pending && !error,
           "hover:bg-toolbarBackgroundHover": !pending && !active && !error,
         }
       )}

--- a/src/devtools/client/themes/variables.css
+++ b/src/devtools/client/themes/variables.css
@@ -222,8 +222,7 @@
   --testsuites-error-bgcolor: #ffe9e9;
   --testsuites-error-bgcolor-hover: #ffe0e0;
   --testsuites-error-color: #eb5757;
-  --testsuites-steps-bgcolor: #f9f9f9;
-  --testsuites-steps-bgcolor-hover: #eee;
+  --testsuites-steps-bgcolor: #fafafa;
 
   /* To organise (Light) */
   --jellyfish-bgcolor: rgba(255, 255, 255, 0.8);
@@ -506,7 +505,6 @@
   --testsuites-error-bgcolor-hover: #7a1712;
   --testsuites-error-color: white;
   --testsuites-steps-bgcolor: var(--theme-base-100);
-  --testsuites-steps-bgcolor-hover: var(--theme-base-95);
 
   /* To organise (Dark) */
   --jellyfish-bgcolor: rgba(40, 40, 40, 0.8);

--- a/src/ui/components/Library/Team/View/TestRuns/Overview/RunSummary.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/Overview/RunSummary.tsx
@@ -28,7 +28,7 @@ export function Attributes({ testRun }: { testRun: TestRun }) {
   const { user, date, mergeId, mergeTitle, branch } = testRun;
 
   return (
-    <div className="flex flex-row flex-wrap items-center pl-1">
+    <div className="flex flex-row flex-wrap items-center">
       <AttributeContainer icon="schedule">{getTruncatedRelativeDate(date)}</AttributeContainer>
       <AttributeContainer icon="person">{user!}</AttributeContainer>
       {mergeId && (

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -54,7 +54,6 @@ module.exports = {
         testsuitesErrorBgcolorHover: "var(--testsuites-error-bgcolor-hover)",
         testsuitesErrorColor: "var(--testsuites-error-color)",
         testsuitesStepsBgcolor: "var(--testsuites-steps-bgcolor)",
-        testsuitesStepsBgcolorHover: "var(--testsuites-steps-bgcolor-hover)",
         themeBorder: "var(--theme-border)",
         themeFocuserBgcolor: "var(--theme-focuser-bgcolor)",
         themeMenuHighlight: "var(--theme-menu-highlight)",


### PR DESCRIPTION
This reverts commit 76e9150176b20af29dc3798fa617a481640653da.

That commit broke styles for the new components. Going to revert it for now.

Style values in `bvaughn-architecture-package` should not reference style variables in the legacy app. Those variables **don't exist** (just like the legacy Redux state doesn't exist for the components in that package). Changes like that will break our automated tests.

After that change, running tests against main will cause unexpected/broken screenshot diffs like this one:
![image](https://user-images.githubusercontent.com/29597/209875430-9811db01-d057-4cf9-b7af-127f62a64495.png)
