### PR TITLE
Add checkbox for "Rerun Routines" experimental flag

### DIFF
--- a/packages/protocol/socket.ts
+++ b/packages/protocol/socket.ts
@@ -128,6 +128,7 @@ export type ExperimentalSettings = {
   disableStableQueryCache?: boolean;
   disableUnstableQueryCache?: boolean;
   enableRoutines?: boolean;
+  rerunRoutines?: boolean;
   profileWorkerThreads?: boolean;
 };
 

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -202,6 +202,7 @@ export function createSocket(
         listenForMetrics: !!prefs.listenForMetrics,
         profileWorkerThreads: !!features.profileWorkerThreads,
         enableRoutines: !!features.enableRoutines,
+        rerunRoutines: !!features.rerunRoutines,
       };
       if (features.newControllerOnRefresh) {
         experimentalSettings.controllerKey = String(Date.now());

--- a/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
+++ b/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
@@ -50,7 +50,7 @@ const EXPERIMENTAL_SETTINGS: ExperimentalSetting[] = [
     key: "consoleFilterDrawerDefaultsToOpen",
   },
   {
-    label: "Disable Scan Data Cache",
+    label: "Disable scan data cache",
     description: "Do not cache the results of indexing the recording",
     key: "disableScanDataCache",
   },
@@ -60,9 +60,14 @@ const EXPERIMENTAL_SETTINGS: ExperimentalSetting[] = [
     key: "brokenSourcemapWorkaround",
   },
   {
-    label: "Enable Backend Processing Routines",
+    label: "Enable backend processing routines",
     description: "Enable backend support for running processing routines (like React DevTools)",
     key: "enableRoutines",
+  },
+  {
+    label: "Retry backend processing routines",
+    description: "Always re-run routines instead of using cached results",
+    key: "rerunRoutines",
   },
 ];
 
@@ -117,6 +122,7 @@ export default function ExperimentalSettings({}) {
   );
 
   const { value: enableRoutines, update: updateEnableRoutines } = useFeature("enableRoutines");
+  const { value: rerunRoutines, update: updatererunRoutines } = useFeature("rerunRoutines");
 
   const onChange = (key: ExperimentalKey, value: any) => {
     if (key == "enableColumnBreakpoints") {
@@ -137,6 +143,8 @@ export default function ExperimentalSettings({}) {
       updateBrokenSourcemapWorkaround(!brokenSourcemapWorkaround);
     } else if (key === "enableRoutines") {
       updateEnableRoutines(!enableRoutines);
+    } else if (key === "rerunRoutines") {
+      updatererunRoutines(!rerunRoutines);
     }
   };
 
@@ -149,6 +157,7 @@ export default function ExperimentalSettings({}) {
     enableColumnBreakpoints,
     enableUnstableQueryCache,
     enableRoutines,
+    rerunRoutines,
     profileWorkerThreads,
   };
 

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -23,6 +23,7 @@ export type LocalExperimentalUserSettings = {
   enableColumnBreakpoints: boolean;
   enableUnstableQueryCache: boolean;
   enableRoutines: boolean;
+  rerunRoutines: boolean;
   profileWorkerThreads: boolean;
   brokenSourcemapWorkaround: boolean;
 };

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -37,6 +37,7 @@ pref("devtools.features.newControllerOnRefresh", false);
 pref("devtools.features.originalClassNames", false);
 pref("devtools.features.profileWorkerThreads", false);
 pref("devtools.features.enableRoutines", false);
+pref("devtools.features.rerunRoutines", false);
 pref("devtools.features.protocolTimeline", false);
 pref("devtools.features.repaintEvaluations", false);
 pref("devtools.features.resolveRecording", false);
@@ -77,6 +78,7 @@ export const features = new PrefsHelper("devtools.features", {
   protocolTimeline: ["Bool", "protocolTimeline"],
   repaintEvaluations: ["Bool", "repaintEvaluations"],
   resolveRecording: ["Bool", "resolveRecording"],
+  rerunRoutines: ["Bool", "rerunRoutines"],
   chromiumNetMonitor: ["Bool", "chromiumNetMonitor"],
   brokenSourcemapWorkaround: ["Bool", "brokenSourcemapWorkaround"],
 });


### PR DESCRIPTION
@jcmorrow recently added a `rerunRoutines` flag to the backend, but there was no corresponding checkbox in the "Experimental Settings" dialog. Added that.

Josh, I can see that the value is getting sent, so I _think_ this is okay to merge.