### PR TITLE
Plaintext Source preview handles bracket notation

### DIFF
--- a/packages/replay-next/components/sources/utils/getExpressionFromString.test.ts
+++ b/packages/replay-next/components/sources/utils/getExpressionFromString.test.ts
@@ -171,6 +171,17 @@ describe("getExpressionFromString", () => {
     expect(getExpressionHelper("test(foo, bar|)")).toBe("bar");
   });
 
+  // FE-1136
+  it("should properly handle bracket notation", () => {
+    expect(getExpressionHelper("const foo = b|ar[baz];")).toBe("bar");
+    expect(getExpressionHelper("const foo = ba|r[baz];")).toBe("bar");
+    expect(getExpressionHelper("const foo = bar|[baz];")).toBe("bar");
+
+    expect(getExpressionHelper("const foo = bar[b|az];")).toBe("bar[baz]");
+    expect(getExpressionHelper("const foo = bar[ba|z];")).toBe("bar[baz]");
+    expect(getExpressionHelper("const foo = bar[baz|];")).toBe("bar[baz]");
+  });
+
   describe("minified/mangled code", () => {
     it("keywords", () => {
       expect(getExpressionHelper('!fu|nction(){"use strict";var e={4:function(e,t,n)')).toBe(

--- a/packages/replay-next/components/sources/utils/getExpressionFromString.ts
+++ b/packages/replay-next/components/sources/utils/getExpressionFromString.ts
@@ -75,6 +75,7 @@ export default function getExpressionFromString(
       case ")":
       case ",":
       case ".":
+      case "[":
         break nextLoop;
     }
 


### PR DESCRIPTION
Fixes issue captured in [Replay 46a7334d-07a6-4050-bea1-6df7c54a2835](https://app.replay.io/recording/46a7334d-07a6-4050-bea1-6df7c54a2835) and adds regression tests.

cc @Andarist 