### PR TITLE
Add assert capsules

### DIFF
--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -476,10 +476,15 @@
   --breakpoint-label: var(--cm-string);
 
   /* Testsuites (Dark) */
-  --testsuites-error-bgcolor: var(--background-color-error);
-  --testsuites-error-bgcolor-hover: #7a1712;
-  --testsuites-error-icon-bgcolor: rgb(255, 115, 115);
-  --testsuites-error-color: rgb(255, 197, 197);
+  --testsuites-error-border-color: var(--testsuites-error-icon-bgcolor);
+  --testsuites-capsule-success-bgcolor: var(--testsuites-success-color);
+  --testsuites-capsule-success-color: rgb(16, 114, 0);
+  --testsuites-capsule-error-bgcolor: rgb(237, 36, 36);
+  --testsuites-capsule-error-color: white;
+  --testsuites-error-bgcolor: rgba(237, 36, 36, 0.672);
+  --testsuites-error-bgcolor-hover: rgba(237, 36, 36, 0.672);
+  --testsuites-error-icon-bgcolor: rgb(237, 36, 36);
+  --testsuites-error-color: #ffe0e0;
   --testsuites-steps-bgcolor: var(--theme-base-100);
   --testsuites-steps-bgcolor-hover: var(--theme-base-90);
   --testsuites-success-color: #30e60b;
@@ -950,10 +955,15 @@
   --breakpoint-label: var(--cm-string);
 
   /* Testsuites (Light) */
+  --testsuites-error-border-color: var(--testsuites-error-icon-bgcolor);
   --testsuites-error-bgcolor: #ffe9e9;
   --testsuites-error-bgcolor-hover: #ffe0e0;
-  --testsuites-error-icon-bgcolor: #eb5757;
+  --testsuites-error-icon-bgcolor: rgb(203, 0, 0);
   --testsuites-error-color: #eb5757;
+  --testsuites-capsule-success-bgcolor: var(--testsuites-success-color);
+  --testsuites-capsule-success-color: #ffffff;
+  --testsuites-capsule-error-bgcolor: rgb(203, 0, 0);
+  --testsuites-capsule-error-color: #fff;
   --testsuites-steps-bgcolor: #f7f7f7;
   --testsuites-steps-bgcolor-hover: #f4f4f4;
   --testsuites-success-color: #058b00;

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.module.css
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.module.css
@@ -1,0 +1,22 @@
+.BorderPending {
+  border-left: transparent;
+}
+
+.BorderActive {
+  border-left: var(--primary-accent);
+}
+
+.BorderError {
+  border-left: red;
+}
+
+.step {
+  border-radius: 4px;
+  padding: 1px 3px;
+  margin-right: 3px;
+}
+
+.BorderError .assert {
+  background-color: red;
+  color: #fff;
+}

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.module.css
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.module.css
@@ -3,20 +3,30 @@
 }
 
 .BorderActive {
-  border-left: var(--primary-accent);
+  border-left: 2px solid var(--primary-accent);
 }
 
 .BorderError {
-  border-left: red;
+  border-left: 2px solid var(--testsuites-error-border-color);
 }
 
 .step {
   border-radius: 4px;
+  margin-right: 5px;
+}
+
+.BorderError .assert,
+.BorderPending .assert {
   padding: 1px 3px;
-  margin-right: 3px;
 }
 
 .BorderError .assert {
-  background-color: red;
-  color: #fff;
+  background-color: var(--testsuites-capsule-error-bgcolor);
+  color: var(--testsuites-capsule-error-color);
+}
+
+.BorderActive .assert,
+.BorderPending .assert {
+  background-color: var(--testsuites-capsule-success-bgcolor);
+  color: var(--testsuites-capsule-success-color);
 }

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.module.css
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.module.css
@@ -1,5 +1,5 @@
 .BorderPending {
-  border-left: transparent;
+  border-left: 2px solid transparent;
 }
 
 .BorderActive {
@@ -16,7 +16,8 @@
 }
 
 .BorderError .assert,
