### PR TITLE
Fix theme colors for sourcemap viewer

### DIFF
--- a/packages/third-party/sourcemap-visualizer/sourcemapVisualizer.css
+++ b/packages/third-party/sourcemap-visualizer/sourcemapVisualizer.css
@@ -122,51 +122,9 @@ body.sourcemap-visualizer {
   margin-left: -50px;
 }
 
-/* ---------- Light colors ---------- */
-
-body.sourcemap-visualizer:not([data-theme="dark"]) {
-  color: #222;
-  fill: #222;
-  stroke: #222;
-  background: white;
-}
-
-body.sourcemap-visualizer:not([data-theme="dark"]) #theme-dark {
-  display: none;
-}
-
-/* ---------- Dark colors ---------- */
-
-body.sourcemap-visualizer[data-theme="dark"] {
-  color: #eee;
-  fill: #eee;
-  stroke: #eee;
-  background: #333;
-}
-
-body.sourcemap-visualizer[data-theme="dark"] #theme-light {
-  display: none;
-}
-
-body.sourcemap-visualizer[data-theme="dark"] #theme-dark {
-  display: block;
-}
-
-/* ---------- Dark colors without JavaScript ---------- */
-
-@media (prefers-color-scheme: dark) {
-  body.sourcemap-visualizer:not([data-theme="light"]) {
-    color: #333;
-    fill: #eee;
-    stroke: #eee;
-    background: #eee;
-  }
-
-  body.sourcemap-visualizer:not([data-theme="light"]) #theme-light {
-    display: none;
-  }
-
-  body.sourcemap-visualizer:not([data-theme="light"]) #theme-dark {
-    display: block;
-  }
+body.sourcemap-visualizer {
+  background: var(--body-bgcolor);
+  color: var(--body-color);
+  fill: var(--body-color);
+  stroke: var(--body-color);
 }


### PR DESCRIPTION
Our previous CSS organization was kind of confusing and caused mismatches with light/dark Replay theme vs light/dark operating system preference. I've changed the CSS to use the same global `--body-color`/`--body-bgcolor` variables and tested the different combinations:

<img width="1684" alt="Screen Shot 2023-01-11 at 12 48 52 PM" src="https://user-images.githubusercontent.com/29597/211880796-d7a16675-401b-45a8-90ab-2c775c0a38ac.png">
<img width="1681" alt="Screen Shot 2023-01-11 at 12 48 59 PM" src="https://user-images.githubusercontent.com/29597/211880798-34ff5259-443f-4dfd-b2c0-56c6c5d0c0be.png">
<img width="1681" alt="Screen Shot 2023-01-11 at 12 49 43 PM" src="https://user-images.githubusercontent.com/29597/211880800-958885aa-430d-47b0-8571-c784dc23c4c2.png">
<img width="1681" alt="Screen Shot 2023-01-11 at 12 49 53 PM" src="https://user-images.githubusercontent.com/29597/211880802-66b7c07a-4971-449a-86c1-a01f574756bf.png">
