### PR TITLE
Copy change for out-of-date browser

### DIFF
--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -117,8 +117,7 @@ const SessionErrorMessages: Record<number, Partial<UnexpectedError>> = {
       "This error has been fixed in an updated version of Replay. Please try upgrading Replay and trying a new recording.",
   },
   [SessionError.OldBuild]: {
-    content:
-      "This recording is no longer available because we have updated Replay. Please try recording a new replay.",
+    content: "This recording is no longer available. Please try recording a new replay.",
   },
   [SessionError.LongRecording]: {
     content: "You’ve hit an error that happens with long recordings. Can you try a shorter one?",


### PR DESCRIPTION
Anderist reported that the text here is confusing, so I removed the "we have updated Replay" bit because that's covered in the header of the error message, making this redundant/confusing.