-.BorderPending .assert {
+.BorderPending .assert,
+.BorderActive .assert {
   padding: 1px 3px;
 }
 

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -309,7 +309,7 @@ export function TestStepItem({ step, argString, index, id }: TestStepItemProps) 
       {step.name === "get" && matchingElementCount > 1 ? (
         <span
           className={classNames(
-            "-my-1 flex-shrink rounded p-1 text-xs",
+            "-my-1 flex-shrink rounded p-1 text-xs text-gray-800",
             isSelected ? "bg-gray-300" : "bg-gray-200"
           )}
         >
@@ -319,7 +319,7 @@ export function TestStepItem({ step, argString, index, id }: TestStepItemProps) 
       {step.alias ? (
         <span
           className={classNames(
-            "-my-1 flex-shrink rounded p-1 text-xs",
+            "-my-1 flex-shrink rounded p-1 text-xs text-gray-800",
             isSelected ? "bg-gray-300" : "bg-gray-200"
           )}
           title={`'${argString}' aliased as '${step.alias}'`}

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -21,6 +21,7 @@ import { TestCaseContext } from "./TestCase";
 import { TestInfoContext } from "./TestInfo";
 import { TestInfoContextMenuContext } from "./TestInfoContextMenuContext";
 import { TestStepRow } from "./TestStepRow";
+import styles from "./TestStepItem.module.css";
 
 // relies on the scrolling parent to be the nearest positioning context
 function scrollIntoView(node: HTMLDivElement) {
@@ -300,8 +301,9 @@ export function TestStepItem({ step, argString, index, id }: TestStepItemProps) 
         </div>
         <div className="opacity-70 ">{index + 1}</div>
         <div className={`flex-grow font-medium ${state === "paused" ? "font-bold" : ""}`}>
-          {step.parentId ? "- " : ""}
-          {step.name} <span className="opacity-70">{argString}</span>
+          {step.parentId ? "- " : ""}{" "}
+          <span className={`${styles.step} ${styles[step.name]}`}>{step.name}</span>
+          <span className="opacity-70">{argString}</span>
         </div>
       </button>
       {step.name === "get" && matchingElementCount > 1 ? (

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepRow.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepRow.tsx
@@ -1,6 +1,8 @@
 import classnames from "classnames";
 import React, { forwardRef } from "react";
 
+import styles from "./TestStepItem.module.css";
+
 interface TestStepRowProps {
   error?: boolean;
   active?: boolean;
@@ -24,9 +26,9 @@ export function TestStepRowBase({
         "group/step relative flex items-start gap-1 border-b border-l-2 border-themeBase-90 py-2 pl-3 pr-1 font-mono",
         {
           // border
-          "border-l-transparent": pending,
-          "border-l-red-500": (!pending || active) && error,
-          "border-l-primaryAccent": (!pending || active) && !error,
+          [styles.BorderPending]: pending,
+          [styles.BorderError]: (!pending || active) && error,
+          [styles.BorderActive]: (!pending || active) && !error,
 
           // background / foreground
           "text-testsuitesErrorColor": error,


### PR DESCRIPTION
Changes to top-level (screen 1/3):

* Aligned red error colors more
* Moving colors from Tailwind to CSS modules

Old:
![image](https://user-images.githubusercontent.com/9154902/215239627-1aaddc05-e25a-433f-aea9-e6fcf75f0dba.png)

New:
![image](https://user-images.githubusercontent.com/9154902/215239614-c2eab278-2040-4579-bf10-cb87d1c76212.png)

Old:
![image](https://user-images.githubusercontent.com/9154902/215239660-41dc2bd0-57a4-46df-9ec8-d78556f6a0d1.png)

New:
![image](https://user-images.githubusercontent.com/9154902/215239662-54886f81-6145-4594-b8e9-1bcad8f95406.png)

--

Changes to top-level (screen 2/3):

* Green assert capsule
* Fixed text color issue

Old:
![image](https://user-images.githubusercontent.com/9154902/215239901-3e6d6aa5-b626-4807-a6bf-0780574a72b7.png)

New:
![image](https://user-images.githubusercontent.com/9154902/215239904-bd16fdf2-ee7f-4969-8d7a-57a1f30b15e1.png)

Old:
![image](https://user-images.githubusercontent.com/9154902/215239918-42a5df20-5b05-4b9d-8f45-35b639cb3521.png)

New:
![image](https://user-images.githubusercontent.com/9154902/215239913-51efc681-7442-405a-98f6-9ed56d31ac34.png)

--

Changes to top-level (screen 3/3):

* Red assert capsule
* More tweaking of reds to align better

Old:
![image](https://user-images.githubusercontent.com/9154902/215239946-2b7e72a6-0744-488d-9509-a2ff6e136b16.png)

New:
![image](https://user-images.githubusercontent.com/9154902/215239935-b4e0f0f4-45c9-473f-87ee-e5d5eb4995c6.png)

Old:
![image](https://user-images.githubusercontent.com/9154902/215239965-198491ad-0d3c-4d11-9fa3-8c25d2f3e6f5.png)

New:
![image](https://user-images.githubusercontent.com/9154902/215239970-d5fbf711-8dbe-4af8-a919-b4641867fdda.png)


