### PR TITLE
Remove unsafe uses of ThreadFront.currentPause.pauseId

### DIFF
--- a/packages/protocol/graphics.ts
+++ b/packages/protocol/graphics.ts
@@ -294,7 +294,7 @@ export async function repaint(force = false) {
     ThreadFront.currentTime,
     await ThreadFront.getCurrentPauseId(replayClient),
     (_time, pauseId) => {
-      return pauseId !== ThreadFront.currentPause.pauseId;
+      return pauseId !== ThreadFront.currentPauseIdUnsafe;
     },
     force
   );

--- a/packages/protocol/thread/thread.ts
+++ b/packages/protocol/thread/thread.ts
@@ -219,15 +219,14 @@ class _ThreadFront {
     });
   }
 
-  get currentPause(): Pause {
-    return {
-      point: this.currentPoint,
-      time: this.currentTime,
-      pauseId:
-        this.currentPauseId ??
-        getPauseIdForExecutionPointIfCached(this.currentPoint)?.value ??
-        null,
-    };
+  /**
+   * This may be null if the pauseId for the current execution point hasn't been
+   * received from the backend yet. Use `await getCurrentPauseId()` instead if possible.
+   */
+  get currentPauseIdUnsafe() {
+    return (
+      this.currentPauseId ?? getPauseIdForExecutionPointIfCached(this.currentPoint)?.value ?? null
+    );
   }
 
   async getCurrentPauseId(replayClient: ReplayClientInterface): Promise<PauseId> {

--- a/src/devtools/client/debugger/src/components/shared/InspectorContextReduxAdapter.tsx
+++ b/src/devtools/client/debugger/src/components/shared/InspectorContextReduxAdapter.tsx
@@ -45,7 +45,7 @@ export default function InspectorContextReduxAdapter({ children }: { children: R
 
   const inspectHTMLElement = useCallback(
     (protocolValue: ProtocolValue, pauseId: PauseId, point: ExecutionPoint, time: number) => {
-      if (pauseId !== ThreadFront.currentPause.pauseId) {
+      if (pauseId !== ThreadFront.currentPauseIdUnsafe) {
         ThreadFront.timeWarpToPause({ point, time, pauseId }, false);
       }
       dispatch(selectNode(protocolValue.object!));

--- a/src/devtools/client/inspector/boxmodel/actions/box-model.ts
+++ b/src/devtools/client/inspector/boxmodel/actions/box-model.ts
@@ -1,4 +1,4 @@
-import type { UIStore, UIThunkAction } from "ui/actions";
+import type { UIStore } from "ui/actions";
 import { isInspectorSelected } from "ui/reducers/app";
 import { AppStartListening } from "ui/setup/listenerMiddleware";
 import { getBoundingRectAsync, getComputedStyleAsync } from "ui/suspense/styleCaches";
@@ -17,7 +17,7 @@ export function setupBoxModel(store: UIStore, startAppListening: AppStartListeni
       const state = getState();
       const { selectedNode, tree } = state.markup;
 
-      if (!isInspectorSelected(state) || !selectedNode || !ThreadFront.currentPause?.pauseId) {
+      if (!isInspectorSelected(state) || !selectedNode) {
         return;
       }
 
@@ -27,19 +27,11 @@ export function setupBoxModel(store: UIStore, startAppListening: AppStartListeni
         return;
       }
 
+      const pauseId = await ThreadFront.getCurrentPauseId(replayClient);
+
       const [bounds, style] = await Promise.all([
-        getBoundingRectAsync(
-          protocolClient,
-          ThreadFront.sessionId!,
-          ThreadFront.currentPause.pauseId,
-          selectedNode
-        ),
-        getComputedStyleAsync(
-          protocolClient,
-          ThreadFront.sessionId!,
-          ThreadFront.currentPause.pauseId,
-          selectedNode
-        ),
+        getBoundingRectAsync(protocolClient, ThreadFront.sessionId!, pauseId, selectedNode),
+        getComputedStyleAsync(protocolClient, ThreadFront.sessionId!, pauseId, selectedNode),
       ]);
 
       if (!bounds || !style) {

--- a/src/devtools/client/inspector/computed/actions/index.ts
+++ b/src/devtools/client/inspector/computed/actions/index.ts
@@ -32,14 +32,12 @@ export type InspectorThunkAction<TReturn = void> = ThunkAction<
 >;
 
 export function setComputedProperties(elementStyle: ElementStyle): InspectorThunkAction {
-  return async (dispatch, getState, { protocolClient, ThreadFront }) => {
-    if (!ThreadFront.currentPause?.pauseId) {
-      return;
-    }
+  return async (dispatch, getState, { protocolClient, ThreadFront, replayClient }) => {
+    const pauseId = await ThreadFront.getCurrentPauseId(replayClient);
     const computed = await getComputedStyleAsync(
       protocolClient,
       ThreadFront.sessionId!,
-      ThreadFront.currentPause.pauseId,
+      pauseId,
       elementStyle.nodeId
     );
     const properties = await createComputedProperties(elementStyle, computed);

--- a/src/devtools/client/inspector/markup/actions/markup.ts
+++ b/src/devtools/client/inspector/markup/actions/markup.ts
@@ -1,6 +1,6 @@
 import { ProtocolClient, Object as ProtocolObject } from "@replayio/protocol";
 
-import { getPauseId, paused } from "devtools/client/debugger/src/reducers/pause";
+import { paused } from "devtools/client/debugger/src/reducers/pause";
 import NodeConstants from "devtools/shared/dom-node-constants";
 import { Deferred, assert, defer } from "protocol/utils";
 import { getObjectWithPreviewHelper } from "replay-next/src/suspense/ObjectPreviews";
@@ -50,19 +50,20 @@ export function setupMarkup(store: UIStore, startAppListening: AppStartListening
   startAppListening({
     actionCreator: nodeSelected,
     effect: async (action, listenerApi) => {
-      const { extra, getState, dispatch } = listenerApi;
-      const { ThreadFront, protocolClient, replayClient } = extra;
+      const { getState, dispatch } = listenerApi;
       const state = getState();
       const { selectedNode, selectionReason } = state.markup;
 
-      if (!isInspectorSelected(state) || !selectedNode || !ThreadFront.currentPause?.pauseId) {
+      if (!isInspectorSelected(state) || !selectedNode) {
         return;
       }
 
       // Ignore any `nodeSelected` actions dispatched during `selectionChanged` (could cause an infinite loop)
       listenerApi.unsubscribe();
 
-      dispatch(selectionChanged(selectionReason === "navigateaway", selectionReason !== "markup"));
+      await dispatch(
+        selectionChanged(selectionReason === "navigateaway", selectionReason !== "markup")
+      );
 
       // Restore listening to `nodeSelected`
       listenerApi.subscribe();
@@ -79,7 +80,7 @@ export function setupMarkup(store: UIStore, startAppListening: AppStartListening
 
       cancelActiveListeners();
 
-      const originalPauseId = getPauseId(getState());
+      const originalPauseId = await ThreadFront.getCurrentPauseId(replayClient);
 
       // every time we pause, clear the existing DOM node info
       dispatch(reset());
@@ -88,17 +89,16 @@ export function setupMarkup(store: UIStore, startAppListening: AppStartListening
         await ThreadFront.ensureAllSources();
 
         // Clear selection if pauses have differed
-        let currentPauseId = getPauseId(getState());
         const selectedNodeId = getSelectedDomNodeId(getState());
 
-        if (selectedNodeId && currentPauseId && currentPauseId !== originalPauseId) {
+        if (selectedNodeId && ThreadFront.currentPauseIdUnsafe !== originalPauseId) {
           dispatch(nodeSelected(null));
+          return;
         }
 
         // Clear out and reset all the node tree data
         await dispatch(newRoot());
-        currentPauseId = getPauseId(getState());
-        if (currentPauseId !== originalPauseId) {
+        if (ThreadFront.currentPauseIdUnsafe !== originalPauseId) {
           return;
         }
 
@@ -111,11 +111,11 @@ export function setupMarkup(store: UIStore, startAppListening: AppStartListening
             protocolClient,
             replayClient,
             ThreadFront.sessionId!,
-            ThreadFront.currentPause!.pauseId!,
+            originalPauseId!,
             { type: "document" }
           );
 
-          if (!rootNode) {
+          if (!rootNode || ThreadFront.currentPauseIdUnsafe !== originalPauseId) {
             return;
           }
 
@@ -124,12 +124,15 @@ export function setupMarkup(store: UIStore, startAppListening: AppStartListening
             protocolClient,
             replayClient,
             ThreadFront.sessionId!,
-            ThreadFront.currentPause!.pauseId!,
+            originalPauseId!,
             { type: "querySelector", nodeId: rootNode.objectId, selector: "body" }
           );
 
-          currentPauseId = getPauseId(getState());
-          if (defaultNode && !selectedNodeId && currentPauseId === originalPauseId) {
+          if (
+            defaultNode &&
+            !selectedNodeId &&
+            ThreadFront.currentPauseIdUnsafe === originalPauseId
+          ) {
             dispatch(nodeSelected(defaultNode.objectId, "navigateaway"));
           }
         }
@@ -173,20 +176,17 @@ export function reset() {
  */
 export function newRoot(): UIThunkAction<Promise<void>> {
   return async (dispatch, getState, { ThreadFront, replayClient, protocolClient }) => {
-    const pause = ThreadFront.currentPause;
-    assert(pause, "no current pause");
-    const originalPauseId = getPauseId(getState());
+    const originalPauseId = await ThreadFront.getCurrentPauseId(replayClient);
 
     const [rootNodeData] = await getNodeDataAsync(
       protocolClient,
       replayClient,
       ThreadFront.sessionId!,
-      ThreadFront.currentPause!.pauseId!,
+      originalPauseId,
       { type: "document" }
     );
 
-    let currentPauseId = getPauseId(getState());
-    if (!rootNodeData || currentPauseId !== originalPauseId) {
+    if (!rootNodeData || ThreadFront.currentPauseIdUnsafe !== originalPauseId) {
       return;
     }
     const rootNode = await convertNode(
@@ -194,11 +194,10 @@ export function newRoot(): UIThunkAction<Promise<void>> {
       replayClient,
       protocolClient,
       ThreadFront.sessionId!,
-      currentPauseId!
+      originalPauseId
     );
 
-    currentPauseId = getPauseId(getState());
-    if (currentPauseId !== originalPauseId) {
+    if (ThreadFront.currentPauseIdUnsafe !== originalPauseId) {
       return;
     }
 
@@ -229,7 +228,7 @@ export function addChildren(
       return node.nodeType !== NodeConstants.TEXT_NODE || /[^\s]/.exec(node.nodeValue!);
     });
 
-    const originalPauseId = getPauseId(getState());
+    const originalPauseId = await ThreadFront.getCurrentPauseId(replayClient);
 
     // Always ensure we have a parent
     const parent = await convertNode(
@@ -252,8 +251,7 @@ export function addChildren(
       )
     );
 
-    let currentPauseId = getPauseId(getState());
-    if (currentPauseId !== originalPauseId) {
+    if (ThreadFront.currentPauseIdUnsafe !== originalPauseId) {
       return;
     }
 
@@ -267,8 +265,6 @@ export function collapseNode(nodeId: string) {
 
 export function toggleNodeExpanded(nodeId: string, isExpanded: boolean): UIThunkAction {
   return (dispatch, getState, { ThreadFront }) => {
-    assert(ThreadFront.currentPause, "no current pause");
-
     if (isExpanded) {
       dispatch(collapseNode(nodeId));
     } else {
@@ -303,26 +299,22 @@ export function expandNode(
         dispatch(updateScrollIntoViewNode(node.id));
       }
 
-      const originalPauseId = getPauseId(getState());
-
-      assert(originalPauseId, "no current pause");
+      const originalPauseId = await ThreadFront.getCurrentPauseId(replayClient);
 
       const childNodes = await getNodeDataAsync(
         protocolClient,
         replayClient,
         ThreadFront.sessionId!,
-        ThreadFront.currentPause!.pauseId!,
+        originalPauseId,
         { type: "childNodes", nodeId }
       );
 
-      let currentPauseId = getPauseId(getState());
-      if (currentPauseId !== originalPauseId) {
+      if (ThreadFront.currentPauseIdUnsafe !== originalPauseId) {
         return;
       }
       await dispatch(addChildren(nodeId, childNodes));
 
-      currentPauseId = getPauseId(getState());
-      if (currentPauseId !== originalPauseId) {
+      if (ThreadFront.currentPauseIdUnsafe !== originalPauseId) {
         return;
       }
       dispatch(updateChildrenLoading({ nodeId, isLoadingChildren: false }));
@@ -339,8 +331,8 @@ export function expandNode(
 export function selectionChanged(
   expandSelectedNode: boolean,
   shouldScrollIntoView = false
-): UIThunkAction {
-  return async (dispatch, getState, { replayClient }) => {
+): UIThunkAction<Promise<void>> {
+  return async (dispatch, getState, { replayClient, ThreadFront }) => {
     const selectedNodeId = getSelectedDomNodeId(getState());
 
     if (!selectedNodeId) {
@@ -357,7 +349,7 @@ export function selectionChanged(
       return;
     }
 
-    const pauseId = getPauseId(getState())!;
+    const pauseId = await ThreadFront.getCurrentPauseId(replayClient);
 
     dispatch(nodeSelected(latestSelectedNodeId));
 
@@ -398,15 +390,16 @@ export function selectionChanged(
 export function selectNode(nodeId: string, reason?: SelectionReason): UIThunkAction {
   return async (dispatch, getState, { ThreadFront, replayClient, protocolClient }) => {
     // Ensure we have the data loaded
+    const originalPauseId = await ThreadFront.getCurrentPauseId(replayClient);
     const nodes = await getNodeDataAsync(
       protocolClient,
       replayClient,
       ThreadFront.sessionId!,
-      ThreadFront.currentPause!.pauseId!,
+      originalPauseId,
       { type: "parentNodes", nodeId }
     );
 
-    if (nodes.length) {
+    if (nodes.length && ThreadFront.currentPauseIdUnsafe === originalPauseId) {
       dispatch(highlightNode(nodeId, 1000));
 
       dispatch(nodeSelected(nodeId, reason));
@@ -592,18 +585,14 @@ export function highlightNodes(
   pauseId?: string,
   duration?: number
 ): UIThunkAction {
-  return async (dispatch, getState, { ThreadFront, protocolClient }) => {
+  return async (dispatch, getState, { ThreadFront, protocolClient, replayClient }) => {
     if (nodeIds.length === 0) {
       return;
     }
 
     if (!pauseId) {
       // We're trying to highlight nodes from the current pause.
-      // Bail out if we're not paused
-      if (!ThreadFront.currentPause) {
-        return;
-      }
-      pauseId = ThreadFront.currentPause.pauseId!;
+      pauseId = await ThreadFront.getCurrentPauseId(replayClient);
     }
 
     const { highlightedNodes } = getState().markup;

--- a/src/devtools/client/webconsole/actions/toolbox.ts
+++ b/src/devtools/client/webconsole/actions/toolbox.ts
@@ -6,97 +6,9 @@
 
 import { selectSource } from "devtools/client/debugger/src/actions/sources";
 import { showSource } from "devtools/client/debugger/src/actions/ui";
-import { openSourceLink } from "devtools/client/debugger/src/actions/ui";
 import { getContext } from "devtools/client/debugger/src/selectors";
-import { nodeSelected } from "devtools/client/inspector/markup/reducers/markup";
 import type { UIThunkAction } from "ui/actions";
-import { setSelectedPanel } from "ui/actions/layout";
-import { clearHoveredItem, setHoveredItem } from "ui/actions/timeline";
-import { isRegionLoaded } from "ui/reducers/app";
 import { getSourceDetails, getSourceToDisplayForUrl } from "ui/reducers/sources";
-
-type $FixTypeLater = any;
-
-export function highlightDomElement(grip: $FixTypeLater): UIThunkAction {
-  return async (dispatch, getState, { ThreadFront }) => {
-    if (grip.getPause() !== ThreadFront.currentPause) {
-      return;
-    }
-
-    const { highlightNode } = await import("devtools/client/inspector/markup/actions/markup");
-
-    const nodeFront = grip.getNodeFront();
-    if (nodeFront) {
-      dispatch(highlightNode(nodeFront.id));
-    }
-  };
-}
-
-export function unHighlightDomElement(): UIThunkAction {
-  return async dispatch => {
-    const { unhighlightNode } = await import("devtools/client/inspector/markup/actions/markup");
-
-    dispatch(unhighlightNode());
-  };
-}
-
-export function openLink(url: string): UIThunkAction {
-  return (dispatch, getState) => {
-    const source = getSourceToDisplayForUrl(getState(), url);
-    if (source?.id) {
-      dispatch(openSourceLink(source.id));
-    } else {
-      window.open(url, "_blank");
-    }
-  };
-}
-
-// TODO This function is called by `InspectorContextReduxAdapter`, but disabled
-export function openNodeInInspector(
-  nodeId: string,
-  reason: "console" | "debugger" = "console"
-): UIThunkAction<Promise<void>> {
-  return async (dispatch, getState, { ThreadFront, replayClient, protocolClient }) => {
-    /*
-    const pause = valueFront.getPause()!;
-
-    if (ThreadFront.currentPause !== pause && isRegionLoaded(getState(), pause.time)) {
-      ThreadFront.timeWarpToPause(pause);
-    }
-
-    dispatch(setSelectedPanel("inspector"));
-
-    // TODO Replace this with `getNodeDataAsync` and load parents
-
-    // @ts-expect-error private field usage?
-    const nodeFront = await pause.ensureDOMFrontAndParents(valueFront!._object!.objectId);
-
-    // TODO Replace this
-    dispatch(nodeSelected(nodeFront.objectId()));
-    */
-  };
-}
-
-export function onMessageHover(
-  type: "mouseenter" | "mouseleave",
-  message: $FixTypeLater
-): UIThunkAction {
-  return dispatch => {
-    if (type == "mouseenter") {
-      const hoveredItem = {
-        target: "console",
-        point: message.executionPoint,
-        time: message.executionPointTime,
-        location: message.frame,
-      };
-      // @ts-expect-error HoveredItem mismatch
-      dispatch(setHoveredItem(hoveredItem));
-    }
-    if (type == "mouseleave") {
-      dispatch(clearHoveredItem);
-    }
-  };
-}
 
 export function onViewSourceInDebugger(
   frame: { sourceId?: string; url: string; line?: number; column: number },

--- a/src/ui/components/SecondaryToolbox/react-devtools/injectReactDevtoolsBackend.ts
+++ b/src/ui/components/SecondaryToolbox/react-devtools/injectReactDevtoolsBackend.ts
@@ -96,7 +96,7 @@ export async function injectReactDevtoolsBackend(
   ThreadFront: typeof TF,
   replayClient: ReplayClientInterface
 ) {
-  const pauseId = ThreadFront.currentPause?.pauseId;
+  const pauseId = await ThreadFront.getCurrentPauseId(replayClient);
   if (!pauseId || pausesWithDevtoolsInjected.has(pauseId)) {
     return;
   }


### PR DESCRIPTION
In some places (mostly the Elements panel) we still used `ThreadFront.currentPause.pauseId`. The problem is that this property is `null` when the user switched to a new execution point and the new `pauseId` has not yet been received from the backend. That's why `await ThreadFront.getCurrentPauseId()` should be preferred whenever possible.
I think the only uses of `ThreadFront.currentPause.pauseId` that can be considered safe are:
- to check if the user has navigated (or is currently navigating) to a different pause
- if we need to get the `pauseId` synchronously and bail out if it's `null`

This fixes some of the Sentry issues in FE-1056.