### PR TITLE
Do not switch from cypress panel when changing view modes

### DIFF
--- a/src/ui/actions/layout.ts
+++ b/src/ui/actions/layout.ts
@@ -62,7 +62,10 @@ export function setViewMode(viewMode: ViewMode): UIThunkAction {
     // Otherwise, it's possible for the nag to not be properly dismissed.
     if (viewMode === "dev" && !localNags.includes(LocalNag.YANK_TO_SOURCE)) {
       dispatch(dismissLocalNag(LocalNag.YANK_TO_SOURCE));
-      dispatch(setSelectedPrimaryPanel("explorer"));
+      const currentPrimaryPanel = getSelectedPrimaryPanel(getState());
+      if (currentPrimaryPanel !== "cypress") {
+        dispatch(setSelectedPrimaryPanel("explorer"));
+      }
     }
 
     // If switching to non-dev mode, we check the selectedPrimaryPanel and update to comments

--- a/src/ui/state/layout.ts
+++ b/src/ui/state/layout.ts
@@ -10,7 +10,7 @@ export type LayoutState = {
 };
 
 export type ViewMode = "dev" | "non-dev";
-export const VIEWER_PANELS = ["events", "comments"] as const;
+export const VIEWER_PANELS = ["cypress", "events", "comments"] as const;
 type ViewerPrimaryPanelName = typeof VIEWER_PANELS[number];
 export type PrimaryPanelName =
   | "explorer"


### PR DESCRIPTION
* Adds `cypress` as a viewer panel
* Suppresses switching to the source explorer when switching to Devtools

## Additional Considerations

I think this is worth trying but I worry the devtools features will be missed by not switching the primary panel which draws attention to that side. The new icons appearing on the left are easy to miss.

cc: @jonbell-lot23 