### PR TITLE
Upgrade react-resizable-panels from 0.0.33 to 0.0.34

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "react-lazyload": "^3.2.0",
     "react-merge-refs": "^1.1.0",
     "react-redux": "^8.0.2",
-    "react-resizable-panels": "^0.0.33",
+    "react-resizable-panels": "^0.0.34",
     "react-table": "^7.7.0",
     "react-tooltip": "^4.2.21",
     "react-transition-group": "^4.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19734,13 +19734,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-resizable-panels@npm:^0.0.33":
-  version: 0.0.33
-  resolution: "react-resizable-panels@npm:0.0.33"
+"react-resizable-panels@npm:^0.0.34":
+  version: 0.0.34
+  resolution: "react-resizable-panels@npm:0.0.34"
   peerDependencies:
     react: ^16.14.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0
-  checksum: a99c319b08e40d8926eadfa2d51986ef784a583f6ad2767b4b15feefa44d18656a31eaddd1485057b23018069d2220ef9bdb292cd27ecc7393a36e9acc6c7897
+  checksum: 42f70195663fc1385a0567eb2fb8a56c63322877d2bf36cce10daa5c84d8d0cbc26321847798ade32eda583a7e53bdee9404b2b95e96615898377e0aad67669f
   languageName: node
   linkType: hard
 
@@ -20158,7 +20158,7 @@ __metadata:
     react-lazyload: ^3.2.0
     react-merge-refs: ^1.1.0
     react-redux: ^8.0.2
-    react-resizable-panels: ^0.0.33
+    react-resizable-panels: ^0.0.34
     react-table: ^7.7.0
     react-tooltip: ^4.2.21
     react-transition-group: ^4.4.2


### PR DESCRIPTION
View the [v0.0.34 Changelog](https://github.com/bvaughn/react-resizable-panels/blob/main/packages/react-resizable-panels/CHANGELOG.md#0034).

This is just a janitorial commit.