### PR TITLE
Console assumes original scope but falls back to "generated" if unavailable

### DIFF
--- a/packages/e2e-tests/tests/logpoints-05.test.ts
+++ b/packages/e2e-tests/tests/logpoints-05.test.ts
@@ -4,7 +4,7 @@ import { openDevToolsTab, startTest } from "../helpers";
 import {
   addLogpoint,
   editLogPoint,
-  verifyLogPointTypeAheadSuggestions,
+  verifyLogPointContentTypeAheadSuggestions,
 } from "../helpers/source-panel";
 
 const url = "log_points_and_block_scope.html";
@@ -19,10 +19,10 @@ test(`logpoints-05: should auto-complete based on log point location`, async ({ 
 
   // Verify different auto-complete options based on location
   await editLogPoint(page, { content: "array", lineNumber: 5, saveAfterEdit: false, url });
-  await verifyLogPointTypeAheadSuggestions(page, ["arrayGlobal", "Array", "ArrayBuffer"]);
+  await verifyLogPointContentTypeAheadSuggestions(page, ["arrayGlobal", "Array", "ArrayBuffer"]);
 
   await editLogPoint(page, { content: "array", lineNumber: 12, saveAfterEdit: false, url });
-  await verifyLogPointTypeAheadSuggestions(page, [
+  await verifyLogPointContentTypeAheadSuggestions(page, [
     "arrayBlockOne",
     "arrayBlockOuter",
     "arrayGlobal",
@@ -31,7 +31,7 @@ test(`logpoints-05: should auto-complete based on log point location`, async ({ 
   ]);
 
   await editLogPoint(page, { content: "array", lineNumber: 17, saveAfterEdit: false, url });
-  await verifyLogPointTypeAheadSuggestions(page, [
+  await verifyLogPointContentTypeAheadSuggestions(page, [
     "arrayBlockOuter",
     "arrayBlockTwo",
     "arrayGlobal",
@@ -41,10 +41,10 @@ test(`logpoints-05: should auto-complete based on log point location`, async ({ 
 
   // Alpha sorting should impact priority
   await editLogPoint(page, { content: "Array", lineNumber: 5, saveAfterEdit: false, url });
-  await verifyLogPointTypeAheadSuggestions(page, ["Array", "ArrayBuffer", "arrayGlobal"]);
+  await verifyLogPointContentTypeAheadSuggestions(page, ["Array", "ArrayBuffer", "arrayGlobal"]);
 
   await editLogPoint(page, { content: "Array", lineNumber: 12, saveAfterEdit: false, url });
-  await verifyLogPointTypeAheadSuggestions(page, [
+  await verifyLogPointContentTypeAheadSuggestions(page, [
     "Array",
     "ArrayBuffer",
     "arrayBlockOne",
@@ -53,7 +53,7 @@ test(`logpoints-05: should auto-complete based on log point location`, async ({ 
   ]);
 
   await editLogPoint(page, { content: "Array", lineNumber: 17, saveAfterEdit: false, url });
-  await verifyLogPointTypeAheadSuggestions(page, [
+  await verifyLogPointContentTypeAheadSuggestions(page, [
     "Array",
     "ArrayBuffer",
     "arrayBlockOuter",

--- a/packages/replay-next/components/console/ConsoleInput.tsx
+++ b/packages/replay-next/components/console/ConsoleInput.tsx
@@ -162,6 +162,7 @@ function ConsoleInputSuspends({ inputRef }: { inputRef?: RefObject<ImperativeHan
         <div className={styles.Input}>
           <CodeEditor
             autoFocus={autoFocus}
+            context="console"
             dataTestId="ConsoleTerminalInput"
             editable={true}
             initialValue={expression}
@@ -170,7 +171,6 @@ function ConsoleInputSuspends({ inputRef }: { inputRef?: RefObject<ImperativeHan
             onSave={onSubmit}
             pauseAndFrameId={selectedPauseAndFrameId}
             ref={inputRef}
-            useOriginalVariables={true}
           />
         </div>
       </div>

--- a/packages/replay-next/components/lexical/CodeEditor.tsx
+++ b/packages/replay-next/components/lexical/CodeEditor.tsx
@@ -37,6 +37,7 @@ import { PauseAndFrameId } from "replay-next/src/contexts/SelectedFrameContext";
 
 import LexicalEditorRefSetter from "./LexicalEditorRefSetter";
 import CodeCompletionPlugin from "./plugins/code-completion/CodeCompletionPlugin";
+import { Context } from "./plugins/code-completion/findMatches";
 import CodeNode from "./plugins/code/CodeNode";
 import CodePlugin from "./plugins/code/CodePlugin";
 import parsedTokensToCodeTextNode from "./plugins/code/utils/parsedTokensToCodeTextNode";
@@ -55,6 +56,7 @@ type Props = {
   allowWrapping?: boolean;
   autoFocus?: boolean;
   autoSelect?: boolean;
+  context: Context;
   dataTestId?: string;
   dataTestName?: string;
   editable: boolean;
@@ -65,13 +67,13 @@ type Props = {
   onSave: (markdown: string, editorState: SerializedEditorState) => void;
   pauseAndFrameId: PauseAndFrameId | null;
   placeholder?: string;
-  useOriginalVariables: boolean;
 };
 
 function CodeEditor({
   allowWrapping = true,
   autoFocus = false,
   autoSelect = false,
+  context,
   dataTestId,
   dataTestName,
   editable,
@@ -82,7 +84,6 @@ function CodeEditor({
   onSave,
   pauseAndFrameId,
   placeholder = "",
-  useOriginalVariables,
 }: Props): JSX.Element {
   const historyState = useMemo(() => createEmptyHistoryState(), []);
 
@@ -237,10 +238,10 @@ function CodeEditor({
         <FormPlugin onCancel={onFormCancel} onChange={onFormChange} onSubmit={onFormSubmit} />
         <CodePlugin />
         <CodeCompletionPlugin
+          context={context}
           dataTestId={dataTestId ? `${dataTestId}-CodeTypeAhead` : undefined}
           dataTestName={dataTestName ? `${dataTestName}-CodeTypeAhead` : undefined}
           pauseAndFrameId={pauseAndFrameId}
-          useOriginalVariables={useOriginalVariables}
         />
       </>
     </LexicalComposer>

--- a/packages/replay-next/components/lexical/plugins/code-completion/CodeCompletionPlugin.tsx
+++ b/packages/replay-next/components/lexical/plugins/code-completion/CodeCompletionPlugin.tsx
@@ -8,22 +8,22 @@ import { PauseAndFrameId } from "replay-next/src/contexts/SelectedFrameContext";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
 import TypeAheadPlugin from "../typeahead/TypeAheadPlugin";
-import findMatches from "./findMatches";
+import findMatches, { Context } from "./findMatches";
 import getQueryData from "./getQueryData";
 import isExactMatch from "./isExactMatch";
 import { Match } from "./types";
 import styles from "./styles.module.css";
 
 export default function CodeCompletionPlugin({
+  context,
   dataTestId,
   dataTestName = "CodeTypeAhead",
   pauseAndFrameId = null,
-  useOriginalVariables,
 }: {
+  context: Context;
   dataTestId?: string;
   dataTestName?: string;
   pauseAndFrameId: PauseAndFrameId | null;
-  useOriginalVariables: boolean;
 }): JSX.Element {
   const [editor] = useLexicalComposerContext();
 
@@ -37,7 +37,7 @@ export default function CodeCompletionPlugin({
   }
 
   const findMatchesWrapper = (query: string, queryScope: string | null) => {
-    return findMatches(query, queryScope, replayClient, frameId, pauseId, useOriginalVariables);
+    return findMatches(query, queryScope, replayClient, frameId, pauseId, context);
   };
 
   useEffect(() => {

--- a/packages/replay-next/components/sources/log-point-panel/LogPointPanel.tsx
+++ b/packages/replay-next/components/sources/log-point-panel/LogPointPanel.tsx
@@ -176,7 +176,8 @@ function PointPanelWithHitPoints({
     );
     source = getSource(client, source.generatedSourceIds[0]);
   }
-  const useOriginalVariables = source?.kind === "sourceMapped";
+  const context =
+    source?.kind === "sourceMapped" ? "logpoint-original-source" : "logpoint-generated-source";
 
   const shouldLog = point.shouldLog === POINT_BEHAVIOR_ENABLED;
 
@@ -331,6 +332,7 @@ function PointPanelWithHitPoints({
                       allowWrapping={false}
                       autoFocus={editReason === "condition"}
                       autoSelect={editReason === "condition"}
+                      context={context}
                       dataTestId={`PointPanel-ConditionInput-${lineNumber}`}
                       dataTestName="PointPanel-ConditionInput"
                       editable={true}
@@ -339,7 +341,6 @@ function PointPanelWithHitPoints({
                       onChange={onEditableConditionChange}
                       onSave={onSubmit}
                       pauseAndFrameId={pauseAndFrameId}
-                      useOriginalVariables={useOriginalVariables}
                     />
                   </div>
 
@@ -396,6 +397,7 @@ function PointPanelWithHitPoints({
                     allowWrapping={false}
                     autoFocus={showEditBreakpointNag || editReason === "content"}
                     autoSelect={editReason === "content"}
+                    context={context}
                     dataTestId={`PointPanel-ContentInput-${lineNumber}`}
                     dataTestName="PointPanel-ContentInput"
                     editable={true}
@@ -404,7 +406,6 @@ function PointPanelWithHitPoints({
                     onChange={onEditableContentChange}
                     onSave={onSubmit}
                     pauseAndFrameId={pauseAndFrameId}
-                    useOriginalVariables={useOriginalVariables}
                   />
                 </div>
               </div>

--- a/packages/replay-next/playwright/tests/utils/console.ts
+++ b/packages/replay-next/playwright/tests/utils/console.ts
@@ -242,6 +242,7 @@ export async function verifyConsoleMessage(
     await message.waitFor();
   }
 }
+
 export async function verifyTypeAheadContainsSuggestions(page: Page, ...suggestions: Expected[]) {
   const typeAhead = getConsoleInputTypeAhead(page);
 


### PR DESCRIPTION
e2e tests also updated