### PR TITLE
Baby steps: adding core design tokens to replay-next

### DIFF
--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -33,7 +33,7 @@
   --theme-base-60: #c3c6c8;
 
   --scroll-thumb-color: #454950;
-  --dropshadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --dropshadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
 
   --background-color-contrast-1: #0e1119;
   --background-color-contrast-2: #192230;
@@ -108,7 +108,7 @@
   --context-menu-bgcolor: #3d4552;
   --context-menu-bgcolor-divider: var(--background-color-contrast-3);
   --context-menu-bgcolor-hover: var(--theme-base-95);
-  --context-menu-dropshadow: var(--dropshadow-md);
+  --context-menu-dropshadow: var(--dropshadow);
 
   --comment-card-source-preview-background-color: #081221;
   --comment-card-source-preview-background-color-hover: #3e434a;
@@ -220,7 +220,7 @@
   --theme-base-60: hsl(0, 0%, 60%);
 
   --scroll-thumb-color: #aaaaaa;
-  --dropshadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --dropshadow: 0 4px 6px -1px rgb(100 100 255 / 0.7), 0 2px 4px -2px rgb(0 0 0 / 0.1);
 
   --background-color-contrast-1: #e6e6e6;
   --background-color-contrast-2: #ffffff;
@@ -295,7 +295,7 @@
   --context-menu-bgcolor: #f8f8f9;
   --context-menu-bgcolor-divider: #e0e0e0;
   --context-menu-bgcolor-hover: var(--theme-base-95);
-  --context-menu-dropshadow: var(--dropshadow-md);
+  --context-menu-dropshadow: var(--dropshadow);
 
   --comment-card-source-preview-background-color: #f2f3f2;
   --comment-card-source-preview-background-color-hover: #e6e6e6;

