### PR TITLE
Add a video endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ storybook-static/
 .pnp.*
 *.tgz
 test/.yarn/cache/
+*.mp4
+videos/

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@apollo/client": "^3.5.10",
     "@auth0/auth0-react": "1.2.0",
+    "@ffmpeg-installer/ffmpeg": "^1.1.0",
     "@headlessui/react": "^1.4.3",
     "@heroicons/react": "^1.0.6",
     "@lexical/link": "^0.6.5",
@@ -54,6 +55,7 @@
     "design": "workspace:*",
     "dotenv": "^16.0.0",
     "escape-html": "^1.0.3",
+    "fluent-ffmpeg": "^2.1.2",
     "framer-motion": "^6.3.6",
     "fuzzaldrin-plus": "^0.6.0",
     "graphql-ws": "^5.9.0",
@@ -68,6 +70,7 @@
     "next": "^12.2",
     "next-global-css": "^1.3.1",
     "node-fetch": "2.x",
+    "node-protocol": "workspace:*",
     "parse-script-tags": "^0.1.7",
     "pretty-ms": "^7.0.1",
     "prop-types": "^15.8.1",

--- a/packages/node-protocol/README.md
+++ b/packages/node-protocol/README.md
@@ -1,0 +1,21 @@
+## Replay Node Protocol
+
+Provides a protocol client that can be used from Node.js scripts to communicate with the Replay.io backend via the [protocol](https://replay.io/protocol).
+
+### Example usage
+
+This script, creates a Replay client that can create a debugging session.
+
+```js
+import { createClient } from "node-protocol";
+
+const recordingId = "889363e9-08b9-4755-904f-447549558575";
+
+const { client } = await createClient();
+const { sessionId } = await client.Recording.createSession({ recordingId });
+console.log(`sessionId: ${sessionId}`);
+```
+
+### Case Study: Downloading a video
+
+See [video.ts](https://github.com/replayio/devtools/blob/main/pages/api/video.ts) for an example of how the protocol can be used to create a video of a recording on demand.

--- a/packages/node-protocol/index.ts
+++ b/packages/node-protocol/index.ts
@@ -1,0 +1,114 @@
+import {
+  CommandMethods,
+  CommandParams,
+  CommandResult,
+  EventMethods,
+  EventParams,
+  PauseId,
+  ProtocolClient,
+  SessionId,
+} from "@replayio/protocol";
+import WebSocket from "ws";
+
+import { defer } from "./utils";
+
+const DEFAULT_ADDRESS = "wss://dispatch.replay.io";
+
+interface Message {
+  id: number;
+  method: string;
+  params: any;
+  sessionId?: string;
+  pauseId?: string;
+}
+
+interface MessageWaiter {
+  method: string;
+  resolve: (value: any) => void;
+  reject: (reason: any) => void;
+}
+
+type clientRes = { client: ProtocolClient; sendMessage: any; addEventListener: any };
+
+export function createClient({
+  address = DEFAULT_ADDRESS,
+}: {
+  address: string | undefined;
+}): Promise<clientRes> {
+  const { promise, resolve } = defer<clientRes>();
+  function addEventListener<M extends EventMethods>(
+    event: M,
+    handler: (params: EventParams<M>) => void
+  ) {
+    gEventListeners.set(event, handler);
+  }
+
+  function removeEventListener() {}
+
+  const gMessageWaiters = new Map<number, MessageWaiter>();
+  const gEventListeners = new Map<string, (ev: any) => void>();
+  let gSocketOpen: boolean;
+  let gNextMessageId = 1;
+  let gPendingMessages: Message[] = [];
+
+  const socket = new WebSocket(address);
+  socket.onopen = () => {
+    console.log("socket open");
+    gSocketOpen = true;
+    resolve({ client, sendMessage, addEventListener });
+  };
+  socket.onclose = () => {
+    console.log("onclose");
+    gSocketOpen = false;
+  };
+  socket.onerror = () => console.log("onerror");
+
+  socket.onmessage = evt => {
+    const msg = JSON.parse(evt.data as any);
+    if (msg.id) {
+      const { method, resolve, reject } = gMessageWaiters.get(msg.id)!;
+
+      gMessageWaiters.delete(msg.id);
+      if (msg.error) {
+        console.warn("Message failed", method, msg.error, msg.data);
+        reject(msg.error);
+      } else {
+        resolve(msg.result);
+      }
+    } else if (gEventListeners.has(msg.method)) {
+      const handler = gEventListeners.get(msg.method)!;
+      handler(msg.params);
+    } else {
+      console.error("Received unknown message", msg);
+    }
+  };
+
+  function sendMessage<M extends CommandMethods>(
+    method: M,
+    params: CommandParams<M>,
+    sessionId?: SessionId,
+    pauseId?: PauseId
+  ): Promise<CommandResult<M>> {
+    const id = gNextMessageId++;
+    const msg = { id, sessionId, pauseId, method, params };
+
+    if (gSocketOpen) {
+      socket.send(JSON.stringify(msg));
+    } else {
+      gPendingMessages.push(msg);
+    }
+
+    const { promise, resolve, reject } = defer<any>();
+    gMessageWaiters.set(id, { method, resolve, reject });
+
+    return promise;
+  }
+
+  const client = new ProtocolClient({
+    sendCommand: sendMessage,
+    addEventListener,
+    removeEventListener,
+  });
+
+  return promise;
+}

--- a/packages/node-protocol/package.json
+++ b/packages/node-protocol/package.json
@@ -1,0 +1,5 @@
+{
+    "private": true,
+    "name": "node-protocol",
+    "version": "0.0.0"
+}

--- a/packages/node-protocol/utils.ts
+++ b/packages/node-protocol/utils.ts
@@ -1,0 +1,102 @@
+export function makeInfallible(fn: (...args: any[]) => void, thisv?: any) {
+  return (...args: any[]) => {
+    try {
+      fn.apply(thisv, args);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+}
+
+export interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: any) => void;
+}
+
+export function defer<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: any) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+export const waitForTime = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+
+export function throttle(callback: () => void, time: number) {
+  let scheduled = false;
+  return () => {
+    if (scheduled) {
+      return;
+    }
+    scheduled = true;
+    setTimeout(() => {
+      scheduled = false;
+      callback();
+    }, time);
+  };
+}
+
+export function clamp(value: number, min: number, max: number) {
+  assert(min < max, "min should be less than max");
+  return Math.max(min, Math.min(max, value));
+}
+
+export function assert(condition: any, msg = "Assertion failed!"): asserts condition {
+  if (!condition) {
+    console.error(msg);
+    throw new Error(msg);
+  }
+}
+
+export interface EventEmitter<T, E = string> {
+  eventListeners: Map<E, ((value?: T) => void)[]>;
+  on: (name: E, handler: (value?: T) => void) => void;
+  off: (name: E, handler: (value?: T) => void) => void;
+  emit: (name: E, value?: T) => void;
+}
+
+export const EventEmitter = {
+  decorate<T, E = string>(obj: EventEmitter<T, E>) {
+    obj.eventListeners = new Map<E, ((value?: T) => void)[]>();
+
+    obj.on = (name, handler) => {
+      if (obj.eventListeners.has(name)) {
+        obj.eventListeners.get(name)!.push(handler);
+      } else {
+        obj.eventListeners.set(name, [handler]);
+      }
+    };
+
+    obj.off = (name, handler) => {
+      obj.eventListeners.set(
+        name,
+        (obj.eventListeners.get(name) || []).filter(h => h != handler)
+      );
+    };
+
+    obj.emit = (name, ...values) => {
+      (obj.eventListeners.get(name) || []).forEach(handler => handler(...values));
+    };
+  },
+};
+
+// Map from keys to arrays of values.
+export class ArrayMap<K, V> {
+  map: Map<K, V[]>;
+
+  constructor() {
+    this.map = new Map<K, V[]>();
+  }
+
+  add(key: K, value: V) {
+    if (this.map.has(key)) {
+      this.map.get(key)!.push(value);
+    } else {
+      this.map.set(key, [value]);
+    }
+  }
+}

--- a/pages/api/video.ts
+++ b/pages/api/video.ts
@@ -1,0 +1,119 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { PaintPoint, ProtocolClient } from "@replayio/protocol";
+import { NextApiRequest, NextApiResponse } from "next";
+
+import { defer } from "node-protocol/utils";
+import { createClient } from "node-protocol";
+
+const ffmpegPath = require("@ffmpeg-installer/ffmpeg").path;
+
+const ffmpeg = require("fluent-ffmpeg");
+ffmpeg.setFfmpegPath(ffmpegPath);
+
+const address = process.env.NEXT_PUBLIC_DISPATCH_URL;
+
+async function fetchPaintPoints({
+  client,
+  sessionId,
+}: {
+  client: ProtocolClient;
+  sessionId: string;
+}) {
+  const findPaints = client.Graphics.findPaints({}, sessionId);
+  let gPaints: PaintPoint[] = [];
+  client.Graphics.addPaintPointsListener(({ paints }) => {
+    gPaints.push(...paints);
+  });
+
+  await findPaints;
+  console.log("found points", gPaints.length);
+
+  return gPaints;
+}
+
+async function fetchGraphics(
+  tmpDir: string,
+  paintPoints: PaintPoint[],
+  { client, sessionId }: { client: ProtocolClient; sessionId: string }
+) {
+  let prevTime = 0;
+  let input = "";
+  const numPaints = paintPoints.length;
+  await Promise.all(
+    paintPoints.map(async (point, index) => {
+      const duration = (point.time - prevTime) / 1000;
+      const filename = path.join(tmpDir, `/${index}-${point.point}-${point.time}.jpeg`);
+      input += `file '${filename}'\nduration ${duration}\n`;
+
+      prevTime = point.time;
+
+      const { screen } = await client.Graphics.getPaintContents(
+        { point: point.point, mimeType: point.screenShots[0].mimeType },
+        sessionId
+      );
+      console.log(`${index}/${numPaints} - ${filename}`);
+      fs.writeFileSync(filename, Buffer.from(screen.data, "base64"));
+    })
+  );
+
+  const inputFilename = path.join(tmpDir, "/input.txt");
+  console.log(inputFilename);
+  fs.writeFileSync(inputFilename, input);
+  return inputFilename;
+}
+
+async function createVideo(tmpDir: string, input: string, recordingId: string): Promise<string> {
+  const { promise, resolve, reject } = defer<string>();
+  const filename = path.join(tmpDir, `/${recordingId}.mp4`);
+
+  console.log(`starting ffmpeg`);
+  const proc = ffmpeg();
+  proc.input(input).inputOptions(["-safe 0"]).inputFormat("concat");
+
+  proc
+    .on("end", () => {
+      console.log("Finished processing");
+      resolve(filename);
+    })
+    .on("error", (err: any) => {
+      console.log("Error:", err);
+      reject(err);
+    })
+    .outputOptions(["-c:v libx264", "-r 30", "-pix_fmt yuv420p"])
+    .save(filename);
+
+  return promise;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { recordingId, token } = req.body;
+  const tmpDir = os.tmpdir();
+  console.log(`creating video for ${recordingId}...`);
+
+  try {
+    const { client } = await createClient({ address });
+    await client.Authentication.setAccessToken({ accessToken: token });
+
+    const { sessionId } = await client.Recording.createSession({ recordingId });
+    console.log(`sessionId: ${sessionId}`);
+
+    const paintPoints = await fetchPaintPoints({ client, sessionId });
+    const inputFilename = await fetchGraphics(tmpDir, paintPoints, { client, sessionId });
+
+    const videoFilename = await createVideo(tmpDir, inputFilename, recordingId);
+    console.log(sessionId, inputFilename, videoFilename);
+
+    const fileStream = fs.createReadStream(videoFilename);
+    const filename = path.basename(videoFilename);
+
+    res.setHeader("Content-Type", "video/mp4");
+    res.setHeader("Content-Disposition", `inline; filename="${filename}"`);
+
+    fileStream.pipe(res);
+  } catch (error) {
+    console.error(error);
+    res.status(500).send({ error: true });
+  }
+}

--- a/src/ui/components/shared/SharingModal/SharingModal.tsx
+++ b/src/ui/components/shared/SharingModal/SharingModal.tsx
@@ -1,6 +1,8 @@
-import React, { useState } from "react";
+import { ScreenShot } from "@replayio/protocol";
+import React, { useEffect, useRef, useState } from "react";
 import { ConnectedProps, connect } from "react-redux";
 
+import { getGraphicsAtTime } from "protocol/graphics";
 import { actions } from "ui/actions";
 import { AvatarImage } from "ui/components/Avatar";
 import Modal from "ui/components/shared/NewModal";
@@ -10,13 +12,15 @@ import {
   getUniqueDomains,
 } from "ui/components/UploadScreen/Privacy";
 import hooks from "ui/hooks";
-import { useHasNoRole } from "ui/hooks/recordings";
+import { getRecording, useHasNoRole } from "ui/hooks/recordings";
 import * as selectors from "ui/reducers/app";
 import { getRecordingTarget } from "ui/reducers/app";
+import { getCurrentTime } from "ui/reducers/timeline";
 import { useAppSelector } from "ui/setup/hooks";
 import { UIState } from "ui/state";
 import { OperationsData } from "ui/types";
 import { CollaboratorRequest, Recording } from "ui/types";
+import useToken from "ui/utils/useToken";
 
 import { PrimaryButton } from "../Button";
 import MaterialIcon from "../MaterialIcon";
@@ -123,9 +127,176 @@ function EnvironmentVariablesRow() {
   return <div className="text-xs">This node recording contains all env variables</div>;
 }
 
+function SharingSection({
+  recording,
+  showEnvironmentVariables,
+  showPrivacy,
+  setShowPrivacy,
+}: {
+  recording: Recording;
+  showEnvironmentVariables: boolean;
+  showPrivacy: boolean;
+  setShowPrivacy: React.Dispatch<React.SetStateAction<boolean>>;
+}) {
+  return (
+    <>
+      <CollaboratorsSection recording={recording} />
+      <section className="flex flex-grow flex-row items-center justify-between space-x-2 bg-menuHoverBgcolor px-8 pt-8">
+        <div className="flex flex-row items-start space-x-3 overflow-hidden">
+          <div className="mt-1 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-blue-200 font-bold">
+            <MaterialIcon className="text-blue-600" iconSize="xl">
+              people
+            </MaterialIcon>
+          </div>
+          <div className="flex flex-col space-y-1 overflow-hidden">
+            <div className="font-bold">Privacy Settings</div>
+            <PrivacyDropdown {...{ recording }} />
+            {showEnvironmentVariables ? <EnvironmentVariablesRow /> : null}
+          </div>
+        </div>
+        <CopyButton recording={recording} />
+      </section>
+      {recording.operations && (
+        <section className="bg-menuHoverBgcolor px-8 pb-6">
+          <ToggleShowPrivacyButton
+            showPrivacy={showPrivacy}
+            operations={recording.operations}
+            setShowPrivacy={setShowPrivacy}
+          />
+        </section>
+      )}
+    </>
+  );
+}
+
+type ModalMode = "sharing" | "download";
+
+function Header({
+  modalMode,
+  setModalMode,
+}: {
+  modalMode: ModalMode;
+  setModalMode: React.Dispatch<React.SetStateAction<ModalMode>>;
+}) {
+  const Tab = ({
+    label,
+    onClick,
+    active,
+    className = "",
+  }: {
+    label: string;
+    onClick: any;
+    active: boolean;
+    className?: string;
+  }) => (
+    <div
+      onClick={onClick}
+      className={
+        (active
+          ? "rounded-xl bg-menuHoverBgcolor px-4 py-1 font-bold text-slate-700 hover:text-slate-800"
+          : "text-slate-500 hover:text-slate-600") + ` ${className} cursor-pointer`
+      }
+    >
+      {label}
+    </div>
+  );
+
+  return (
+    <section className="justify-left flex flex-row items-center space-x-2  px-8 py-4">
+      <Tab
+        label="Sharing"
+        onClick={() => setModalMode("sharing")}
+        active={modalMode == "sharing"}
+      />
+      <Tab
+        label="Downloads"
+        onClick={() => setModalMode("download")}
+        active={modalMode == "download"}
+      />
+    </section>
+  );
+}
+
+function DownloadSection({ recording }: { recording: Recording }) {
+  const token = useToken();
+  const currentTime = useAppSelector(getCurrentTime);
+  const [screen, setScreen] = useState<ScreenShot | null>(null);
+
+  const [downloadState, setDownloadState] = useState<
+    "not-started" | "downloading" | "success" | "error"
+  >("not-started");
+
+  useEffect(() => {
+    getGraphicsAtTime(currentTime).then(res => res.screen && setScreen(res.screen));
+  }, [currentTime]);
+
+  const buttonStates = {
+    "not-started": {
+      label: "Download video",
+      icon: "download",
+    },
+    downloading: {
+      label: "Downloading video",
+      icon: "loop",
+    },
+    success: {
+      label: "Downloaded video",
+      icon: "check",
+    },
+    error: {
+      label: "Failed to download",
+      icon: "error",
+    },
+  };
+
+  const onDownload = () => {
+    console.log(`Download recording ${recording.id}`);
+
+    const xhr = new XMLHttpRequest();
+    xhr.responseType = "blob";
+    xhr.onload = function () {
+      const a = document.createElement("a");
+      a.href = window.URL.createObjectURL(xhr.response);
+      setDownloadState("success");
+
+      a.download = "replay.mp4";
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+    };
+    xhr.onerror = function () {
+      console.error(`Failed to download video ${recording.id}`);
+      setDownloadState("error");
+    };
+    xhr.open("POST", "/api/video");
+    xhr.setRequestHeader("Content-Type", "application/json");
+    xhr.send(JSON.stringify({ recordingId: recording.id, token: token.token }));
+    setDownloadState("downloading");
+  };
+
+  return (
+    <div className="flex flex-col">
+      {screen && <img className="mx-10" src={`data:image/jpeg;base64,${screen.data}`} />}
+      <div className="my-4 mt-4 flex flex-col items-center">
+        <button
+          className="mr-0 flex items-center space-x-1.5 rounded-lg bg-primaryAccent py-1 px-2 text-sm text-buttontextColor hover:bg-primaryAccentHover focus:outline-none focus:ring-2 focus:ring-primaryAccent focus:ring-offset-2"
+          onClick={onDownload}
+        >
+          <MaterialIcon className="mr-2">{buttonStates[downloadState].icon}</MaterialIcon>
+          {buttonStates[downloadState].label}
+        </button>
+        {downloadState == "downloading" && (
+          <div className="mt-2 italic text-slate-400">Takes approximately 30 seconds...</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function SharingModal({ recording, hideModal }: SharingModalProps) {
   const recordingTarget = useAppSelector(getRecordingTarget);
   const [showPrivacy, setShowPrivacy] = useState(false);
+  const [modalMode, setModalMode] = useState<ModalMode>("sharing");
   const showEnvironmentVariables = recordingTarget == "node";
 
   return (
@@ -135,31 +306,17 @@ function SharingModal({ recording, hideModal }: SharingModalProps) {
         style={{ width: showPrivacy ? 720 : 460 }}
       >
         <div className="flex flex-col space-y-0" style={{ width: 460 }}>
-          <CollaboratorsSection recording={recording} />
-          <section className="flex flex-grow flex-row items-center justify-between space-x-2 bg-menuHoverBgcolor px-8 pt-8">
-            <div className="flex flex-row items-start space-x-3 overflow-hidden">
-              <div className="mt-1 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-blue-200 font-bold">
-                <MaterialIcon className="text-blue-600" iconSize="xl">
-                  people
-                </MaterialIcon>
-              </div>
-              <div className="flex flex-col space-y-1 overflow-hidden">
-                <div className="font-bold">Privacy Settings</div>
-                <PrivacyDropdown {...{ recording }} />
-                {showEnvironmentVariables ? <EnvironmentVariablesRow /> : null}
-              </div>
-            </div>
-            <CopyButton recording={recording} />
-          </section>
-          {recording.operations ? (
-            <section className="bg-menuHoverBgcolor px-8 pb-6">
-              <ToggleShowPrivacyButton
-                showPrivacy={showPrivacy}
-                operations={recording.operations}
-                setShowPrivacy={setShowPrivacy}
-              />
-            </section>
-          ) : null}
+          <Header modalMode={modalMode} setModalMode={setModalMode} />
+          {modalMode == "sharing" ? (
+            <SharingSection
+              recording={recording}
+              showEnvironmentVariables={showEnvironmentVariables}
+              showPrivacy={showPrivacy}
+              setShowPrivacy={setShowPrivacy}
+            />
+          ) : (
+            <DownloadSection recording={recording} />
+          )}
         </div>
         {showPrivacy ? (
           <div className="relative flex overflow-auto bg-menuHoverBgcolor">

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "functions": {
+    "pages/api/*": {
+      "memory": 3008,
+      "maxDuration": 60
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2159,6 +2159,95 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ffmpeg-installer/darwin-arm64@npm:4.1.5":
+  version: 4.1.5
+  resolution: "@ffmpeg-installer/darwin-arm64@npm:4.1.5"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@ffmpeg-installer/darwin-x64@npm:4.1.0":
+  version: 4.1.0
+  resolution: "@ffmpeg-installer/darwin-x64@npm:4.1.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@ffmpeg-installer/ffmpeg@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@ffmpeg-installer/ffmpeg@npm:1.1.0"
+  dependencies:
+    "@ffmpeg-installer/darwin-arm64": 4.1.5
+    "@ffmpeg-installer/darwin-x64": 4.1.0
+    "@ffmpeg-installer/linux-arm": 4.1.3
+    "@ffmpeg-installer/linux-arm64": 4.1.4
+    "@ffmpeg-installer/linux-ia32": 4.1.0
+    "@ffmpeg-installer/linux-x64": 4.1.0
+    "@ffmpeg-installer/win32-ia32": 4.1.0
+    "@ffmpeg-installer/win32-x64": 4.1.0
+  dependenciesMeta:
+    "@ffmpeg-installer/darwin-arm64":
+      optional: true
+    "@ffmpeg-installer/darwin-x64":
+      optional: true
+    "@ffmpeg-installer/linux-arm":
+      optional: true
+    "@ffmpeg-installer/linux-arm64":
+      optional: true
+    "@ffmpeg-installer/linux-ia32":
+      optional: true
+    "@ffmpeg-installer/linux-x64":
+      optional: true
+    "@ffmpeg-installer/win32-ia32":
+      optional: true
+    "@ffmpeg-installer/win32-x64":
+      optional: true
+  checksum: 9725b2ae23a705204ac3f2f21ae796c06150d7f1c757583b664523a305be91bd8276859c25717a0d55cc4d2d6afde6d25acb5515050dc0d2d69bcf77c7c59aa4
+  languageName: node
+  linkType: hard
+
+"@ffmpeg-installer/linux-arm64@npm:4.1.4":
+  version: 4.1.4
+  resolution: "@ffmpeg-installer/linux-arm64@npm:4.1.4"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@ffmpeg-installer/linux-arm@npm:4.1.3":
+  version: 4.1.3
+  resolution: "@ffmpeg-installer/linux-arm@npm:4.1.3"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@ffmpeg-installer/linux-ia32@npm:4.1.0":
+  version: 4.1.0
+  resolution: "@ffmpeg-installer/linux-ia32@npm:4.1.0"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@ffmpeg-installer/linux-x64@npm:4.1.0":
+  version: 4.1.0
+  resolution: "@ffmpeg-installer/linux-x64@npm:4.1.0"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@ffmpeg-installer/win32-ia32@npm:4.1.0":
+  version: 4.1.0
+  resolution: "@ffmpeg-installer/win32-ia32@npm:4.1.0"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@ffmpeg-installer/win32-x64@npm:4.1.0":
+  version: 4.1.0
+  resolution: "@ffmpeg-installer/win32-x64@npm:4.1.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@gar/promisify@npm:^1.0.1, @gar/promisify@npm:^1.1.3":
   version: 1.1.3
   resolution: "@gar/promisify@npm:1.1.3"
@@ -8332,7 +8421,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"async@npm:^3.2.3":
+"async@npm:>=0.2.9, async@npm:^3.2.3":
   version: 3.2.4
   resolution: "async@npm:3.2.4"
   checksum: 43d07459a4e1d09b84a20772414aa684ff4de085cbcaec6eea3c7a8f8150e8c62aa6cd4e699fe8ee93c3a5b324e777d34642531875a0817a35697522c1b02e89
@@ -12955,6 +13044,16 @@ __metadata:
   version: 3.2.5
   resolution: "flatted@npm:3.2.5"
   checksum: 3c436e9695ccca29620b4be5671dd72e5dd0a7500e0856611b7ca9bd8169f177f408c3b9abfa78dfe1493ee2d873e2c119080a8a9bee4e1a186a9e60ca6c89f1
+  languageName: node
+  linkType: hard
+
+"fluent-ffmpeg@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "fluent-ffmpeg@npm:2.1.2"
+  dependencies:
+    async: ">=0.2.9"
+    which: ^1.1.1
+  checksum: ab7ed909486298f33b991af051c38e40410ae5b03b0b6d33d0855636a0b56330ffe9efed6c7eedb00f1c6c713c795cbdb283f6f2216db925ae5e737a22c6a97f
   languageName: node
   linkType: hard
 
@@ -18427,6 +18526,12 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-protocol@workspace:*, node-protocol@workspace:packages/node-protocol":
+  version: 0.0.0-use.local
+  resolution: "node-protocol@workspace:packages/node-protocol"
+  languageName: unknown
+  linkType: soft
+
 "node-releases@npm:^2.0.5":
   version: 2.0.5
   resolution: "node-releases@npm:2.0.5"
@@ -20932,6 +21037,7 @@ __metadata:
     "@babel/preset-typescript": ^7.15.0
     "@babel/types": ^7.14.8
     "@bcoe/v8-coverage": ^0.2.3
+    "@ffmpeg-installer/ffmpeg": ^1.1.0
     "@headlessui/react": ^1.4.3
     "@heroicons/react": ^1.0.6
     "@jest/console": ^28.0.2
@@ -21014,6 +21120,7 @@ __metadata:
     eslint-plugin-sort-keys-fix: ^1.1.2
     fake-indexeddb: ^3.1.7
     file-loader: ^6.2.0
+    fluent-ffmpeg: ^2.1.2
     framer-motion: ^6.3.6
     fs-extra: ^10.0.1
     fuzzaldrin-plus: ^0.6.0
@@ -21044,6 +21151,7 @@ __metadata:
     next-compose-plugins: ^2.2.1
     next-global-css: ^1.3.1
     node-fetch: 2.x
+    node-protocol: "workspace:*"
     parse-script-tags: ^0.1.7
     postcss: ^8.4.12
     postcss-loader: ^6.2.1
@@ -25224,7 +25332,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which@npm:^1.2.9, which@npm:^1.3.1":
+"which@npm:^1.1.1, which@npm:^1.2.9, which@npm:^1.3.1":
   version: 1.3.1
   resolution: "which@npm:1.3.1"
   dependencies:


### PR DESCRIPTION
This adds a video endpoint that uses the protocol to synthesize a movie. Eventually, this should live in the backend, but given that it seemed fairly easy to implement with a vercel endpoint with sufficient caching, i was curious to see how far this experiment could go...

Motivation:
I want to be able to include replay videos in linear issues

Steps
- [x] Add a video.ts endpoint that can create a video given a recordingId
- [x] Add a video.js script that can download a video and write it to disk
- [x] Expose the endpoint in the UI so that users can download the video
- [x] Add authentication so that logged in users can download their own videos
- [x] Add a UI for downloading the video


I think this is ready to go
https://www.loom.com/share/54e7f05b39ba4175819a00ab4bf9c5d5

