### PR TITLE
Remove next-transpile-modules

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,13 +1,10 @@
 const { patchWebpackConfig } = require("next-global-css");
-const transpileModules = require("next-transpile-modules");
 const { RetryChunkLoadPlugin } = require("webpack-retry-chunk-load-plugin");
 const withPlugins = require("next-compose-plugins");
 
 const withBundleAnalyzer = require("@next/bundle-analyzer")({
   enabled: process.env.ANALYZE === "true",
 });
-
-const withTM = transpileModules(["replay-next", "design"]);
 
 /**
  * @type {Pick<
@@ -202,4 +199,4 @@ const baseNextConfig = {
   },
 };
 
-module.exports = withPlugins([withTM, withBundleAnalyzer], baseNextConfig);
+module.exports = withPlugins([withBundleAnalyzer], baseNextConfig);


### PR DESCRIPTION
In recordings of app.replay.io, the "original" sources under `packages/replay-next/` are actually transpiled sources. When I remove `next-transpile-modules` from our next config, these sources are the real originals. I've used this config locally for a while now and didn't notice any problems.