### PR TITLE
Improve loading state for console props

### DIFF
--- a/src/devtools/client/debugger/src/components/TestInfo/StepDetails.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/StepDetails.tsx
@@ -1,4 +1,5 @@
-import React, { useContext } from "react";
+import classNames from "classnames";
+import React, { useContext, useEffect } from "react";
 
 import ErrorBoundary from "replay-next/components/ErrorBoundary";
 import PropertiesRenderer from "replay-next/components/inspector/PropertiesRenderer";
@@ -14,19 +15,24 @@ function ConsoleProps({ open }: { open: boolean }) {
 
   const { pauseId, consoleProps } = getCypressConsolePropsSuspense(client, selectedStep) || {};
 
-  if (!pauseId || !consoleProps) {
-    // maybe an error?
-    return null;
-  }
-
   return (
     <div
       className={`flex flex-grow flex-col gap-1 overflow-y-auto p-2 font-mono transition-all  ${
         open ? "visible" : "hidden"
       }`}
     >
-      <div className={`flex flex-grow flex-col gap-1 p-2 font-mono`}>
-        <PropertiesRenderer pauseId={pauseId} object={consoleProps} />
+      <div
+        className={classNames(`flex flex-grow flex-col gap-1 p-2 font-mono`, {
+          "items-center justify-center": !consoleProps || !selectedStep,
+        })}
+      >
+        {!selectedStep ? (
+          <span>Select a step above to view its details</span>
+        ) : pauseId && consoleProps ? (
+          <PropertiesRenderer pauseId={pauseId} object={consoleProps} />
+        ) : (
+          <span>Unable to retrieve step details for this step</span>
+        )}
       </div>
     </div>
   );

--- a/src/devtools/client/debugger/src/components/TestInfo/StepDetails.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/StepDetails.tsx
@@ -1,0 +1,87 @@
+import React, { useContext } from "react";
+
+import ErrorBoundary from "replay-next/components/ErrorBoundary";
+import PropertiesRenderer from "replay-next/components/inspector/PropertiesRenderer";
+import useLocalStorage from "replay-next/src/hooks/useLocalStorage";
+import { ReplayClientContext } from "shared/client/ReplayClientContext";
+import { useTestInfo } from "ui/hooks/useTestInfo";
+
+import { getCypressConsolePropsSuspense } from "./getCypressConsolePropsSuspense";
+
+function ConsoleProps({ open }: { open: boolean }) {
+  const client = useContext(ReplayClientContext);
+  const { selectedStep } = useTestInfo();
+
+  const { pauseId, consoleProps } = getCypressConsolePropsSuspense(client, selectedStep) || {};
+
+  if (!pauseId || !consoleProps) {
+    // maybe an error?
+    return null;
+  }
+
+  return (
+    <div
+      className={`flex flex-grow flex-col gap-1 overflow-y-auto p-2 font-mono transition-all  ${
+        open ? "visible" : "hidden"
+      }`}
+    >
+      <div className={`flex flex-grow flex-col gap-1 p-2 font-mono`}>
+        <PropertiesRenderer pauseId={pauseId} object={consoleProps} />
+      </div>
+    </div>
+  );
+}
+
+export function StepDetails() {
+  const { selectedTest } = useTestInfo();
+
+  const [showStepDetails, setShowStepDetails] = useLocalStorage<boolean>(
+    `Replay:TestInfo:StepDetails`,
+    true
+  );
+
+  const errorFallback = (
+    <div className="flex flex-grow items-center justify-center align-middle font-mono text-xs opacity-50">
+      Failed to load step info
+    </div>
+  );
+
+  const loadingFallback = (
+    <div className="flex flex-grow items-center justify-center align-middle text-xs opacity-50">
+      Loading ...
+    </div>
+  );
+
+  return (
+    <>
+      <div
+        className={`overflow-none flex flex-shrink-0 flex-col py-2 ${
+          showStepDetails ? "h-64" : "h-12"
+        } delay-0 duration-300 ease-in-out`}
+        style={{
+          borderTop: "1px solid var(--chrome)",
+        }}
+        key={selectedTest ? selectedTest.id : "no-selected-test"}
+      >
+        <div
+          className="text-md var(--theme-tab-font-size) p-2  px-4 hover:cursor-pointer"
+          onClick={() => setShowStepDetails(!showStepDetails)}
+          style={{
+            fontSize: "15px",
+          }}
+        >
+          <div className="flex select-none items-center space-x-2">
+            <div className={`img arrow ${showStepDetails ? "expanded" : null}`}></div>
+            <span className="overflow-hidden overflow-ellipsis whitespace-pre">Step Details</span>
+          </div>
+        </div>
+
+        <ErrorBoundary fallback={errorFallback}>
+          <React.Suspense fallback={loadingFallback}>
+            <ConsoleProps open={showStepDetails} />
+          </React.Suspense>
+        </ErrorBoundary>
+      </div>
+    </>
+  );
+}

--- a/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
@@ -111,7 +111,7 @@ export default function TestInfo({ testCases }: { testCases: TestItem[] }) {
               <TestCase test={testCases[selectedTest]} index={selectedTest} />
             )}
           </div>
