### PR TITLE
Small testsuite tweaks

### DIFF
--- a/src/devtools/client/debugger/src/components/TestInfo/ContextMenu.module.css
+++ b/src/devtools/client/debugger/src/components/TestInfo/ContextMenu.module.css
@@ -8,12 +8,13 @@
 
   /* Ensure the context menu is always above console rows and the current time indicator */
   z-index: 11;
+  box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
 }
 
 .ContextMenuItem {
   background-color: var(--context-menu-background-color);
   color: var(--color-default);
-  padding: 0.5rem 1rem;
+  padding: 0.5rem 1rem 0.5rem 0.5rem;
   user-select: none;
   cursor: pointer;
   display: flex;

--- a/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
@@ -34,7 +34,7 @@ export default function TestInfo({ testCases }: { testCases: TestItem[] }) {
     <TestInfoContext.Provider value={{ consoleProps, setConsoleProps, pauseId, setPauseId }}>
       <TestInfoContextMenuContextRoot>
         <div className="flex flex-grow flex-col overflow-hidden">
-          <div className="relative flex flex-grow flex-col space-y-1 overflow-auto px-2">
+          <div className="relative flex flex-grow flex-col space-y-1 overflow-auto px-2 pt-3">
             {testCases.map((t, i) => showTest(i) && <TestCase test={t} key={i} index={i} />)}
           </div>
           {selectedTest !== null ? <Console /> : null}

--- a/src/ui/components/Library/Team/View/TestRuns/Overview/RunSummary.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/Overview/RunSummary.tsx
@@ -28,7 +28,7 @@ export function Attributes({ testRun }: { testRun: TestRun }) {
   const { user, date, mergeId, mergeTitle, branch } = testRun;
 
   return (
-    <div className="flex flex-row flex-wrap items-center">
+    <div className="flex flex-row flex-wrap items-center pl-1">
       <AttributeContainer icon="schedule">{getTruncatedRelativeDate(date)}</AttributeContainer>
       <AttributeContainer icon="person">{user!}</AttributeContainer>
       {mergeId && (


### PR DESCRIPTION
I recently [submitted a PR](https://github.com/replayio/devtools/pull/8408/files) that made some color adjustments. We reverted that PR so this is a much smaller change with no conflicting color changes.

Changes:

* Added a dropshadow to our overflow menu
* Centered overflow menu content
* Two small nudges to get things on the grid