### PR TITLE
Adjusting width of privacy window

### DIFF
--- a/src/ui/components/shared/SharingModal/PrivacyDropdown.tsx
+++ b/src/ui/components/shared/SharingModal/PrivacyDropdown.tsx
@@ -91,9 +91,7 @@ function useGetPrivacyOptions(
     options.push(
       <DropdownItem onClick={setPublic} key="option-public">
         <DropdownItemContent icon="globe" selected={!isPrivate}>
-          <span className="overflow-hidden overflow-ellipsis whitespace-pre text-xs">
-            Anyone with the link
-          </span>
+          <span className="text-xs">Anyone with the link</span>
         </DropdownItemContent>
       </DropdownItem>
     );
@@ -115,7 +113,7 @@ function useGetPrivacyOptions(
           <DropdownItem onClick={() => handleMoveToTeam(id)} key={id}>
             <DropdownItemContent icon="group" selected={!!isPrivate && id === workspaceId}>
               <span className="overflow-hidden overflow-ellipsis whitespace-pre text-xs">
-                Members of {name}
+                {name}
               </span>
             </DropdownItemContent>
           </DropdownItem>
@@ -169,9 +167,7 @@ export default function PrivacyDropdown({ recording }: { recording: Recording })
         distance={0}
         position="bottom-right"
       >
-        <Dropdown menuItemsClassName="z-50 overflow-auto max-h-48" widthClass="w-80">
-          {privacyOptions}
-        </Dropdown>
+        <Dropdown menuItemsClassName="z-50 overflow-auto max-h-48">{privacyOptions}</Dropdown>
       </PortalDropdown>
     </>
   );


### PR DESCRIPTION
[Linear ticket](https://linear.app/replay/issue/DES-54/our-privacy-dropdown-menu-is-too-wide)

We were forcing the dropdown to be w-80 rather than letting it flex based on the content inside. I had trouble allowing the flex, but removing the w-80 and the "members of" string should address the 99.9% case.

Old:
<img width="378" alt="image" src="https://user-images.githubusercontent.com/9154902/210188513-3af50707-83ba-4dee-adf2-82b5e6a9a369.png">

New:
<img width="338" alt="image" src="https://user-images.githubusercontent.com/9154902/210188506-1567a9a7-b501-439a-a7c6-c850593c1ea4.png">
