### PR TITLE
Upgrade react-resizable-panels to 0.0.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "react-lazyload": "^3.2.0",
     "react-merge-refs": "^1.1.0",
     "react-redux": "^8.0.2",
-    "react-resizable-panels": "^0.0.22",
+    "react-resizable-panels": "^0.0.23",
     "react-table": "^7.7.0",
     "react-tooltip": "^4.2.21",
     "react-transition-group": "^4.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20663,13 +20663,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-resizable-panels@npm:^0.0.22":
-  version: 0.0.22
-  resolution: "react-resizable-panels@npm:0.0.22"
+"react-resizable-panels@npm:^0.0.23":
+  version: 0.0.23
+  resolution: "react-resizable-panels@npm:0.0.23"
   peerDependencies:
     react: ^16.14.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0
-  checksum: b66c96a7ec710e8deb7c9b37d8b1ee5afdb74f5aee0f9eef88f5b57a8a758a14425d1ecb38138257feb6a00fca4f9125379bc991d5f33f0cbc8b63c1cb8fb107
+  checksum: 32232ba6f68ad5b1fa6878c5dd97b13952b84a28000e6a1229f706a102c33edb224b990857778b0d3639cb9cccf6d4e1ed3bf9e8b8a428a64b017d76cee773a2
   languageName: node
   linkType: hard
 
@@ -21103,7 +21103,7 @@ __metadata:
     react-lazyload: ^3.2.0
     react-merge-refs: ^1.1.0
     react-redux: ^8.0.2
-    react-resizable-panels: ^0.0.22
+    react-resizable-panels: ^0.0.23
     react-table: ^7.7.0
     react-tooltip: ^4.2.21
     react-transition-group: ^4.4.2


### PR DESCRIPTION
Small improvement to resize/drag cancelling behavior (see [CHANGELOG](https://github.com/bvaughn/react-resizable-panels/blob/main/packages/react-resizable-panels/CHANGELOG.md#0023)).