### PR TITLE
Changed code completion type-ahead behavior

### DIFF
--- a/packages/bvaughn-architecture-demo/components/lexical/plugins/code-completion/CodeCompletionPlugin.tsx
+++ b/packages/bvaughn-architecture-demo/components/lexical/plugins/code-completion/CodeCompletionPlugin.tsx
@@ -51,6 +51,7 @@ export default function CodeCompletionPlugin({
 
   return (
     <TypeAheadPlugin<Match>
+      arrowKeysShouldDismiss={true}
       createItemNode={createItemNode}
       dataTestId={dataTestId}
       dataTestName={dataTestName}


### PR DESCRIPTION
Update Lexical type-ahead plug-in to more closely mirror Chrome devtools behavior:
1. Don't suggest a code completion after up/down arrow keys
2. Auto dismiss an active suggestion after left/right arrow keys

![Demo of Console auto-complete change](https://user-images.githubusercontent.com/29597/210085359-f00fbc13-2422-429f-9c82-6d3d70e65e70.gif)

This change should not impact the _mentions_ plug-in.

cc @Andarist 