### PR TITLE
Upgrade react-resizable-panels for collapsible support

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "react-lazyload": "^3.2.0",
     "react-merge-refs": "^1.1.0",
     "react-redux": "^8.0.2",
-    "react-resizable-panels": "^0.0.26",
+    "react-resizable-panels": "^0.0.27",
     "react-table": "^7.7.0",
     "react-tooltip": "^4.2.21",
     "react-transition-group": "^4.4.2",

--- a/packages/bvaughn-architecture-demo/pages/index.module.css
+++ b/packages/bvaughn-architecture-demo/pages/index.module.css
@@ -113,4 +113,20 @@
 
 .PanelResizeHandle {
   width: 0.5rem;
+  padding: 0.125rem;
+}
+.PanelResizeHandle:focus {
+  outline: none;
+}
+
+.PanelResizeHandleInner {
+  width: 100%;
+  height: 100%;
+  border-radius: 0.25rem;
+  transition: 250ms linear background-color;
+}
+
+.PanelResizeHandle[aria-valuenow="0"] .PanelResizeHandleInner,
+.PanelResizeHandle[data-resize-handle-active] .PanelResizeHandleInner {
+  background-color: var(--background-color-resize-handle);
 }

--- a/packages/bvaughn-architecture-demo/pages/index.tsx
+++ b/packages/bvaughn-architecture-demo/pages/index.tsx
@@ -111,7 +111,13 @@ export default function HomePage({ apiKey }: { apiKey?: string }) {
                         </div>
                         <div className={styles.PanelGroup}>
                           <PanelGroup autoSaveId="bvaughn-layout-main" direction="horizontal">
-                            <Panel className={styles.Panel} defaultSize={15} id="left" minSize={10}>
+                            <Panel
+                              className={styles.Panel}
+                              collapsible={true}
+                              defaultSize={15}
+                              minSize={10}
+                              maxSize={20}
+                            >
                               <div className={styles.CommentsContainer}>
                                 <Suspense fallback={<Loader />}>
                                   <LazyOffscreen mode={panel == "comments" ? "visible" : "hidden"}>
@@ -130,27 +136,21 @@ export default function HomePage({ apiKey }: { apiKey?: string }) {
                                   </LazyOffscreen>
                                 </Suspense>
                               </div>
-                              <PanelResizeHandle className={styles.PanelResizeHandle} />
                             </Panel>
-                            <Panel
-                              className={styles.Panel}
-                              defaultSize={50}
-                              id="middle"
-                              minSize={35}
-                            >
+                            <PanelResizeHandle className={styles.PanelResizeHandle}>
+                              <div className={styles.PanelResizeHandleInner} />
+                            </PanelResizeHandle>
+                            <Panel className={styles.Panel} defaultSize={50} minSize={35}>
                               <div className={styles.SourcesContainer}>
                                 <Suspense fallback={<Loader />}>
                                   <Sources />
                                 </Suspense>
                               </div>
                             </Panel>
-                            <Panel
-                              className={styles.Panel}
-                              defaultSize={35}
-                              id="right"
-                              minSize={25}
-                            >
-                              <PanelResizeHandle className={styles.PanelResizeHandle} />
+                            <PanelResizeHandle className={styles.PanelResizeHandle}>
+                              <div className={styles.PanelResizeHandleInner} />
+                            </PanelResizeHandle>
+                            <Panel className={styles.Panel} defaultSize={35} minSize={25}>
                               <div className={styles.ConsoleContainer}>
                                 <TerminalContextRoot>
                                   <ConsoleRoot showSearchInputByDefault={false} />

--- a/packages/bvaughn-architecture-demo/pages/variables.css
+++ b/packages/bvaughn-architecture-demo/pages/variables.css
@@ -49,6 +49,7 @@
   --background-color-warning: #42381f;
   --background-color-inputs: #0e1119;
   --background-color-source-search: #25364e;
+  --background-color-resize-handle: #242e3d;
 
   --border-color: #e1e6ed;
   --border-color-current-execution-point: #2563be;
@@ -208,6 +209,7 @@
   --background-color-warning: #fffac8;
   --background-color-inputs: #e6e6e6;
   --background-color-source-search: #eaf3ff;
+  --background-color-resize-handle: #cfcfcf;
 
   --border-color: #081121;
   --border-color-current-execution-point: #69a6ff;

--- a/yarn.lock
+++ b/yarn.lock
@@ -20663,13 +20663,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-resizable-panels@npm:^0.0.26":
-  version: 0.0.26
-  resolution: "react-resizable-panels@npm:0.0.26"
+"react-resizable-panels@npm:^0.0.27":
+  version: 0.0.27
+  resolution: "react-resizable-panels@npm:0.0.27"
   peerDependencies:
     react: ^16.14.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0
-  checksum: 9ae220f0315f0e23c1265b99bc4be3db5cf36a3fc7befac20a66f579274a66013749afd29eddc8e4928cdaf738370ea7f7196d35b1ad030b13de261cf53f373c
+  checksum: d644e65c7df2010931fdaf69db0b33b380d4b2734bba5d851926e512455a66f9b91c4c889600103e516b7446ddd4c22c6875c1670ca24bda49ef7bfc04ad8494
   languageName: node
   linkType: hard
 
@@ -21103,7 +21103,7 @@ __metadata:
     react-lazyload: ^3.2.0
     react-merge-refs: ^1.1.0
     react-redux: ^8.0.2
-    react-resizable-panels: ^0.0.26
+    react-resizable-panels: ^0.0.27
     react-table: ^7.7.0
     react-tooltip: ^4.2.21
     react-transition-group: ^4.4.2


### PR DESCRIPTION
This version adds support for _collapsible_ panels, which we may decide to add to Replay in _some_ places, e.g.

https://user-images.githubusercontent.com/29597/210280741-b8bae3cc-811d-4269-a1de-550dc7d034d3.mp4
