### PR TITLE
tilt: reset next cache on tilt up

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,3 +1,3 @@
 def devtools(working_directory=config.main_dir, api='https://api.replay.io/v1/graphql', subscriptions='wss://api.replay.io/v1/graphql', dispatch='wss://dispatch.replay.io'):
   local_resource("devtools deps", "yarn install", deps=["package.json"], dir=working_directory)
-  local_resource("devtools webpack", serve_cmd="yarn dev", deps=[], resource_deps=["devtools deps"], serve_dir=working_directory, serve_env={"NEXT_PUBLIC_API_URL": api, "NEXT_PUBLIC_DISPATCH_URL": dispatch, "NEXT_PUBLIC_API_SUBSCRIPTION_URL": subscriptions})
+  local_resource("devtools webpack", serve_cmd="rm -rf .next && yarn dev", deps=[], resource_deps=["devtools deps"], serve_dir=working_directory, serve_env={"NEXT_PUBLIC_API_URL": api, "NEXT_PUBLIC_DISPATCH_URL": dispatch, "NEXT_PUBLIC_API_SUBSCRIPTION_URL": subscriptions})


### PR DESCRIPTION
This solves a problem we have run in to a couple times where, after changing some `NEXT_` environment variables (like for cloud-dev or the backend pre-prod environment) the old values still seem to persist.