### PR TITLE
Align Figma and codebase for Source Explorer, Search, and Console

### DIFF
--- a/packages/replay-next/components/console/ConsoleInput.module.css
+++ b/packages/replay-next/components/console/ConsoleInput.module.css
@@ -8,7 +8,7 @@
   gap: 0.25rem;
   color: var(--color-default);
   border-bottom-right-radius: 0.5rem;
-  border-top: 1px solid var(--background-color-default);
+  border-top: 1px solid var(--theme-splitter-color);
 }
 
 .PromptRow,
@@ -17,8 +17,8 @@
   flex-direction: Row;
   align-items: center;
   gap: 1ch;
-  min-height: 1.5rem;
-  line-height: 1.5rem;
+  min-height: 1rem;
+  line-height: 1rem;
   padding: 0 1ch;
 }
 

--- a/packages/replay-next/components/console/ConsoleRoot.module.css
+++ b/packages/replay-next/components/console/ConsoleRoot.module.css
@@ -27,7 +27,7 @@
   flex: 1 1 auto;
   overflow: auto;
   height: 100%;
-  border-top: 1px solid var(--background-color-default);
+  border-top: 1px solid var(--theme-splitter-color);
 }
 
 .PanelResizeHandleContainer {
@@ -57,7 +57,7 @@
   display: block;
   height: 100%;
   width: 1px;
-  background-color: var(--background-color-default);
+  background-color: var(--theme-splitter-color);
 }
 
 .RightColumnActionsRow {
@@ -69,7 +69,7 @@
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  border-top: 1px solid var(--background-color-default);
+  border-top: 1px solid var(--theme-splitter-color);
 }
 
 .ConsoleSearchRow {

--- a/packages/replay-next/components/console/filters/FilterText.module.css
+++ b/packages/replay-next/components/console/filters/FilterText.module.css
@@ -4,7 +4,7 @@
   background-color: var(--background-color-inputs);
   color: var(--color-default);
   padding: 0 0.25rem;
-  margin: 0.25rem 0.25rem 0.25rem 0;
+  margin: 0.25rem;
   border: 2px solid transparent;
   border-radius: 0.25rem;
   outline: none;

--- a/packages/replay-next/components/console/filters/FilterToggles.module.css
+++ b/packages/replay-next/components/console/filters/FilterToggles.module.css
@@ -19,7 +19,7 @@
   width: 100%;
   flex: 0 0 1px;
   border: none;
-  background-color: var(--background-color-default);
+  background-color: var(--theme-splitter-color);
 }
 
 .ExceptionsErrorIcon {

--- a/packages/replay-next/components/console/renderers/shared.module.css
+++ b/packages/replay-next/components/console/renderers/shared.module.css
@@ -9,7 +9,7 @@
   padding-top: calc(0.25rem + 1px);
   padding-left: 1.5rem;
 
-  border-bottom: 1px solid var(--background-color-contrast-1);
+  border-bottom: 1px solid var(--theme-splitter-color);
   position: relative;
 }
 .ErrorRow {

--- a/packages/replay-next/components/search-files/ResultsListRow.module.css
+++ b/packages/replay-next/components/search-files/ResultsListRow.module.css
@@ -21,7 +21,7 @@
 }
 .LocationRow:hover,
 .MatchRow:hover {
-  background-color: var(--background-color-contrast-3);
+  background-color: var(--theme-selection-background-hover);
 }
 
 .MatchRow {

--- a/src/devtools/client/themes/variables.css
+++ b/src/devtools/client/themes/variables.css
@@ -158,7 +158,7 @@
   --theme-focuser-bgcolor: var(--primary-accent);
   --theme-sidebar-background: var(--theme-base-100);
   --theme-text-field-color: var(--theme-body-color);
-  --theme-text-field-bgcolor: var(--theme-base-90);
+  --theme-text-field-bgcolor: var(--background-color-inputs);
   --theme-text-field-bgcolor-hover: var(--theme-base-85);
   --text-field-border: var(--cool-gray-300);
   --tab-selected-bgcolor: var(--theme-base-100); /* current tab */
@@ -174,6 +174,7 @@
   /* Code Mirror (Light) */
   /* Breakpoints (Light) */
   /* Testsuites (Light) */
+
   /* Toolbar (Light) */
   /* Toolbar buttons (Light) */
   /* Buttons (Light) */
@@ -355,7 +356,7 @@
   --theme-focuser-bgcolor: var(--primary-accent);
   --theme-sidebar-background: var(--body-bgcolor);
   --theme-text-field-color: #fff;
-  --theme-text-field-bgcolor: var(--theme-base-85);
+  --theme-text-field-bgcolor: var(--background-color-inputs);
   --theme-text-field-bgcolor-hover: var(--theme-base-90);
   --text-field-border: var(--theme-base-85);
   --tab-selected-bgcolor: var(--theme-base-95);


### PR DESCRIPTION
Aligning to Figma by matching these visuals. Some things were out of whack.

<img width="798" alt="image" src="https://user-images.githubusercontent.com/9154902/211238294-fcb1de69-8cc6-4e72-b2f8-f74fa691dcfb.png">

<img width="714" alt="image" src="https://user-images.githubusercontent.com/9154902/211238309-376caae2-a497-44b4-8914-bfbdc941a719.png">

<img width="914" alt="image" src="https://user-images.githubusercontent.com/9154902/211238343-b95bbad4-f0d9-44f9-81d9-7bfa7a1498b0.png">
