### PR TITLE
Treat jQuery wrappers as arrays

### DIFF
--- a/packages/replay-next/src/utils/protocol.ts
+++ b/packages/replay-next/src/utils/protocol.ts
@@ -179,6 +179,7 @@ export function protocolValueToClientValue(
         case "Uint8ClampedArray":
         case "Uint16Array":
         case "Uint32Array":
+        case "jQuery.fn.init":
           type = "array";
           break;
         case "Date":


### PR DESCRIPTION
Cypress uses jQuery to query for elements and returns that wrapped object as the `subject` for assertions which we display in the Step Details pane. It's currently presented as an object which, while true, is a bit unexpected for the user who doesn't care about jQuery.

The proposed change may be (is?) controversial as we likely don't want to blindly assume `className`'s for third party libraries but opening up for discussion. This isn't a big UX win so fine to ignore it if this doesn't work and an alternative isn't obvious.

Before:
<img width="540" alt="image" src="https://user-images.githubusercontent.com/788456/214962798-45dd9aba-91af-4c94-9677-821601034ff8.png">
<img width="549" alt="image" src="https://user-images.githubusercontent.com/788456/214963049-0c6c71e3-a363-45e3-97bb-93b26e1b9bcd.png">

After:
<img width="389" alt="image" src="https://user-images.githubusercontent.com/788456/214963000-69e3ea6c-7ed0-4f51-8033-9981cbd9b6be.png">
<img width="414" alt="image" src="https://user-images.githubusercontent.com/788456/214962719-0b31d6c1-40af-435f-91a1-f5ce92268d1e.png">
