### PR TITLE
Wait for the first LoadedRegions event before initializing devtools

### DIFF
--- a/packages/protocol/thread/thread.ts
+++ b/packages/protocol/thread/thread.ts
@@ -160,6 +160,9 @@ class _ThreadFront {
   // Waiter which resolves when the debugger has loaded and we've warped to the endpoint.
   initializedWaiter = defer<void>();
 
+  // Waiter which resolves when there is at least one loading region
+  loadingHasBegun = defer<void>();
+
   // Waiter which resolves when all sources have been loaded.
   private allSourcesWaiter = defer<void>();
   hasAllSources = false;
@@ -332,6 +335,8 @@ class _ThreadFront {
 
       client.Session.addLoadedRegionsListener((loadedRegions: LoadedRegions) => {
         this._mostRecentLoadedRegions = loadedRegions;
+
+        this.loadingHasBegun.resolve();
 
         this._loadedRegionsListeners.forEach(callback => callback(loadedRegions));
       });

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -331,7 +331,7 @@ export function createSocket(
 
       ThreadFront.on("paused", ({ point }) => dispatch(setCurrentPoint(point)));
 
-      await ThreadFront.waitForSession();
+      await ThreadFront.loadingHasBegun.promise;
       dispatch(jumpToInitialPausePoint());
     } catch (e: any) {
       const currentError = selectors.getUnexpectedError(getState());


### PR DESCRIPTION
This is a partial revert of #8451.
That PR was necessary because we couldn't rely on getting at least one `LoadedRegions` event from the backend (see [FE-1076](https://linear.app/replay/issue/FE-1076/session-is-created-but-sessionwaiter-never-resolves)) and then devtools would be stuck. But the PR also introduced a different problem: if [this check](https://github.com/replayio/devtools/blob/ba7e3ab36e7253cb92e91178a7470f5c35ea089d/src/ui/actions/timeline.ts#L125) was executed before we received a `LoadedRegions` event, devtools would use the end of the recording as the initial pause point.
The backend/protocol issue was fixed in replayio/backend#6871, so now we can wait for the first `LoadedRegions` event again and ensure we use the right initial pause point.