-          {selectedTest !== null ? <StepDetails /> : null}
+          {selectedTest !== null && info.supportsStepAnnotations ? <StepDetails /> : null}
           <ContextMenuWrapper />
         </div>
       </TestInfoContextMenuContextRoot>

--- a/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
@@ -1,10 +1,6 @@
 import { Object as ProtocolObject } from "@replayio/protocol";
-import cloneDeep from "lodash/cloneDeep";
-import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
+import React, { createContext, useEffect, useMemo, useState } from "react";
 
-import ErrorBoundary from "replay-next/components/ErrorBoundary";
-import PropertiesRenderer from "replay-next/components/inspector/PropertiesRenderer";
-import useLocalStorage from "replay-next/src/hooks/useLocalStorage";
 import { useTestInfo } from "ui/hooks/useTestInfo";
 import { getSelectedTest, setSelectedTest } from "ui/reducers/reporter";
 import { setPlaybackFocusRegion } from "ui/reducers/timeline";
@@ -12,6 +8,7 @@ import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { TestItem } from "ui/types";
 
 import ContextMenuWrapper from "./ContextMenu";
+import { StepDetails } from "./StepDetails";
 import { TestCase } from "./TestCase";
 import { TestInfoContextMenuContextRoot } from "./TestInfoContextMenuContext";
 
@@ -114,7 +111,7 @@ export default function TestInfo({ testCases }: { testCases: TestItem[] }) {
               <TestCase test={testCases[selectedTest]} index={selectedTest} />
             )}
           </div>
-          {selectedTest !== null ? <Console /> : null}
+          {selectedTest !== null ? <StepDetails /> : null}
           <ContextMenuWrapper />
         </div>
       </TestInfoContextMenuContextRoot>
@@ -180,82 +177,4 @@ function TestCaseTree({ testCases }: { testCases: TestItem[] }) {
   );
 
   return <TestCaseBranch tree={tree} />;
-}
-
-function Console() {
-  const { loading, pauseId, consoleProps } = useContext(TestInfoContext);
-
-  const [showStepDetails, setShowStepDetails] = useLocalStorage<boolean>(
-    `Replay:TestInfo:StepDetails`,
-    true
-  );
-
-  const sanitizedConsoleProps = useMemo(() => {
-    const sanitized = cloneDeep(consoleProps);
-    if (sanitized?.preview?.properties) {
-      sanitized.preview.properties = sanitized.preview.properties.filter(
-        p => p.name !== "Snapshot"
-      );
-
-      // suppress the prototype entry in the properties output
-      sanitized.preview.prototypeId = undefined;
-    }
-
-    return sanitized;
-  }, [consoleProps]);
-
-  const hideProps = !sanitizedConsoleProps;
-
-  const errorFallback = (
-    <div className="flex flex-grow items-center justify-center align-middle font-mono text-xs opacity-50">
-      Failed to load step info
-    </div>
-  );
-
-  return (
-    <>
-      <div
-        className={`overflow-none flex flex-shrink-0 flex-col py-2 ${
-          showStepDetails ? "h-64" : "h-12"
-        } delay-0 duration-300 ease-in-out`}
-        style={{
-          borderTop: "1px solid var(--chrome)",
-        }}
-        key={pauseId || "no-pause-id"}
-      >
-        <div
-          className="text-md var(--theme-tab-font-size) p-2  px-4 hover:cursor-pointer"
-          onClick={() => setShowStepDetails(!showStepDetails)}
-          style={{
-            fontSize: "15px",
-          }}
-        >
-          <div className="flex select-none items-center space-x-2">
-            <div className={`img arrow ${showStepDetails ? "expanded" : null}`}></div>
-            <span className="overflow-hidden overflow-ellipsis whitespace-pre">Step Details</span>
-          </div>
-        </div>
-
-        <ErrorBoundary fallback={errorFallback}>
-          <div
-            className={`flex flex-grow flex-col gap-1 overflow-y-auto p-2 font-mono transition-all  ${
-              showStepDetails ? "visible" : "hidden"
-            }`}
-          >
-            <div className={`flex flex-grow flex-col gap-1 p-2 font-mono`}>
-              {loading ? (
-                <div className="flex flex-grow items-center justify-center align-middle text-xs opacity-50">
-                  Loading ...
-                </div>
-              ) : hideProps ? (
-                errorFallback
-              ) : (
-                <PropertiesRenderer pauseId={pauseId!} object={sanitizedConsoleProps} />
-              )}
-            </div>
-          </div>
-        </ErrorBoundary>
-      </div>
-    </>
-  );
 }

