### PR TITLE
Consolidating CSS in Testsuites

### DIFF
--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -486,6 +486,10 @@
   --breakpoint-tip: #fff;
 
   /* Testsuites (Dark) */
+  --testsuites-capsule-alias-bgcolor: var(--theme-base-85);
+  --testsuites-capsule-alias-color: var(--body-color);
+  --testsuites-capsule-alias-selected-bgcolor: var(--theme-base-100);
+  --testsuites-capsule-alias-selected-color: var(--body-color);
   --testsuites-capsule-error-bgcolor: rgb(237, 36, 36);
   --testsuites-capsule-error-color: white;
   --testsuites-capsule-success-bgcolor: var(--testsuites-success-color);
@@ -974,6 +978,10 @@
   --breakpoint-tip: var(--theme-highlight-purple);
 
   /* Testsuites (Light) */
+  --testsuites-capsule-alias-bgcolor: var(--theme-base-85);
+  --testsuites-capsule-alias-color: var(--body-color);
+  --testsuites-capsule-alias-selected-bgcolor: var(--theme-base-100);
+  --testsuites-capsule-alias-selected-color: var(--body-color);
   --testsuites-capsule-error-bgcolor: rgb(203, 0, 0);
   --testsuites-capsule-error-color: #fff;
   --testsuites-capsule-success-bgcolor: var(--testsuites-success-color);

--- a/src/devtools/client/debugger/src/components/TestInfo/TestInfo.module.css
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestInfo.module.css
@@ -35,16 +35,3 @@
 .TestsuitesErrorColor {
   color: var(--testsuites-error-color);
 }
-
-#TestSteps {
-  display: flex;
-  overflow: auto;
-  position: relative;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
-  padding-top: 0.75rem;
-  margin-top: 0.25rem;
-  flex-direction: column;
-  flex-grow: 1;
-  border-top-width: 1px;
-}

--- a/src/devtools/client/debugger/src/components/TestInfo/TestInfo.module.css
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestInfo.module.css
@@ -35,3 +35,16 @@
 .TestsuitesErrorColor {
   color: var(--testsuites-error-color);
 }
+
+#TestSteps {
+  display: flex;
+  overflow: auto;
+  position: relative;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0.75rem;
+  margin-top: 0.25rem;
+  flex-direction: column;
+  flex-grow: 1;
+  border-top-width: 1px;
+}

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -20,7 +20,7 @@ import {
 import { TestCaseContext } from "./TestCase";
 import { TestInfoContextMenuContext } from "./TestInfoContextMenuContext";
 import { TestStepRow } from "./TestStepRow";
-import styles from "./TestStepItem.module.css";
+import styles from "./TestInfo.module.css";
 
 function preventClickFromSpaceBar(ev: React.KeyboardEvent<HTMLButtonElement>) {
   if (ev.key === " ") {

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepRow.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepRow.tsx
@@ -2,7 +2,7 @@ import classnames from "classnames";
 import React, { forwardRef } from "react";
 
 import { ProgressBar } from "./ProgressBar";
-import styles from "./TestStepItem.module.css";
+import styles from "./TestInfo.module.css";
 
 interface TestStepRowProps {
   error?: boolean;


### PR DESCRIPTION
See https://github.com/replayio/devtools/pull/8667 for context.

That PR is attempting to hide certain classes when the panel gets too small. @ryanjduffy and I decided to split things across this CSS-oriented PR and a PR where he'll wire it up.