### PR TITLE
Log point panel disabled state

### DIFF
--- a/packages/replay-next/components/sources/log-point-panel/LogPointPanel.module.css
+++ b/packages/replay-next/components/sources/log-point-panel/LogPointPanel.module.css
@@ -1,17 +1,12 @@
-.PanelEnabled,
-.PanelDisabled {
+.Panel {
   display: flex;
   flex-direction: column;
   padding: 0.5rem;
   gap: 0.25rem;
+  background-color: var(--point-panel-background-color);
+
   --badge-picker-button-size: 1.25rem;
   --badge-picker-icon-size: 1rem;
-}
-.PanelEnabled {
-  background-color: var(--point-panel-background-color);
-}
-.PanelDisabled {
-  background-color: var(--point-panel-disabled-background-color);
 }
 
 .FocusModeLink {
@@ -62,11 +57,14 @@
   align-items: center;
   gap: 1ch;
 }
+.ContentWrapper[data-logging-disabled] {
+  background-color: var(--point-panel-input-disabled-background-color);
+}
 .ContentWrapper:hover {
   border-color: var(--point-panel-input-border-color-hover);
 }
-.PanelEnabled[data-test-state="edit"] .ContentWrapper:focus,
-.PanelEnabled[data-test-state="edit"] .ContentWrapper:focus-within {
+.Panel[data-test-state="edit"] .ContentWrapper:focus,
+.Panel[data-test-state="edit"] .ContentWrapper:focus-within {
   border-color: var(--point-panel-input-border-color-focus);
 }
 

--- a/packages/replay-next/components/sources/log-point-panel/LogPointPanel.tsx
+++ b/packages/replay-next/components/sources/log-point-panel/LogPointPanel.tsx
@@ -307,7 +307,7 @@ function PointPanelWithHitPoints({
 
   return (
     <div
-      className={`${shouldLog ? styles.PanelEnabled : styles.PanelDisabled} ${className}`}
+      className={`${styles.Panel} ${className}`}
       data-test-id={`PointPanel-${lineNumber}`}
       data-test-state={isEditing ? "edit" : "view"}
     >
@@ -316,6 +316,7 @@ function PointPanelWithHitPoints({
           <div className={styles.EditableContentWrapperRow}>
             <div
               className={isConditionValid ? styles.ContentWrapper : styles.ContentWrapperInvalid}
+              data-logging-disabled={!shouldLog || undefined}
               onClick={showTooManyPointsMessage ? undefined : () => startEditing("condition")}
             >
               <div
@@ -386,6 +387,7 @@ function PointPanelWithHitPoints({
         ) : (
           <div
             className={isContentValid ? styles.ContentWrapper : styles.ContentWrapperInvalid}
+            data-logging-disabled={!shouldLog || undefined}
             onClick={showTooManyPointsMessage ? undefined : () => startEditing("content")}
           >
             <BadgePicker invalid={!isContentValid} point={point} />

--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -292,7 +292,6 @@
   --value-type-html-text: #d7d7db;
 
   --point-panel-background-color: #1f2b43;
-  --point-panel-disabled-background-color: #121723;
   --point-panel-conditional-icon: var(--blue-40);
   --point-panel-input-background-color: #000000;
   --point-panel-input-border-color: transparent;
@@ -302,9 +301,10 @@
   --point-panel-input-edit-button-color-hover: var(--primary-accent);
   --point-panel-input-cancel-button-color: #484445;
   --point-panel-input-cancel-button-color-hover: #747476;
-  --point-panel-input-disabled-link-color-hover: #fff;
+  --point-panel-input-disabled-background-color: #121723;
   --point-panel-input-disabled-cancel-button-color: #a65858;
   --point-panel-input-disabled-cancel-button-color-hover: #d3aaaa;
+  --point-panel-input-disabled-link-color-hover: #fff;
   --point-panel-timeline-background-color: #000000;
   --point-panel-timeline-button-background-color: #000000;
   --point-panel-timeline-button-color: var(--color-brand);
@@ -780,7 +780,6 @@
   --value-type-undefined: #737373;
 
   --point-panel-background-color: #f0f1f4;
-  --point-panel-disabled-background-color: #e4e4e4;
   --point-panel-conditional-icon: var(--blue-60);
   --point-panel-input-background-color: #ffffff;
   --point-panel-input-border-color-focus: var(--theme-selection-background);
@@ -788,6 +787,7 @@
   --point-panel-input-border-color: transparent;
   --point-panel-input-cancel-button-color-hover: #afafb5;
   --point-panel-input-cancel-button-color: #e2e2e2;
+  --point-panel-input-disabled-background-color: #e4e4e4;
   --point-panel-input-disabled-cancel-button-color-hover: #c07171;
   --point-panel-input-disabled-cancel-button-color: #d3aaaa;
   --point-panel-input-disabled-link-color-hover: #b9000d;


### PR DESCRIPTION
I misinterpreted what was meant by "_disabled background color_" in FE-1200. This PR updates log point panels to use this color for the background of the _input element_ rather than the _panel itself_.

<img width="671" alt="Screen Shot 2023-01-31 at 3 25 20 PM" src="https://user-images.githubusercontent.com/29597/215875395-f710a015-9ffc-4b00-8cf9-4b5fa30c62ea.png">

<img width="672" alt="Screen Shot 2023-01-31 at 3 25 27 PM" src="https://user-images.githubusercontent.com/29597/215875397-b654399a-34ec-4ec0-a26e-15b80d470a8a.png">

cc @jonbell-lot23 