### PR TITLE
Fix Info panel horizontal alignment of icons and text

### DIFF
--- a/src/ui/components/Events/ReplayInfo.tsx
+++ b/src/ui/components/Events/ReplayInfo.tsx
@@ -95,7 +95,7 @@ function ReplayInfo({ setModal }: PropsFromRedux) {
           {recording.metadata && (
             <>
               <Row>
-                <MaterialIcon>schedule</MaterialIcon>
+                <MaterialIcon className="text-xl">schedule</MaterialIcon>
                 <div
                   className="overflow-hidden overflow-ellipsis whitespace-pre"
                   title={recording.metadata.source?.branch}

--- a/src/ui/components/shared/PortalDropdown.tsx
+++ b/src/ui/components/shared/PortalDropdown.tsx
@@ -50,7 +50,7 @@ export default function PortalDropdown(props: PortalDropdownProps) {
     <div className="portal-dropdown-wrapper">
       <button
         type="button"
-        className={`expand-dropdown mr-1 flex w-full px-2 py-1 ${buttonStyle}`}
+        className={`expand-dropdown mr-1 flex w-full py-1 ${buttonStyle}`}
         disabled={props.disabled}
         id="portal-dropdown-button"
         data-test-id="consoleDockButton"


### PR DESCRIPTION
### Before
<img width="400" src="https://user-images.githubusercontent.com/29597/210431227-002c7927-9573-4564-92da-bd020289b5cd.png">

### After

<img width="286" src="https://user-images.githubusercontent.com/29597/210431190-00f6864f-2902-4ac6-8fde-c598ec850a01.png">

I think the _schedule_ icon was always slightly too small (causing the text after it to be misaligned). The "Anyone with link..." dropdown misalignment seems to have regressed in #8190
