### PR TITLE
Disable opening test case if it is missing steps

### DIFF
--- a/src/devtools/client/debugger/src/components/TestInfo/ContextMenu.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/ContextMenu.tsx
@@ -24,8 +24,8 @@ function ContextMenu({
   const classnames = classNames.bind(styles);
   const actions = useTestStepActions(testStep);
 
-  const isFirstStep = test.steps[0].id === testStep.id;
-  const isLastStep = test.steps[test.steps.length - 1].id === testStep.id;
+  const isFirstStep = test.steps?.[0].id === testStep.id;
+  const isLastStep = test.steps?.[test.steps.length - 1].id === testStep.id;
 
   useModalDismissSignal(ref, hide, true);
 

--- a/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
@@ -47,7 +47,7 @@ export const TestCaseContext = createContext<TestCaseContextType>(null as any);
 export function TestCase({ test, index }: { test: TestItem; index: number }) {
   const [expandSteps, setExpandSteps] = useState(false);
   const dispatch = useAppDispatch();
-  const expandable = test.steps || test.error;
+  const expandable = !!test.steps;
   const selectedTest = useAppSelector(getSelectedTest);
   const isSelected = selectedTest === index;
   const annotationsEnd = useAppSelector(getReporterAnnotationsForTitleEnd);

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -175,7 +175,7 @@ export type TestItem = {
   result: TestResult;
   relativeStartTime?: number;
   duration?: number;
-  steps: TestStep[];
+  steps?: TestStep[];
   id?: string;
   path?: string[];
   error?: TestItemError;


### PR DESCRIPTION
We were throwing an error trying to access `test.steps` when trying to open a test with an error but no steps.

I changed the condition to disable the test when we're missing steps but also fixed the code to handle steps missing. I decided to continue to disable interactivity on the test cases for now because clicking on one is a bad experience (empty cypress panel, forever loading step details). Will open a follow up to add some in-app docs on configuring the support side of the plugin in this case.