### PR TITLE
Fix click-and-drag text selection inside of a log point panel

### DIFF
--- a/packages/replay-next/components/sources/PointPanel.tsx
+++ b/packages/replay-next/components/sources/PointPanel.tsx
@@ -1,6 +1,5 @@
 import { TimeStampedPoint } from "@replayio/protocol";
 import {
-  MouseEvent,
   Suspense,
   unstable_useCacheRefresh as useCacheRefresh,
   useContext,
@@ -143,11 +142,6 @@ function PointPanelWithHitPoints({
     };
   }
 
-  // Prevent hovers over syntax highlighted tokens from showing preview popups.
-  const onMouseMove = (event: MouseEvent) => {
-    event.preventDefault();
-  };
-
   const shouldLog = point.shouldLog === POINT_BEHAVIOR_ENABLED;
 
   if (isEditing) {
@@ -185,7 +179,6 @@ function PointPanelWithHitPoints({
       <div
         className={`${shouldLog ? styles.PanelEnabled : styles.PanelDisabled} ${className}`}
         data-test-id={`PointPanel-${lineNumber}`}
-        onMouseMove={onMouseMove}
       >
         <div className={styles.LayoutRow}>
           <div className={styles.MainColumn}>
@@ -342,7 +335,6 @@ function PointPanelWithHitPoints({
       <div
         className={`${shouldLog ? styles.PanelEnabled : styles.PanelDisabled} ${className}`}
         data-test-id={`PointPanel-${lineNumber}`}
-        onMouseMove={onMouseMove}
       >
         <div className={styles.LayoutRow}>
           <div className={styles.MainColumn}>


### PR DESCRIPTION
This commit fixes the click-and-drag method of selecting text inside of a log point panel. That operation was previously getting interrupted by a `"mousemove"` event handler that called `event.preventDefault()`. This commit _removes_ that handler, which fixes the text selection problem.

---

Back in November (90c7f03) we added the following code to the `PointPanel` to prevent a preview popup showing if a user hovered over the syntax highlighted text within that panel:
```js
// Prevent hovers over syntax highlighted tokens from showing preview popups.
const onMouseMove = (event: MouseEvent) => {
  event.preventDefault();
};
```

This was necessary at the time because the preview popup was configured to try to fetch any syntax highlighted text. A few days ago (43c56b3) I changed this to be more explicit, through the use of a new `data-inspectable-token` attribute– so that we would not try to fetch previews for tokens that didn't contain inspectable values:
```jsx
<span
  className={className}
  data-column-index={token.columnIndex}
  data-inspectable-token={inspectable || undefined}
  key={key}
>
```

This more recent change means that the `preventDefault` work around is no longer required.