### PR TITLE
Testsuites: Hide alias badge when the window gets tiny

### DIFF
--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -486,6 +486,10 @@
   --breakpoint-tip: #fff;
 
   /* Testsuites (Dark) */
+  --testsuites-capsule-alias-bgcolor: var(--theme-base-85);
+  --testsuites-capsule-alias-color: var(--body-color);
+  --testsuites-capsule-alias-selected-bgcolor: var(--theme-base-100);
+  --testsuites-capsule-alias-selected-color: var(--body-color);
   --testsuites-capsule-error-bgcolor: rgb(237, 36, 36);
   --testsuites-capsule-error-color: white;
   --testsuites-capsule-success-bgcolor: var(--testsuites-success-color);
@@ -974,6 +978,10 @@
   --breakpoint-tip: var(--theme-highlight-purple);
 
   /* Testsuites (Light) */
+  --testsuites-capsule-alias-bgcolor: var(--theme-base-85);
+  --testsuites-capsule-alias-color: var(--body-color);
+  --testsuites-capsule-alias-selected-bgcolor: var(--theme-base-100);
+  --testsuites-capsule-alias-selected-color: var(--body-color);
   --testsuites-capsule-error-bgcolor: rgb(203, 0, 0);
   --testsuites-capsule-error-color: #fff;
   --testsuites-capsule-success-bgcolor: var(--testsuites-success-color);

--- a/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
@@ -20,7 +20,8 @@ import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { TestItem, TestResult, TestStep } from "ui/types";
 
 import { TestSteps } from "./TestSteps";
