### PR TITLE
Add 60s timeout to wait step of Delta Workflow

### DIFF
--- a/.github/workflows/playwright-snapshots.yml
+++ b/.github/workflows/playwright-snapshots.yml
@@ -51,7 +51,7 @@ jobs:
         run: yarn dev &
         working-directory: packages/bvaughn-architecture-demo
       - name: Wait until server is up
-        run: npx wait-on http-get://localhost:3000
+        run: npx wait-on --timeout=60000 http-get://localhost:3000
       - name: Run playwright tests
         run: yarn visuals
         working-directory: packages/bvaughn-architecture-demo/playwright  


### PR DESCRIPTION
The [`wait-on` docs](https://www.npmjs.com/package/wait-on) say:
```
 -t, --timeout

  Maximum time in ms to wait before exiting with failure (1) code,
  default Infinity
```