### PR TITLE
Playwright screenshot helper clips visible bounds

### DIFF
--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -621,7 +621,7 @@
   --theme-selection-color: #ffffff;
 
   /* Border color that splits the toolbars/panels/headers. */
-  --theme-splitter-color: var(--grey-25);
+  --theme-splitter-color: #e0e0e2; /* TODO @jonbell var(--grey-25) is undefined */
   --theme-emphasized-splitter-color: var(--grey-30);
   --theme-emphasized-splitter-color-hover: var(--grey-40);
 

--- a/packages/replay-next/playwright/tests/console.ts
+++ b/packages/replay-next/playwright/tests/console.ts
@@ -107,12 +107,12 @@ test("should expand and inspect arrays", async ({ page }) => {
   await toggleProtocolMessage(page, "warnings", true);
 
   const listItem = await locateMessage(page, "console-warning", "This is a warning");
-  await takeScreenshot(page, listItem, "array-collapsed", 1);
+  await takeScreenshot(page, listItem, "array-collapsed");
 
   const outer = listItem.locator("[data-test-name=Expandable]", { hasText: "This is a warning" });
   const keyValue = outer.locator("[data-test-name=Expandable]", { hasText: "(3) [" });
   await keyValue.click();
-  await takeScreenshot(page, listItem, "array-expanded", 1);
+  await takeScreenshot(page, listItem, "array-expanded");
 });
 
 test("should expand and inspect objects", async ({ page }) => {

--- a/packages/replay-next/playwright/tests/source-preview.ts
+++ b/packages/replay-next/playwright/tests/source-preview.ts
@@ -15,20 +15,27 @@ function getSourcePreview(page: Page, partialText: string) {
   return page.locator("[data-test-name=SourcePreviewInspector]", { hasText: partialText });
 }
 
+async function takeScreenshotHelper(page: Page, partialText: string, title: string) {
+  const locator = getSourcePreview(page, partialText);
+  await locator.scrollIntoViewIfNeeded();
+
+  await takeScreenshot(page, locator, title);
+}
+
 test("should render headers for complex data correctly", async ({ page }) => {
-  await takeScreenshot(page, getSourcePreview(page, "ƒ SomeFunction()"), "function");
-  await takeScreenshot(page, getSourcePreview(page, "Array(3)"), "array");
-  await takeScreenshot(page, getSourcePreview(page, `bar: "abc"`), "object");
-  await takeScreenshot(page, getSourcePreview(page, "Map(2)"), "map");
-  await takeScreenshot(page, getSourcePreview(page, "Set(2)"), "set");
-  await takeScreenshot(page, getSourcePreview(page, "HTMLUListElementPrototype"), "html-element");
-  await takeScreenshot(page, getSourcePreview(page, "#text"), "html-text");
-  await takeScreenshot(page, getSourcePreview(page, "/abc/g"), "regexp");
+  await takeScreenshotHelper(page, "ƒ SomeFunction()", "function");
+  await takeScreenshotHelper(page, "Array(3)", "array");
+  await takeScreenshotHelper(page, `bar: "abc"`, "object");
+  await takeScreenshotHelper(page, "Map(2)", "map");
+  await takeScreenshotHelper(page, "Set(2)", "set");
+  await takeScreenshotHelper(page, "HTMLUListElementPrototype", "html-element");
+  await takeScreenshotHelper(page, "#text", "html-text");
+  await takeScreenshotHelper(page, "/abc/g", "regexp");
 });
 
 test("should render primitive data correctly", async ({ page }) => {
-  await takeScreenshot(page, getSourcePreview(page, "bigInt"), "bigint");
-  await takeScreenshot(page, getSourcePreview(page, "string"), "string");
-  await takeScreenshot(page, getSourcePreview(page, "number"), "number");
-  await takeScreenshot(page, getSourcePreview(page, "boolean"), "boolean");
+  await takeScreenshotHelper(page, "bigInt", "bigint");
+  await takeScreenshotHelper(page, "string", "string");
+  await takeScreenshotHelper(page, "number", "number");
+  await takeScreenshotHelper(page, "boolean", "boolean");
 });

--- a/packages/replay-next/playwright/tests/utils/general.ts
+++ b/packages/replay-next/playwright/tests/utils/general.ts
@@ -100,16 +100,58 @@ export function getTestUrl(testRoute: string, additionalQueryParams: string[] = 
   return `http://${host}:3000/tests/${testRoute}?${queryParams.join("&")}`;
 }
 
+type Rect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export async function getVisibleRectForLocator(locator: Locator): Promise<Rect> {
+  const rect = await locator.evaluate((element: HTMLElement) => {
+    let elementRect = element.getBoundingClientRect();
+
+    let visibleRect = {
+      left: elementRect.left,
+      right: elementRect.right,
+      top: elementRect.top,
+      bottom: elementRect.bottom,
+    };
+
+    let currentElement: HTMLElement | null = element;
+    while (currentElement !== null) {
+      const overflow = window.getComputedStyle(currentElement).getPropertyValue("overflow");
+      if (overflow === "visible") {
+        currentElement = currentElement.parentElement;
+        continue;
+      }
+
+      const rect = currentElement.getBoundingClientRect();
+
+      visibleRect.left = Math.max(visibleRect.left, rect.left);
+      visibleRect.right = Math.min(visibleRect.right, rect.right);
+      visibleRect.top = Math.max(visibleRect.top, rect.top);
+      visibleRect.bottom = Math.min(visibleRect.bottom, rect.bottom);
+
+      currentElement = currentElement.parentElement;
+    }
+
+    return visibleRect;
+  });
+
+  return {
+    x: rect.left,
+    y: rect.top,
+    width: rect.right - rect.left,
+    height: rect.bottom - rect.top,
+  };
+}
+
 export async function stopHovering(page: Page): Promise<void> {
   await page.mouse.move(0, 0);
 }
 
-export async function takeScreenshot(
-  page: Page,
-  locator: Locator,
-  name: string,
-  margin: number = 0
-): Promise<void> {
+export async function takeScreenshot(page: Page, locator: Locator, name: string): Promise<void> {
   if (RECORD_PROTOCOL_DATA) {
     // We aren't visually debugging; we're just recording snapshot data.
     // Skip this method to make the tests run faster.
@@ -129,7 +171,7 @@ export async function takeScreenshot(
   }
 
   await page.emulateMedia({ colorScheme: "dark" });
-  const screenshotDark = await takeScreenshotHelper(page, locator, margin);
+  const screenshotDark = await takeScreenshotHelper(page, locator);
 
   if (VISUALS) {
     const darkDir = path.join(__dirname, `../../visuals/`, "dark");
@@ -141,7 +183,7 @@ export async function takeScreenshot(
   }
 
   await page.emulateMedia({ colorScheme: "light" });
-  const screenshotLight = await takeScreenshotHelper(page, locator, margin);
+  const screenshotLight = await takeScreenshotHelper(page, locator);
   if (VISUALS) {
     const lightDir = path.join(__dirname, `../../visuals/`, "light");
     fs.mkdirSync(lightDir, { recursive: true });
@@ -152,27 +194,13 @@ export async function takeScreenshot(
   }
 }
 
-async function takeScreenshotHelper(
-  page: Page,
-  locator: Locator,
-  margin: number = 0
-): Promise<Buffer> {
-  if (margin > 0) {
-    const viewport = page.viewportSize()!;
-    const bounds = (await locator.boundingBox())!;
+async function takeScreenshotHelper(page: Page, locator: Locator): Promise<Buffer> {
+  const rect = await getVisibleRectForLocator(locator);
 
-    return page.screenshot({
-      ...SCREENSHOT_OPTIONS,
-      clip: {
-        x: Math.max(0, bounds.x - margin),
-        y: Math.max(0, bounds.y - margin),
-        width: Math.min(bounds.width + margin * 2, viewport.width),
-        height: Math.min(bounds.height + margin * 2, viewport.height),
-      },
-    });
-  } else {
-    return locator.screenshot(SCREENSHOT_OPTIONS);
-  }
+  return page.screenshot({
+    ...SCREENSHOT_OPTIONS,
+    clip: rect,
+  });
 }
 
 export async function typeCommandKey(page: Page, key: string) {


### PR DESCRIPTION
So far as I can tell from the [sparse documentation](https://playwright.dev/docs/screenshots#element-screenshot) there is no way to tell Playwright to trim the hidden/overflowing parts of screenshots. This causes unnecessary churn for parts of our UI that overflow and get hidden. For example, lines in the Source viewer may overflow horizontally:
![image](https://user-images.githubusercontent.com/29597/211432394-9a19600e-0218-43c0-9cd6-587de69bdd8f.png)

Because of this, screenshots incorrectly include partial Console messages:
![image](https://user-images.githubusercontent.com/29597/211432135-8258e084-cf7a-452e-b968-bbfa05e1730e.png)

This has the downstream effect of causing screenshots to be invalidated when unrelated things change (like Console messages).

This PR changes our screenshot helper to auto trim. The above screenshot should now look like this:
![image](https://user-images.githubusercontent.com/29597/211432192-25ee2824-d56f-4a82-a80b-d5e673b8d110.png)

I expect a lot of Delta conflicts from this PR.