### PR TITLE
Suppress trying to refresh auth token when in the replay browser

### DIFF
--- a/src/ui/utils/tokenManager.tsx
+++ b/src/ui/utils/tokenManager.tsx
@@ -168,7 +168,12 @@ class TokenManager {
   }
 
   private async update(refresh: boolean) {
-    if (!this.auth0Client || this.auth0Client.isLoading || typeof window === "undefined") {
+    if (
+      !this.auth0Client ||
+      this.auth0Client.isLoading ||
+      typeof window === "undefined" ||
+      window.__IS_RECORD_REPLAY_RUNTIME__
+    ) {
       return;
     }
 


### PR DESCRIPTION
No need to refresh the auth token when we're in the replay browser because it'll be injected by the browser when available. This avoids a failed refresh from clearing the token that was injected by the browser during the fetch.