### PR TITLE
Left sidebar can be fully collapsed

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "react-lazyload": "^3.2.0",
     "react-merge-refs": "^1.1.0",
     "react-redux": "^8.0.2",
-    "react-resizable-panels": "^0.0.30",
+    "react-resizable-panels": "^0.0.32",
     "react-table": "^7.7.0",
     "react-tooltip": "^4.2.21",
     "react-transition-group": "^4.4.2",

--- a/packages/e2e-tests/tests/resizable-panels-01.test.ts
+++ b/packages/e2e-tests/tests/resizable-panels-01.test.ts
@@ -1,0 +1,47 @@
+import test, { Page, expect } from "@playwright/test";
+
+import { startTest } from "../helpers";
+import { delay, waitFor } from "../helpers/utils";
+
+async function waitForPanelSize(page: Page, expectedSize: number) {
+  const sidePanel = page.locator('[data-panel-id="Panel-SidePanel"]');
+  await waitFor(async () => {
+    const actualSize = parseInt((await sidePanel.getAttribute("data-panel-size")) || "");
+    if (actualSize !== expectedSize) {
+      throw `Expected panel size to be ${expectedSize} but was ${actualSize}`;
+    }
+  });
+}
+
+test("resizable-panels-01: Left side Toolbar should be collapsible", async ({ page }) => {
+  await startTest(page, "doc_rr_basic.html");
+
+  const button = page.locator('[data-test-name="ToolbarButton-ExpandSidePanel"]');
+  const resizeHandle = page.locator('[data-panel-resize-handle-id="PanelResizeHandle-SidePanel"]');
+  await resizeHandle.waitFor();
+
+  // Collapse panel via the Window Splitter API
+  await resizeHandle.focus();
+  await page.keyboard.press("Home");
+  await waitForPanelSize(page, 0);
+
+  await delay(1_000); // Give the panel coordinates time to save
+
+  // Reload page and panel should still be collapsed
+  await page.reload();
+  await waitForPanelSize(page, 0);
+
+  // Expand panel
+  await button.click();
+  await waitForPanelSize(page, 15);
+
+  await delay(1_000); // Give the panel coordinates time to save
+
+  // Reload page and panel should still be expanded
+  await page.reload();
+  await waitForPanelSize(page, 15);
+
+  // Collapse panel via the side toggle
+  await button.click();
+  await waitForPanelSize(page, 0);
+});

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -124,13 +124,17 @@ function Body() {
               className="flex=1 flex h-full overflow-hidden"
               collapsible
               defaultSize={20}
+              id="Panel-SidePanel"
               minSize={15}
               onCollapse={onSidePanelCollapse}
               ref={sidePanelRef}
             >
               <SidePanel />
             </Panel>
-            <PanelResizeHandle className={`h-full ${sidePanelCollapsed ? "w-0" : "w-2"}`} />
+            <PanelResizeHandle
+              className={`h-full ${sidePanelCollapsed ? "w-0" : "w-2"}`}
+              id="PanelResizeHandle-SidePanel"
+            />
             <Panel className="flex h-full overflow-hidden" minSize={50}>
               {viewMode === "dev" ? (
                 <React.Suspense fallback={<ViewLoader />}>

--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -1,6 +1,6 @@
 import classnames from "classnames";
 import classNames from "classnames";
-import React, { useContext, useEffect, useState } from "react";
+import React, { ReactNode, useContext, useEffect, useState } from "react";
 
 import AccessibleImage from "devtools/client/debugger/src/components/shared/AccessibleImage";
 import { getPauseId } from "devtools/client/debugger/src/selectors";
@@ -95,7 +95,7 @@ function ToolbarButton({
   );
 }
 
-export default function Toolbar() {
+export default function Toolbar({ sidePanelToggle }: { sidePanelToggle: ReactNode }) {
   const replayClient = useContext(ReplayClientContext);
   const pauseId = useAppSelector(getPauseId);
   const frames = useGetFrames(replayClient, pauseId);
@@ -122,7 +122,7 @@ export default function Toolbar() {
 
   return (
     <div className="toolbox-toolbar-container flex flex-col items-center justify-between py-1">
-      <div id="toolbox-toolbar space-y-1">
+      <div id="toolbox-toolbar">
         {recording?.metadata?.test?.runner?.name == "cypress" ? (
           <ToolbarButton icon="cypress" label="Cypress Panel" name="events" />
         ) : (
@@ -147,6 +147,13 @@ export default function Toolbar() {
           </>
         ) : null}
         {logProtocol ? <ToolbarButton icon="code" label="Protocol" name="protocol" /> : null}
+
+        {sidePanelToggle !== null && (
+          <>
+            <div className="grow"></div>
+            <div className="relative px-2">{sidePanelToggle}</div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/ui/components/Toolbox.css
+++ b/src/ui/components/Toolbox.css
@@ -12,6 +12,7 @@
 #toolbox-toolbar {
   display: flex;
   flex-direction: column;
+  flex-grow: 1;
   border-top: 0px;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -20731,13 +20731,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-resizable-panels@npm:^0.0.30":
-  version: 0.0.30
-  resolution: "react-resizable-panels@npm:0.0.30"
+"react-resizable-panels@npm:^0.0.32":
+  version: 0.0.32
+  resolution: "react-resizable-panels@npm:0.0.32"
   peerDependencies:
     react: ^16.14.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0
-  checksum: 7c7bb657a71559f01ff5fff021d5c5843ea3db9fb2059fe2d282f8f32692959979f60470d3d065f927a2cebc030cbced470f01a1a52ece2afb6ed5c0c5cea934
+  checksum: 56de4722155c66da30f7336bb3660039d85b8f4c0d49e563e9c2caada975897a184d5a43fc11d2a2f283e1b48cb87eac02bff8c792d390f95b2ad83978dcec56
   languageName: node
   linkType: hard
 
@@ -21173,7 +21173,7 @@ __metadata:
     react-lazyload: ^3.2.0
     react-merge-refs: ^1.1.0
     react-redux: ^8.0.2
-    react-resizable-panels: ^0.0.30
+    react-resizable-panels: ^0.0.32
     react-table: ^7.7.0
     react-tooltip: ^4.2.21
     react-transition-group: ^4.4.2


### PR DESCRIPTION
### [Loom overview/demo](https://www.loom.com/share/5b15dd06e205442ca48627ee89f427ac)

- [x] Upgrade `react-resizable-panels` package from 0.0.30 to 0.0.31
- [x] Left toolbar panel is now fully collapsible via mouse and keyboard interactions.
  - [x] Toggle button added to left toolbar to expand/collapse as well.
- [x] New e2e test added for collapsible behavior.

cc @jonbell-lot23 
