### PR TITLE
Fix flashing the root suspense fallback for a cypress test

### DIFF
--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -171,7 +171,9 @@ export function TestStepItem({ step, argString, index, id }: TestStepItemProps) 
           <span className="opacity-70">{argString}</span>
         </div>
       </button>
-      <MatchingElementBadge selected={isSelected} step={step} />
+      <React.Suspense>
+        <MatchingElementBadge selected={isSelected} step={step} />
+      </React.Suspense>
       {step.alias ? (
         <span
           className={classNames(


### PR DESCRIPTION
The matching element badge used the console props suspense provider but missed wrapping it in a fallback so the root fallback was taking effect instead.

Adding that fallback in downstream resolves this.