-import styles from "src/ui/components/SidePanel.module.css";
+import stylesTestInfo from "src/devtools/client/debugger/src/components/TestInfo/TestInfo.module.css";
+import stylesSidePanel from "src/ui/components/SidePanel.module.css";
 
 export type TestCaseContextType = {
   test: TestItem;
@@ -106,6 +107,18 @@ export function TestCase({ test, index }: { test: TestItem; index: number }) {
     dispatch(startPlayback({ beginTime, endTime: testEndTime - 1 }));
   };
 
+  /*
+  const TestStepsDiv = document.getElementById(stylesTestInfo.TestSteps);
+
+  if (TestStepsDiv && TestStepsDiv.offsetWidth < 380) {
+    TestStepsDiv.classList.add(stylesTestInfo.tiny);
+    console.log("add tiny");
+  } else if (TestStepsDiv && TestStepsDiv.offsetWidth > 380) {
+    console.log("remove tiny");
+    TestStepsDiv.classList.remove(stylesTestInfo.tiny);
+  }
+*/
+
   return (
     <TestCaseContext.Provider
       value={{ startTime: testStartTime, endTime: testEndTime, onReplay, onPlayFromHere, test }}
@@ -156,7 +169,7 @@ export function Status({ result }: { result: TestResult }) {
     <Icon
       filename={result === "passed" ? "testsuites-success" : "testsuites-fail"}
       size="small"
-      className={result === "passed" ? styles.SuccessIcon : styles.ErrorIcon}
+      className={result === "passed" ? stylesSidePanel.SuccessIcon : stylesSidePanel.ErrorIcon}
     />
   );
 }

--- a/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
@@ -20,8 +20,7 @@ import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { TestItem, TestResult, TestStep } from "ui/types";
 
 import { TestSteps } from "./TestSteps";
-import stylesTestInfo from "src/devtools/client/debugger/src/components/TestInfo/TestInfo.module.css";
-import stylesSidePanel from "src/ui/components/SidePanel.module.css";
+import styles from "src/ui/components/SidePanel.module.css";
 
 export type TestCaseContextType = {
   test: TestItem;
@@ -107,18 +106,6 @@ export function TestCase({ test, index }: { test: TestItem; index: number }) {
     dispatch(startPlayback({ beginTime, endTime: testEndTime - 1 }));
   };
 
-  /*
-  const TestStepsDiv = document.getElementById(stylesTestInfo.TestSteps);
-
-  if (TestStepsDiv && TestStepsDiv.offsetWidth < 380) {
-    TestStepsDiv.classList.add(stylesTestInfo.tiny);
-    console.log("add tiny");
-  } else if (TestStepsDiv && TestStepsDiv.offsetWidth > 380) {
-    console.log("remove tiny");
-    TestStepsDiv.classList.remove(stylesTestInfo.tiny);
-  }
-*/
-
   return (
     <TestCaseContext.Provider
       value={{ startTime: testStartTime, endTime: testEndTime, onReplay, onPlayFromHere, test }}
@@ -169,7 +156,7 @@ export function Status({ result }: { result: TestResult }) {
     <Icon
       filename={result === "passed" ? "testsuites-success" : "testsuites-fail"}
       size="small"
-      className={result === "passed" ? stylesSidePanel.SuccessIcon : stylesSidePanel.ErrorIcon}
+      className={result === "passed" ? styles.SuccessIcon : styles.ErrorIcon}
     />
   );
 }

--- a/src/devtools/client/debugger/src/components/TestInfo/TestInfo.module.css
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestInfo.module.css
@@ -1,0 +1,12 @@
+#TestSteps {
+  display: flex;
+  overflow: auto;
+  position: relative;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0.75rem;
+  margin-top: 0.25rem;
+  flex-direction: column;
+  flex-grow: 1;
+  border-top-width: 1px;
+}

--- a/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
@@ -11,6 +11,7 @@ import ContextMenuWrapper from "./ContextMenu";
 import { StepDetails } from "./StepDetails";
 import { TestCase } from "./TestCase";
 import { TestInfoContextMenuContextRoot } from "./TestInfoContextMenuContext";
+import styles from "./TestInfo.module.css";
 
 type TestInfoContextType = {
   consoleProps?: ProtocolObject;
@@ -55,7 +56,7 @@ export default function TestInfo({ testCases }: { testCases: TestItem[] }) {
     >
       <TestInfoContextMenuContextRoot>
         <div className="flex flex-grow flex-col overflow-hidden">
-          <div className="relative flex flex-grow flex-col space-y-1 overflow-auto border-t border-splitter px-2 pt-3">
+          <div id={styles.TestSteps}>
             {missingSteps ? (
               <aside className="m-1 space-y-4 rounded-lg border border-amber-200 bg-amber-100 px-4 py-3">
                 <div>

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.module.css
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.module.css
@@ -35,3 +35,21 @@
 .TestsuitesErrorColor {
   color: var(--testsuites-error-color);
 }
+
+.Alias {
+  padding: 0.25rem;
+  color: #1f2937;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  flex-shrink: 1;
+  border-radius: 0.25rem;
+  background-color: #ececec;
+}
+
+.AliasSelected {
+  background-color: #bbb;
+}
+
+.AliasHidden {
+  display: none;
+}

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.module.css
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.module.css
@@ -43,13 +43,27 @@
   line-height: 1rem;
   flex-shrink: 1;
   border-radius: 0.25rem;
-  background-color: #ececec;
+  background-color: var(--testsuites-capsule-alias-bgcolor);
+  color: var(--testsuites-capsule-alias-color);
 }
 
 .AliasSelected {
-  background-color: #bbb;
+  background-color: var(--testsuites-capsule-alias-selected-bgcolor);
+  color: var(--testsuites-capsule-alias-selected-color);
 }
 
 .AliasHidden {
   display: none;
+}
+
+.Badge {
+  padding: 0.25rem;
+  margin-top: -0.25rem;
+  margin-bottom: -0.25rem;
+  background-color: var(--testsuites-capsule-alias-bgcolor);
+  color: var(--testsuites-capsule-alias-color);
+  font-size: 0.75rem;
+  line-height: 1rem;
+  flex-shrink: 1;
+  border-radius: 0.25rem;
 }

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.module.css
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.module.css
@@ -47,7 +47,8 @@
   color: var(--testsuites-capsule-alias-color);
 }
 
-.AliasSelected {
+.AliasSelected,
+.BadgeSelected {
   background-color: var(--testsuites-capsule-alias-selected-bgcolor);
   color: var(--testsuites-capsule-alias-selected-color);
 }

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -189,7 +189,7 @@ export function TestStepItem({ step, argString, index, id }: TestStepItemProps) 
       <React.Suspense>
         <MatchingElementBadge selected={isSelected} step={step} />
       </React.Suspense>
-      {styles.Alias ? (
+      {step.alias ? (
         <span
           className={`${styles.Alias} ${isSelected ? styles.AliasSelected : ""}`}
           title={`'${argString}' aliased as '${step.alias}'`}

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -20,6 +20,7 @@ import { AnnotatedTestStep } from "ui/types";
 import { TestCaseContext } from "./TestCase";
 import { TestInfoContextMenuContext } from "./TestInfoContextMenuContext";
 import { TestStepRow } from "./TestStepRow";
+import stylesTestInfo from "src/devtools/client/debugger/src/components/TestInfo/TestInfo.module.css";
 import styles from "./TestStepItem.module.css";
 
 function preventClickFromSpaceBar(ev: React.KeyboardEvent<HTMLButtonElement>) {
@@ -147,6 +148,20 @@ export function TestStepItem({ step, argString, index, id }: TestStepItemProps) 
     (step.duration === 1 && state === "paused") || progress == 100 ? 0 : progress;
   const isSelected = selectedStep?.id === id;
 
+  const TestStepsDiv = document.getElementById(stylesTestInfo.TestSteps);
+  const AliasDivs = document.querySelectorAll(`.${styles.Alias}`);
+
+  if (TestStepsDiv && TestStepsDiv.offsetWidth < 380) {
+    AliasDivs.forEach(aliasDiv => {
+      aliasDiv.classList.add(styles.AliasHidden);
+    });
+    console.log(AliasDivs);
+  } else if (TestStepsDiv && TestStepsDiv.offsetWidth > 380) {
+    AliasDivs.forEach(aliasDiv => {
+      aliasDiv.classList.remove(styles.AliasHidden);
+    });
+  }
+
   return (
     <TestStepRow
       active={state === "paused"}
@@ -174,12 +189,9 @@ export function TestStepItem({ step, argString, index, id }: TestStepItemProps) 
       <React.Suspense>
         <MatchingElementBadge selected={isSelected} step={step} />
       </React.Suspense>
-      {step.alias ? (
+      {styles.Alias ? (
         <span
-          className={classNames(
-            "-my-1 flex-shrink rounded p-1 text-xs text-gray-800",
-            isSelected ? "bg-gray-300" : "bg-gray-200"
-          )}
+          className={`${styles.Alias} ${isSelected ? styles.AliasSelected : ""}`}
           title={`'${argString}' aliased as '${step.alias}'`}
         >
           {step.alias}

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -219,9 +219,7 @@ function MatchingElementBadge({ step, selected }: { step: AnnotatedTestStep; sel
   }
 
   return (
-    <span className={classNames(styles.Badge, selected ? "bg-gray-300" : "bg-gray-200")}>
-      {count}
-    </span>
+    <span className={classNames(styles.Badge, selected ? styles.BadgeSelected : "")}>{count}</span>
   );
 }
 

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -1,5 +1,12 @@
 import classNames from "classnames";
-import React, { useCallback, useContext, useEffect, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 
 import { highlightNodes, unhighlightNode } from "devtools/client/inspector/markup/actions/markup";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
@@ -140,6 +147,18 @@ export function TestStepItem({ step, argString, index, id }: TestStepItemProps) 
     }
   }, [step, ref, onClick]);
 
+  useLayoutEffect(() => {
+    if (TestStepsDiv && TestStepsDiv.offsetWidth < 380) {
+      AliasDivs.forEach(aliasDiv => {
+        aliasDiv.classList.add(styles.AliasHidden);
+      });
+    } else if (TestStepsDiv && TestStepsDiv.offsetWidth > 380) {
+      AliasDivs.forEach(aliasDiv => {
+        aliasDiv.classList.remove(styles.AliasHidden);
+      });
+    }
+  });
+
   // This math is bananas don't look here until this is cleaned up :)
   const bump = state !== "pending" ? 10 : 0;
   const actualProgress = bump + 90 * ((currentTime - step.absoluteStartTime) / step.duration);
@@ -150,17 +169,6 @@ export function TestStepItem({ step, argString, index, id }: TestStepItemProps) 
 
   const TestStepsDiv = document.getElementById(stylesTestInfo.TestSteps);
   const AliasDivs = document.querySelectorAll(`.${styles.Alias}`);
-
-  if (TestStepsDiv && TestStepsDiv.offsetWidth < 380) {
-    AliasDivs.forEach(aliasDiv => {
-      aliasDiv.classList.add(styles.AliasHidden);
-    });
-    console.log(AliasDivs);
-  } else if (TestStepsDiv && TestStepsDiv.offsetWidth > 380) {
-    AliasDivs.forEach(aliasDiv => {
-      aliasDiv.classList.remove(styles.AliasHidden);
-    });
-  }
 
   return (
     <TestStepRow

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -219,12 +219,7 @@ function MatchingElementBadge({ step, selected }: { step: AnnotatedTestStep; sel
   }
 
   return (
-    <span
-      className={classNames(
-        "-my-1 flex-shrink rounded p-1 text-xs text-gray-800",
-        selected ? "bg-gray-300" : "bg-gray-200"
-      )}
-    >
+    <span className={classNames(styles.Badge, selected ? "bg-gray-300" : "bg-gray-200")}>
       {count}
     </span>
   );


### PR DESCRIPTION
This PR hides the alias badges when things get too narrow:
https://www.loom.com/share/2755b1377d374dcd807d1f4adb155081

We can discuss other visual treatments like little minimised icons or something, but this is a good start.