### PR TITLE
Source viewer tracks "cursor" position

### DIFF
--- a/packages/replay-next/src/utils/array.ts
+++ b/packages/replay-next/src/utils/array.ts
@@ -78,11 +78,11 @@ export function findIndexString(sortedItems: string[], targetItem: string): numb
   return findIndex<string>(sortedItems, targetItem, compareStrings);
 }
 
-export function insert<T>(
+export function findInsertIndex<T>(
   sortedItems: T[],
   item: T,
   comparisonFunction: ComparisonFunction<T>
-): T[] {
+): number {
   let lowIndex = 0;
   let highIndex = sortedItems.length;
   while (lowIndex < highIndex) {
@@ -95,7 +95,15 @@ export function insert<T>(
     }
   }
 
-  const insertAtIndex = lowIndex;
+  return lowIndex;
+}
+
+export function insert<T>(
+  sortedItems: T[],
+  item: T,
+  comparisonFunction: ComparisonFunction<T>
+): T[] {
+  const insertAtIndex = findInsertIndex(sortedItems, item, comparisonFunction);
 
   sortedItems.splice(insertAtIndex, 0, item);
 

--- a/src/devtools/client/debugger/src/components/Editor/Footer.css
+++ b/src/devtools/client/debugger/src/components/Editor/Footer.css
@@ -18,12 +18,6 @@
   box-sizing: border-box;
 }
 
-.source-footer-end {
-  display: flex;
-  align-items: center;
-  margin-left: auto;
-}
-
 .source-footer .commands * {
   user-select: none;
 }

--- a/src/devtools/client/debugger/src/components/Editor/Footer.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Footer.tsx
@@ -28,12 +28,6 @@ function SourceFooter() {
             <SourcemapVisualizerLinkSuspends cursorPosition={cursorPosition} />
           </Suspense>
         </ErrorBoundary>
-
-        <div className="source-footer-end">
-          <div className="cursor-position">
-            Line {(cursorLineIndex || 0) + 1}, Column {(cursorColumnIndex || 0) + 1}
-          </div>
-        </div>
       </div>
     </div>
   );

--- a/src/devtools/client/debugger/src/components/Editor/Footer.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Footer.tsx
@@ -1,9 +1,7 @@
-import React, { Suspense, memo, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { Suspense, memo, useContext } from "react";
 
 import ErrorBoundary from "replay-next/components/ErrorBoundary";
-import { getSelectedSource } from "ui/reducers/sources";
-import { useAppSelector } from "ui/setup/hooks";
-import { localStorageGetItem, localStorageSetItem } from "ui/utils/storage";
+import { SourcesContext } from "replay-next/src/contexts/SourcesContext";
 
 import SourcemapToggleSuspends from "./SourcemapToggle";
 import SourcemapVisualizerLinkSuspends from "./SourcemapVisualizerLink";
@@ -13,123 +11,13 @@ export type CursorPosition = {
   readonly line: number;
 };
 
-type ScrollPosition = {
-  sourceId: string;
-  left: number;
-  top: number;
-};
-
-const LOCAL_STORAGE_KEY = "SourceFooter.scrollPosition";
-
 function SourceFooter() {
-  const selectedSource = useAppSelector(getSelectedSource);
-  const [cursorPosition, setCursorPosition] = useState<CursorPosition>({
-    line: 0,
-    column: 0,
-  });
+  const { cursorColumnIndex, cursorLineIndex } = useContext(SourcesContext);
 
-  // On mount, restore the scroll position for the source we have selected.
-  // Only do this if it's the same source though.
-  //
-  // HACK:
-  // Note that we only do this for the most recently selected source.
-  // Trying to track and restore scroll positions for multiple sources was finicky;
-  // CodeMirror seems to have small scroll position discrepancies that were noticeable.
-  const selectedSourceOnMountRef = useRef(selectedSource);
-  useLayoutEffect(() => {
-    const selectedSourceOnMount = selectedSourceOnMountRef.current;
-    if (!selectedSourceOnMount) {
-      return;
-    }
-
-    const eventDoc = document.querySelector(".editor-mount .CodeMirror");
-    const codeMirror = (eventDoc as any)?.CodeMirror;
-    if (!codeMirror) {
-      return;
-    }
-
-    let timeoutId: NodeJS.Timeout | null = null;
-
-    try {
-      const scrollPosition = JSON.parse(localStorageGetItem(LOCAL_STORAGE_KEY));
-      if (scrollPosition != null && scrollPosition.sourceId === selectedSourceOnMount.id) {
-        // HACK:
-        // 1. CodeMirror's own CodeMirror.scrollIntoView() method should handle this but it doesn't work.
-        //    That method only scrolls up (not down) due to what looks like a logic bug in the internal implementation.
-        // 2. CodeMirror also sometimes requires an async delay before it works,
-        //    probably due to some internal initialization detail.
-        timeoutId = setTimeout(() => {
-          timeoutId = null;
-
-          codeMirror.display.scroller.scrollLeft = scrollPosition.left;
-          codeMirror.display.scroller.scrollTop = scrollPosition.top;
-        }, 1);
-      }
-
-      return () => {
-        if (timeoutId !== null) {
-          clearTimeout(timeoutId);
-        }
-      };
-    } catch (error) {}
-  }, []);
-
-  // Before unmounting, save scroll position info for this source so that it can be restored later.
-  useLayoutEffect(() => {
-    if (!selectedSource) {
-      return;
-    }
-
-    const eventDoc = document.querySelector(".editor-mount .CodeMirror");
-    const codeMirror = (eventDoc as any)?.CodeMirror;
-    if (!codeMirror) {
-      return;
-    }
-
-    return () => {
-      const scrollInfo = codeMirror.getScrollInfo();
-      if (scrollInfo) {
-        const newScrollPosition: ScrollPosition = {
-          sourceId: selectedSource.id,
-          left: scrollInfo.left,
-          top: scrollInfo.top,
-        };
-
-        localStorageSetItem(LOCAL_STORAGE_KEY, JSON.stringify(newScrollPosition));
-      }
-    };
-  });
-
-  useEffect(() => {
-    const eventDoc = document.querySelector(".editor-mount .CodeMirror");
-    const codeMirror = (eventDoc as any)?.CodeMirror;
-    if (codeMirror) {
-      const onCursorActivity = (event: any) => {
-        const { line, ch } = event.doc.getCursor();
-        setCursorPosition({ line, column: ch });
-      };
-
-      codeMirror.on("cursorActivity", onCursorActivity);
-      return () => {
-        codeMirror.off("cursorActivity", onCursorActivity);
-      };
-    }
-  });
-
-  let cursorPositionUI = null;
-  if (selectedSource) {
-    const { line, column } = cursorPosition;
-
-    const text = `(${line + 1}, ${column + 1})`;
-    // @ts-ignore
-    const title = `(Line ${line + 1}, column ${column + 1})`;
-
-    cursorPositionUI = (
-      <div className="cursor-position" title={title}>
-        {text}
-      </div>
-    );
-  }
+  const cursorPosition = {
+    column: cursorColumnIndex || 0,
+    line: cursorLineIndex || 0,
+  };
 
   return (
     <div className="source-footer-wrapper">
@@ -140,7 +28,12 @@ function SourceFooter() {
             <SourcemapVisualizerLinkSuspends cursorPosition={cursorPosition} />
           </Suspense>
         </ErrorBoundary>
-        <div className="source-footer-end">{cursorPositionUI}</div>
+
+        <div className="source-footer-end">
+          <div className="cursor-position">
+            Line {(cursorLineIndex || 0) + 1}, Column {(cursorColumnIndex || 0) + 1}
+          </div>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
### [Loom overview](https://www.loom.com/share/56df5baa948e4793ac8e65679a6f994f)

- [x] Track which line and column the user has most recently clicked on (or right-clicked on).
- [x] ~~Show this location in the Source footer and use it when opening source maps.~~ Delete footer label.
  - [x] Also deleted some old React state that didn't seem to be used anymore?
- [x] Hook the location into the source search hook to find the nearest initial match.
