### PR TITLE
Add support for cypress aliases

### DIFF
--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -1,4 +1,5 @@
 import { Object as ProtocolObject } from "@replayio/protocol";
+import classNames from "classnames";
 import React, { useCallback, useContext, useEffect, useRef, useState } from "react";
 
 import { highlightNodes, unhighlightNode } from "devtools/client/inspector/markup/actions/markup";
@@ -257,6 +258,10 @@ export function TestStepItem({ step, argString, index, id }: TestStepItemProps) 
   const progress = actualProgress > 100 ? 100 : actualProgress;
   const displayedProgress =
     (step.duration === 1 && state === "paused") || progress == 100 ? 0 : progress;
+  const isSelected = selectedStep?.id === id;
+  const matchingElementCount = consoleProps?.preview?.properties?.find(
+    p => p.name === "Elements"
+  )?.value;
 
   return (
     <TestStepRow
@@ -277,12 +282,33 @@ export function TestStepItem({ step, argString, index, id }: TestStepItemProps) 
           <ProgressBar progress={displayedProgress} error={!!step.error} />
         </div>
         <div className="opacity-70 ">{index + 1}</div>
-        <div className={`truncate font-medium ${state === "paused" ? "font-bold" : ""}`}>
+        <div className={`flex-grow truncate font-medium ${state === "paused" ? "font-bold" : ""}`}>
           {step.parentId ? "- " : ""}
           {step.name} <span className="opacity-70">{argString}</span>
         </div>
       </button>
-      <Actions step={step} isSelected={selectedStep?.id === id} />
+      {step.name === "get" && matchingElementCount > 1 ? (
+        <span
+          className={classNames(
+            "-my-1 flex-shrink rounded p-1 text-xs",
+            isSelected ? "bg-gray-300" : "bg-gray-200"
+          )}
+        >
+          {matchingElementCount}
+        </span>
+      ) : null}
+      {step.alias ? (
+        <span
+          className={classNames(
+            "-my-1 flex-shrink rounded p-1 text-xs",
+            isSelected ? "bg-gray-300" : "bg-gray-200"
+          )}
+          title={`'${argString}' aliased as '${step.alias}'`}
+        >
+          {step.alias}
+        </span>
+      ) : null}
+      <Actions step={step} isSelected={isSelected} />
     </TestStepRow>
   );
 }

--- a/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
@@ -55,8 +55,22 @@ function useGetTestSections(
   const events = useAppSelector(getEvents);
 
   return useMemo(() => {
+    const simplifiedSteps = steps?.reduce<TestStep[]>((acc, s) => {
+      const previous = acc[acc.length - 1];
+      if (previous && s.name === "as" && typeof s.args?.[0] === "string") {
+        acc[acc.length - 1] = {
+          ...previous,
+          alias: s.args[0],
+        };
+      } else {
+        acc.push(s);
+      }
+
+      return acc;
+    }, []);
+
     const stepsByTime =
-      steps?.map<StepEvent>((s, i) => {
+      simplifiedSteps?.map<StepEvent>((s, i) => {
         const annotations = {
           end: annotationsEnd.find(a => a.message.id === s.id),
           enqueue: annotationsEnqueue.find(a => a.message.id === s.id),

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -210,6 +210,7 @@ export type TestStep = {
   relativeStartTime?: number;
   id: string;
   parentId?: string;
+  alias?: string;
   error?: TestItemError;
   hook?: "beforeEach" | "afterEach";
 };


### PR DESCRIPTION
* Collapses `as` commands into aliases on the previous command
* Extracts the `Elements` value from `consoleProps` to display the count (when > 1)
<img width="617" alt="image" src="https://user-images.githubusercontent.com/788456/214732670-d85fb9ad-cee9-4d5a-9c64-fecb1e527956.png">
