### PR TITLE
Video player collapse UX changes

### DIFF
--- a/packages/replay-next/pages/index.tsx
+++ b/packages/replay-next/pages/index.tsx
@@ -113,7 +113,7 @@ export default function HomePage({ apiKey }: { apiKey?: string }) {
                           <PanelGroup autoSaveId="bvaughn-layout-main" direction="horizontal">
                             <Panel
                               className={styles.Panel}
-                              collapsible={true}
+                              collapsible
                               defaultSize={15}
                               minSize={10}
                               maxSize={20}

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -5,12 +5,10 @@ import { openQuickOpen } from "devtools/client/debugger/src/actions/quick-open";
 import { shallowEqual } from "devtools/client/debugger/src/utils/compare";
 import { prefs } from "devtools/client/debugger/src/utils/prefs";
 import { ThreadFront as ThreadFrontType } from "protocol/thread";
-import { isValidPoint } from "replay-next/src/contexts/PointsContext";
 import { ReplayClientInterface } from "shared/client/types";
 import { CommandKey } from "ui/components/CommandPalette/CommandPalette";
 import * as selectors from "ui/reducers/app";
 import { getTheme } from "ui/reducers/app";
-import { getShowVideoPanel } from "ui/reducers/layout";
 import { Canvas, EventKind, ReplayEvent, ReplayNavigationEvent } from "ui/state/app";
 import { getBoundingRectsAsync } from "ui/suspense/nodeCaches";
 import { compareBigInt } from "ui/utils/helpers";
@@ -34,7 +32,6 @@ import {
   hideCommandPalette,
   setSelectedPanel,
   setSelectedPrimaryPanel,
-  setShowVideoPanel,
   setToolboxLayout,
   setViewMode,
 } from "./layout";
@@ -318,9 +315,6 @@ export function executeCommand(key: CommandKey): UIThunkAction {
       dispatch(setModal("sharing", { recordingId }));
     } else if (key === "toggle_edit_focus") {
       dispatch(toggleFocusMode());
-    } else if (key === "toggle_video") {
-      const showVideoPanel = getShowVideoPanel(getState());
-      dispatch(setShowVideoPanel(!showVideoPanel));
     } else if (key === "toggle_dark_mode") {
       dispatch(toggleTheme());
     } else if (key === "pin_to_bottom") {

--- a/src/ui/actions/layout.ts
+++ b/src/ui/actions/layout.ts
@@ -26,9 +26,6 @@ type SetShowCommandPaletteAction = Action<"set_show_command_palette"> & { value:
 type SetToolboxLayoutAction = Action<"set_toolbox_layout"> & {
   layout: ToolboxLayout;
 };
-type SetShowVideoPanelAction = Action<"set_show_video_panel"> & {
-  showVideoPanel: boolean;
-};
 type SetViewModeAction = Action<"set_view_mode"> & { viewMode: ViewMode };
 type DismissLocalNagAction = Action<"dismiss_local_nag"> & { nag: LocalNag };
 export type SetSelectedPanelAction = Action<"set_selected_panel"> & { panel: SecondaryPanelName };
@@ -37,7 +34,6 @@ export type LayoutAction =
   | SetSelectedPrimaryPanelAction
   | SetShowCommandPaletteAction
   | SetToolboxLayoutAction
-  | SetShowVideoPanelAction
   | SetViewModeAction
   | DismissLocalNagAction;
 
@@ -79,11 +75,6 @@ export function setViewMode(viewMode: ViewMode): UIThunkAction {
     dispatch({ type: "set_view_mode", viewMode });
     trackEvent(viewMode == "dev" ? "layout.devtools" : "layout.viewer");
   };
-}
-export function setShowVideoPanel(showVideoPanel: boolean): SetShowVideoPanelAction {
-  trackEvent("toolbox.secondary.video_toggle");
-
-  return { type: "set_show_video_panel", showVideoPanel };
 }
 
 export function setToolboxLayout(layout: ToolboxLayout): UIThunkAction {

--- a/src/ui/components/CommandPalette/CommandPalette.tsx
+++ b/src/ui/components/CommandPalette/CommandPalette.tsx
@@ -43,8 +43,7 @@ export type CommandKey =
   | "show_replay_info"
   | "show_sharing"
   | "toggle_dark_mode"
-  | "toggle_edit_focus"
-  | "toggle_video";
+  | "toggle_edit_focus";
 
 const COMMANDS: readonly Command[] = [
   { key: "open_console", label: "Open Console" },
@@ -70,7 +69,6 @@ const COMMANDS: readonly Command[] = [
   { key: "show_sharing", label: "Show Sharing Options" },
   { key: "toggle_dark_mode", label: "Toggle Dark Mode", shortcut: "Alt+Shift+T" },
   { key: "toggle_edit_focus", label: "Toggle Edit Focus Mode", shortcut: "Shift+F" },
-  { key: "toggle_video", label: "Toggle Video" },
   { key: "pin_to_bottom", label: "Pin Toolbox To Bottom" },
   { key: "pin_to_left", label: "Pin Toolbox To Left" },
   { key: "pin_to_bottom_right", label: "Pin Toolbox To Bottom Right" },

--- a/src/ui/components/SecondaryToolbox/ToolboxButton.tsx
+++ b/src/ui/components/SecondaryToolbox/ToolboxButton.tsx
@@ -1,8 +1,7 @@
-import { setShowVideoPanel } from "ui/actions/layout";
-import { getShowVideoPanel } from "ui/reducers/layout";
-import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
+import { RefObject } from "react";
+import { ImperativePanelHandle } from "react-resizable-panels";
 
-import Icon from "../shared/Icon";
+import MaterialIcon from "ui/components/shared/MaterialIcon";
 
 interface ToolboxButtonProps {
   title?: string;
@@ -22,21 +21,27 @@ export const ToolboxButton = ({ children, title, onClick = () => {} }: ToolboxBu
   );
 };
 
-export const ShowVideoButton = () => {
-  const dispatch = useAppDispatch();
-  const showVideoPanel = useAppSelector(getShowVideoPanel);
-
+export const ShowVideoButton = ({
+  videoPanelCollapsed,
+  videoPanelRef,
+}: {
+  videoPanelCollapsed: Boolean;
+  videoPanelRef: RefObject<ImperativePanelHandle>;
+}) => {
   const onClick = () => {
-    dispatch(setShowVideoPanel(true));
+    const panel = videoPanelRef.current;
+    if (panel) {
+      if (videoPanelCollapsed) {
+        panel.expand();
+      } else {
+        panel.collapse();
+      }
+    }
   };
 
-  if (showVideoPanel) {
-    return null;
-  }
-
   return (
-    <ToolboxButton title="Show Video" onClick={onClick}>
-      <Icon filename="video" className="bg-iconColor" size="small" />
+    <ToolboxButton title={videoPanelCollapsed ? "Show Video" : "Hide Video"} onClick={onClick}>
+      <MaterialIcon>{videoPanelCollapsed ? "videocam_on" : "videocam_off"}</MaterialIcon>
     </ToolboxButton>
   );
 };

--- a/src/ui/components/SecondaryToolbox/index.tsx
+++ b/src/ui/components/SecondaryToolbox/index.tsx
@@ -1,6 +1,7 @@
 import "ui/setup/dynamic/inspector";
 import classnames from "classnames";
-import React, { FC, ReactNode, Suspense, useContext } from "react";
+import React, { FC, ReactNode, RefObject, Suspense, useContext } from "react";
+import { ImperativePanelHandle } from "react-resizable-panels";
 
 import { EditorPane } from "devtools/client/debugger/src/components/Editor/EditorPane";
 import { RecordingCapabilities } from "protocol/thread/thread";
@@ -128,15 +129,27 @@ function PanelButtonsScrollOverflowGradient() {
   return <div className="secondary-toolbox-scroll-overflow-gradient"></div>;
 }
 
-export default function SecondaryToolboxSuspenseWrapper() {
+export default function SecondaryToolboxSuspenseWrapper({
+  videoPanelCollapsed,
+  videoPanelRef,
+}: {
+  videoPanelCollapsed: Boolean;
+  videoPanelRef: RefObject<ImperativePanelHandle>;
+}) {
   return (
     <Suspense fallback={<Loader />}>
-      <SecondaryToolbox />
+      <SecondaryToolbox videoPanelCollapsed={videoPanelCollapsed} videoPanelRef={videoPanelRef} />
     </Suspense>
   );
 }
 
-function SecondaryToolbox() {
+function SecondaryToolbox({
+  videoPanelCollapsed,
+  videoPanelRef,
+}: {
+  videoPanelCollapsed: Boolean;
+  videoPanelRef: RefObject<ImperativePanelHandle>;
+}) {
   const selectedPanel = useAppSelector(getSelectedPanel);
   const hasReactComponents = useAppSelector(selectors.hasReactComponents);
   const toolboxLayout = useAppSelector(getToolboxLayout);
@@ -163,7 +176,10 @@ function SecondaryToolbox() {
         />
         <div className="secondary-toolbox-right-buttons-container flex">
           <PanelButtonsScrollOverflowGradient />
-          <ShowVideoButton />
+          <ShowVideoButton
+            videoPanelCollapsed={videoPanelCollapsed}
+            videoPanelRef={videoPanelRef}
+          />
           <ToolboxOptions />
         </div>
       </header>

--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -147,13 +147,8 @@ export default function Toolbar({ sidePanelToggle }: { sidePanelToggle: ReactNod
           </>
         ) : null}
         {logProtocol ? <ToolbarButton icon="code" label="Protocol" name="protocol" /> : null}
-
-        {sidePanelToggle !== null && (
-          <>
-            <div className="grow"></div>
-            <div className="relative px-2">{sidePanelToggle}</div>
-          </>
-        )}
+        <div className="grow"></div>
+        <div className="relative px-2">{sidePanelToggle}</div>
       </div>
     </div>
   );

--- a/src/ui/components/Video.tsx
+++ b/src/ui/components/Video.tsx
@@ -1,41 +1,21 @@
 import {} from "devtools/client/inspector/markup/reducers/markup";
-import React, { FC, useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { ConnectedProps, connect } from "react-redux";
 
 import { CypressToggler } from "devtools/client/debugger/src/components/TestInfo/CypressToggler";
 import { PreviewNodeHighlighter } from "devtools/client/inspector/markup/components/PreviewNodeHighlighter";
 import { installObserver, refreshGraphics } from "protocol/graphics";
-import { setShowVideoPanel } from "ui/actions/layout";
 import CommentsOverlay from "ui/components/Comments/VideoComments/index";
 import CommentTool from "ui/components/shared/CommentTool";
 import hooks from "ui/hooks";
-import { getSelectedPanel, getSelectedPrimaryPanel, getViewMode } from "ui/reducers/layout";
-import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
+import { getSelectedPrimaryPanel, getViewMode } from "ui/reducers/layout";
+import { useAppSelector } from "ui/setup/hooks";
 import { UIState } from "ui/state";
 
 import { selectors } from "../reducers";
-import MaterialIcon from "./shared/MaterialIcon";
 import ReplayLogo from "./shared/ReplayLogo";
 import Spinner from "./shared/Spinner";
 import Tooltip from "./shared/Tooltip";
-
-const HideVideoButton: FC = () => {
-  const dispatch = useAppDispatch();
-
-  const onClick = () => {
-    dispatch(setShowVideoPanel(false));
-  };
-
-  return (
-    <button
-      className="video-picker-button absolute top-0 right-0 flex rounded-full bg-tabBgcolor p-1"
-      title="Hide Video"
-      onClick={onClick}
-    >
-      <MaterialIcon>videocam_off</MaterialIcon>
-    </button>
-  );
-};
 
 function CommentLoader({ recordingId }: { recordingId: string }) {
   const { comments, loading } = hooks.useGetComments(recordingId);
@@ -121,7 +101,6 @@ function Video({
           <PreviewNodeHighlighter key={nodeId} nodeId={nodeId} />
         ))}
       </div>
-      {viewMode === "dev" ? <HideVideoButton /> : null}
     </div>
   );
 }

--- a/src/ui/components/Viewer.tsx
+++ b/src/ui/components/Viewer.tsx
@@ -1,24 +1,21 @@
-import React from "react";
-import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
+import { useRef, useState } from "react";
+import {
+  ImperativePanelHandle,
+  Panel,
+  PanelGroup,
+  PanelResizeHandle,
+} from "react-resizable-panels";
 
 import Video from "ui/components/Video";
-import { getRecordingTarget } from "ui/reducers/app";
-import { getShowVideoPanel, getToolboxLayout } from "ui/reducers/layout";
+import { getToolboxLayout } from "ui/reducers/layout";
 import { useAppSelector } from "ui/setup/hooks";
-import { ToolboxLayout } from "ui/state/layout";
-import { prefs } from "ui/utils/prefs";
 
 import SecondaryToolbox from "./SecondaryToolbox";
 import Toolbox from "./Toolbox";
 
-const useGetShowVideo = () => {
-  const recordingTarget = useAppSelector(getRecordingTarget);
-  const showVideoPanel = useAppSelector(getShowVideoPanel);
-  return showVideoPanel && recordingTarget !== "node";
-};
-
 const Vertical = () => {
-  const showVideo = useGetShowVideo();
+  const videoPanelRef = useRef<ImperativePanelHandle>(null);
+  const [videoPanelCollapsed, setVideoPanelCollapsed] = useState(false);
 
   return (
     <PanelGroup
@@ -26,37 +23,40 @@ const Vertical = () => {
       className="w-full overflow-hidden"
       direction="vertical"
     >
-      {showVideo && (
-        <>
-          <Panel
-            className="flex-column flex flex-1"
-            defaultSize={50}
-            id="video"
-            minSize={10}
-            order={1}
-          >
-            <div className="flex-column flex flex-1">
-              <Video />
-            </div>
-          </Panel>
-          <PanelResizeHandle className="h-2 w-full" />
-        </>
-      )}
+      <Panel
+        className="flex-column flex flex-1"
+        collapsible
+        defaultSize={50}
+        id="Panel-Video"
+        minSize={10}
+        onCollapse={setVideoPanelCollapsed}
+        order={1}
+        ref={videoPanelRef}
+      >
+        <div className="flex-column flex flex-1">
+          <Video />
+        </div>
+      </Panel>
+      <PanelResizeHandle
+        className={videoPanelCollapsed ? "" : "h-2 w-full"}
+        id="PanelResizeHandle-Video"
+      />
       <Panel
         className="flex-column flex flex-1"
         defaultSize={50}
-        id="secondary-toolbox"
+        id="Panel-SecondaryToolbox"
         minSize={30}
         order={2}
       >
-        <SecondaryToolbox />
+        <SecondaryToolbox videoPanelCollapsed={videoPanelCollapsed} videoPanelRef={videoPanelRef} />
       </Panel>
     </PanelGroup>
   );
 };
 
 const Horizontal = () => {
-  const showVideo = useGetShowVideo();
+  const videoPanelRef = useRef<ImperativePanelHandle>(null);
+  const [videoPanelCollapsed, setVideoPanelCollapsed] = useState(false);
 
   return (
     <PanelGroup
@@ -67,50 +67,36 @@ const Horizontal = () => {
       <Panel
         className="flex flex-1 flex-row"
         defaultSize={50}
-        id="secondary-toolbox"
+        id="Panel-SecondaryToolbox"
         minSize={30}
         order={1}
       >
         <div className="flex flex-1 flex-row">
-          <SecondaryToolbox />
-          <PanelResizeHandle className="w-2" />
+          <SecondaryToolbox
+            videoPanelCollapsed={videoPanelCollapsed}
+            videoPanelRef={videoPanelRef}
+          />
+          <PanelResizeHandle
+            className={videoPanelCollapsed ? "" : "w-2"}
+            id="PanelResizeHandle-Video"
+          />
         </div>
       </Panel>
-      {showVideo && (
-        <Panel className="flex flex-1 flex-row" defaultSize={50} id="video" minSize={10} order={2}>
-          <Video />
-        </Panel>
-      )}
+      <Panel
+        className="flex flex-1 flex-row"
+        collapsible
+        defaultSize={50}
+        id="Panel-Video"
+        minSize={10}
+        onCollapse={setVideoPanelCollapsed}
+        order={2}
+        ref={videoPanelRef}
+      >
+        <Video />
+      </Panel>
     </PanelGroup>
   );
 };
-
-function minSize(sidePanelCollapsed: boolean, toolboxLayout: ToolboxLayout): `${number}px` {
-  if (!sidePanelCollapsed && toolboxLayout === "ide") {
-    return "300px";
-  }
-
-  if (!sidePanelCollapsed || toolboxLayout === "ide") {
-    return "200px";
-  }
-
-  return "0px";
-}
-
-function maxSize(
-  sidePanelCollapsed: boolean,
-  toolboxLayout: ToolboxLayout
-): `${number}` | `${number}%` | `${number}px` {
-  if (toolboxLayout === "ide") {
-    return "80%";
-  }
-
-  if (sidePanelCollapsed) {
-    return "0";
-  }
-
-  return String(prefs.sidePanelSize) as `${number}px`;
-}
 
 export default function Viewer() {
   const toolboxLayout = useAppSelector(getToolboxLayout);

--- a/src/ui/reducers/layout.ts
+++ b/src/ui/reducers/layout.ts
@@ -8,7 +8,6 @@ export const syncInitialLayoutState: LayoutState = {
   showCommandPalette: false,
   selectedPrimaryPanel: "events",
   viewMode: prefs.defaultMode as ViewMode,
-  showVideoPanel: true,
   toolboxLayout: "ide",
   selectedPanel: "console",
   localNags: [],
@@ -39,10 +38,6 @@ export default function update(state = syncInitialLayoutState, action: LayoutAct
       return { ...state, viewMode: action.viewMode };
     }
 
-    case "set_show_video_panel": {
-      return { ...state, showVideoPanel: action.showVideoPanel };
-    }
-
     case "set_toolbox_layout": {
       return { ...state, toolboxLayout: action.layout };
     }
@@ -68,6 +63,5 @@ export const getShowCommandPalette = (state: UIState) => state.layout.showComman
 export const getSelectedPrimaryPanel = (state: UIState) => state.layout.selectedPrimaryPanel;
 export const getSelectedPanel = (state: UIState) => state.layout.selectedPanel;
 export const getViewMode = (state: UIState) => state.layout.viewMode;
-export const getShowVideoPanel = (state: UIState) => state.layout.showVideoPanel;
 export const getToolboxLayout = (state: UIState) => state.layout.toolboxLayout;
 export const getLocalNags = (state: UIState) => state.layout.localNags;

--- a/src/ui/setup/index.ts
+++ b/src/ui/setup/index.ts
@@ -89,7 +89,7 @@ export async function getInitialLayoutState(): Promise<LayoutState> {
     };
   }
 
-  const { viewMode, showVideoPanel, toolboxLayout, selectedPanel } = syncInitialLayoutState;
+  const { viewMode, toolboxLayout, selectedPanel } = syncInitialLayoutState;
   const initialViewMode = session.viewMode || viewMode;
   trackEvent(initialViewMode == "dev" ? "layout.default_devtools" : "layout.default_viewer");
 
@@ -98,7 +98,6 @@ export async function getInitialLayoutState(): Promise<LayoutState> {
     viewMode: initialViewMode,
     selectedPanel: "selectedPanel" in session ? session.selectedPanel : selectedPanel,
     selectedPrimaryPanel: getDefaultSelectedPrimaryPanel(session, recording),
-    showVideoPanel: "showVideoPanel" in session ? session.showVideoPanel : showVideoPanel,
     toolboxLayout: "toolboxLayout" in session ? session.toolboxLayout : toolboxLayout,
     localNags: "localNags" in session ? session.localNags : [],
   };

--- a/src/ui/setup/prefs.ts
+++ b/src/ui/setup/prefs.ts
@@ -11,7 +11,6 @@ import {
   getLocalNags,
   getSelectedPanel,
   getSelectedPrimaryPanel,
-  getShowVideoPanel,
   getToolboxLayout,
   getViewMode,
 } from "ui/reducers/layout";
@@ -25,7 +24,6 @@ export interface ReplaySessions {
 }
 export interface ReplaySession {
   viewMode: ViewMode;
-  showVideoPanel: boolean;
   toolboxLayout: ToolboxLayout;
   selectedPrimaryPanel: PrimaryPanelName;
   selectedPanel: SecondaryPanelName;
@@ -153,7 +151,6 @@ async function maybeUpdateReplaySessions(state: UIState) {
   const currentReplaySession = {
     viewMode: getViewMode(state),
     toolboxLayout: getToolboxLayout(state),
-    showVideoPanel: getShowVideoPanel(state),
     selectedPrimaryPanel: getSelectedPrimaryPanel(state),
     selectedPanel: getSelectedPanel(state),
     localNags: getLocalNags(state),

--- a/src/ui/state/layout.ts
+++ b/src/ui/state/layout.ts
@@ -2,7 +2,6 @@ import { LocalNag } from "ui/setup/prefs";
 
 export type LayoutState = {
   showCommandPalette: boolean;
-  showVideoPanel: boolean;
   selectedPrimaryPanel: PrimaryPanelName;
   selectedPanel: SecondaryPanelName;
   viewMode: ViewMode;


### PR DESCRIPTION
### [Loom overview](https://www.loom.com/share/e3b7c346c6c94038ba90fd68af160804)

- [x] Remove video player collapse state from Redux.
- [x] Enable `collapsible` property in `react-resizable-panel` for Video player and use it instead.
- [x] Change show/hide video player button icon to mirror the left sidebar one (see #8513)