### PR TITLE
Testsuites color and alignment polish

### DIFF
--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -479,7 +479,7 @@
   --testsuites-error-bgcolor: var(--background-color-error);
   --testsuites-error-bgcolor-hover: #7a1712;
   --testsuites-error-icon-bgcolor: rgb(255, 115, 115);
-  --testsuites-error-color: rgb(255, 115, 115);
+  --testsuites-error-color: rgb(255, 197, 197);
   --testsuites-steps-bgcolor: var(--theme-base-100);
   --testsuites-steps-bgcolor-hover: var(--theme-base-90);
   --testsuites-success-color: #30e60b;

--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -478,9 +478,11 @@
   /* Testsuites (Dark) */
   --testsuites-error-bgcolor: var(--background-color-error);
   --testsuites-error-bgcolor-hover: #7a1712;
-  --testsuites-error-color: white;
+  --testsuites-error-icon-bgcolor: rgb(255, 115, 115);
+  --testsuites-error-color: rgb(255, 115, 115);
   --testsuites-steps-bgcolor: var(--theme-base-100);
   --testsuites-steps-bgcolor-hover: var(--theme-base-90);
+  --testsuites-success-color: #30e60b;
 
   /* To organise (Dark) */
   --timejump-text: var(--buttontext-color);
@@ -950,9 +952,11 @@
   /* Testsuites (Light) */
   --testsuites-error-bgcolor: #ffe9e9;
   --testsuites-error-bgcolor-hover: #ffe0e0;
+  --testsuites-error-icon-bgcolor: #eb5757;
   --testsuites-error-color: #eb5757;
   --testsuites-steps-bgcolor: #f7f7f7;
   --testsuites-steps-bgcolor-hover: #f4f4f4;
+  --testsuites-success-color: #058b00;
 
   /* To organise (Light) */
   --timejump-text: var(--buttontext-color);

--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -476,7 +476,7 @@
   --breakpoint-label: var(--cm-string);
 
   /* Testsuites (Dark) */
-  --testsuites-error-bgcolor: #770702;
+  --testsuites-error-bgcolor: var(--background-color-error);
   --testsuites-error-bgcolor-hover: #7a1712;
   --testsuites-error-color: white;
   --testsuites-steps-bgcolor: var(--theme-base-100);

--- a/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
@@ -20,6 +20,7 @@ import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { TestItem, TestResult, TestStep } from "ui/types";
 
 import { TestSteps } from "./TestSteps";
+import styles from "src/ui/components/SidePanel.module.css";
 
 export type TestCaseContextType = {
   test: TestItem;
@@ -155,7 +156,7 @@ export function Status({ result }: { result: TestResult }) {
     <Icon
       filename={result === "passed" ? "testsuites-success" : "testsuites-fail"}
       size="small"
-      className={result === "passed" ? "bg-[#219653]" : "bg-[#EB5757]"}
+      className={result === "passed" ? styles.SuccessIcon : styles.ErrorIcon}
     />
   );
 }

--- a/src/ui/components/SidePanel.module.css
+++ b/src/ui/components/SidePanel.module.css
@@ -30,3 +30,7 @@
 .ErrorText {
   color: var(--testsuites-error-color);
 }
+
+.ErrorTextLighter {
+  color: var(--testsuites-error-icon-bgcolor);
+}

--- a/src/ui/components/SidePanel.module.css
+++ b/src/ui/components/SidePanel.module.css
@@ -14,3 +14,19 @@
   border-color: var(--theme-border);
   align-items: center;
 }
+
+.SuccessIcon {
+  background-color: var(--testsuites-success-color);
+}
+
+.SuccessText {
+  color: var(--testsuites-success-color);
+}
+
+.ErrorIcon {
+  background-color: var(--testsuites-error-icon-bgcolor);
+}
+
+.ErrorText {
+  color: var(--testsuites-error-color);
+}

