### PR TITLE
Fix issues with React Event Listener implementation

### DIFF
--- a/src/ui/components/SecondaryToolbox/redux-devtools/injectReduxDevtoolsProcessing.ts
+++ b/src/ui/components/SecondaryToolbox/redux-devtools/injectReduxDevtoolsProcessing.ts
@@ -55,16 +55,16 @@ declare global {
     logMessage: (message: string) => void;
     jsondiffpatch: any;
   }
-
-  // These types aren't actually attached to `window`, but _should_ be in
-  // scope when we evaluate code at the original annotation timestamps.
-  let latestDispatchedActions: Record<string, LastSavedValues>;
-
-  let action: AnyAction;
-  let state: any;
-  let extractedConfig: ExtractedExtensionConfig;
-  let config: Config;
 }
+
+// These types aren't actually attached to `window`, but _should_ be in
+// scope when we evaluate code at the original annotation timestamps.
+// Use `declare let x` to make code in _this_ file only accept those.
+declare let latestDispatchedActions: Record<string, LastSavedValues>;
+declare let action: AnyAction;
+declare let state: any;
+declare let extractedConfig: ExtractedExtensionConfig;
+declare let config: Config;
 
 function mutateWindowForSetup() {
   window.evaluationLogs = [];


### PR DESCRIPTION
Fixed a couple stupid mistakes:

- I moved some code at the last minute without checking it, and needed to use `getLoadedRegions(getState())`  instead of `getLoadedRegions(state)`
- But that compiled cleanly because the `injectReduxDevtools` file had declared `state` _globally_, which meant that any file could legally reference that variable name and TS would accept it.

I'd considered the potential for that global thing to bite us, just didn't expect it to be that fast :)

Fortunately yesterday I'd asked on Twitter for other options, and turns out you can do `declare let x` in a file and it'll _only_ be "in scope" for that file.

Also threw in a check to exclude React Event Listeners from jumping straight into React's own internals if we fall back to the "vanilla JS handler" case.