### PR TITLE
Fix collaborator heading showing for non-owner

### DIFF
--- a/src/ui/components/shared/SharingModal/Collaborators.tsx
+++ b/src/ui/components/shared/SharingModal/Collaborators.tsx
@@ -18,11 +18,14 @@ export default function Collaborators({ recordingId }: CollaboratorsProps) {
   }
 
   return (
-    <section className="flex w-full flex-col space-y-4">
-      <div className="border border-transparent">
-        <EmailForm recordingId={recordingId} />
-      </div>
-      <CollaboratorsList {...{ owner, collaborators }} />
-    </section>
+    <>
+      <div className="mt-4 mb-2 font-bold">Add People</div>
+      <section className="flex w-full flex-col space-y-4">
+        <div className="border border-transparent">
+          <EmailForm recordingId={recordingId} />
+        </div>
+        <CollaboratorsList {...{ owner, collaborators }} />
+      </section>
+    </>
   );
 }

--- a/src/ui/components/shared/SharingModal/SharingModal.tsx
+++ b/src/ui/components/shared/SharingModal/SharingModal.tsx
@@ -124,8 +124,6 @@ function CollaboratorsSection({
               )}
             </div>
 
-            <div className="mt-4 mb-2 font-bold">Add People</div>
-
             <Collaborators recordingId={recording.id} />
           </div>
           <CollaboratorRequests recording={recording} />
@@ -287,7 +285,6 @@ function DownloadSection({ recording }: { recording: Recording }) {
         </MaterialIcon>
         {buttonStates[downloadState].label}
       </button>
-
     </div>
   );
 }
@@ -307,14 +304,12 @@ function SharingModal({ recording, hideModal }: SharingModalProps) {
         <div className="flex flex-col space-y-0" style={{ width: 390 }}>
           <Header modalMode={modalMode} setModalMode={setModalMode} />
           {modalMode == "sharing" ? (
-            <>
-              <SharingSection
-                recording={recording}
-                showEnvironmentVariables={showEnvironmentVariables}
-                showPrivacy={showPrivacy}
-                setShowPrivacy={setShowPrivacy}
-              />
-            </>
+            <SharingSection
+              recording={recording}
+              showEnvironmentVariables={showEnvironmentVariables}
+              showPrivacy={showPrivacy}
+              setShowPrivacy={setShowPrivacy}
+            />
           ) : null}
         </div>
         {showPrivacy ? (


### PR DESCRIPTION
* Moves the header node into the `Collaborators` component so it can conditionally show it along with the picker.

![image](https://user-images.githubusercontent.com/788456/214455918-5c04bc0f-6fac-491c-a9a0-06e8dee72868.png)

> **Note**
> I thought that we were allowing non-owners to add collaborators but that's not how this is currently implemented. I didn't change that here but noting it for discussion.