--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -63,7 +63,7 @@ function TestResultsSummary({ testCases }: { testCases: TestItem[] }) {
       </div>
       <div className="mr-1 flex items-center gap-1">
         <Icon filename="testsuites-fail" size="small" className={styles.ErrorIcon} />
-        <div className={`text-sm ${styles.ErrorText}`}>{failed}</div>
+        <div className={`text-sm ${styles.ErrorTextLighter}`}>{failed}</div>
       </div>
     </div>
   );
@@ -141,16 +141,12 @@ function EventsPane({ items }: { items: any[] }) {
       <div className="flex h-full flex-1 flex-col overflow-hidden">
         <div className={styles.ToolbarHeader}>
           {selectedTest !== null ? (
-            <button
-              onClick={onReset}
-              className="flex flex-grow gap-1 truncate"
-              style={{ alignSelf: "flex-start" }}
-            >
+            <button onClick={onReset} className="my-1 flex flex-grow gap-1 self-start truncate">
               <div
-                className="img arrowhead-right h-32 w-32"
-                style={{ transform: "rotate(180deg)" }}
+                className="img arrowhead-right mt-1 h-32 w-32"
+                style={{ transform: "rotate(180deg)", marginTop: "2px" }}
               />
-              <span className="flex-grow text-left" style={{ whiteSpace: "normal" }}>
+              <span className="flex-grow whitespace-normal text-left">
                 {" "}
                 {testCases[selectedTest].title}
               </span>
@@ -158,8 +154,7 @@ function EventsPane({ items }: { items: any[] }) {
                 <Icon
                   filename="testsuites-fail"
                   size="small"
-                  className="bg-red-500"
-                  style={{ alignSelf: "flex-start" }}
+                  className={`self-start ${styles.ErrorIcon}`}
                 />
               ) : (
                 <Icon

--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -58,12 +58,12 @@ function TestResultsSummary({ testCases }: { testCases: TestItem[] }) {
   return (
     <div className="ml-4 flex gap-2 px-1 py-1">
       <div className="flex items-center gap-1">
-        <Icon filename="testsuites-success" size="small" className="bg-green-700" />
-        <div className="text-sm text-green-700">{passed}</div>
+        <Icon filename="testsuites-success" size="small" className={styles.SuccessIcon} />
+        <div className={`text-sm ${styles.SuccessText}`}>{passed}</div>
       </div>
       <div className="mr-1 flex items-center gap-1">
-        <Icon filename="testsuites-fail" size="small" className="bg-red-500" />
-        <div className="text-sm text-red-500">{failed}</div>
+        <Icon filename="testsuites-fail" size="small" className={styles.ErrorIcon} />
+        <div className={`text-sm ${styles.ErrorText}`}>{failed}</div>
       </div>
     </div>
   );
@@ -144,7 +144,7 @@ function EventsPane({ items }: { items: any[] }) {
             <button
               onClick={onReset}
               className="flex flex-grow gap-1 truncate"
-              style={{ minHeight: "64px", alignSelf: "flex-start" }}
+              style={{ alignSelf: "flex-start" }}
             >
               <div
                 className="img arrowhead-right h-32 w-32"
@@ -165,7 +165,7 @@ function EventsPane({ items }: { items: any[] }) {
                 <Icon
                   filename="testsuites-success"
                   size="medium"
-                  className="bg-green-700"
+                  className={styles.SuccessIcon}
                   style={{ alignSelf: "flex-start" }}
                 />
               )}
@@ -211,7 +211,7 @@ function TestRunAttributes({ workspaceId, testRunId }: { workspaceId: string; te
   };
 
   return (
-    <div className="p-2">
+    <div className="p-2 pt-0">
       <Attributes testRun={thisSpecRun} />
     </div>
   );

--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -138,7 +138,7 @@ function EventsPane({ items }: { items: any[] }) {
 
   if (recording?.metadata?.test?.tests?.length) {
     return (
-      <div className="flex flex-1 flex-col overflow-hidden" style={{ flexWrap: "wrap" }}>
+      <div className="flex h-full flex-1 flex-col overflow-hidden">
         <div className={styles.ToolbarHeader}>
           {selectedTest !== null ? (
             <button

--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -138,17 +138,37 @@ function EventsPane({ items }: { items: any[] }) {
 
   if (recording?.metadata?.test?.tests?.length) {
     return (
-      <div className="flex h-full flex-1 flex-col overflow-hidden">
+      <div className="flex flex-1 flex-col overflow-hidden" style={{ flexWrap: "wrap" }}>
         <div className={styles.ToolbarHeader}>
           {selectedTest !== null ? (
-            <button onClick={onReset} className="flex flex-grow items-center gap-1 truncate">
-              <MaterialIcon>chevron_left</MaterialIcon>
+            <button
+              onClick={onReset}
+              className="flex flex-grow gap-1 truncate"
+              style={{ minHeight: "64px", alignSelf: "flex-start" }}
+            >
+              <div
+                className="img arrowhead-right h-32 w-32"
+                style={{ transform: "rotate(180deg)" }}
+              />
+              <span className="flex-grow text-left" style={{ whiteSpace: "normal" }}>
+                {" "}
+                {testCases[selectedTest].title}
+              </span>
               {testCases[selectedTest].error ? (
-                <Icon filename="testsuites-fail" size="small" className="bg-red-500" />
+                <Icon
+                  filename="testsuites-fail"
+                  size="small"
+                  className="bg-red-500"
+                  style={{ alignSelf: "flex-start" }}
+                />
               ) : (
-                <Icon filename="testsuites-success" size="small" className="bg-green-700" />
+                <Icon
+                  filename="testsuites-success"
+                  size="medium"
+                  className="bg-green-700"
+                  style={{ alignSelf: "flex-start" }}
+                />
               )}
-              <span className="flex-grow text-left"> {testCases[selectedTest].title}</span>
             </button>
           ) : (
             <>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3957,18 +3957,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@replayio/playwright@npm:0.3.11":
-  version: 0.3.11
-  resolution: "@replayio/playwright@npm:0.3.11"
+"@replayio/playwright@npm:0.3.16":
+  version: 0.3.16
+  resolution: "@replayio/playwright@npm:0.3.16"
   dependencies:
-    "@replayio/replay": ^0.10.7
-    "@replayio/test-utils": ^0.3.5
+    "@replayio/replay": ^0.12.0
+    "@replayio/test-utils": ^0.4.0
     uuid: ^8.3.2
   peerDependencies:
     "@playwright/test": 1.19.x
   bin:
     replayio-playwright: bin/replayio-playwright.js
-  checksum: 7d6a81cdef66666c0603075daf5ebb84b8f12ecd946f9e8bfb544370e4e7f7ec339cae67171968e5913c7827636c273aef6161ac1ffa006792d3770132b38739
+  checksum: 752228129cf7499d8b8f199c1108105698a3119e04a51a546c94bf6784cd8ac178dc34780ac7ee4d14360603220811a2813f4f1724847498a2bad2e5b7c87fbd
   languageName: node
   linkType: hard
 
@@ -3993,21 +3993,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@replayio/replay@npm:^0.10.7":
-  version: 0.10.7
-  resolution: "@replayio/replay@npm:0.10.7"
+"@replayio/replay@npm:^0.12.0":
+  version: 0.12.0
+  resolution: "@replayio/replay@npm:0.12.0"
   dependencies:
     "@replayio/sourcemap-upload": ^1.0.5
     commander: ^7.2.0
     debug: ^4.3.4
     is-uuid: ^1.0.2
     jsonata: ^1.8.6
+    node-fetch: ^2.6.8
+    p-map: ^4.0.0
     superstruct: ^0.15.4
     text-table: ^0.2.0
     ws: ^7.5.0
   bin:
     replay: bin/replay.js
-  checksum: ed1d256026f71ad6e4041a2083e97561586e82bed33887ffd277a3106b026bad0e96337acaf814742890ebb61eb053977aacf0096d6e06ec064ec3f34d9b1599
+  checksum: ccc278b5ecd55197d098e8c1e404fa0cfd103192cc94d47ef544641e4b4a2fd73a5fe2025b6d63798c980dde993d319b7a0b38ff57196c5506561c14128fc8d4
   languageName: node
   linkType: hard
 
@@ -4055,15 +4057,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@replayio/test-utils@npm:^0.3.5":
-  version: 0.3.5
-  resolution: "@replayio/test-utils@npm:0.3.5"
+"@replayio/test-utils@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@replayio/test-utils@npm:0.4.0"
   dependencies:
-    "@replayio/replay": ^0.10.7
+    "@replayio/replay": ^0.12.0
     "@types/node-fetch": ^2.6.2
     node-fetch: ^2.6.7
     uuid: ^8.3.2
-  checksum: c620d00a62c9576bb87a4825cecc306322c84cb10c4b76e87dd6da22632ebbeafc044375306f0395102f7eb89c913d727698f4fb0ae419b3818973dbf57f4b20
+  checksum: 9936f553fab1a2d224a89b1df709da40c7beaa81660543948d1befa06d8da87958693fb288a14ff1f8dd9de4f9a2dd265d87510b26f471851a8cf42d7fb886d4
   languageName: node
   linkType: hard
 
@@ -12772,7 +12774,7 @@ __metadata:
   dependencies:
     "@playwright/test": ^1.25.1
     "@recordreplay/playwright": ^1.18.3
-    "@replayio/playwright": 0.3.11
+    "@replayio/playwright": 0.3.16
     chalk: ^4
     cli-spinners: ^2.7.0
     log-update: ^4
@@ -17487,6 +17489,20 @@ __metadata:
     encoding:
       optional: true
   checksum: 8d816ffd1ee22cab8301c7756ef04f3437f18dace86a1dae22cf81db8ef29c0bf6655f3215cb0cdb22b420b6fe141e64b26905e7f33f9377a7fa59135ea3e10b
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^2.6.8":
+  version: 2.6.8
+  resolution: "node-fetch@npm:2.6.8"
+  dependencies:
+    whatwg-url: ^5.0.0
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: 91f57be68e29f9b1382750693619e199733a6936998e6d618f1aa779853ad8fc4a2facf170db7957bf1d2510bad33449edf74b5802713d81b63de5986fa3be00
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Improvements**

* Making more use of css modules rather than inline styles and tailwind
* Adjusted the header to be more consistent between hub and spoke ([DES-251](https://linear.app/replay/issue/DES-251/design-taller-header-for-spoke-in-testsuites))
* Tweaked dark theme colors for better contrast (more to do here)
* Icon moved to the right in the "spoke" view
* Better spacing overall

**Review note**

There's a lot of legacy cruft in these files (such as inline styles) so I'm going to keep filing PRs iteratively to fix it all. But I want to make sure to ship smaller things more frequently rather than trying to do everything in a giant ticket.


**Screenshots**

Here's the "hub" view:
![Group 9](https://user-images.githubusercontent.com/9154902/214456889-c9114398-8436-4739-832a-9e1279300beb.png)
![Group 10](https://user-images.githubusercontent.com/9154902/214456878-895969d4-b4e4-4f9a-9c81-b99c020c64ea.png)

And here's the "spoke" view:
![Group 11](https://user-images.githubusercontent.com/9154902/214456939-8675a842-2cec-422a-aa12-e3a3f607e24e.png)
![Group 12](https://user-images.githubusercontent.com/9154902/214456929-b257e42e-bac0-4171-b1b6-10870f37e38c.png)