### PR TITLE
Testsuites polish

### DIFF
--- a/packages/replay-next/components/search-files/ResultsListRow.module.css
+++ b/packages/replay-next/components/search-files/ResultsListRow.module.css
@@ -21,7 +21,7 @@
 }
 .LocationRow:hover,
 .MatchRow:hover {
-  background-color: var(--background-color-contrast-3);
+  background-color: var(--theme-selection-background-hover);
 }
 
 .MatchRow {

--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -272,6 +272,7 @@
   --testsuites-error-bgcolor-hover: #7a1712;
   --testsuites-error-color: white;
   --testsuites-steps-bgcolor: var(--theme-base-100);
+  --testsuites-steps-bgcolor-hover: var(--theme-base-90);
 
   /* To organise (Dark) */
   --jellyfish-bgcolor: rgba(40, 40, 40, 0.8);
@@ -583,9 +584,11 @@
 
   /* Testsuites (Light) */
   --testsuites-error-bgcolor: #ffe9e9;
+  --testsuites-error-bgcolor: #ffe9e9;
   --testsuites-error-bgcolor-hover: #ffe0e0;
   --testsuites-error-color: #eb5757;
-  --testsuites-steps-bgcolor: #fafafa;
+  --testsuites-steps-bgcolor: #f7f7f7;
+  --testsuites-steps-bgcolor-hover: #f4f4f4;
 
   /* Toolbar */
   --theme-tab-toolbar-background: var(--grey-20);

--- a/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
@@ -39,7 +39,7 @@ export default function TestInfo({ testCases }: { testCases: TestItem[] }) {
     >
       <TestInfoContextMenuContextRoot>
         <div className="flex flex-grow flex-col overflow-hidden">
-          <div className="relative flex flex-grow flex-col space-y-1 overflow-auto px-2 pt-3">
+          <div className="relative flex flex-grow flex-col space-y-1 overflow-auto border-t border-splitter px-2 pt-3">
             {testCases.map((t, i) => showTest(i) && <TestCase test={t} key={i} index={i} />)}
           </div>
           {selectedTest !== null ? <Console /> : null}

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepRow.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepRow.tsx
@@ -21,7 +21,7 @@ export function TestStepRowBase({
       ref={clientRef}
       className={classnames(
         className,
-        "group/step relative flex items-start gap-1 border-b border-l-2 border-themeBase-90 px-3 py-2 font-mono",
+        "group/step relative flex items-start gap-1 border-b border-l-2 border-themeBase-90 py-2 pl-3 pr-1 font-mono",
         {
           // border
           "border-l-transparent": pending,
@@ -33,8 +33,8 @@ export function TestStepRowBase({
           "bg-testsuitesErrorBgcolor hover:bg-testsuitesErrorBgcolorHover": error && pending,
           "bg-testsuitesErrorBgcolorHover": error && active,
           "bg-toolbarBackgroundHover": active && !error,
-          "bg-testsuitesStepsBgcolor hover:bg-toolbarBackgroundHover": pending && !error,
-          "hover:bg-toolbarBackgroundHover": !pending && !active && !error,
+          "bg-testsuitesStepsBgcolor hover:bg-testsuitesStepsBgcolorHover": pending && !error,
+          "hover:bg-testsuitesStepsBgcolorHover": !pending && !active && !error,
         }
       )}
     />

--- a/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
@@ -237,7 +237,7 @@ function TestSection({ events, header }: { events: CompositeTestEvent[]; header?
       {header ? (
         <div
           data-test-id="TestSuites-TestCase-SectionHeader"
-          className="pt-6 pb-2 pl-2  font-semibold uppercase opacity-50"
+          className="pt-6 pb-2  font-semibold uppercase opacity-50 first:pt-0"
           style={{ fontSize: "10px" }}
         >
           {header}

--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -191,7 +191,7 @@ function TestRunAttributes({ workspaceId, testRunId }: { workspaceId: string; te
   };
 
   return (
-    <div className="border-b p-2">
+    <div className="p-2">
       <Attributes testRun={thisSpecRun} />
     </div>
   );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -54,6 +54,7 @@ module.exports = {
         testsuitesErrorBgcolorHover: "var(--testsuites-error-bgcolor-hover)",
         testsuitesErrorColor: "var(--testsuites-error-color)",
         testsuitesStepsBgcolor: "var(--testsuites-steps-bgcolor)",
+        testsuitesStepsBgcolorHover: "var(--testsuites-steps-bgcolor-hover)",
         themeBorder: "var(--theme-border)",
         themeFocuserBgcolor: "var(--theme-focuser-bgcolor)",
         themeMenuHighlight: "var(--theme-menu-highlight)",


### PR DESCRIPTION
Small changes to color, spacing, and layout.

Old:
<img width="401" alt="image" src="https://user-images.githubusercontent.com/9154902/211460291-a0c11eb7-ad88-47f0-acd7-201a4f561679.png">

New:
<img width="402" alt="image" src="https://user-images.githubusercontent.com/9154902/211460245-32e8c9ad-2f6a-4791-bb16-b35b35336855.png">

Number 3 in a series. [This was the first PR](https://github.com/replayio/devtools/pull/8408) but that had some issues with the variables.css file, so we pushed [this PR soon afterwards](https://github.com/replayio/devtools/pull/8412). 
