### PR TITLE
Improve handling of Session.createPause failures (FE-1021)

### DIFF
--- a/packages/replay-next/components/console/ConsoleInput.tsx
+++ b/packages/replay-next/components/console/ConsoleInput.tsx
@@ -22,8 +22,9 @@ import useTerminalHistory from "./hooks/useTerminalHistory";
 import styles from "./ConsoleInput.module.css";
 
 export default function ConsoleInput({ inputRef }: { inputRef?: RefObject<ImperativeHandle> }) {
+  const { executionPoint } = useContext(TimelineContext);
   return (
-    <ErrorBoundary fallback={<ErrorFallback />}>
+    <ErrorBoundary resetKey={executionPoint} fallback={<ErrorFallback />}>
       <Suspense fallback={<Loader />}>
         <ConsoleInputSuspends inputRef={inputRef} />
       </Suspense>
@@ -186,7 +187,7 @@ function ErrorFallback() {
   return (
     <div className={styles.FallbackState}>
       <Icon className={styles.Icon} type="terminal-prompt" />
-      Input disabled for session because of an error
+      Input disabled because of an error
     </div>
   );
 }

--- a/packages/replay-next/components/sources/log-point-panel/LogPointPanel.tsx
+++ b/packages/replay-next/components/sources/log-point-panel/LogPointPanel.tsx
@@ -38,6 +38,7 @@ import {
   POINT_BEHAVIOR_ENABLED,
   Point,
 } from "shared/client/types";
+import { isThennable } from "shared/proxy/utils";
 
 import Loader from "../../Loader";
 import { SetLinePointState } from "../SourceListRow";
@@ -157,15 +158,22 @@ function PointPanelWithHitPoints({
   // Otherwise fall back to using the global execution point.
   const executionPoint = closestHitPoint ? closestHitPoint.point : currentExecutionPoint;
   const time = closestHitPoint ? closestHitPoint.time : currentTime;
-  const pauseId = getPauseIdSuspense(client, executionPoint, time);
-  const frames = getFramesSuspense(client, pauseId);
-  const frameId = frames?.[0]?.frameId ?? null;
   let pauseAndFrameId: PauseAndFrameId | null = null;
-  if (frameId !== null) {
-    pauseAndFrameId = {
-      frameId,
-      pauseId,
-    };
+  try {
+    const pauseId = getPauseIdSuspense(client, executionPoint, time);
+    const frames = getFramesSuspense(client, pauseId);
+    const frameId = frames?.[0]?.frameId ?? null;
+    if (frameId !== null) {
+      pauseAndFrameId = {
+        frameId,
+        pauseId,
+      };
+    }
+  } catch (errorOrPromise) {
+    if (isThennable(errorOrPromise)) {
+      throw errorOrPromise;
+    }
+    console.error(`Failed to fetch frames for point ${executionPoint}`, errorOrPromise);
   }
 
   let source = getSource(client, point.location.sourceId);

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/index.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/index.tsx
@@ -8,7 +8,7 @@ import React from "react";
 
 import { useAppSelector } from "ui/setup/hooks";
 
-import { getPauseId } from "../../reducers/pause";
+import { getPauseErrored, getPauseId } from "../../reducers/pause";
 import { useDebuggerPrefs } from "../../utils/prefs";
 import BreakpointsPane from "./BreakpointsPane";
 import CommandBar from "./CommandBar";
@@ -21,6 +21,7 @@ import { Accordion, AccordionPane } from "@recordreplay/accordion";
 
 export default function SecondaryPanes() {
   const pauseId = useAppSelector(getPauseId);
+  const pauseErrored = useAppSelector(getPauseErrored);
   const { value: scopesExpanded, update: updateScopesExpanded } =
     useDebuggerPrefs("scopes-visible");
   const { value: callstackVisible, update: updateCallstackVisible } =
@@ -58,6 +59,11 @@ export default function SecondaryPanes() {
           onToggle={() => updateCallstackVisible(!callstackVisible)}
         >
           {pauseId && <NewFrames pauseId={pauseId} panel="debugger" />}
+          {pauseErrored && (
+            <div className="pane frames" data-test-id="FramesPanel">
+              <div className="pane-info empty">Error loading frames</div>
+            </div>
+          )}
         </AccordionPane>
         <AccordionPane
           header="Scopes"

--- a/src/devtools/client/debugger/src/reducers/pause.ts
+++ b/src/devtools/client/debugger/src/reducers/pause.ts
@@ -284,6 +284,10 @@ export function getPauseId(state: UIState) {
   return state.pause.id;
 }
 
+export function getPauseErrored(state: UIState) {
+  return state.pause.pauseErrored;
+}
+
 export function getPausePreviewLocation(state: UIState) {
   return state.pause.pausePreviewLocation;
 }

--- a/src/ui/components/SecondaryToolbox/TerminalContextAdapter.tsx
+++ b/src/ui/components/SecondaryToolbox/TerminalContextAdapter.tsx
@@ -22,11 +22,13 @@ export default function TerminalContextController({ children }: PropsWithChildre
   const addMessage = useCallback((partialTerminalExpression: NewTerminalExpression) => {
     // New expressions should be added in a transition because they suspend.
     startTransition(() => {
+      const id = idCounterRef.current++;
+
       setMessages(prev => [
         ...prev,
         {
           ...partialTerminalExpression,
-          id: idCounterRef.current++,
+          id,
           type: "TerminalExpression",
         },
       ]);

--- a/src/ui/components/SecondaryToolbox/TimelineContextAdapter.tsx
+++ b/src/ui/components/SecondaryToolbox/TimelineContextAdapter.tsx
@@ -33,10 +33,9 @@ export default function TimelineContextAdapter({ children }: PropsWithChildren) 
 
   const update = useCallback(
     async (time: number, executionPoint: ExecutionPoint, openSource: boolean) => {
-      const pauseId = await getPauseIdAsync(client, executionPoint, time);
-      dispatch(seek(executionPoint, time, openSource, pauseId));
+      dispatch(seek(executionPoint, time, openSource));
     },
-    [client, dispatch]
+    [dispatch]
   );
 
   useLayoutEffect(() => {


### PR DESCRIPTION
- `TimelineContextAdapter`: leave fetching the `pauseId` to the `seek()` thunk, which will also handle any failures
- handle `Session.createPause` failures in `LogPointPanel`
- show an error message in the Frames panel when `Session.createPause` fails
- ensure that the `ErrorBoundary` of `ConsoleInput` is reset when seeking to a different point, otherwise the console would remain disabled for the entire session after a `Session.createPause` failure
- fixed a bug in `TerminalContextAdapter` that showed up in e2e tests: for some reason `setMessages()` inside `startTransition()` in `addMessage()` was called repeatedly for one of the messages, hence the id for that message changed repeatedly, hence the evaluation was started repeatedly and its result was never displayed. See https://app.replay.io/recording/replay-of-localhost8080--6e9e7698-de48-4204-b621-b2fa8a75d2cf