### PR TITLE
Change code type-ahead suggestion to favor own properties

### DIFF
--- a/packages/replay-next/components/lexical/plugins/code-completion/findMatches.ts
+++ b/packages/replay-next/components/lexical/plugins/code-completion/findMatches.ts
@@ -69,7 +69,6 @@ function fetchQueryData(
           !PREVIEW_CAN_OVERFLOW
         );
 
-        // TODO [FE-1168] These need to be weighted more
         properties =
           preview?.properties?.map(property => ({
             ...property,
@@ -94,7 +93,6 @@ function fetchQueryData(
               distance: depth + 1,
             })) ?? [];
 
-          // TODO [FE-1168] These need to be weighted less
           properties = properties ? properties.concat(weightedProperties) : weightedProperties;
 
           currentPrototypeId = prototypePreview?.prototypeId;

--- a/packages/replay-next/components/lexical/plugins/code-completion/findMatchingScopesAndProperties.test.ts
+++ b/packages/replay-next/components/lexical/plugins/code-completion/findMatchingScopesAndProperties.test.ts
@@ -1,11 +1,23 @@
 import { Property, Scope } from "@replayio/protocol";
 
+import { WeightedProperty } from "replay-next/components/lexical/plugins/code-completion/findMatches";
+
 import findMatches from "./findMatchingScopesAndProperties";
 
-function createPropertiesFromNames(...names: string[]): Property[] {
-  return names.map(name => ({
-    name,
-  }));
+function createPropertiesFromNames(...names: string[]): WeightedProperty[] {
+  return names.map(name => {
+    let distance = 0;
+    if (name.indexOf(":") >= 0) {
+      const pieces = name.split(":");
+      name = pieces[0];
+      distance = parseInt(pieces[1], 10);
+    }
+
+    return {
+      distance,
+      name,
+    };
+  });
 }
 
 function createScopesFromNames(...names: string[]): Scope[] {
@@ -89,13 +101,36 @@ describe("findMatches", () => {
 
   // FE-1133
   it("should not suggest array indices or any other names that require bracket notations", () => {
-    expect(
-      findMatches(
-        "array",
-        null,
-        createScopesFromNames(),
-        createPropertiesFromNames("0", "1", "foo", "foo-bar", "foo_bar", "qux2")
-      )
-    ).toEqual(["foo", "foo_bar", "qux2"]);
+    const properties = createPropertiesFromNames(
+      "0",
+      "1",
+      "2",
+      "foo",
+      "foo-bar",
+      "foo_bar",
+      "qux2"
+    );
+    const scopes = createScopesFromNames();
+
+    expect(findMatches("array", null, scopes, properties)).toEqual(["foo", "foo_bar", "qux2"]);
+    expect(findMatches("array", "2", scopes, properties)).toEqual(["qux2"]);
+  });
+
+  // FE-1169
+  it("should display matches for an object's own properties above inherited properties", () => {
+    const properties = createPropertiesFromNames("foo:0", "fooBar:1", "fooBaz:1", "fooBarBaz:2");
+    const scopes = createScopesFromNames();
+
+    expect(findMatches("array", null, scopes, properties)).toEqual([
+      "foo",
+      "fooBar",
+      "fooBaz",
+      "fooBarBaz",
+    ]);
+    expect(findMatches("array", "fooB", scopes, properties)).toEqual([
+      "fooBar",
+      "fooBaz",
+      "fooBarBaz",
+    ]);
   });
 });


### PR DESCRIPTION
### [Overview of the change](https://www.loom.com/share/5f03925f7dbd49b68a21bf641ce54a2f)

This brings us more closely in alignment with Chrome's behavior, although not 100%. The Loom video explains the remaining differences (and why).