### PR TITLE
Add createdByUserId and recordingId to Point object

### DIFF
--- a/packages/replay-next/src/contexts/PointsContext.tsx
+++ b/packages/replay-next/src/contexts/PointsContext.tsx
@@ -105,6 +105,7 @@ export function PointsContextRoot({ children }: PropsWithChildren<{}>) {
             }
           : null,
         createdAtTime: Date.now(),
+        recordingId,
         shouldBreak: POINT_BEHAVIOR_DISABLED,
         shouldLog: POINT_BEHAVIOR_DISABLED,
         ...partialPoint,
@@ -120,7 +121,7 @@ export function PointsContextRoot({ children }: PropsWithChildren<{}>) {
         return prevPoints.slice(0, index).concat([point], prevPoints.slice(index));
       });
     },
-    [currentUserInfo, setPointsHelper, trackEvent]
+    [currentUserInfo, recordingId, setPointsHelper, trackEvent]
   );
 
   const deletePoints = useCallback(

--- a/packages/replay-next/src/contexts/PointsContext.tsx
+++ b/packages/replay-next/src/contexts/PointsContext.tsx
@@ -59,7 +59,7 @@ export const isValidPoint = (maybePoint: unknown): maybePoint is Point => {
 export const PointsContext = createContext<PointsContextType>(null as any);
 
 export function PointsContextRoot({ children }: PropsWithChildren<{}>) {
-  const { recordingId, trackEvent } = useContext(SessionContext);
+  const { currentUserInfo, recordingId, trackEvent } = useContext(SessionContext);
   const replayClient = useContext(ReplayClientContext);
   const [isPending, startTransition] = useTransition();
 
@@ -96,6 +96,14 @@ export function PointsContextRoot({ children }: PropsWithChildren<{}>) {
         badge: null,
         content: "",
         condition: null,
+        createdByUser: currentUserInfo
+          ? {
+              email: currentUserInfo.email,
+              id: currentUserInfo.id,
+              name: currentUserInfo.name,
+              picture: currentUserInfo.picture,
+            }
+          : null,
         createdAtTime: Date.now(),
         shouldBreak: POINT_BEHAVIOR_DISABLED,
         shouldLog: POINT_BEHAVIOR_DISABLED,
@@ -112,7 +120,7 @@ export function PointsContextRoot({ children }: PropsWithChildren<{}>) {
         return prevPoints.slice(0, index).concat([point], prevPoints.slice(index));
       });
     },
-    [setPointsHelper, trackEvent]
+    [currentUserInfo, setPointsHelper, trackEvent]
   );
 
   const deletePoints = useCallback(

--- a/packages/replay-next/src/contexts/PointsContext.tsx
+++ b/packages/replay-next/src/contexts/PointsContext.tsx
@@ -96,14 +96,7 @@ export function PointsContextRoot({ children }: PropsWithChildren<{}>) {
         badge: null,
         content: "",
         condition: null,
-        createdByUser: currentUserInfo
-          ? {
-              email: currentUserInfo.email,
-              id: currentUserInfo.id,
-              name: currentUserInfo.name,
-              picture: currentUserInfo.picture,
-            }
-          : null,
+        createdByUserId: currentUserInfo?.id ?? null,
         createdAtTime: Date.now(),
         recordingId,
         shouldBreak: POINT_BEHAVIOR_DISABLED,

--- a/packages/shared/client/types.ts
+++ b/packages/shared/client/types.ts
@@ -78,12 +78,20 @@ type PointBehavior =
   | typeof POINT_BEHAVIOR_DISABLED
   | typeof POINT_BEHAVIOR_DISABLED_TEMPORARILY;
 
+export type PartialUser = {
+  email: string;
+  id: string;
+  name: string | null;
+  picture: string | null;
+};
+
 export type PointId = string;
 export type Badge = "blue" | "green" | "orange" | "purple" | "unicorn" | "yellow";
 export type Point = {
   badge: Badge | null;
   condition: string | null;
   content: string;
+  createdByUser: PartialUser | null;
   createdAtTime: number;
   id: PointId;
   location: Location;

--- a/packages/shared/client/types.ts
+++ b/packages/shared/client/types.ts
@@ -95,6 +95,7 @@ export type Point = {
   createdAtTime: number;
   id: PointId;
   location: Location;
+  recordingId: RecordingId;
   shouldBreak: PointBehavior;
   shouldLog: PointBehavior;
 };

--- a/packages/shared/client/types.ts
+++ b/packages/shared/client/types.ts
@@ -78,20 +78,13 @@ type PointBehavior =
   | typeof POINT_BEHAVIOR_DISABLED
   | typeof POINT_BEHAVIOR_DISABLED_TEMPORARILY;
 
-export type PartialUser = {
-  email: string;
-  id: string;
-  name: string | null;
-  picture: string | null;
-};
-
 export type PointId = string;
 export type Badge = "blue" | "green" | "orange" | "purple" | "unicorn" | "yellow";
 export type Point = {
   badge: Badge | null;
   condition: string | null;
   content: string;
-  createdByUser: PartialUser | null;
+  createdByUserId: string | null;
   createdAtTime: number;
   id: PointId;
   location: Location;


### PR DESCRIPTION
This is an incremental step toward shared print statements:
- [x] Add `createdByUserId` to `Point` objects.
- [x] Add `recordingId` to `Point` objects.

~~I think the user information stored should be sufficient to render the user's picture (or some fallback) without also needing to fetch the user info from Replay.~~ Decided instead to just store `createdByUserId` and fetch whatever information we need for the user using the `useRecordingUsers` hook.

Next steps:
- [ ] Move log points from Indexed DB to GraphQL.
- [ ] Fetch and display all (shared) log points for the current recording.