### PR TITLE
Don't call client.breakpointAdded unless point.shouldBreak

### DIFF
--- a/packages/replay-next/src/hooks/useBreakpointIdsFromServer.ts
+++ b/packages/replay-next/src/hooks/useBreakpointIdsFromServer.ts
@@ -61,10 +61,13 @@ export default function useBreakpointIdsFromServer(
               // We haven't fetched breakable positions for this yet. Get them.
               await getBreakpointPositionsAsync(client, point.location.sourceId);
             }
+
             // _Now_ we can tell the backend about this breakpoint.
-            client.breakpointAdded(point.location, point.condition).then(serverIds => {
-              pointIdToBreakpointIdMap.set(point.id, serverIds);
-            });
+            if (point.shouldBreak === POINT_BEHAVIOR_ENABLED) {
+              client.breakpointAdded(point.location, point.condition).then(serverIds => {
+                pointIdToBreakpointIdMap.set(point.id, serverIds);
+              });
+            }
           }
 
           if (pointsToRemove.length > 0) {


### PR DESCRIPTION
Recording before ([768d4769-11d5-4509-a6d9-11cbba311d51](https://app.replay.io/recording/768d4769-11d5-4509-a6d9-11cbba311d51)) vs after ([6913956b-9a09-4d42-9cd3-38973d5afb42](https://app.replay.io/recording/6913956b-9a09-4d42-9cd3-38973d5afb42)). At first, I assumed this was a regression from #8494 but the code in question wasn't changed by that PR. I think maybe this has been around for a while?