### PR TITLE
Hide objects from step args

### DIFF
--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -309,7 +309,7 @@ export function TestStepItem({ step, argString, index, id }: TestStepItemProps) 
       <button
         onClick={onClick}
         className="flex w-0 flex-grow items-start space-x-2 text-start"
-        title={`Step ${index + 1}: ${step.name} ${argString}`}
+        title={`Step ${index + 1}: ${step.name} ${argString || ""}`}
       >
         <div title={"" + displayedProgress} className="flex h-4 items-center">
           <ProgressBar progress={displayedProgress} error={!!step.error} />

--- a/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
@@ -250,7 +250,9 @@ function TestSection({ events, header }: { events: CompositeTestEvent[]; header?
             step={s}
             key={s.id}
             index={s.index}
-            argString={s.args?.toString()}
+            argString={
+              s.args ? s.args.filter((s): s is string => s && typeof s === "string").join(", ") : ""
+            }
             id={s.id}
           />
         ) : type === "network" ? (

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -204,7 +204,7 @@ export interface Annotation {
 }
 
 export type TestStep = {
-  args?: string[];
+  args?: any[];
   name: string;
   duration: number;
   relativeStartTime?: number;


### PR DESCRIPTION
Some args can be objects. For now, let's hide them rather than displaying `[Object object]`.