### PR TITLE
Aligning grays

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Footer.css
+++ b/src/devtools/client/debugger/src/components/Editor/Footer.css
@@ -10,7 +10,6 @@
 
 .source-footer {
   background: var(--body-bgcolor);
-  border-radius: 0.5em;
   display: flex;
   opacity: 1;
   width: 100%;

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/CommandBar.css
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/CommandBar.css
@@ -40,7 +40,7 @@ html[dir="rtl"] .command-bar {
 
 .command-bar .divider {
   width: 1px;
-  background: var(--theme-splitter-color);
-  height: 10px;
+  background: var(--body-color);
+  height: 14px;
   margin: 11px 6px 0 6px;
 }

--- a/src/devtools/client/themes/variables.css
+++ b/src/devtools/client/themes/variables.css
@@ -272,7 +272,7 @@
   --theme-selection-color: #ffffff;
 
   /* Border color that splits the toolbars/panels/headers. */
-  --theme-splitter-color: var(--grey-25);
+  --theme-splitter-color: var(--chrome);
   --theme-emphasized-splitter-color: var(--grey-30);
   --theme-emphasized-splitter-color-hover: var(--grey-40);
 


### PR DESCRIPTION
A few small tweaks to the site to bring it in line with the designs.

* Divider lines should blend into the background
* Footer of the editor shouldn't be fully rounded
* Brought divider line back to the command bar

Old:
<img width="112" alt="image" src="https://user-images.githubusercontent.com/9154902/210702122-411d1772-6cb8-45e4-8c11-97f9a3bfd9a3.png">

New:
<img width="117" alt="image" src="https://user-images.githubusercontent.com/9154902/210702153-e239a87e-9ed9-4648-8b49-f55192edc7ce.png">

Old:
<img width="349" alt="image" src="https://user-images.githubusercontent.com/9154902/210702180-ca9958bf-903f-4177-9706-23d887e85452.png">

New:
<img width="280" alt="image" src="https://user-images.githubusercontent.com/9154902/210702217-9ad62973-1823-4571-9228-3f48a10d2a8c.png">

Old:
<img width="349" alt="image" src="https://user-images.githubusercontent.com/9154902/210702871-4ac03a6d-27bb-486f-bebd-7dbbf9987dfe.png">

New:
<img width="279" alt="image" src="https://user-images.githubusercontent.com/9154902/210702911-55b5706a-8c1e-4f66-b6fa-6413a7d87056.png">
