### PR TITLE
Remove source contents loading from Redux and fix breakpoint text

### DIFF
--- a/packages/replay-next/src/suspense/SourcesCache.ts
+++ b/packages/replay-next/src/suspense/SourcesCache.ts
@@ -568,3 +568,24 @@ function sourceIdAndFocusRangeToKey(
   }
   return key;
 }
+
+export const {
+  getValueAsync: getSourceContentsAsync,
+  getValueSuspense: getSourceContentsSuspense,
+  getValueIfCached: getSourceContentsIfCached,
+  getStatus: getSourceContentsStatus,
+} = createGenericCache<
+  [replayClient: ReplayClientInterface, sourceId: string],
+  StreamingSourceContents | undefined
+>(
+  "sourceContentsCache",
+  async (replayClient, sourceId) => {
+    const res = await getStreamingSourceContentsHelper(replayClient, sourceId);
+    if (res) {
+      // Ensure that follow-on caches have the entire text available
+      const sourceContents = await res.resolver;
+      return sourceContents;
+    }
+  },
+  (replayClient, sourceId) => sourceId
+);

--- a/packages/replay-next/src/suspense/createGenericCache.ts
+++ b/packages/replay-next/src/suspense/createGenericCache.ts
@@ -13,11 +13,16 @@ import {
   Wakeable,
 } from "./types";
 
+export { STATUS_PENDING, STATUS_REJECTED, STATUS_RESOLVED } from "./types";
+
+type CacheRecordStatus = typeof STATUS_PENDING | typeof STATUS_RESOLVED | typeof STATUS_REJECTED;
+
 export interface GenericCache<TParams extends Array<any>, TValue> {
   getValueSuspense(...args: TParams): TValue;
   getValueAsync(...args: TParams): Thennable<TValue> | TValue;
   getValueIfCached(...args: TParams): { value: TValue } | undefined;
   addValue(value: TValue, ...args: TParams): void;
+  getStatus(...args: TParams): CacheRecordStatus | undefined;
 }
 
 export interface GenericCache2<TExtra, TParams extends Array<any>, TValue> {
@@ -25,6 +30,7 @@ export interface GenericCache2<TExtra, TParams extends Array<any>, TValue> {
   getValueAsync(extra: TExtra, ...args: TParams): Thennable<TValue> | TValue;
   getValueIfCached(...args: TParams): { value: TValue } | undefined;
   addValue(value: TValue, ...args: TParams): void;
+  getStatus(...args: TParams): CacheRecordStatus | undefined;
 }
 
 interface HookState<TValue> {
@@ -48,6 +54,7 @@ export function createGenericCache<TParams extends Array<any>, TValue>(
     getValueAsync: (...args) => cache.getValueAsync(undefined, ...args),
     getValueIfCached: (...args) => cache.getValueIfCached(...args),
     addValue: (value, ...args) => cache.addValue(value, ...args),
+    getStatus: (...args) => cache.getStatus(...args),
   };
 }
 
@@ -138,6 +145,11 @@ export function createGenericCache2<TExtra, TParams extends Array<any>, TValue>(
     addValue(value: TValue, ...args: TParams) {
       const cacheKey = getCacheKey(...args);
       recordMap.set(cacheKey, { status: STATUS_RESOLVED, value });
+    },
+
+    getStatus(...args: TParams) {
+      const cacheKey = getCacheKey(...args);
+      return recordMap.get(cacheKey)?.status;
     },
   };
 }

--- a/src/devtools/client/debugger/src/actions/sources/select.ts
+++ b/src/devtools/client/debugger/src/actions/sources/select.ts
@@ -16,7 +16,6 @@ import {
   getSourceDetails,
   getSourceIdToDisplayForUrl,
   getSourceToDisplayForUrl,
-  loadSourceText,
   locationSelected,
   preferSource,
 } from "ui/reducers/sources";
@@ -172,10 +171,6 @@ export function selectLocation(
       dispatch(setSelectedPanel("debugger"));
     }
 
