### PR TITLE
Upgrade react-resizable-panels from v0.0.27 to v0.0.30

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "react-lazyload": "^3.2.0",
     "react-merge-refs": "^1.1.0",
     "react-redux": "^8.0.2",
-    "react-resizable-panels": "^0.0.27",
+    "react-resizable-panels": "^0.0.30",
     "react-table": "^7.7.0",
     "react-tooltip": "^4.2.21",
     "react-transition-group": "^4.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20626,13 +20626,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-resizable-panels@npm:^0.0.27":
-  version: 0.0.27
-  resolution: "react-resizable-panels@npm:0.0.27"
+"react-resizable-panels@npm:^0.0.30":
+  version: 0.0.30
+  resolution: "react-resizable-panels@npm:0.0.30"
   peerDependencies:
     react: ^16.14.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0
-  checksum: d644e65c7df2010931fdaf69db0b33b380d4b2734bba5d851926e512455a66f9b91c4c889600103e516b7446ddd4c22c6875c1670ca24bda49ef7bfc04ad8494
+  checksum: 7c7bb657a71559f01ff5fff021d5c5843ea3db9fb2059fe2d282f8f32692959979f60470d3d065f927a2cebc030cbced470f01a1a52ece2afb6ed5c0c5cea934
   languageName: node
   linkType: hard
 
@@ -21065,7 +21065,7 @@ __metadata:
     react-lazyload: ^3.2.0
     react-merge-refs: ^1.1.0
     react-redux: ^8.0.2
-    react-resizable-panels: ^0.0.27
+    react-resizable-panels: ^0.0.30
     react-table: ^7.7.0
     react-tooltip: ^4.2.21
     react-transition-group: ^4.4.2


### PR DESCRIPTION
This has a couple of small but nice improvements:
* v0.0.29: Disable `pointer-events` inside of Panels during resize. This avoid edge cases like nested iframes.
* v0.0.30: Reduce volume/frequency of `localStorage` writes for PanelGroups configured to auto-save.