### PR TITLE
Add source-map-loader to Replay's build config to use library sourcemaps

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -162,6 +162,17 @@ const baseNextConfig = {
       fs: false,
     };
 
+    config.module.rules.push({
+      test: /\.js$/,
+      enforce: "pre",
+      use: ["source-map-loader"],
+    });
+
+    if (!config.ignoreWarnings) {
+      config.ignoreWarnings = [];
+    }
+    config.ignoreWarnings.push(/Failed to parse source map/);
+
     // JS files that need to be imported as strings,
     // such as the React DevTools backend to be injected into pauses
     config.module.rules.push({

--- a/package.json
+++ b/package.json
@@ -200,6 +200,7 @@
     "prettier-plugin-tailwindcss": "^0.1.7",
     "raw-loader": "^4.0.2",
     "sharp": "^0.30.3",
+    "source-map-loader": "^4.0.1",
     "storybook-addon-root-attribute": "^1.0.2",
     "storybook-css-modules-preset": "^1.1.1",
     "style-loader": "^3.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13939,7 +13939,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2":
+"iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2, iconv-lite@npm:^0.6.3":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
   dependencies:
@@ -20205,6 +20205,7 @@ __metadata:
     shared: "workspace:*"
     sharp: ^0.30.3
     slugify: ^1.6.5
+    source-map-loader: ^4.0.1
     storybook-addon-root-attribute: ^1.0.2
     storybook-css-modules-preset: ^1.1.1
     style-loader: ^3.3.1
@@ -21492,6 +21493,19 @@ __metadata:
   version: 1.0.2
   resolution: "source-map-js@npm:1.0.2"
   checksum: c049a7fc4deb9a7e9b481ae3d424cc793cb4845daa690bc5a05d428bf41bf231ced49b4cf0c9e77f9d42fdb3d20d6187619fc586605f5eabe995a316da8d377c
+  languageName: node
+  linkType: hard
+
+"source-map-loader@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "source-map-loader@npm:4.0.1"
+  dependencies:
+    abab: ^2.0.6
+    iconv-lite: ^0.6.3
+    source-map-js: ^1.0.2
+  peerDependencies:
+    webpack: ^5.72.1
+  checksum: 4ddca8b03dc61f406effd4bffe70de4b87fef48bae6f737017b2dabcbc7d609133325be1e73838e9265331de28039111d729fcbb8bce88a6018a816bef510eb1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
It's been bugging me for a while that even though RTK ships our own sourcemaps in the package, those haven't been showing up when we record or debug.  Instead, I only ever see the transpiled `redux-toolkit.esm.js` artifact and its contents.

Turns out apparently you have to add `source-map-loader` to Webpack in order to get library sourcemaps included correctly? 🤷‍♂️ It's shocking that neither Webpack nor Next do that automatically.

But hey, here's RTK's `createSlice` now correctly showing up in Chrome's debugger:

![image](https://user-images.githubusercontent.com/1128784/214998864-86b47814-a351-4610-8c69-f9a2ad67cc69.png)