-    // This adds the source's text to the client-side parser, which is a necessary step
-    // before we can ask the parser to return symbols in `fetchSymbolsForSource`.
-    await dispatch(loadSourceText(source.id));
-
     // Set shownSource to null first, then the actual source to trigger
     // a proper re-render in the SourcesTree component
     dispatch(setShownSource(null));
@@ -188,6 +183,7 @@ export function selectLocation(
       return;
     }
 
+    // Kick off Babel parsing for symbols so that the "Outline" view can display functions
     dispatch(fetchSymbolsForSource(loadedSource.id));
   };
 }

--- a/src/devtools/client/debugger/src/actions/ui.ts
+++ b/src/devtools/client/debugger/src/actions/ui.ts
@@ -6,8 +6,9 @@
 
 import type { Context } from "devtools/client/debugger/src/reducers/pause";
 import { copyToClipboard as copyTextToClipboard } from "replay-next/components/sources/utils/clipboard";
+import { getSourceContentsIfCached } from "replay-next/src/suspense/SourcesCache";
 import type { UIThunkAction } from "ui/actions";
-import { SourceDetails, getSourceContent, getSourceDetails } from "ui/reducers/sources";
+import { SourceDetails, getSourceDetails } from "ui/reducers/sources";
 
 import { closeQuickOpen } from "../reducers/quick-open";
 import {
@@ -99,10 +100,11 @@ export function flashLineRange(location: HighlightedRange): UIThunkAction {
 }
 
 export function copyToClipboard(source: SourceDetails): UIThunkAction {
-  return (dispatch, getState) => {
-    const content = getSourceContent(getState(), source.id);
-    if (content?.value?.type === "text") {
-      copyTextToClipboard(content.value.value);
+  return (dispatch, getState, { replayClient }) => {
+    const sourceContents = getSourceContentsIfCached(replayClient, source.id);
+
+    if (typeof sourceContents?.value?.contents === "string") {
+      copyTextToClipboard(sourceContents.value.contents);
     }
   };
 }

--- a/src/devtools/client/debugger/src/components/PrimaryPanes/SourcesTreeItem.tsx
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/SourcesTreeItem.tsx
@@ -12,7 +12,7 @@ import { showMenu } from "devtools/shared/contextmenu";
 import { copyToClipboard } from "replay-next/components/sources/utils/clipboard";
 import { Redacted } from "ui/components/Redacted";
 import type { SourceDetails } from "ui/reducers/sources";
-import { getHasSiblingOfSameName, getSourceContent, isFulfilled } from "ui/reducers/sources";
+import { getHasSiblingOfSameName } from "ui/reducers/sources";
 import type { UIState } from "ui/state";
 
 import type { ContextMenuItem } from "../../reducers/types";
@@ -37,11 +37,10 @@ interface STIProps {
 }
 
 const mapStateToProps = (state: UIState, props: STIProps) => {
-  const { source, item } = props;
+  const { source } = props;
   return {
     cx: getContext(state),
     hasSiblingOfSameName: getHasSiblingOfSameName(state, source),
-    sourceContent: source ? getSourceContentValue(state, source) : null,
   };
 };
 
@@ -209,11 +208,6 @@ class SourceTreeItem extends Component<FinalSTIProps> {
       </div>
     );
   }
-}
-
-function getSourceContentValue(state: UIState, source: SourceDetails) {
-  const content = getSourceContent(state, source.id);
-  return content && isFulfilled(content) ? content.value : null;
 }
 
 export default connector(SourceTreeItem);

--- a/src/devtools/client/debugger/src/components/QuickOpenModal.tsx
+++ b/src/devtools/client/debugger/src/components/QuickOpenModal.tsx
@@ -8,13 +8,14 @@ import debounce from "lodash/debounce";
 import React, { Component } from "react";
 import { ConnectedProps, connect } from "react-redux";
 
+import { STATUS_RESOLVED } from "replay-next/src/suspense/createGenericCache";
+import { getSourceContentsStatus } from "replay-next/src/suspense/SourcesCache";
 import { setViewMode } from "ui/actions/layout";
 import { getViewMode } from "ui/reducers/layout";
 import {
   SourceDetails,
   getAllSourceDetails,
   getSelectedSource,
-  getSourceContentsLoaded,
   getSourcesLoading,
   getSourcesToDisplayByUrl,
 } from "ui/reducers/sources";
@@ -53,8 +54,6 @@ const maxResults = 100;
 
 const SIZE_BIG = { size: "big" };
 const SIZE_DEFAULT = {};
-
-type $FixTypeLater = any;
 
 function filter(values: SearchResult[], query: string) {
   const preparedQuery = fuzzyAldrin.prepareQuery(query);
@@ -307,9 +306,13 @@ export class QuickOpenModal extends Component<PropsFromRedux, QOMState> {
   };
 
   onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { selectedSource, selectedContentLoaded, setQuickOpenQuery } = this.props;
+    const { selectedSource, setQuickOpenQuery } = this.props;
     setQuickOpenQuery(e.target.value);
+
+    const selectedContentLoaded =
+      selectedSource && getSourceContentsStatus(null as any, selectedSource.id) === STATUS_RESOLVED;
     const noSource = !selectedSource || !selectedContentLoaded;
+
     if ((noSource && this.isFunctionQuery()) || this.isGotoQuery()) {
       return;
     }
@@ -494,9 +497,6 @@ function mapStateToProps(state: UIState) {
     project: getQuickOpenProject(state),
     query: getQuickOpenQuery(state),
     searchType: getQuickOpenType(state),
-    selectedContentLoaded: selectedSource
-      ? getSourceContentsLoaded(state, selectedSource.id)
-      : undefined,
     selectedSource,
     showOnlyOpenSources: getShowOnlyOpenSources(state),
     sourcesForTabs: getSourcesForTabs(state),

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointOptions.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointOptions.tsx
@@ -1,23 +1,42 @@
-import React from "react";
+import React, { Suspense, useContext, useMemo } from "react";
 
+import Loader from "replay-next/components/Loader";
 import SyntaxHighlightedLine from "replay-next/components/sources/SyntaxHighlightedLine";
+import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { Point } from "shared/client/types";
-import { getSelectedSource, getSourceContent } from "ui/reducers/sources";
-import { useAppSelector } from "ui/setup/hooks";
-
-import { getTextAtPosition } from "../../../utils/source";
+import { getSourceLinesSuspense } from "ui/suspense/sourceCaches";
 
 type BreakpointProps = {
   type: "breakpoint" | "logpoint";
   breakpoint: Point;
 };
 
-export default function BreakpointOptions({ breakpoint, type }: BreakpointProps) {
-  const selectedSource = useAppSelector(getSelectedSource);
-  const sourceContent = useAppSelector(state =>
-    selectedSource ? getSourceContent(state, selectedSource.id) : null
-  );
+function BreakpointLineContents({ breakpoint }: BreakpointProps) {
+  const replayClient = useContext(ReplayClientContext);
+  const { sourceId } = breakpoint.location;
 
+  const sourceLines = getSourceLinesSuspense(replayClient, sourceId);
+
+  const snippet = useMemo(() => {
+    const { column, line = 0 } = breakpoint.location;
+    let snippet = "";
+
+    if (sourceLines.length > 0) {
+      const lineText = sourceLines[line - 1];
+      return lineText.slice(column, column! + 100).trim();
+    }
+
+    return snippet;
+  }, [sourceLines, breakpoint]);
+
+  if (!snippet) {
+    return null;
+  }
+
+  return <SyntaxHighlightedLine code={snippet} />;
+}
+
+export default function BreakpointOptions({ breakpoint, type }: BreakpointProps) {
   let children = null;
   if (type === "logpoint") {
     if (breakpoint.condition) {
@@ -41,15 +60,11 @@ export default function BreakpointOptions({ breakpoint, type }: BreakpointProps)
       );
     }
   } else {
-    if (sourceContent == null) {
-      return null;
-    }
-
-    const text = getTextAtPosition(sourceContent, breakpoint.location);
-
     children = (
       <span className="breakpoint-label cm-s-mozilla devtools-monospace">
-        <SyntaxHighlightedLine code={text} />
+        <Suspense fallback={<Loader />}>
+          <BreakpointLineContents breakpoint={breakpoint} type={type} />
+        </Suspense>
       </span>
     );
   }

--- a/src/devtools/client/debugger/src/reducers/ast.ts
+++ b/src/devtools/client/debugger/src/reducers/ast.ts
@@ -8,6 +8,7 @@ import { SourceLocation } from "@replayio/protocol";
 import { getSourceIDsToSearch } from "devtools/client/debugger/src/utils/sourceVisualizations";
 import { MiniSource, SourceDetails, getSourceDetailsEntities } from "ui/reducers/sources";
 import { UIState } from "ui/state";
+import { getSymbolsAsync } from "ui/suspense/sourceCaches";
 import { LoadingStatus } from "ui/utils/LoadingStatus";
 import { ThunkExtraArgs } from "ui/utils/thunk";
 
@@ -108,11 +109,11 @@ export const fetchSymbolsForSource = createAsyncThunk<
   { state: UIState; extra: ThunkExtraArgs }
 >(
   "ast/fetchSymbolsForSource",
-  async sourceId => {
-    const { parser } = await import("devtools/client/debugger/src/utils/bootstrap");
+  async (sourceId, { extra }) => {
+    const { replayClient } = extra;
 
-    const symbols = (await parser.getSymbols(sourceId)) as SymbolDeclarations;
-    return symbols;
+    const symbols = await getSymbolsAsync(replayClient, sourceId);
+    return symbols!;
   },
   {
     condition(arg, thunkApi) {

--- a/src/ui/setup/store.ts
+++ b/src/ui/setup/store.ts
@@ -55,14 +55,6 @@ const OMITTED = "<OMITTED>";
 const sanitizeStateForDevtools = <S>(state: S) => {
   // Use Immer to simplify nested immutable updates when making a copy of the state
   const sanitizedState = customImmer.produce(state, (draft: UIState) => {
-    if (draft.sources) {
-      Object.values(draft.sources.contents.entities).forEach(contentsItem => {
-        if (contentsItem!.value) {
-          contentsItem!.value.value = OMITTED;
-        }
-      });
-    }
-
     if (draft.protocolMessages) {
       // @ts-expect-error
       draft.protocolMessages = OMITTED;

--- a/src/ui/suspense/sourceCaches.ts
+++ b/src/ui/suspense/sourceCaches.ts
@@ -1,0 +1,72 @@
+import type { SymbolDeclarations } from "devtools/client/debugger/src/reducers/ast";
+import { createGenericCache } from "replay-next/src/suspense/createGenericCache";
+import {
+  StreamingSourceContents,
+  getStreamingSourceContentsHelper,
+} from "replay-next/src/suspense/SourcesCache";
+import { ReplayClientInterface } from "shared/client/types";
+
+export const {
+  getValueAsync: getSourceContentsAsync,
+  getValueSuspense: getSourceContentsSuspense,
+  getStatus: getSourceContentsStatus,
+} = createGenericCache<
+  [replayClient: ReplayClientInterface, sourceId: string],
+  StreamingSourceContents | undefined
+>(
+  "sourceContentsCache",
+  async (replayClient, sourceId) => {
+    const res = await getStreamingSourceContentsHelper(replayClient, sourceId);
+    if (res) {
+      // Ensure that follow-on caches have the entire text available
+      const sourceContents = await res.resolver;
+      return sourceContents;
+    }
+  },
+  (replayClient, sourceId) => sourceId
+);
+
+export const {
+  getValueAsync: getSymbolsAsync,
+  getStatus: getSymbolsStatus,
+  getValueSuspense: getSymbolsSuspense,
+} = createGenericCache<
+  [replayClient: ReplayClientInterface, sourceId: string],
+  SymbolDeclarations | undefined
+>(
+  "sourceSymbolsCache",
+  async (replayClient, sourceId) => {
+    const { parser } = await import("devtools/client/debugger/src/utils/bootstrap");
+    const sourceContents = await getSourceContentsAsync(replayClient, sourceId);
+
+    if (sourceContents !== undefined) {
+      const { contents, contentType } = sourceContents;
+
+      // Our Babel parser worker requires a copy of the source text be sent over first
+      parser.setSource(sourceId, {
+        type: "text",
+        value: contents,
+        contentType,
+      });
+      const symbols = (await parser.getSymbols(sourceId)) as SymbolDeclarations;
+      return symbols;
+    }
+  },
+  (replayClient, sourceId) => sourceId
+);
+
+export const { getValueAsync: getSourceLinesAsync, getValueSuspense: getSourceLinesSuspense } =
+  createGenericCache<[replayClient: ReplayClientInterface, sourceId: string], string[]>(
+    "sourceLinesCache",
+    async (replayClient, sourceId) => {
+      const sourceContents = await getSourceContentsAsync(replayClient, sourceId);
+      if (!sourceContents) {
+        return [];
+      }
+
+      const { contents } = sourceContents;
+
+      return contents?.split("\n") ?? [];
+    },
+    (replayClient, sourceId) => sourceId
+  );

--- a/src/ui/suspense/sourceCaches.ts
+++ b/src/ui/suspense/sourceCaches.ts
@@ -1,30 +1,7 @@
 import type { SymbolDeclarations } from "devtools/client/debugger/src/reducers/ast";
 import { createGenericCache } from "replay-next/src/suspense/createGenericCache";
-import {
-  StreamingSourceContents,
-  getStreamingSourceContentsHelper,
-} from "replay-next/src/suspense/SourcesCache";
+import { getSourceContentsAsync } from "replay-next/src/suspense/SourcesCache";
 import { ReplayClientInterface } from "shared/client/types";
-
-export const {
-  getValueAsync: getSourceContentsAsync,
-  getValueSuspense: getSourceContentsSuspense,
-  getStatus: getSourceContentsStatus,
-} = createGenericCache<
-  [replayClient: ReplayClientInterface, sourceId: string],
-  StreamingSourceContents | undefined
->(
-  "sourceContentsCache",
-  async (replayClient, sourceId) => {
-    const res = await getStreamingSourceContentsHelper(replayClient, sourceId);
-    if (res) {
-      // Ensure that follow-on caches have the entire text available
-      const sourceContents = await res.resolver;
-      return sourceContents;
-    }
-  },
-  (replayClient, sourceId) => sourceId
-);
 
 export const {
   getValueAsync: getSymbolsAsync,


### PR DESCRIPTION
After the source viewer rewrite, a handful of components were still looking to find loaded source file contents in the Redux store:

- `<QuickOpenModal>` was doing an update bailout if not loaded
- `<BreakpointOptions>` uses the text to show a line snippet

Additionally, the source text was needed for Babel symbol parsing.

Along the way, I found out that our `<BreakpointOptions>` component has been broken since the "points refactor" in October - it was always trying to use the _selected_ source to read out line snippets, when it actually needs to be the source where the _breakpoint_ is located. That led to a display bug like this, where the line snippets are from the wrong file:

![image](https://user-images.githubusercontent.com/1128784/215892132-a2d5e1cd-52e0-4a99-bb4e-a73e0d464138.png)


I've created Suspense caches for source contents, split source lines, and Babel-parsed symbols.

I also added a new `getStatus` method to the caches to let us check the loading status of a record.

`<QuickOpenModal>` now just imports the contents cache and and checks to see if the given source is loaded.

`<BreakpointOptions>` now suspends waiting for the source lines, and does the line text trimming itself.

This let me remove a couple hundred lines of Redux-based loading state tracking, and a lot of dead code in `utils/source.ts`.

You can see that the breakpoint snippets now show the correct text even if another file or _no_ file is selected, and they show "Loading" if suspended:

![image](https://user-images.githubusercontent.com/1128784/215892048-0af3faed-33c2-4ea7-89bf-f52435426e8e.png)
