### PR TITLE
Always jump to an initial pause point

### DIFF
--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -124,6 +124,8 @@ export function jumpToInitialPausePoint(): UIThunkAction {
     }
     if (isPointInLoadingRegion(state, point)) {
       ThreadFront.timeWarp(point, time, false);
+    } else {
+      ThreadFront.timeWarp(endpoint.point, endpoint.time, false);
     }
   };
 }


### PR DESCRIPTION
If the initial pause point was not in a loading region, `jumpToInitialPausePoint()` would not call `ThreadFront.timeWarp()` at all - it should jump to the endpoint instead (that's what it already does if it doesn't find a pause point from URL parameters, comments or paints but the case that it *does* find such a point but it isn't in a loading region wasn't handled correctly).