### PR TITLE
Don't let the CypressToggler wrapper steal mouse events (FE-1128)

### DIFF
--- a/src/devtools/client/debugger/src/components/TestInfo/CypressToggler.module.css
+++ b/src/devtools/client/debugger/src/components/TestInfo/CypressToggler.module.css
@@ -7,6 +7,7 @@
   justify-content: center;
   padding-bottom: 0.5rem;
   filter: drop-shadow(0px 2px 4px rgba(0, 0, 0, 0.25));
+  pointer-events: none;
 }
 
 .ToggleContainer {
@@ -14,6 +15,7 @@
   display: flex;
   background: var(--theme-toggle-bgcolor);
   padding: 0.25rem;
+  pointer-events: auto;
 }
 
 .ToggleButton {


### PR DESCRIPTION
Fixes FE-1128
The `CypressToggler` component shows an overlay (with Before/After buttons) over the `Video` component. The wrapper of that overlay covers the entire `Video` component and hence the `Video` component doesn't receive any mouse events anymore.