### PR TITLE
Fix jumping playhead to start of test after selecting it

### DIFF
--- a/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
@@ -55,7 +55,7 @@ export function TestCase({ test, index }: { test: TestItem; index: number }) {
   const testStartTime = test.relativeStartTime || 0;
   const testEndTime = testStartTime + (test.duration || 0);
 
-  const onFocus = () => {
+  const onFocus = useCallback(() => {
     if (testEndTime > testStartTime) {
       dispatch(
         setFocusRegionFromTimeRange({
@@ -66,11 +66,10 @@ export function TestCase({ test, index }: { test: TestItem; index: number }) {
     }
     dispatch(syncFocusedRegion());
     dispatch(updateFocusRegionParam());
-  };
+  }, [testStartTime, testEndTime, dispatch]);
+
   const toggleExpand = () => {
     dispatch(setSelectedTest({ index, title: test.title }));
-
-    onFocus();
   };
 
   const seekToFirstStep = useCallback(() => {
@@ -93,10 +92,11 @@ export function TestCase({ test, index }: { test: TestItem; index: number }) {
     if (isSelected) {
       setExpandSteps(true);
       seekToFirstStep();
+      onFocus();
     } else {
       setExpandSteps(false);
     }
-  }, [isSelected, seekToFirstStep]);
+  }, [isSelected, seekToFirstStep, onFocus]);
 
   const onReplay = () => {
     dispatch(startPlayback({ beginTime: testStartTime, endTime: testEndTime - 1 }));

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -87,6 +87,7 @@ export interface TestStepItemProps {
 }
 
 export function TestStepItem({ step, argString, index, id }: TestStepItemProps) {
+  const hasScrolled = useRef(false);
   const ref = useRef<HTMLDivElement>(null);
   const [localPauseData, setLocalPauseData] = useState<{
     startPauseFailed?: boolean;
@@ -217,21 +218,22 @@ export function TestStepItem({ step, argString, index, id }: TestStepItemProps) 
     }
   }, [localPauseData, loading, setLoading]);
 
+  const { endPauseId, consoleProps } = localPauseData || {};
   const onClick = useCallback(() => {
     if (id) {
       if (pointEnd) {
-        if (localPauseData?.endPauseId && localPauseData.consoleProps) {
-          setConsoleProps(localPauseData.consoleProps);
-          setPauseId(localPauseData.endPauseId);
+        if (endPauseId && consoleProps) {
+          setConsoleProps(consoleProps);
+          setPauseId(endPauseId);
         }
-        dispatch(seek(pointEnd!, step.absoluteEndTime, false, localPauseData?.endPauseId));
+        dispatch(seek(pointEnd!, step.absoluteEndTime, false, endPauseId));
       } else {
         dispatch(seekToTime(step.absoluteEndTime, false));
       }
 
       dispatch(setSelectedStep(step));
     }
-  }, [step, pointEnd, localPauseData, dispatch, setConsoleProps, id, setPauseId]);
+  }, [step, pointEnd, endPauseId, consoleProps, dispatch, setConsoleProps, id, setPauseId]);
 
   const onMouseEnter = () => {
     if (state === "paused") {
@@ -273,7 +275,8 @@ export function TestStepItem({ step, argString, index, id }: TestStepItemProps) 
   }, [isPlaying, ref, currentTime, step]);
 
   useEffect(() => {
-    if (step.error && ref.current) {
+    if (step.error && ref.current && !hasScrolled.current) {
+      hasScrolled.current = true;
       scrollIntoView(ref.current);
       onClick();
     }


### PR DESCRIPTION
Does what is says on the tin ... We had the code there before but it wasn't working because of the order of operations. Previously, we fetched the annotations when the test case row was mounted (but not yet selected). That reference (without any values because no test is selected) was captured in the `toggleExpand()` closure causing it to do nothing (because the `pointStart` value on now Line 83 was falsey.

By deferring to an effect (which we already had), we ensure that we have annotations and the seek works as expected.

Also fixes SCS-609 by moving the focus setting into the same effect and fixes the playhead landing in the wrong place when switching from a test with an error to another test caused by the effect that scrolls the error into view firing more than once.