### PR TITLE
Code type-ahead does not suggest names that require bracket notation

### DIFF
--- a/packages/replay-next/components/lexical/plugins/code-completion/findMatches.ts
+++ b/packages/replay-next/components/lexical/plugins/code-completion/findMatches.ts
@@ -3,7 +3,6 @@ import { FrameId, PauseId, Property, Scope } from "@replayio/protocol";
 import { getObjectWithPreviewSuspense } from "replay-next/src/suspense/ObjectPreviews";
 import { evaluateSuspense } from "replay-next/src/suspense/PauseCache";
 import { getFrameScopesSuspense } from "replay-next/src/suspense/ScopeCache";
-import { isNumeric } from "replay-next/src/utils/text";
 import { ReplayClientInterface } from "shared/client/types";
 
 import findMatchingScopesAndProperties from "./findMatchingScopesAndProperties";
@@ -96,11 +95,6 @@ function fetchQueryData(
         }
       }
     }
-  }
-
-  // Type-ahead should not suggest numeric values (e.g. array indices).
-  if (properties) {
-    properties = properties.filter(({ name }) => !isNumeric(name));
   }
 
   return { properties, scopes };

--- a/packages/replay-next/components/lexical/plugins/code-completion/findMatches.ts
+++ b/packages/replay-next/components/lexical/plugins/code-completion/findMatches.ts
@@ -3,6 +3,7 @@ import { FrameId, PauseId, Property, Scope } from "@replayio/protocol";
 import { getObjectWithPreviewSuspense } from "replay-next/src/suspense/ObjectPreviews";
 import { evaluateSuspense } from "replay-next/src/suspense/PauseCache";
 import { getFrameScopesSuspense } from "replay-next/src/suspense/ScopeCache";
+import { isNumeric } from "replay-next/src/utils/text";
 import { ReplayClientInterface } from "shared/client/types";
 
 import findMatchingScopesAndProperties from "./findMatchingScopesAndProperties";
@@ -95,6 +96,11 @@ function fetchQueryData(
         }
       }
     }
+  }
+
+  // Type-ahead should not suggest numeric values (e.g. array indices).
+  if (properties) {
+    properties = properties.filter(({ name }) => !isNumeric(name));
   }
 
   return { properties, scopes };

--- a/packages/replay-next/components/lexical/plugins/code-completion/findMatchingScopesAndProperties.test.ts
+++ b/packages/replay-next/components/lexical/plugins/code-completion/findMatchingScopesAndProperties.test.ts
@@ -87,14 +87,15 @@ describe("findMatches", () => {
     ).toEqual(["Array", "array", "UintArray"]);
   });
 
-  it("should escape special characters", () => {
+  // FE-1133
+  it("should not suggest array indices or any other names that require bracket notations", () => {
     expect(
       findMatches(
+        "array",
         null,
-        "fb(",
-        null,
-        createPropertiesFromNames("fooBar()", "fooBarBaz()", "barBaz()")
+        createScopesFromNames(),
+        createPropertiesFromNames("0", "1", "foo", "foo-bar", "foo_bar", "qux2")
       )
-    ).toEqual(["fooBar()", "fooBarBaz()"]);
+    ).toEqual(["foo", "foo_bar", "qux2"]);
   });
 });

--- a/packages/replay-next/src/utils/text.test.ts
+++ b/packages/replay-next/src/utils/text.test.ts
@@ -1,6 +1,24 @@
-import { truncate } from "replay-next/src/utils/text";
+import { isNumeric, truncate } from "replay-next/src/utils/text";
 
 describe("text utils", () => {
+  describe("isNumeric", () => {
+    it("should reject non-numeric values", () => {
+      expect(isNumeric("")).toBe(false);
+      expect(isNumeric("a")).toBe(false);
+      expect(isNumeric("true")).toBe(false);
+      expect(isNumeric(" 1")).toBe(false);
+      expect(isNumeric("1 ")).toBe(false);
+    });
+
+    it("should accept numeric values", () => {
+      expect(isNumeric("1")).toBe(true);
+      expect(isNumeric("123")).toBe(true);
+      expect(isNumeric("1.2")).toBe(true);
+      expect(isNumeric(".1")).toBe(true);
+      expect(isNumeric("0.234")).toBe(true);
+    });
+  });
+
   describe("truncate", () => {
     it("should not truncate strings shorter than the max length", () => {
       expect(truncate("12345", { maxLength: 10 })).toEqual("12345");

--- a/packages/replay-next/src/utils/text.ts
+++ b/packages/replay-next/src/utils/text.ts
@@ -1,3 +1,12 @@
+export function isNumeric(text: string): boolean {
+  return (
+    typeof text === "string" &&
+    text.match(/\s/) === null &&
+    !isNaN(text as any) &&
+    !isNaN(parseFloat(text))
+  );
+}
+
 export function truncate(
   text: string,
   options: {


### PR DESCRIPTION
This includes array indices, properties with hyphens, etc. (This mirrors Chrome's behavior.)

Given the following object:
```js
object = {
  0: 1,
  foo: 2,
  foo_bar: 3,
  "foo-bar": 4,
  bar2: 5,
}
```

Typing `object.` should recommend "foo", "foo_bar", and "bar2" (along with any inherited properties). It should _not_ recommend "0" or "foo-bar" as those would not be valid suggestions using dot notation.

Typing `object["` should recommend "foo-bar" (in addition to the above) but our code editor plug-in does not currently support suggestions for bracket notation. (No one has asked for this yet. If they do, we could probably add it.)

cc @Andarist 