--- a/src/devtools/client/debugger/src/components/TestInfo/getCypressConsolePropsSuspense.ts
+++ b/src/devtools/client/debugger/src/components/TestInfo/getCypressConsolePropsSuspense.ts
@@ -24,40 +24,48 @@ export function getCypressConsolePropsSuspense(
   const frames = getFramesSuspense(client, endPauseId);
   const callerFrameId = frames?.[1]?.frameId;
 
-  if (!callerFrameId) {
-    return;
-  }
-
-  const { returned: logResult } = evaluateSuspense(client, endPauseId, callerFrameId, logVariable);
-
-  if (logResult?.object) {
-    const logObject = getObjectWithPreviewSuspense(client, endPauseId, logResult.object);
-    const consolePropsProperty = logObject.preview?.properties?.find(
-      p => p.name === "consoleProps"
+  if (callerFrameId) {
+    const { returned: logResult } = evaluateSuspense(
+      client,
+      endPauseId,
+      callerFrameId,
+      logVariable
     );
 
-    if (consolePropsProperty?.object) {
-      const consoleProps = getObjectWithPreviewSuspense(
-        client,
-        endPauseId,
-        consolePropsProperty.object,
-        true
+    if (logResult?.object) {
+      const logObject = getObjectWithPreviewSuspense(client, endPauseId, logResult.object);
+      const consolePropsProperty = logObject.preview?.properties?.find(
+        p => p.name === "consoleProps"
       );
 
-      const sanitized = cloneDeep(consoleProps);
-      if (sanitized?.preview?.properties) {
-        sanitized.preview.properties = sanitized.preview.properties.filter(
-          p => p.name !== "Snapshot"
+      if (consolePropsProperty?.object) {
+        const consoleProps = getObjectWithPreviewSuspense(
+          client,
+          endPauseId,
+          consolePropsProperty.object,
+          true
         );
 
-        // suppress the prototype entry in the properties output
-        sanitized.preview.prototypeId = undefined;
-      }
+        const sanitized = cloneDeep(consoleProps);
+        if (sanitized?.preview?.properties) {
+          sanitized.preview.properties = sanitized.preview.properties.filter(
+            p => p.name !== "Snapshot"
+          );
 
-      return {
-        consoleProps: sanitized,
-        pauseId: endPauseId,
-      };
+          // suppress the prototype entry in the properties output
+          sanitized.preview.prototypeId = undefined;
+        }
+
+        return {
+          consoleProps: sanitized,
+          pauseId: endPauseId,
+        };
+      }
     }
   }
+
+  return {
+    consoleProps: undefined,
+    pauseId: endPauseId,
+  };
 }

--- a/src/devtools/client/debugger/src/components/TestInfo/getCypressConsolePropsSuspense.ts
+++ b/src/devtools/client/debugger/src/components/TestInfo/getCypressConsolePropsSuspense.ts
@@ -1,0 +1,63 @@
+import cloneDeep from "lodash/cloneDeep";
+
+import { getFramesSuspense } from "replay-next/src/suspense/FrameCache";
+import { getObjectWithPreviewSuspense } from "replay-next/src/suspense/ObjectPreviews";
+import { evaluateSuspense, getPauseIdSuspense } from "replay-next/src/suspense/PauseCache";
+import { ReplayClientInterface } from "shared/client/types";
+import { AnnotatedTestStep } from "ui/types";
+
+export function getCypressConsolePropsSuspense(
+  client: ReplayClientInterface,
+  step: AnnotatedTestStep | null
+) {
+  const {
+    point,
+    time,
+    message: { logVariable } = { logVariable: undefined },
+  } = step?.annotations.end || {};
+
+  if (!logVariable || !point || time == null) {
+    return;
+  }
+
+  const endPauseId = getPauseIdSuspense(client, point, time);
+  const frames = getFramesSuspense(client, endPauseId);
+  const callerFrameId = frames?.[1]?.frameId;
+
+  if (!callerFrameId) {
+    return;
+  }
+
+  const { returned: logResult } = evaluateSuspense(client, endPauseId, callerFrameId, logVariable);
+
+  if (logResult?.object) {
+    const logObject = getObjectWithPreviewSuspense(client, endPauseId, logResult.object);
+    const consolePropsProperty = logObject.preview?.properties?.find(
+      p => p.name === "consoleProps"
+    );
+
+    if (consolePropsProperty?.object) {
+      const consoleProps = getObjectWithPreviewSuspense(
+        client,
+        endPauseId,
+        consolePropsProperty.object,
+        true
+      );
+
+      const sanitized = cloneDeep(consoleProps);
+      if (sanitized?.preview?.properties) {
+        sanitized.preview.properties = sanitized.preview.properties.filter(
+          p => p.name !== "Snapshot"
+        );
+
+        // suppress the prototype entry in the properties output
+        sanitized.preview.prototypeId = undefined;
+      }
+
+      return {
+        consoleProps: sanitized,
+        pauseId: endPauseId,
+      };
+    }
+  }
+}

--- a/src/ui/hooks/useTestInfo.ts
+++ b/src/ui/hooks/useTestInfo.ts
@@ -1,4 +1,8 @@
-import { getReporterAnnotationsComplete } from "ui/reducers/reporter";
+import {
+  getReporterAnnotationsComplete,
+  getSelectedStep,
+  getSelectedTest,
+} from "ui/reducers/reporter";
 import { useAppSelector } from "ui/setup/hooks";
 import { gte } from "ui/utils/semver";
 
@@ -7,9 +11,13 @@ import { useGetRecording, useGetRecordingId } from "./recordings";
 export function useTestInfo() {
   const recordingId = useGetRecordingId();
   const { loading, recording } = useGetRecording(recordingId);
+  const selectedTestIndex = useAppSelector(getSelectedTest);
+  const selectedStep = useAppSelector(getSelectedStep);
+
   const annotationsComplete = useAppSelector(getReporterAnnotationsComplete);
 
   const metadata = recording?.metadata?.test;
+  const selectedTest = metadata?.tests?.[selectedTestIndex || -1];
   const isTestSuiteReplay = metadata != null;
   const testRunId = metadata?.run?.id;
   const runner = metadata?.runner?.name;
@@ -24,6 +32,8 @@ export function useTestInfo() {
   return {
     loading: isLoading,
     metadata,
+    selectedTest,
+    selectedStep,
     isTestSuiteReplay,
     testRunId,
     runner,


### PR DESCRIPTION
## Issue

Console props are loaded by each `TestStepItem` and then fed to the step details pane via context. There's also a `loading` member on the context but it's misused and not communicating correctly to the user

## Resolution

https://app.replay.io/recording/improve-cypress-step-details-loading-and-error-states--bb575380-87c3-4def-8ada-cf8c1d0e3e06

* Refactors the logic to fetch the pause and frames to use the suspense caches to avoid recreating them
* Refactors the console props logic into a suspense provider which is used by both the step details and the matching element badge on the step row
* Improves the loading and error states for step details to hide the details when not supported (playwright atm), to show loading via suspense fallback, and error message when fetching fails.