### PR TITLE
Share Modal + Privacy Panel fix

### DIFF
--- a/src/ui/components/UploadScreen/Privacy.tsx
+++ b/src/ui/components/UploadScreen/Privacy.tsx
@@ -31,7 +31,7 @@ export function ToggleShowPrivacyButton({
     <button
       type="button"
       onClick={() => setShowPrivacy(!showPrivacy)}
-      className="group flex w-full flex-row items-center justify-between rounded-lg p-3 text-left font-normal"
+      className="group flex w-full flex-row items-center justify-between rounded-lg px-3 pt-3 text-left font-normal"
     >
       <div className="flex flex-row items-center space-x-2">
         <MaterialIcon iconSize="xl">storage</MaterialIcon>

--- a/src/ui/components/shared/SharingModal/SharingModal.tsx
+++ b/src/ui/components/shared/SharingModal/SharingModal.tsx
@@ -141,30 +141,32 @@ function SharingSection({
   return (
     <>
       <CollaboratorsSection recording={recording} />
-      <section className="flex flex-grow flex-row items-center justify-between space-x-2 bg-menuHoverBgcolor px-8 pt-8">
-        <div className="flex flex-row items-start space-x-3 overflow-hidden">
-          <div className="mt-1 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-blue-200 font-bold">
-            <MaterialIcon className="text-blue-600" iconSize="xl">
-              people
-            </MaterialIcon>
+      <section className="flex flex-col bg-menuHoverBgcolor px-8 py-8">
+        <div className="flex flex-grow flex-row items-center justify-between space-x-2 ">
+          <div className="flex flex-row items-start space-x-3 overflow-hidden">
+            <div className="mt-1 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-blue-200 font-bold">
+              <MaterialIcon className="text-blue-600" iconSize="xl">
+                people
+              </MaterialIcon>
+            </div>
+            <div className="flex flex-col space-y-1 overflow-hidden">
+              <div className="font-bold">Privacy Settings</div>
+              <PrivacyDropdown {...{ recording }} />
+              {showEnvironmentVariables ? <EnvironmentVariablesRow /> : null}
+            </div>
           </div>
-          <div className="flex flex-col space-y-1 overflow-hidden">
-            <div className="font-bold">Privacy Settings</div>
-            <PrivacyDropdown {...{ recording }} />
-            {showEnvironmentVariables ? <EnvironmentVariablesRow /> : null}
-          </div>
+          <CopyButton recording={recording} />
         </div>
-        <CopyButton recording={recording} />
+        <div>
+          {!recording.private && recording.operations && (
+            <ToggleShowPrivacyButton
+              showPrivacy={showPrivacy}
+              operations={recording.operations}
+              setShowPrivacy={setShowPrivacy}
+            />
+          )}
+        </div>
       </section>
-      {recording.operations && (
-        <section className="bg-menuHoverBgcolor px-8 pb-6">
-          <ToggleShowPrivacyButton
-            showPrivacy={showPrivacy}
-            operations={recording.operations}
-            setShowPrivacy={setShowPrivacy}
-          />
-        </section>
-      )}
     </>
   );
 }


### PR DESCRIPTION
When we designed the privacy panel, the idea was that we would only show the privacy information for public replays. @jaril / @jonbell-lot23 was there a moment where we intentionally decided to show it all the time?

<img width="690" alt="Screenshot 2023-01-10 at 8 07 58 AM" src="https://user-images.githubusercontent.com/254562/211602671-d46604cb-fbbb-430d-b82f-0b25d5327f24.png">

<img width="643" alt="Screenshot 2023-01-10 at 8 07 53 AM" src="https://user-images.githubusercontent.com/254562/211602682-f643dfac-4cfe-4daa-8a7f-8e7e52cb671c.png">
