### PR TITLE
Better caching for terminal expressions and eager eval

### DIFF
--- a/packages/e2e-tests/helpers/lexical.ts
+++ b/packages/e2e-tests/helpers/lexical.ts
@@ -31,6 +31,7 @@ export async function hideTypeAheadSuggestions(page: Page, selector: string) {
     await input.type("Escape");
   }
 }
+
 export async function type(page: Page, selector: string, text: string, shouldSubmit: boolean) {
   await clearText(page, selector);
 
@@ -38,22 +39,29 @@ export async function type(page: Page, selector: string, text: string, shouldSub
   await input.type(text);
 
   if (shouldSubmit) {
-    await hideTypeAheadSuggestions(page, selector);
+    await submitCurrentText(page, selector);
+  }
+}
 
-    let loopCounter = 0;
+export async function submitCurrentText(page: Page, selector: string) {
+  const input = page.locator(selector);
+  const initialText = await input.textContent();
 
-    // Timing awkwardness;
-    // Sometimes the typeahead misses an "Enter" command and doesn't submit the form.
-    while ((await input.textContent()) === text) {
-      await delay(100);
+  await hideTypeAheadSuggestions(page, selector);
 
-      await input.press("Enter");
+  let loopCounter = 0;
 
-      if (loopCounter++ > 5) {
-        // Give up after a few tries;
-        // This likely indicates something unexpected.
-        break;
-      }
+  // Timing awkwardness;
+  // Sometimes the typeahead misses an "Enter" command and doesn't submit the form.
+  while ((await input.textContent()) === initialText) {
+    await delay(100);
+
+    await input.press("Enter");
+
+    if (loopCounter++ > 5) {
+      // Give up after a few tries;
+      // This likely indicates something unexpected.
+      break;
     }
   }
 }

--- a/packages/e2e-tests/helpers/pause-information-panel.ts
+++ b/packages/e2e-tests/helpers/pause-information-panel.ts
@@ -291,8 +291,8 @@ export async function verifyFramesCount(page: Page, expectedCount: number) {
   const framesPanel = getFramesPanel(page);
   return waitFor(async () => {
     const frameListItems = framesPanel.locator(".frame");
-    const numFrames = await frameListItems.count();
-    expect(numFrames === expectedCount).toBe(true);
+    const actualCount = await frameListItems.count();
+    expect(actualCount).toBe(expectedCount);
   });
 }
 

--- a/packages/e2e-tests/tests/console-expressions-01.test.ts
+++ b/packages/e2e-tests/tests/console-expressions-01.test.ts
@@ -1,0 +1,40 @@
+import test from "@playwright/test";
+
+import { openDevToolsTab, startTest } from "../helpers";
+import {
+  executeAndVerifyTerminalExpression,
+  executeTerminalExpression,
+  openConsolePanel,
+  submitCurrentText,
+  verifyConsoleMessage,
+  verifyEagerEvaluationResult,
+  verifyEvaluationResult,
+  warpToMessage,
+} from "../helpers/console-panel";
+import { selectFrame, verifyFramesCount } from "../helpers/pause-information-panel";
+import { addLogpoint } from "../helpers/source-panel";
+
+const url = "doc_async.html";
+
+test("console-expressions-01: should cache input eager eval and terminal expressions per instance", async ({
+  page,
+}) => {
+  await startTest(page, url);
+  await openDevToolsTab(page);
+  await openConsolePanel(page);
+
+  await warpToMessage(page, "baz 2", 19);
+  await verifyFramesCount(page, 5); // 2 sync + 3 async
+
+  await executeTerminalExpression(page, "`n: ${n}`", false);
+  await verifyEagerEvaluationResult(page, "n: 2");
+  await submitCurrentText(page);
+  await verifyEvaluationResult(page, "n: 2");
+
+  await executeAndVerifyTerminalExpression(page, "n = 10", "10");
+
+  await executeTerminalExpression(page, "`n: ${n}`", false);
+  await verifyEagerEvaluationResult(page, "n: 10");
+  await submitCurrentText(page);
+  await verifyEvaluationResult(page, "n: 10");
+});

--- a/packages/replay-next/components/console/ConsoleInput.tsx
+++ b/packages/replay-next/components/console/ConsoleInput.tsx
@@ -167,13 +167,11 @@ function ConsoleInputSuspends() {
       </div>
       <div className={styles.ResultRow}>
         {expression !== "" && <Icon className={styles.Icon} type="terminal-result" />}
-        <EagerEvaluationResult expression={expression} />
+        <EagerEvaluationResult cacheKey={"" + incrementedKey} expression={expression} />
       </div>
     </div>
   );
 }
-
-function noop() {}
 
 function ErrorFallback() {
   return (

--- a/packages/replay-next/components/console/EagerEvaluationResult.tsx
+++ b/packages/replay-next/components/console/EagerEvaluationResult.tsx
@@ -80,5 +80,9 @@ function EagerEvaluationResultSuspends({
     }
   }
 
-  return <div className={styles.Wrapper}>{children}</div>;
+  return (
+    <div className={styles.Wrapper} data-test-id="ConsoleTerminalInputEagerEvaluationResult">
+      {children}
+    </div>
+  );
 }

--- a/packages/replay-next/components/console/EagerEvaluationResult.tsx
+++ b/packages/replay-next/components/console/EagerEvaluationResult.tsx
@@ -10,7 +10,13 @@ import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
 import styles from "./EagerEvaluationResult.module.css";
 
-export default function EagerEvaluationResult({ expression }: { expression: string }) {
+export default function EagerEvaluationResult({
+  cacheKey,
+  expression,
+}: {
+  cacheKey: string;
+  expression: string;
+}) {
   const { selectedPauseAndFrameId } = useContext(SelectedFrameContext);
 
   let pauseId: PauseId | null = null;
@@ -26,23 +32,30 @@ export default function EagerEvaluationResult({ expression }: { expression: stri
 
   return (
     <Suspense>
-      <EagerEvaluationResultSuspends expression={expression} pauseId={pauseId} frameId={frameId} />
+      <EagerEvaluationResultSuspends
+        cacheKey={cacheKey}
+        expression={expression}
+        pauseId={pauseId}
+        frameId={frameId}
+      />
     </Suspense>
   );
 }
 
 function EagerEvaluationResultSuspends({
+  cacheKey,
   expression,
   frameId,
   pauseId,
 }: {
+  cacheKey: string;
   expression: string;
   frameId: FrameId | null;
   pauseId: PauseId;
 }) {
   const client = useContext(ReplayClientContext);
 
-  const result = evaluateSuspense(client, pauseId, frameId, expression);
+  const result = evaluateSuspense(client, pauseId, frameId, expression, cacheKey);
   const { exception, returned } = result;
 
   let children: ReactNode | null = null;

--- a/packages/replay-next/components/console/renderers/TerminalExpressionRenderer.tsx
+++ b/packages/replay-next/components/console/renderers/TerminalExpressionRenderer.tsx
@@ -131,7 +131,15 @@ function EvaluatedContent({ terminalExpression }: { terminalExpression: Terminal
     [point, time]
   );
 
-  const result = evaluateSuspense(client, pauseId, frameId, terminalExpression.expression);
+  // We pass the id of the terminal expression so that each evaluation is cached separately.
+  // See FE-1111 for an example of why this is beneficial.
+  const result = evaluateSuspense(
+    client,
+    pauseId,
+    frameId,
+    terminalExpression.expression,
+    "" + terminalExpression.id
+  );
   const { exception, returned } = result;
 
   let children: ReactNode | null = null;

--- a/packages/replay-next/src/suspense/PauseCache.ts
+++ b/packages/replay-next/src/suspense/PauseCache.ts
@@ -71,7 +71,7 @@ export const {
   getValueIfCached: getEvaluationResultIfCached,
 } = createGenericCache2<
   ReplayClientInterface,
-  [pauseId: PauseId, frameId: FrameId | null, expression: string],
+  [pauseId: PauseId, frameId: FrameId | null, expression: string, uid?: string],
   Omit<Result, "data">
 >(
   "PauseCache: evaluate",
@@ -81,7 +81,7 @@ export const {
     cachePauseData(client, pauseId, result.data);
     return { exception: result.exception, failed: result.failed, returned: result.returned };
   },
-  (pauseId, frameId, expression) => `${pauseId}:${frameId}:${expression}`
+  (pauseId, frameId, expression, uid = "") => `${pauseId}:${frameId}:${expression}:${uid}`
 );
 
 export function cachePauseData(


### PR DESCRIPTION
### [Loom demo and overview of this change](https://www.loom.com/share/7354e449e266476b879e138886d4285e)

- [x] Suspense cache supports (optional) instance id per expression being evaluated
- [x] Console eager eval and terminal expression renderers pass this instance id to cache-bust
- [x] Add new e2e test and ~~update test fixture data~~

cc @Andarist 