### PR TITLE
Support narrowing playback behavior for selected tests

### DIFF
--- a/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
@@ -6,6 +6,7 @@ import ErrorBoundary from "replay-next/components/ErrorBoundary";
 import PropertiesRenderer from "replay-next/components/inspector/PropertiesRenderer";
 import useLocalStorage from "replay-next/src/hooks/useLocalStorage";
 import { getSelectedTest, setSelectedTest } from "ui/reducers/reporter";
+import { setPlaybackFocusRegion } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { TestItem } from "ui/types";
 
@@ -30,6 +31,10 @@ export default function TestInfo({ testCases }: { testCases: TestItem[] }) {
   const [consoleProps, setConsoleProps] = useState<ProtocolObject>();
   const [loading, setLoading] = useState<boolean>(true);
   const [pauseId, setPauseId] = useState<string | null>(null);
+
+  useEffect(() => {
+    dispatch(setPlaybackFocusRegion(!!selectedTest));
+  }, [dispatch, selectedTest]);
 
   useEffect(() => {
     if (testCases.length === 1) {

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -22,6 +22,12 @@ import { TestInfoContext } from "./TestInfo";
 import { TestInfoContextMenuContext } from "./TestInfoContextMenuContext";
 import { TestStepRow } from "./TestStepRow";
 
+function preventClickFromSpaceBar(ev: React.KeyboardEvent<HTMLButtonElement>) {
+  if (ev.key === " ") {
+    ev.preventDefault();
+  }
+}
+
 // relies on the scrolling parent to be the nearest positioning context
 function scrollIntoView(node: HTMLDivElement) {
   if (!node.offsetParent) {
@@ -292,6 +298,7 @@ export function TestStepItem({ step, argString, index, id }: TestStepItemProps) 
     >
       <button
         onClick={onClick}
+        onKeyUp={preventClickFromSpaceBar}
         className="flex w-0 flex-grow items-start space-x-2 text-start"
         title={`Step ${index + 1}: ${step.name} ${argString || ""}`}
       >

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -33,6 +33,7 @@ import {
   getHoverTime,
   getHoveredItem,
   getPlayback,
+  getPlaybackFocusRegion,
   getPlaybackPrecachedTime,
   getRecordingDuration,
   getShowFocusModeControls,
@@ -325,10 +326,17 @@ export function startPlayback(
       return;
     }
 
-    const endTime = optEndTime || getZoomRegion(state).endTime;
+    const endTime =
+      optEndTime ||
+      (getPlaybackFocusRegion(state) && getFocusRegion(state)?.end.time) ||
+      getZoomRegion(state).endTime;
 
     const beginDate = Date.now();
-    const beginTime = optBeginTime || (currentTime >= endTime ? 0 : currentTime);
+    const beginTime =
+      optBeginTime ||
+      (currentTime >= endTime
+        ? (getPlaybackFocusRegion(state) && getFocusRegion(state)?.begin.time) || 0
+        : currentTime);
 
     dispatch(
       setTimelineState({

--- a/src/ui/reducers/timeline.ts
+++ b/src/ui/reducers/timeline.ts
@@ -18,6 +18,7 @@ function initialTimelineState(): TimelineState {
     hoverTime: null,
     hoveredItem: null,
     playback: null,
+    playbackFocusRegion: false,
     playbackPrecachedTime: 0,
     paints: [{ time: 0, point: "0" }],
     points: [{ time: 0, point: "0" }],
@@ -52,6 +53,9 @@ const timelineSlice = createSlice({
     },
     setPlaybackPrecachedTime(state, action: PayloadAction<number>) {
       state.playbackPrecachedTime = action.payload;
+    },
+    setPlaybackFocusRegion(state, action: PayloadAction<boolean>) {
+      state.playbackFocusRegion = action.payload;
     },
     setFocusRegion(state, action: PayloadAction<FocusRegion | null>) {
       state.focusRegion = action.payload;
@@ -90,6 +94,7 @@ export const {
   setDragging,
   setHoveredItem,
   setPlaybackPrecachedTime,
+  setPlaybackFocusRegion,
   setPlaybackStalled,
   setFocusRegion,
   setDisplayedFocusRegion,
@@ -126,6 +131,7 @@ export const getBasicProcessingProgress = (state: UIState) => {
   return (1.0 * (maxPaint?.time || 0)) / maxPoint.time;
 };
 export const getPlaybackPrecachedTime = (state: UIState) => state.timeline.playbackPrecachedTime;
+export const getPlaybackFocusRegion = (state: UIState) => state.timeline.playbackFocusRegion;
 export const getFocusRegion = (state: UIState) => state.timeline.focusRegion;
 export const getDisplayedFocusRegion = (state: UIState) => state.timeline.displayedFocusRegion;
 export const isMaximumFocusRegion = (state: UIState) => {

--- a/src/ui/state/timeline.ts
+++ b/src/ui/state/timeline.ts
@@ -24,6 +24,7 @@ export interface TimelineState {
     beginDate: number;
     time: number;
   } | null;
+  playbackFocusRegion: boolean;
   playbackPrecachedTime: number;
   paints: TimeStampedPoint[];
   points: TimeStampedPoint[];


### PR DESCRIPTION
* Adds `playbackFocusRegion` timeline state parameter to configure playback to be limited to the focus region
* Prevents space bar from "clicking" the test step button so the playback can run uninterrupted