### PR TITLE
Add disabled print statement treatment

### DIFF
--- a/packages/replay-next/components/sources/log-point-panel/LogPointPanel.module.css
+++ b/packages/replay-next/components/sources/log-point-panel/LogPointPanel.module.css
@@ -4,12 +4,21 @@
   flex-direction: column;
   padding: 0.5rem;
   gap: 0.25rem;
-
   --badge-picker-button-size: 1.25rem;
   --badge-picker-icon-size: 1rem;
 }
 .PanelEnabled {
   background-color: var(--point-panel-background-color);
+}
+
+.PanelDisabled {
+  background: repeating-linear-gradient(
+    45deg,
+    var(--theme-base-100),
+    var(--theme-base-100) 5px,
+    var(--point-panel-background-color) 5px,
+    var(--point-panel-background-color) 10px
+  );
 }
 
 .Loader {

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/Breakpoint.css
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/Breakpoint.css
@@ -54,6 +54,16 @@
   border-top: 1px solid var(--theme-splitter-color);
 }
 
+.disabled {
+  background: repeating-linear-gradient(
+    45deg,
+    var(--theme-base-95),
+    var(--theme-base-95) 5px,
+    var(--theme-base-100) 5px,
+    var(--theme-base-100) 10px
+  );
+}
+
 .breakpoints-list .breakpoint:hover {
   background: var(--theme-toolbar-background-alt);
 }

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/Breakpoint.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/Breakpoint.tsx
@@ -149,6 +149,7 @@ class Breakpoint extends PureComponent<BreakpointProps> {
         className={classnames({
           breakpoint,
           paused: this.isCurrentlyPausedAtBreakpoint(frame),
+          disabled: !isChecked,
         })}
         data-test-name="Breakpoint"
         data-test-type={type}


### PR DESCRIPTION
Old, where a disabled state just looked like floating in space:
![image](https://user-images.githubusercontent.com/9154902/213944882-d39b7a18-91ed-4c7a-ac90-ca169db5e752.png)

New, where we use a pattern treatment to call out disabled state:
![image](https://user-images.githubusercontent.com/9154902/213944899-89b4dd01-e79f-432f-93e6-061002437ac5.png)

FAQ

Q: Do we use a pattern treatment like this anywhere else in the product?
A: Nope, this is our first time.

Q: Have we considered other approaches?
A: Yup, we explored colors. They don't work very well because we have white on grey textfields, surrounded by white. (or the reverse in dark theme). Using another shade of gray wouldn't have explained much, and colors such as red and yellow mean "warn" and "error," whereas things like blue and green often mean success or action. 

Q: Shouldn't we dim/disable the textfields themselves?
A: Maybe? I don't know if it's strictly necessary, but I could see it being useful. On the other hand, I could also see it getting in people's way when they're trying to add a conditional or otherwise manipulate the field. I'd propose trying this treatment without disabling the functionality.