--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -23,12 +23,14 @@
 :root.theme-dark {
   --color-transparent: rgba(0, 0, 0, 0);
 
-  --scroll-thumb-color: #454950;
-
-  --nag-background-color: #ff005b;
-  --nag-gradient-color-begin: #ff2f86;
-  --nag-gradient-color-end: #eb265e;
-  --nag-color: #ffffff;
+  /* Color ramp: this is copy/pasted to align to src/devtools/client/themes/variables.css */
+  --theme-base-100: #000; /* background chrome */
+  --theme-base-95: #192230; /* tab bars */
+  --theme-base-90: #3d4552; /* editor and selected tab */
+  --theme-base-85: #3e434b; /* textfields */
+  --theme-base-80: #797d81;
+  --theme-base-70: #a2a6a8;
+  --theme-base-60: #c3c6c8;
 
   --background-color-contrast-1: #0e1119;
   --background-color-contrast-2: #192230;
@@ -92,6 +94,13 @@
   --color-secondary-background: var(--background-color-contrast-3);
   --color-control-background: var(--background-color-contrast-4);
   --color-control-background-active: var(--background-color-primary-button);
+
+  --scroll-thumb-color: #454950;
+
+  --nag-background-color: #ff005b;
+  --nag-gradient-color-begin: #ff2f86;
+  --nag-gradient-color-end: #eb265e;
+  --nag-color: #ffffff;
 
   --collapsible-toggle-color: #9ba0a5;
 
@@ -199,12 +208,14 @@
 :root.theme-light {
   --color-transparent: rgba(255, 255, 255, 0);
 
-  --scroll-thumb-color: #aaaaaa;
-
-  --nag-background-color: #f02d5e;
-  --nag-gradient-color-begin: #ff3087;
-  --nag-gradient-color-end: #ed265c;
-  --nag-color: #ffffff;
+  /* Color ramp: this is copy/pasted to align to src/devtools/client/themes/variables.css */
+  --theme-base-100: hsl(0, 0%, 100%);
+  --theme-base-95: hsl(0, 0%, 95%);
+  --theme-base-90: hsl(0, 0%, 90%);
+  --theme-base-85: hsl(0, 0%, 85%);
+  --theme-base-80: hsl(0, 0%, 80%);
+  --theme-base-70: hsl(0, 0%, 70%);
+  --theme-base-60: hsl(0, 0%, 60%);
 
   --background-color-contrast-1: #e6e6e6;
   --background-color-contrast-2: #ffffff;
@@ -268,6 +279,13 @@
   --color-secondary-background: #eeeeee;
   --color-control-background: var(--background-color-contrast-1);
   --color-control-background-active: var(--background-color-primary-button);
+
+  --scroll-thumb-color: #aaaaaa;
+
+  --nag-background-color: #f02d5e;
+  --nag-gradient-color-begin: #ff3087;
+  --nag-gradient-color-end: #ed265c;
+  --nag-color: #ffffff;
 
   --collapsible-toggle-color: #868688;
 

--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -32,6 +32,9 @@
   --theme-base-70: #a2a6a8;
   --theme-base-60: #c3c6c8;
 
+  --scroll-thumb-color: #454950;
+  --dropshadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+
   --background-color-contrast-1: #0e1119;
   --background-color-contrast-2: #192230;
   --background-color-contrast-3: #2a3343;
@@ -95,8 +98,6 @@
   --color-control-background: var(--background-color-contrast-4);
   --color-control-background-active: var(--background-color-primary-button);
 
-  --scroll-thumb-color: #454950;
-
   --nag-background-color: #ff005b;
   --nag-gradient-color-begin: #ff2f86;
   --nag-gradient-color-end: #eb265e;
@@ -108,7 +109,6 @@
   --context-menu-bgcolor-divider: var(--background-color-contrast-3);
   --context-menu-bgcolor-hover: var(--theme-base-95);
   --context-menu-dropshadow: var(--dropshadow-md);
-  --dropshadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
 
   --comment-card-source-preview-background-color: #081221;
   --comment-card-source-preview-background-color-hover: #3e434a;
@@ -219,6 +219,9 @@
   --theme-base-70: hsl(0, 0%, 70%);
   --theme-base-60: hsl(0, 0%, 60%);
 
+  --scroll-thumb-color: #aaaaaa;
+  --dropshadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+
   --background-color-contrast-1: #e6e6e6;
   --background-color-contrast-2: #ffffff;
   --background-color-contrast-3: #82888c;
@@ -281,8 +284,6 @@
   --color-secondary-background: #eeeeee;
   --color-control-background: var(--background-color-contrast-1);
   --color-control-background-active: var(--background-color-primary-button);
-
-  --scroll-thumb-color: #aaaaaa;
 
   --nag-background-color: #f02d5e;
   --nag-gradient-color-begin: #ff3087;

--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -24,10 +24,10 @@
   --color-transparent: rgba(0, 0, 0, 0);
 
   /* Color ramp: this is copy/pasted to align to src/devtools/client/themes/variables.css */
-  --theme-base-100: #000; /* background chrome */
-  --theme-base-95: #192230; /* tab bars */
-  --theme-base-90: #3d4552; /* editor and selected tab */
-  --theme-base-85: #3e434b; /* textfields */
+  --theme-base-100: #000;
+  --theme-base-95: #192230;
+  --theme-base-90: #3d4552;
+  --theme-base-85: #3e434b;
   --theme-base-80: #797d81;
   --theme-base-70: #a2a6a8;
   --theme-base-60: #c3c6c8;

--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -23,15 +23,6 @@
 :root.theme-dark {
   --color-transparent: rgba(0, 0, 0, 0);
 
-  /* Color ramp: this is copy/pasted to align to src/devtools/client/themes/variables.css */
-  --theme-base-100: #000;
-  --theme-base-95: #192230;
-  --theme-base-90: #3d4552;
-  --theme-base-85: #3e434b;
-  --theme-base-80: #797d81;
-  --theme-base-70: #a2a6a8;
-  --theme-base-60: #c3c6c8;
-
   --background-color-contrast-1: #0e1119;
   --background-color-contrast-2: #192230;
   --background-color-contrast-3: #2a3343;
@@ -106,7 +97,7 @@
 
   --context-menu-bgcolor: #3d4552;
   --context-menu-bgcolor-divider: var(--background-color-contrast-3);
-  --context-menu-bgcolor-hover: var(--background-color-contrast-3);
+  --context-menu-bgcolor-hover: #f2f2f2; /* this is theme-base-95 */
 
   --comment-card-source-preview-background-color: #081221;
   --comment-card-source-preview-background-color-hover: #3e434a;
@@ -208,15 +199,6 @@
 :root.theme-light {
   --color-transparent: rgba(255, 255, 255, 0);
 
-  /* Color ramp: this is copy/pasted to align to src/devtools/client/themes/variables.css */
-  --theme-base-100: hsl(0, 0%, 100%);
-  --theme-base-95: hsl(0, 0%, 95%);
-  --theme-base-90: hsl(0, 0%, 90%);
-  --theme-base-85: hsl(0, 0%, 85%);
-  --theme-base-80: hsl(0, 0%, 80%);
-  --theme-base-70: hsl(0, 0%, 70%);
-  --theme-base-60: hsl(0, 0%, 60%);
-
   --background-color-contrast-1: #e6e6e6;
   --background-color-contrast-2: #ffffff;
   --background-color-contrast-3: #82888c;
@@ -291,7 +273,7 @@
 
   --context-menu-bgcolor: #f8f8f9;
   --context-menu-bgcolor-divider: #e0e0e0;
-  --context-menu-bgcolor-hover: #e0e0e0;
+  --context-menu-bgcolor-hover: #192230; /* this is theme-base-95 */
 
   --comment-card-source-preview-background-color: #f2f3f2;
   --comment-card-source-preview-background-color-hover: #e6e6e6;

--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -23,6 +23,15 @@
 :root.theme-dark {
   --color-transparent: rgba(0, 0, 0, 0);
 
+  /* Color ramp: this is copy/pasted to align to src/devtools/client/themes/variables.css */
+  --theme-base-100: #000; /* background chrome */
+  --theme-base-95: #192230; /* tab bars */
+  --theme-base-90: #3d4552; /* editor and selected tab */
+  --theme-base-85: #3e434b; /* textfields */
+  --theme-base-80: #797d81;
+  --theme-base-70: #a2a6a8;
+  --theme-base-60: #c3c6c8;
+
   --background-color-contrast-1: #0e1119;
   --background-color-contrast-2: #192230;
   --background-color-contrast-3: #2a3343;
@@ -97,7 +106,9 @@
 
   --context-menu-bgcolor: #3d4552;
   --context-menu-bgcolor-divider: var(--background-color-contrast-3);
-  --context-menu-bgcolor-hover: #f2f2f2; /* this is theme-base-95 */
+  --context-menu-bgcolor-hover: var(--theme-base-95);
+  --context-menu-dropshadow: var(--dropshadow-md);
+  --dropshadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
 
   --comment-card-source-preview-background-color: #081221;
   --comment-card-source-preview-background-color-hover: #3e434a;
@@ -199,6 +210,15 @@
 :root.theme-light {
   --color-transparent: rgba(255, 255, 255, 0);
 
+  /* Color ramp: this is copy/pasted to align to src/devtools/client/themes/variables.css */
+  --theme-base-100: hsl(0, 0%, 100%);
+  --theme-base-95: hsl(0, 0%, 95%);
+  --theme-base-90: hsl(0, 0%, 90%);
+  --theme-base-85: hsl(0, 0%, 85%);
+  --theme-base-80: hsl(0, 0%, 80%);
+  --theme-base-70: hsl(0, 0%, 70%);
+  --theme-base-60: hsl(0, 0%, 60%);
+
   --background-color-contrast-1: #e6e6e6;
   --background-color-contrast-2: #ffffff;
   --background-color-contrast-3: #82888c;
@@ -273,7 +293,8 @@
 
   --context-menu-bgcolor: #f8f8f9;
   --context-menu-bgcolor-divider: #e0e0e0;
-  --context-menu-bgcolor-hover: #192230; /* this is theme-base-95 */
+  --context-menu-bgcolor-hover: var(--theme-base-95);
+  --context-menu-dropshadow: var(--dropshadow-md);
 
   --comment-card-source-preview-background-color: #f2f3f2;
   --comment-card-source-preview-background-color-hover: #e6e6e6;

--- a/src/devtools/client/debugger/src/components/TestInfo/ContextMenu.module.css
+++ b/src/devtools/client/debugger/src/components/TestInfo/ContextMenu.module.css
@@ -5,6 +5,7 @@
   border-radius: 0.5rem;
   overflow: hidden;
   white-space: nowrap;
+  box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
 
   /* Ensure the context menu is always above console rows and the current time indicator */
   z-index: 11;
@@ -13,7 +14,7 @@
 .ContextMenuItem {
   background-color: var(--context-menu-bgcolor);
   color: var(--color-default);
-  padding: 0.5rem 1rem;
+  padding: 0.5rem 1rem 0.5rem 0.5rem;
   user-select: none;
   cursor: pointer;
   display: flex;

--- a/src/devtools/client/debugger/src/components/TestInfo/ContextMenu.module.css
+++ b/src/devtools/client/debugger/src/components/TestInfo/ContextMenu.module.css
@@ -5,7 +5,7 @@
   border-radius: 0.5rem;
   overflow: hidden;
   white-space: nowrap;
-  box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  box-shadow: var(--dropshadow-md);
 
   /* Ensure the context menu is always above console rows and the current time indicator */
   z-index: 11;

--- a/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
@@ -2,8 +2,6 @@ import { Object as ProtocolObject } from "@replayio/protocol";
 import cloneDeep from "lodash/cloneDeep";
 import React, { createContext, useContext, useMemo, useState } from "react";
 
-import ErrorBoundary from "replay-next/components/ErrorBoundary";
-import PropertiesRenderer from "replay-next/components/inspector/PropertiesRenderer";
 import { getSelectedTest } from "ui/reducers/reporter";
 import { useAppSelector } from "ui/setup/hooks";
 import { TestItem } from "ui/types";
@@ -11,6 +9,9 @@ import { TestItem } from "ui/types";
 import ContextMenuWrapper from "./ContextMenu";
 import { TestCase } from "./TestCase";
 import { TestInfoContextMenuContextRoot } from "./TestInfoContextMenuContext";
+
+import ErrorBoundary from "replay-next/components/ErrorBoundary";
+import PropertiesRenderer from "replay-next/components/inspector/PropertiesRenderer";
 
 type TestInfoContextType = {
   consoleProps?: ProtocolObject;
@@ -39,7 +40,7 @@ export default function TestInfo({ testCases }: { testCases: TestItem[] }) {
     >
       <TestInfoContextMenuContextRoot>
         <div className="flex flex-grow flex-col overflow-hidden">
-          <div className="relative flex flex-grow flex-col space-y-1 overflow-auto px-2">
+          <div className="relative flex flex-grow flex-col space-y-1 overflow-auto px-2 pt-3">
             {testCases.map((t, i) => showTest(i) && <TestCase test={t} key={i} index={i} />)}
           </div>
           {selectedTest !== null ? <Console /> : null}

--- a/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
@@ -2,6 +2,8 @@ import { Object as ProtocolObject } from "@replayio/protocol";
 import cloneDeep from "lodash/cloneDeep";
 import React, { createContext, useContext, useMemo, useState } from "react";
 
+import ErrorBoundary from "replay-next/components/ErrorBoundary";
+import PropertiesRenderer from "replay-next/components/inspector/PropertiesRenderer";
 import { getSelectedTest } from "ui/reducers/reporter";
 import { useAppSelector } from "ui/setup/hooks";
 import { TestItem } from "ui/types";
@@ -9,9 +11,6 @@ import { TestItem } from "ui/types";
 import ContextMenuWrapper from "./ContextMenu";
 import { TestCase } from "./TestCase";
 import { TestInfoContextMenuContextRoot } from "./TestInfoContextMenuContext";
-
-import ErrorBoundary from "replay-next/components/ErrorBoundary";
-import PropertiesRenderer from "replay-next/components/inspector/PropertiesRenderer";
 
 type TestInfoContextType = {
   consoleProps?: ProtocolObject;

--- a/src/ui/components/Library/Team/View/TestRuns/Overview/RunSummary.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/Overview/RunSummary.tsx
@@ -13,7 +13,7 @@ import { getDuration } from "../utils";
 function Title({ testRun }: { testRun: TestRun }) {
   const title = testRun?.commitTitle;
 
-  /* boop; */
+  /* boop; testing; */
 
   return (
     <div className="flex flex-row items-center space-x-2 overflow-hidden">

--- a/src/ui/components/Library/Team/View/TestRuns/Overview/RunSummary.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/Overview/RunSummary.tsx
@@ -13,7 +13,7 @@ import { getDuration } from "../utils";
 function Title({ testRun }: { testRun: TestRun }) {
   const title = testRun?.commitTitle;
 
-  boop;
+  /* boop; */
 
   return (
     <div className="flex flex-row items-center space-x-2 overflow-hidden">

--- a/src/ui/components/Library/Team/View/TestRuns/Overview/RunSummary.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/Overview/RunSummary.tsx
@@ -28,7 +28,7 @@ export function Attributes({ testRun }: { testRun: TestRun }) {
   const { user, date, mergeId, mergeTitle, branch } = testRun;
 
   return (
-    <div className="flex flex-row flex-wrap items-center">
+    <div className="flex flex-row flex-wrap items-center pl-1">
       <AttributeContainer icon="schedule">{getTruncatedRelativeDate(date)}</AttributeContainer>
       <AttributeContainer icon="person">{user!}</AttributeContainer>
       {mergeId && (

--- a/src/ui/components/Library/Team/View/TestRuns/Overview/RunSummary.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/Overview/RunSummary.tsx
@@ -13,6 +13,8 @@ import { getDuration } from "../utils";
 function Title({ testRun }: { testRun: TestRun }) {
   const title = testRun?.commitTitle;
 
+  boop;
+
   return (
     <div className="flex flex-row items-center space-x-2 overflow-hidden">
       <div className="overflow-hidden overflow-ellipsis whitespace-nowrap text-xl font-medium">

--- a/src/ui/components/Library/Team/View/TestRuns/Overview/RunSummary.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/Overview/RunSummary.tsx
@@ -13,8 +13,6 @@ import { getDuration } from "../utils";
 function Title({ testRun }: { testRun: TestRun }) {
   const title = testRun?.commitTitle;
 
-  /* boop; testing; */
-
   return (
     <div className="flex flex-row items-center space-x-2 overflow-hidden">
       <div className="overflow-hidden overflow-ellipsis whitespace-nowrap text-xl font-medium">


### PR DESCRIPTION
Rather than undertake a giant reconciliation of a lot of code, this is meant as the lowest possible hanging fruit between our original variables.css document and the one in replay-next.

These tokens are foundational to the entire design system, so by adding these 7 variables across 2 themes, we get our systems much closer together.

There's no rush to get this out, this is just me being proactive to start getting this process moving. Happy to discuss!