### PR TITLE
Initialize devtools as soon as we have a sessionId (FE-1076)

### DIFF
--- a/packages/e2e-tests/helpers/console-panel.ts
+++ b/packages/e2e-tests/helpers/console-panel.ts
@@ -374,3 +374,7 @@ export async function setConsoleMessageAsFocusEnd(page: Page, message: Locator) 
   await message.click({ button: "right" });
   await page.locator('[data-test-id="ConsoleContextMenu-SetFocusEndButton"]').click();
 }
+
+export async function waitForTerminal(page: Page) {
+  await page.locator('[data-test-id="ConsoleTerminalInput"]').waitFor();
+}

--- a/packages/e2e-tests/tests/object_preview-02.test.ts
+++ b/packages/e2e-tests/tests/object_preview-02.test.ts
@@ -1,7 +1,7 @@
 import test, { expect } from "@playwright/test";
 
 import { openDevToolsTab, startTest } from "../helpers";
-import { warpToMessage } from "../helpers/console-panel";
+import { waitForTerminal, warpToMessage } from "../helpers/console-panel";
 import {
   closeBreakpointsAccordionPane,
   closeCallStackAccordionPane,
@@ -18,6 +18,7 @@ const url = "doc_rr_objects.html";
 test(`object_preview-02: should allow objects in scope to be inspected`, async ({ page }) => {
   await startTest(page, url);
   await openDevToolsTab(page);
+  await waitForTerminal(page);
 
   await warpToMessage(page, "Done");
 

--- a/packages/protocol/thread/thread.ts
+++ b/packages/protocol/thread/thread.ts
@@ -160,9 +160,6 @@ class _ThreadFront {
   // Waiter which resolves when the debugger has loaded and we've warped to the endpoint.
   initializedWaiter = defer<void>();
 
-  // Waiter which resolves when there is at least one loading region
-  loadingHasBegun = defer<void>();
-
   // Waiter which resolves when all sources have been loaded.
   private allSourcesWaiter = defer<void>();
   hasAllSources = false;
@@ -336,8 +333,6 @@ class _ThreadFront {
 
       client.Session.addLoadedRegionsListener((loadedRegions: LoadedRegions) => {
         this._mostRecentLoadedRegions = loadedRegions;
-
-        this.loadingHasBegun.resolve();
 
         this._loadedRegionsListeners.forEach(callback => callback(loadedRegions));
       });

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -312,7 +312,7 @@ export function createSocket(
 
       ThreadFront.on("paused", ({ point }) => dispatch(setCurrentPoint(point)));
 
-      await ThreadFront.loadingHasBegun.promise;
+      await ThreadFront.waitForSession();
       dispatch(jumpToInitialPausePoint());
     } catch (e: any) {
       const currentError = selectors.getUnexpectedError(getState());

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -46,7 +46,7 @@ import { FocusRegion, HoveredItem, PlaybackOptions } from "ui/state/timeline";
 import {
   encodeObjectToURL,
   getPausePointParams,
-  getTest,
+  isTest,
   updateUrlWithParams,
 } from "ui/utils/environment";
 import KeyShortcuts, { isEditableElement } from "ui/utils/key-shortcuts";
@@ -106,6 +106,11 @@ export function jumpToInitialPausePoint(): UIThunkAction {
       setTimelineState({ currentTime: time, recordingDuration: time, zoomRegion: newZoomRegion })
     );
 
+    if (isTest()) {
+      ThreadFront.timeWarp(point, time, false);
+      return;
+    }
+
     const initialPausePoint = await getInitialPausePoint(ThreadFront.recordingId!);
 
     if (initialPausePoint) {
@@ -125,10 +130,6 @@ export function jumpToInitialPausePoint(): UIThunkAction {
 }
 
 async function getInitialPausePoint(recordingId: string) {
-  if (getTest()) {
-    return;
-  }
-
   const pausePointParams = getPausePointParams();
   if (pausePointParams) {
     return pausePointParams;


### PR DESCRIPTION
We used to wait for the first `LoadedRegions` event before initializing devtools, but that was unreliable and apparently not necessary (see FE-1076). Now we just wait for the session to be created.