### PR TITLE
Context menu changes

### DIFF
--- a/packages/replay-next/components/Expandable.tsx
+++ b/packages/replay-next/components/Expandable.tsx
@@ -42,6 +42,10 @@ export default function Expandable({
   const [isOpen, setIsOpen] = useState(defaultOpen);
 
   const onClick = (event: MouseEvent) => {
+    if (event.defaultPrevented) {
+      return;
+    }
+
     event.stopPropagation();
 
     if (isPending) {

--- a/packages/replay-next/components/console/useConsoleContextMenu.tsx
+++ b/packages/replay-next/components/console/useConsoleContextMenu.tsx
@@ -1,10 +1,5 @@
 import { useContext } from "react";
 
-import { Badge } from "shared/client/types";
-
-import { Loggable } from "./LoggablesContext";
-import styles from "./ContextMenu.module.css";
-
 import ContextMenuDivider from "replay-next/components/context-menu/ContextMenuDivider";
 import ContextMenuItem from "replay-next/components/context-menu/ContextMenuItem";
 import useContextMenu from "replay-next/components/context-menu/useContextMenu";
@@ -13,6 +8,10 @@ import { FocusContext } from "replay-next/src/contexts/FocusContext";
 import { PointsContext } from "replay-next/src/contexts/PointsContext";
 import { SessionContext } from "replay-next/src/contexts/SessionContext";
 import { getLoggableTime, isPointInstance } from "replay-next/src/utils/loggables";
+import { Badge } from "shared/client/types";
+
+import { Loggable } from "./LoggablesContext";
+import styles from "./ContextMenu.module.css";
 
 const BADGES: Badge[] = ["green", "yellow", "orange", "purple"];
 

--- a/packages/replay-next/components/console/useConsoleContextMenu.tsx
+++ b/packages/replay-next/components/console/useConsoleContextMenu.tsx
@@ -1,5 +1,10 @@
 import { useContext } from "react";
 
+import { Badge } from "shared/client/types";
+
+import { Loggable } from "./LoggablesContext";
+import styles from "./ContextMenu.module.css";
+
 import ContextMenuDivider from "replay-next/components/context-menu/ContextMenuDivider";
 import ContextMenuItem from "replay-next/components/context-menu/ContextMenuItem";
 import useContextMenu from "replay-next/components/context-menu/useContextMenu";
@@ -8,10 +13,6 @@ import { FocusContext } from "replay-next/src/contexts/FocusContext";
 import { PointsContext } from "replay-next/src/contexts/PointsContext";
 import { SessionContext } from "replay-next/src/contexts/SessionContext";
 import { getLoggableTime, isPointInstance } from "replay-next/src/utils/loggables";
-import { Badge } from "shared/client/types";
-
-import { Loggable } from "./LoggablesContext";
-import styles from "./ContextMenu.module.css";
 
 const BADGES: Badge[] = ["green", "yellow", "orange", "purple"];
 

--- a/packages/replay-next/components/context-menu/ContextMenu.module.css
+++ b/packages/replay-next/components/context-menu/ContextMenu.module.css
@@ -5,7 +5,7 @@
   border-radius: 0.5rem;
   overflow: hidden;
   white-space: nowrap;
-  z-index: 15;
+  z-index: 25; /* Higher than Popup */
   filter: drop-shadow(1px 2px 3px rgba(0, 0, 0, 0.5));
   padding: 0.25rem 0;
   background-color: var(--context-menu-bgcolor);

--- a/packages/replay-next/components/context-menu/ContextMenu.tsx
+++ b/packages/replay-next/components/context-menu/ContextMenu.tsx
@@ -1,9 +1,9 @@
 import { ReactNode, useRef } from "react";
 import { createPortal } from "react-dom";
 
-import styles from "./ContextMenu.module.css";
-
 import useModalDismissSignal from "replay-next/src/hooks/useModalDismissSignal";
+
+import styles from "./ContextMenu.module.css";
 
 export default function ContextMenu({
   children,

--- a/packages/replay-next/components/context-menu/ContextMenu.tsx
+++ b/packages/replay-next/components/context-menu/ContextMenu.tsx
@@ -1,10 +1,9 @@
-import { ComponentPropsWithoutRef, ReactElement, ReactNode, useRef } from "react";
+import { ReactNode, useRef } from "react";
 import { createPortal } from "react-dom";
 
-import useModalDismissSignal from "replay-next/src/hooks/useModalDismissSignal";
-
-import ContextMenuItem from "./ContextMenuItem";
 import styles from "./ContextMenu.module.css";
+
+import useModalDismissSignal from "replay-next/src/hooks/useModalDismissSignal";
 
 export default function ContextMenu({
   children,

--- a/packages/replay-next/components/context-menu/ContextMenuItem.tsx
+++ b/packages/replay-next/components/context-menu/ContextMenuItem.tsx
@@ -1,8 +1,8 @@
 import { MouseEvent, ReactNode, useContext } from "react";
 
-import styles from "./ContextMenuItem.module.css";
-
 import { ContextMenuContext } from "replay-next/components/context-menu/ContextMenuContext";
+
+import styles from "./ContextMenuItem.module.css";
 
 export default function ContextMenuItem({
   children,

--- a/packages/replay-next/components/context-menu/ContextMenuItem.tsx
+++ b/packages/replay-next/components/context-menu/ContextMenuItem.tsx
@@ -1,6 +1,8 @@
-import { ReactNode } from "react";
+import { MouseEvent, ReactNode, useContext } from "react";
 
 import styles from "./ContextMenuItem.module.css";
+
+import { ContextMenuContext } from "replay-next/components/context-menu/ContextMenuContext";
 
 export default function ContextMenuItem({
   children,
@@ -15,9 +17,17 @@ export default function ContextMenuItem({
   disabled?: boolean;
   onClick?: () => void;
 }) {
-  const onClick = () => {
-    if (!disabled && onClickProp) {
-      onClickProp();
+  const onClick = (event: MouseEvent) => {
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    event.preventDefault();
+
+    if (!disabled) {
+      if (onClickProp) {
+        onClickProp();
+      }
     }
   };
 

--- a/packages/replay-next/components/context-menu/useContextMenu.tsx
+++ b/packages/replay-next/components/context-menu/useContextMenu.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, ReactNode, useMemo, useState } from "react";
+import { MouseEvent, ReactNode, useCallback, useMemo, useState } from "react";
 
 import ContextMenu from "./ContextMenu";
 import { ContextMenuContext, ContextMenuContextType } from "./ContextMenuContext";
@@ -16,15 +16,21 @@ export default function useContextMenu(
   const { dataTestId, dataTestName } = options;
 
   const [contextMenuEvent, setContextMenuEvent] = useState<MouseEvent | null>(null);
+
   const context = useMemo<ContextMenuContextType>(() => ({ contextMenuEvent }), [contextMenuEvent]);
 
   const onContextMenu = (event: MouseEvent) => {
+    if (event.defaultPrevented) {
+      // Support nested context menus
+      return;
+    }
+
     event.preventDefault();
 
     setContextMenuEvent(event);
   };
 
-  const hideContextMenu = () => setContextMenuEvent(null);
+  const hideContextMenu = useCallback(() => setContextMenuEvent(null), []);
 
   let contextMenu = null;
   if (contextMenuEvent) {

--- a/packages/replay-next/components/sources/SourceListRow.tsx
+++ b/packages/replay-next/components/sources/SourceListRow.tsx
@@ -268,7 +268,6 @@ const SourceListRow = memo(
     };
 
     const { contextMenu, onContextMenu } = useSourceContextMenu({
-      firstBreakableColumnIndex: lineHitCounts?.firstBreakableColumnIndex ?? null,
       lineNumber,
       sourceId: source.sourceId,
       sourceUrl: source.url ?? null,

--- a/packages/replay-next/components/sources/useSourceContextMenu.tsx
+++ b/packages/replay-next/components/sources/useSourceContextMenu.tsx
@@ -1,6 +1,8 @@
 import { SourceId } from "@replayio/protocol";
 import { unstable_useCacheRefresh as useCacheRefresh, useContext, useTransition } from "react";
 
+import { ReplayClientContext } from "shared/client/ReplayClientContext";
+
 import ContextMenuDivider from "replay-next/components/context-menu/ContextMenuDivider";
 import ContextMenuItem from "replay-next/components/context-menu/ContextMenuItem";
 import useContextMenu from "replay-next/components/context-menu/useContextMenu";
@@ -15,15 +17,12 @@ import { SessionContext } from "replay-next/src/contexts/SessionContext";
 import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
 import { addComment as addCommentGraphQL } from "replay-next/src/graphql/Comments";
 import useLocalStorage from "replay-next/src/hooks/useLocalStorage";
-import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
 export default function useSourceContextMenu({
-  firstBreakableColumnIndex,
   lineNumber,
   sourceId,
   sourceUrl,
 }: {
-  firstBreakableColumnIndex: number | null;
   lineNumber: number;
   sourceId: SourceId;
   sourceUrl: string | null;

--- a/packages/replay-next/components/sources/useSourceContextMenu.tsx
+++ b/packages/replay-next/components/sources/useSourceContextMenu.tsx
@@ -1,8 +1,6 @@
 import { SourceId } from "@replayio/protocol";
 import { unstable_useCacheRefresh as useCacheRefresh, useContext, useTransition } from "react";
 
-import { ReplayClientContext } from "shared/client/ReplayClientContext";
-
 import ContextMenuDivider from "replay-next/components/context-menu/ContextMenuDivider";
 import ContextMenuItem from "replay-next/components/context-menu/ContextMenuItem";
 import useContextMenu from "replay-next/components/context-menu/useContextMenu";
@@ -17,6 +15,7 @@ import { SessionContext } from "replay-next/src/contexts/SessionContext";
 import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
 import { addComment as addCommentGraphQL } from "replay-next/src/graphql/Comments";
 import useLocalStorage from "replay-next/src/hooks/useLocalStorage";
+import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
 export default function useSourceContextMenu({
   lineNumber,

--- a/src/ui/hooks/useModalDismissSignal.ts
+++ b/src/ui/hooks/useModalDismissSignal.ts
@@ -41,8 +41,7 @@ export default function useModalDismissSignal(
       ownerDocument.addEventListener("keydown", handleDocumentKeyDown);
       if (dismissOnClickOutside) {
         ownerDocument.addEventListener("click", handleDocumentClick, true);
-      }
-      if (dismissOnClickOutside) {
+        ownerDocument.addEventListener("contextmenu", handleDocumentClick, true);
         ownerDocument.addEventListener("scroll", dismissCallback, true);
       }
     }, 0);
@@ -53,8 +52,10 @@ export default function useModalDismissSignal(
       }
 
       if (ownerDocument !== null) {
-        ownerDocument.removeEventListener("keydown", handleDocumentKeyDown);
         ownerDocument.removeEventListener("click", handleDocumentClick, true);
+        ownerDocument.removeEventListener("contextmenu", handleDocumentClick, true);
+        ownerDocument.removeEventListener("scroll", dismissCallback, true);
+        ownerDocument.removeEventListener("keydown", handleDocumentKeyDown);
       }
     };
   }, [modalRef, dismissCallback, dismissOnClickOutside]);


### PR DESCRIPTION
Done in support of FE-989:
- [x] `Expandable` observes `event.defaultPrevented` so that clicks within a context menus inside of an expandable does not also trigger the expandable.
- [x] `ContextMenu` observes `event.defaultPrevented` so that nested context menus are supported. (Showing the inner menu does not also show the outer menu.)
- [x] `ContextMenu` `z-index` style value increased slightly so that context menus show _on top of_ source preview popups.

I also tweaked two unrelated things I noticed while mucking around the code:
- [x] Leaky event listener issue fixed for `useModalDismissSignal`
- [x] Removed an unused param from `useSourceContextMenu`
