### PR TITLE
Updated Playwright tests to fix flakiness/failures

### DIFF
--- a/packages/e2e-tests/helpers/console-panel.ts
+++ b/packages/e2e-tests/helpers/console-panel.ts
@@ -183,8 +183,9 @@ export async function seekToConsoleMessage(
   await consoleMessage.hover();
   await consoleMessage.locator('[data-test-id="ConsoleMessageHoverButton"]').click();
 
-  await waitFor(async () =>
-    expect(await consoleMessage.getAttribute("data-test-paused-here")).toBe("true")
+  await waitFor(
+    async () =>
+      await expect(await consoleMessage.getAttribute("data-test-paused-here")).toBe("true")
   );
   await waitForPaused(page, line);
 }

--- a/packages/e2e-tests/helpers/pause-information-panel.ts
+++ b/packages/e2e-tests/helpers/pause-information-panel.ts
@@ -38,7 +38,7 @@ export async function expandAllScopesBlocks(page: Page): Promise<void> {
   const blocks = scopesPanel.locator('[data-test-name="ScopesInspector"]');
 
   await waitFor(async () => {
-    await expect(await blocks.count()).toBeGreaterThan(0);
+    expect(await blocks.count()).toBeGreaterThan(0);
   });
 
   await forEach(blocks, async (block: Locator) => {

--- a/packages/e2e-tests/helpers/pause-information-panel.ts
+++ b/packages/e2e-tests/helpers/pause-information-panel.ts
@@ -38,7 +38,7 @@ export async function expandAllScopesBlocks(page: Page): Promise<void> {
   const blocks = scopesPanel.locator('[data-test-name="ScopesInspector"]');
 
   await waitFor(async () => {
-    expect(await blocks.count()).toBeGreaterThan(0);
+    await expect(await blocks.count()).toBeGreaterThan(0);
   });
 
   await forEach(blocks, async (block: Locator) => {

--- a/packages/e2e-tests/helpers/source-panel.ts
+++ b/packages/e2e-tests/helpers/source-panel.ts
@@ -454,7 +454,7 @@ export async function waitForSelectedSource(page: Page, url: string) {
     const editorPanel = page.locator("#toolbox-content-debugger");
     const sourceHeader = editorPanel.locator(`[data-test-name="Source-${url}"]`);
 
-    expect(await sourceHeader.getAttribute("data-status")).toBe("active");
+    await expect(await sourceHeader.getAttribute("data-status")).toBe("active");
 
     // Make sure the visible source is the same source as the selected tab.
     const headerSourceId = await sourceHeader.getAttribute("data-test-sourceid");

--- a/packages/e2e-tests/tests/react_devtools.test.ts
+++ b/packages/e2e-tests/tests/react_devtools.test.ts
@@ -45,7 +45,7 @@ test("react_devtools: Test React DevTools.", async ({ page }) => {
   await enableComponentPicker(page);
   await waitFor(async () => {
     await hoverScreenshot(page, x, y);
-    expect(await page.locator("[class^=InactiveSelectedElement]").count()).toBeGreaterThan(0);
+    await expect(await page.locator("[class^=InactiveSelectedElement]").count()).toBeGreaterThan(0);
   });
   await waitForAndCheckInspectedItem(getInspectedItem(page, "Props", "text"), '"Foo"');
 
@@ -59,7 +59,7 @@ test("react_devtools: Test React DevTools.", async ({ page }) => {
   const highlighter = page.locator("#box-model-content");
   await highlighter.waitFor();
   const expectedHighlighterShape = `M${left},${top} L${right},${top} L${right},${bottom} L${left},${bottom}`;
-  expect(await highlighter.getAttribute("d")).toEqual(expectedHighlighterShape);
+  await expect(await highlighter.getAttribute("d")).toEqual(expectedHighlighterShape);
 
   component = getReactComponents(page).nth(0);
   await component.click();

--- a/packages/replay-next/components/console/Focuser.test.tsx
+++ b/packages/replay-next/components/console/Focuser.test.tsx
@@ -16,8 +16,8 @@ describe("Focuser", () => {
       },
     });
 
-    expect(await screen.queryByText("Focus off")).toBeInTheDocument();
-    expect(await screen.queryByText("0:00 – 1:00")).toBeInTheDocument();
+    await expect(await screen.queryByText("Focus off")).toBeInTheDocument();
+    await expect(await screen.queryByText("0:00 – 1:00")).toBeInTheDocument();
   });
 
   it("should render the current focus region", async () => {
@@ -49,8 +49,8 @@ describe("Focuser", () => {
       },
     });
 
-    expect(await screen.queryByText("Focus on")).toBeInTheDocument();
-    expect(await screen.queryByText("0:00 – 0:30")).toBeInTheDocument();
+    await expect(await screen.queryByText("Focus on")).toBeInTheDocument();
+    await expect(await screen.queryByText("0:00 – 0:30")).toBeInTheDocument();
   });
 
   it("should allow the focus region to be toggled on and off", async () => {

--- a/packages/replay-next/playwright/tests/console.ts
+++ b/packages/replay-next/playwright/tests/console.ts
@@ -1,6 +1,7 @@
 import { Page, expect, test } from "@playwright/test";
 
 import {
+  addTerminalExpression,
   hideSearchInput,
   locateMessage,
   messageLocator,
@@ -465,20 +466,18 @@ test("should show a button to clear terminal expressions", async ({ page }) => {
   await toggleProtocolMessages(page, false);
 
   // Add some expressions
-  await page.fill("[data-test-id=ConsoleTerminalInput]", "location.href");
-  await page.keyboard.press("Enter");
-  await page.fill("[data-test-id=ConsoleTerminalInput]", "+/local");
-  await page.keyboard.press("Enter");
+  await addTerminalExpression(page, "location.href");
+  await addTerminalExpression(page, "+/local");
 
-  expect(await getElementCount(page, "[data-test-name=Message]")).toBe(2);
-  expect(await getElementCount(page, "[data-test-id=ClearConsoleEvaluationsButton]")).toBe(1);
+  await expect(await getElementCount(page, "[data-test-name=Message]")).toBe(2);
+  await expect(await getElementCount(page, "[data-test-id=ClearConsoleEvaluationsButton]")).toBe(1);
 
   // Click the button to clear them
   await page.click("[data-test-id=ClearConsoleEvaluationsButton]");
 
   // Verify an empty terminal
-  expect(await getElementCount(page, "[data-test-name=Message]")).toBe(0);
-  expect(await getElementCount(page, "[data-test-id=ClearConsoleEvaluationsButton]")).toBe(0);
+  await expect(await getElementCount(page, "[data-test-name=Message]")).toBe(0);
+  await expect(await getElementCount(page, "[data-test-id=ClearConsoleEvaluationsButton]")).toBe(0);
 });
 
 test("should escape object expressions in terminal expressions", async ({ page }) => {

--- a/packages/replay-next/playwright/tests/utils/console.ts
+++ b/packages/replay-next/playwright/tests/utils/console.ts
@@ -6,6 +6,17 @@ import { Expected, MessageType } from "./types";
 
 type ToggleName = "errors" | "exceptions" | "logs" | "nodeModules" | "timestamps" | "warnings";
 
+export async function addTerminalExpression(page: Page, text: string): Promise<void> {
+  await debugPrint(page, `Adding terminal expression "${chalk.bold(text)}"`, "addTerminalMessage");
+
+  const input = page.locator("[data-test-id=ConsoleTerminalInput]");
+  await input.waitFor();
+  await input.focus();
+  await input.fill(text);
+  await page.keyboard.press("Enter");
+  await verifyConsoleMessage(page, text, "terminal-expression", 1);
+}
+
 export async function findConsoleMessage(
   page: Page,
   expected?: Expected,

--- a/packages/replay-next/src/suspense/PointsCache.test.ts
+++ b/packages/replay-next/src/suspense/PointsCache.test.ts
@@ -84,43 +84,43 @@ describe("PointsCache", () => {
         before: { time: 20, point: "20" },
         after: { time: 30, point: "30" },
       });
-      expect(await getClosestPointForTimeHelper(22)).toBe("20");
+      await expect(await getClosestPointForTimeHelper(22)).toBe("20");
       expect(mockClient.getPointsBoundingTime).toHaveBeenCalledTimes(1);
 
       mockClient.getPointsBoundingTime.mockReturnValue({
         before: { time: 31, point: "31" },
         after: { time: 34, point: "34" },
       });
-      expect(await getClosestPointForTimeHelper(32)).toBe("31");
+      await expect(await getClosestPointForTimeHelper(32)).toBe("31");
       expect(mockClient.getPointsBoundingTime).toHaveBeenCalledTimes(2);
 
       mockClient.getPointsBoundingTime.mockReturnValue({
         before: { time: 70, point: "70" },
         after: { time: 80, point: "80" },
       });
-      expect(await getClosestPointForTimeHelper(78)).toBe("80");
+      await expect(await getClosestPointForTimeHelper(78)).toBe("80");
       expect(mockClient.getPointsBoundingTime).toHaveBeenCalledTimes(3);
 
       mockClient.getPointsBoundingTime.mockReturnValue({
         before: { time: 50, point: "50" },
         after: { time: 60, point: "60" },
       });
-      expect(await getClosestPointForTimeHelper(50)).toBe("50");
+      await expect(await getClosestPointForTimeHelper(50)).toBe("50");
       expect(mockClient.getPointsBoundingTime).toHaveBeenCalledTimes(4);
 
       // So long as we stay within the pre-cached bounds at this point, no new requests should be made.
       // This test covers our binary array insert and search logic.
-      expect(await getClosestPointForTimeHelper(20)).toBe("20");
-      expect(await getClosestPointForTimeHelper(26)).toBe("30");
-      expect(await getClosestPointForTimeHelper(30)).toBe("30");
-      expect(await getClosestPointForTimeHelper(31)).toBe("31");
-      expect(await getClosestPointForTimeHelper(34)).toBe("34");
-      expect(await getClosestPointForTimeHelper(50)).toBe("50");
-      expect(await getClosestPointForTimeHelper(52)).toBe("50");
-      expect(await getClosestPointForTimeHelper(60)).toBe("60");
-      expect(await getClosestPointForTimeHelper(70)).toBe("70");
-      expect(await getClosestPointForTimeHelper(72)).toBe("70");
-      expect(await getClosestPointForTimeHelper(80)).toBe("80");
+      await expect(await getClosestPointForTimeHelper(20)).toBe("20");
+      await expect(await getClosestPointForTimeHelper(26)).toBe("30");
+      await expect(await getClosestPointForTimeHelper(30)).toBe("30");
+      await expect(await getClosestPointForTimeHelper(31)).toBe("31");
+      await expect(await getClosestPointForTimeHelper(34)).toBe("34");
+      await expect(await getClosestPointForTimeHelper(50)).toBe("50");
+      await expect(await getClosestPointForTimeHelper(52)).toBe("50");
+      await expect(await getClosestPointForTimeHelper(60)).toBe("60");
+      await expect(await getClosestPointForTimeHelper(70)).toBe("70");
+      await expect(await getClosestPointForTimeHelper(72)).toBe("70");
+      await expect(await getClosestPointForTimeHelper(80)).toBe("80");
       expect(mockClient.getPointsBoundingTime).toHaveBeenCalledTimes(4);
     });
   });
@@ -227,12 +227,12 @@ describe("PointsCache", () => {
 
       expect(mockClient.getPointsBoundingTime).toHaveBeenCalledTimes(2);
 
-      expect(await imperativelyGetClosestPointForTime(replayClient, 10)).toBe("10");
-      expect(await imperativelyGetClosestPointForTime(replayClient, 14)).toBe("10");
-      expect(await imperativelyGetClosestPointForTime(replayClient, 20)).toBe("20");
-      expect(await imperativelyGetClosestPointForTime(replayClient, 30)).toBe("30");
-      expect(await imperativelyGetClosestPointForTime(replayClient, 36)).toBe("40");
-      expect(await imperativelyGetClosestPointForTime(replayClient, 40)).toBe("40");
+      await expect(await imperativelyGetClosestPointForTime(replayClient, 10)).toBe("10");
+      await expect(await imperativelyGetClosestPointForTime(replayClient, 14)).toBe("10");
+      await expect(await imperativelyGetClosestPointForTime(replayClient, 20)).toBe("20");
+      await expect(await imperativelyGetClosestPointForTime(replayClient, 30)).toBe("30");
+      await expect(await imperativelyGetClosestPointForTime(replayClient, 36)).toBe("40");
+      await expect(await imperativelyGetClosestPointForTime(replayClient, 40)).toBe("40");
       expect(mockClient.getPointsBoundingTime).toHaveBeenCalledTimes(2);
     });
 
@@ -241,14 +241,14 @@ describe("PointsCache", () => {
         before: { time: 10, point: "10" },
         after: { time: 20, point: "20" },
       });
-      expect(await imperativelyGetClosestPointForTime(replayClient, 12)).toBe("10");
+      await expect(await imperativelyGetClosestPointForTime(replayClient, 12)).toBe("10");
       expect(mockClient.getPointsBoundingTime).toHaveBeenCalledTimes(1);
 
       mockClient.getPointsBoundingTime.mockReturnValue({
         before: { time: 21, point: "21" },
         after: { time: 24, point: "24" },
       });
-      expect(await imperativelyGetClosestPointForTime(replayClient, 21)).toBe("21");
+      await expect(await imperativelyGetClosestPointForTime(replayClient, 21)).toBe("21");
       expect(mockClient.getPointsBoundingTime).toHaveBeenCalledTimes(2);
     });
 
@@ -260,7 +260,7 @@ describe("PointsCache", () => {
       mockClient.getPointsBoundingTime.mockImplementation(() => {
         throw commandError("RecordingUnloaded", ProtocolError.RecordingUnloaded);
       });
-      expect(await imperativelyGetClosestPointForTime(replayClient, 3)).toBe("2");
+      await expect(await imperativelyGetClosestPointForTime(replayClient, 3)).toBe("2");
       expect(mockClient.getPointsBoundingTime).toHaveBeenCalledTimes(1);
     });
 
@@ -285,13 +285,13 @@ describe("PointsCache", () => {
         throw Error("Expected");
       });
 
-      expect(await getClosestPointForTimeSuspense(replayClient, 0)).toBe("0");
-      expect(await getClosestPointForTimeSuspense(replayClient, 2)).toBe("2");
-      expect(await getClosestPointForTimeSuspense(replayClient, 9)).toBe("9");
+      await expect(await getClosestPointForTimeSuspense(replayClient, 0)).toBe("0");
+      await expect(await getClosestPointForTimeSuspense(replayClient, 2)).toBe("2");
+      await expect(await getClosestPointForTimeSuspense(replayClient, 9)).toBe("9");
 
-      expect(await imperativelyGetClosestPointForTime(replayClient, 0)).toBe("0");
-      expect(await imperativelyGetClosestPointForTime(replayClient, 2)).toBe("2");
-      expect(await imperativelyGetClosestPointForTime(replayClient, 9)).toBe("9");
+      await expect(await imperativelyGetClosestPointForTime(replayClient, 0)).toBe("0");
+      await expect(await imperativelyGetClosestPointForTime(replayClient, 2)).toBe("2");
+      await expect(await imperativelyGetClosestPointForTime(replayClient, 9)).toBe("9");
     });
   });
 });

--- a/packages/replay-next/src/suspense/createGenericCache.test.ts
+++ b/packages/replay-next/src/suspense/createGenericCache.test.ts
@@ -24,7 +24,7 @@ describe("Generic suspense cache", () => {
     const cache = createTestCache();
     const thennable = cache.getValueAsync(1);
     expect(isThennable(thennable)).toBe(true);
-    expect(await thennable).toBe(1);
+    await expect(await thennable).toBe(1);
   });
 
   it("should return sync values", () => {

--- a/packages/shared/proxy/proxy.test.ts
+++ b/packages/shared/proxy/proxy.test.ts
@@ -61,14 +61,14 @@ describe("proxy", () => {
     }
 
     const [recorder, entries] = createRecorder(new Target());
-    expect(await recorder.multiplyByTwo(2)).toBe(4);
-    expect(await recorder.multiplyByTwo(3)).toBe(6);
+    await expect(await recorder.multiplyByTwo(2)).toBe(4);
+    await expect(await recorder.multiplyByTwo(3)).toBe(6);
 
     expect(entries).toHaveLength(2);
 
     const player = createPlayer<Target>(serialize(entries));
-    expect(await player.multiplyByTwo(2)).toBe(4);
-    expect(await player.multiplyByTwo(3)).toBe(6);
+    await expect(await player.multiplyByTwo(2)).toBe(4);
+    await expect(await player.multiplyByTwo(3)).toBe(6);
   });
 
   test("should resolve async responses correctly regardless of order", async () => {
@@ -97,13 +97,13 @@ describe("proxy", () => {
     resolvers[1]("second");
     await waitForPromisesToFlush();
 
-    expect(await a).toBe("first");
-    expect(await b).toBe("second");
-    expect(await c).toBe("third");
+    await expect(await a).toBe("first");
+    await expect(await b).toBe("second");
+    await expect(await c).toBe("third");
 
     const player = createPlayer<Target>(serialize(entries));
     // Only the most recent value should be returned.
-    expect(await player.asyncMethod()).toBe("third");
+    await expect(await player.asyncMethod()).toBe("third");
   });
 
   test("should return the latest value for a method with multiple matching calls", async () => {
@@ -114,14 +114,14 @@ describe("proxy", () => {
     }
 
     const [recorder, entries] = createRecorder(new Target());
-    expect(await recorder.multiplyByTwo(2)).toBe(4);
-    expect(await recorder.multiplyByTwo(3)).toBe(6);
+    await expect(await recorder.multiplyByTwo(2)).toBe(4);
+    await expect(await recorder.multiplyByTwo(3)).toBe(6);
 
     expect(entries).toHaveLength(2);
 
     const player = createPlayer<Target>(serialize(entries));
-    expect(await player.multiplyByTwo(2)).toBe(4);
-    expect(await player.multiplyByTwo(3)).toBe(6);
+    await expect(await player.multiplyByTwo(2)).toBe(4);
+    await expect(await player.multiplyByTwo(3)).toBe(6);
   });
 
   test("should support getters", () => {
@@ -366,7 +366,7 @@ describe("proxy", () => {
     const [recorder, entries] = createRecorder(new Target(), {
       sanitizeResult,
     });
-    expect(await recorder.asyncMethod(object)).toEqual(objectSanitizedResult);
+    await expect(await recorder.asyncMethod(object)).toEqual(objectSanitizedResult);
 
     expect(entries).toHaveLength(1);
     expect(entries).toMatchInlineSnapshot(`
@@ -393,7 +393,7 @@ describe("proxy", () => {
     `);
 
     const player = createPlayer<Target>(serialize(entries));
-    expect(await player.asyncMethod(object)).toEqual(objectSanitizedResult);
+    await expect(await player.asyncMethod(object)).toEqual(objectSanitizedResult);
   });
 
   test("should notify of pending async requests", async () => {

--- a/src/devtools/shared/async-store-helper.test.js
+++ b/src/devtools/shared/async-store-helper.test.js
@@ -18,19 +18,19 @@ describe("asycStoreHelper", () => {
     mockAsyncStorage();
     const asyncStore = asyncStoreHelper("root", { a: "_a" });
     asyncStore.a = 3;
-    expect(await asyncStore.a).toEqual(3);
+    await expect(await asyncStore.a).toEqual(3);
   });
 
   it("supports default values", async () => {
     mockAsyncStorage();
     const asyncStore = asyncStoreHelper("root", { a: ["Json", "_a", {}] });
-    expect(await asyncStore.a).toEqual({});
+    await expect(await asyncStore.a).toEqual({});
   });
 
   it("undefined default value", async () => {
     mockAsyncStorage();
     const asyncStore = asyncStoreHelper("root", { a: "_a" });
-    expect(await asyncStore.a).toEqual(null);
+    await expect(await asyncStore.a).toEqual(null);
   });
 
   it("setting an undefined mapping", async () => {

--- a/src/ui/components/__tests__/AppModal.test.tsx
+++ b/src/ui/components/__tests__/AppModal.test.tsx
@@ -53,6 +53,6 @@ describe("AppModal", () => {
     await userEvent.type(document.body, "{Escape}");
 
     // Verify the modal is hidden
-    expect(await screen.queryByText("Privacy")).not.toBeInTheDocument();
+    await expect(await screen.queryByText("Privacy")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Updates an e2e tests that has been cause false negatives from our Playwright/Delta actions lately:
- [x] `tests/console`: _should show a button to clear terminal expressions_

This PR also updates tests to `await expect` when testing async values<sup>1</sup>. This causes Playwright to [_wait until the expected condition is met_](https://playwright.dev/docs/test-assertions) (with a timeout) and so it should also help cut down on small timing related flakes.

Would be nice if we could enforce this with a Lint rule but I don't know how that would work.

<sup>1</sup> Note that I only did this for `await expect(await thing)`. I didn't replace `await expect(asyncValue)` because I didn't have an easy way to grep for them.