### PR TITLE
Use object and eval caches for step details

### DIFF
--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -24,13 +24,6 @@ import { TestInfoContext } from "./TestInfo";
 import { TestInfoContextMenuContext } from "./TestInfoContextMenuContext";
 import { TestStepRow } from "./TestStepRow";
 
-export function returnFirst<T, R>(
-  list: T[] | undefined,
-  fn: (value: T, index: number, list: T[]) => R | null
-) {
-  return list ? list.reduce<R | null>((acc, v, i, l) => acc ?? fn(v, i, l), null) : null;
-}
-
 function useStepState(step: AnnotatedTestStep) {
   const currentTime = useAppSelector(getCurrentTime);
   const currentPoint = useAppSelector(getCurrentPoint);
@@ -174,8 +167,8 @@ export function TestStepItem({ step, argString, index, id }: TestStepItemProps) 
                 endPauseResult.pauseId,
                 logResult.returned.object
               );
-              const consolePropsProperty = returnFirst(logObject.preview?.properties, p =>
-                p.name === "consoleProps" ? p : null
+              const consolePropsProperty = logObject.preview?.properties?.find(
+                p => p.name === "consoleProps"
               );
 
               if (consolePropsProperty?.object) {

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -136,18 +136,15 @@ export function TestStepItem({ step, argString, index, id }: TestStepItemProps) 
                 true
               );
 
-              const length: number | undefined = cmdObject?.preview?.properties?.find(
-                o => o.name === "length"
-              )?.value;
-              const nodeIds = Array.from(
-                { length: length || 0 },
-                (_, i) =>
-                  cmdObject.preview?.properties?.find(
-                    obj =>
-                      obj.object ===
-                      cmdObject?.preview?.properties?.find(p => p.name === String(i))?.object
-                  )?.object
-              ).filter((s): s is string => typeof s === "string");
+              const props = cmdObject?.preview?.properties;
+              const length: number = props?.find(o => o.name === "length")?.value || 0;
+              const nodeIds = [];
+              for (let i = 0; i < length; i++) {
+                const v = props?.find(p => p.name === String(i));
+                if (v?.object) {
+                  nodeIds.push(v.object);
+                }
+              }
 
               setSubjectNodePauseData({ pauseId: endPauseResult.pauseId, nodeIds });
             }

--- a/src/ui/hooks/useTestStepActions.ts
+++ b/src/ui/hooks/useTestStepActions.ts
@@ -1,7 +1,6 @@
 import { useContext } from "react";
 
 import { selectLocation } from "devtools/client/debugger/src/actions/sources";
-import { returnFirst } from "devtools/client/debugger/src/components/TestInfo/TestStepItem";
 import { getContext } from "devtools/client/debugger/src/selectors";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { getCurrentPoint } from "ui/actions/app";
@@ -100,8 +99,8 @@ export const useTestStepActions = (testStep: AnnotatedTestStep | null) => {
 
     if (frames) {
       // find the cypress marker frame
-      const markerFrameIndex = returnFirst(frames, (f: any, i: any, l: any) =>
-        f.functionName === "__stackReplacementMarker" ? i : null
+      const markerFrameIndex = frames.findIndex(
+        (f: any, i: any, l: any) => f.functionName === "__stackReplacementMarker"
       );
 
       // and extract its sourceId
@@ -113,9 +112,9 @@ export const useTestStepActions = (testStep: AnnotatedTestStep | null) => {
 
         // then search from the top for the first frame from the same source
         // as the marker (which should be cypress_runner.js) and return it
-        const frame = returnFirst(userFrames, (f, i, l) => {
-          return l[i + 1]?.functionLocation?.some(fl => fl.sourceId === markerSourceId) ? f : null;
-        });
+        const frame = userFrames.find((f, i, l) =>
+          l[i + 1]?.functionLocation?.some(fl => fl.sourceId === markerSourceId)
+        );
 
         const location = frame?.location[frame.location.length - 1];
 


### PR DESCRIPTION
The protocol expects clients to cache objects already returned in previous calls but this code wasn't using the caches already in place for protocol objects. Swapping both the object lookups and the expression eval greatly improves the UX and reduces UI crashes for that component caused by objects missing from the cache.