### PR TITLE
Memoize Lexical's HistoryPlugin state

### DIFF
--- a/packages/bvaughn-architecture-demo/components/lexical/CodeEditor.tsx
+++ b/packages/bvaughn-architecture-demo/components/lexical/CodeEditor.tsx
@@ -18,7 +18,7 @@ import {
   SerializedEditorState,
   TextNode,
 } from "lexical";
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
 import { PauseAndFrameId } from "bvaughn-architecture-demo/src/contexts/SelectedFrameContext";
 
@@ -59,7 +59,7 @@ export default function CodeEditor({
   pauseAndFrameId: PauseAndFrameId | null;
   placeholder?: string;
 }): JSX.Element {
-  const historyState = createEmptyHistoryState();
+  const historyState = useMemo(() => createEmptyHistoryState(), []);
 
   const editorRef = useRef<LexicalEditor>(null);
   const backupEditorStateRef = useRef<EditorState | null>(null);

--- a/packages/bvaughn-architecture-demo/components/lexical/CommentEditor.tsx
+++ b/packages/bvaughn-architecture-demo/components/lexical/CommentEditor.tsx
@@ -92,7 +92,7 @@ export default function CommentEditor({
   onSave: (editorState: SerializedEditorState) => void;
   placeholder: string;
 }): JSX.Element {
-  const historyState = createEmptyHistoryState();
+  const historyState = useMemo(() => createEmptyHistoryState(), []);
 
   const editorRef = useRef<LexicalEditor>(null);
   const backupEditorStateRef = useRef<EditorState | null>(null);


### PR DESCRIPTION
We were accidentally resetting this state each time an editor rendered.

cc @Andarist This will fix the `cmd+z` issue.