### PR TITLE
Disable repainting graphics in Chromium

### DIFF
--- a/packages/protocol/thread/thread.ts
+++ b/packages/protocol/thread/thread.ts
@@ -43,6 +43,7 @@ import {
 } from "replay-next/src/suspense/PauseCache";
 import { getPauseIdAsync } from "replay-next/src/suspense/PauseCache";
 import { ReplayClientInterface } from "shared/client/types";
+import type { Features } from "ui/utils/prefs";
 
 import { MappedLocationCache } from "../mapped-location-cache";
 import { client } from "../socket";
@@ -236,7 +237,7 @@ class _ThreadFront {
     );
   }
 
-  async setSessionId(sessionId: SessionId) {
+  async setSessionId(sessionId: SessionId, features: Partial<Features>) {
     this.sessionId = sessionId;
     assert(sessionId, "there should be a sessionId");
     this.sessionWaiter.resolve(sessionId);
@@ -254,7 +255,7 @@ class _ThreadFront {
           supportsEagerEvaluation: false,
           supportsEventTypes: false,
           supportsNetworkRequests: false,
-          supportsRepaintingGraphics: true,
+          supportsRepaintingGraphics: features.chromiumRepaints ?? false,
           supportsPureEvaluation: false,
         };
 

--- a/packages/shared/client/ReplayClient.ts
+++ b/packages/shared/client/ReplayClient.ts
@@ -226,7 +226,7 @@ export class ReplayClient implements ReplayClientInterface {
 
     this._sessionId = sessionId;
     this.sessionWaiter.resolve(sessionId);
-    this._threadFront.setSessionId(sessionId);
+    this._threadFront.setSessionId(sessionId, {});
 
     return sessionId;
   }

--- a/src/test/testFixtureUtils.tsx
+++ b/src/test/testFixtureUtils.tsx
@@ -64,7 +64,7 @@ export async function loadFixtureData(
 
   // This is necessary to unblock various event listeners and parsing.
   // Actual session ID value _probably_ doesn't matter here.
-  await ThreadFront.setSessionId(sessionId);
+  await ThreadFront.setSessionId(sessionId, {});
 
   // Initialize state using exported websocket messages,
   // sent through the mock environment straight to socket parsing.

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -317,7 +317,7 @@ export function createSocket(
       });
 
       window.sessionId = sessionId;
-      ThreadFront.setSessionId(sessionId);
+      ThreadFront.setSessionId(sessionId, features);
       const recordingTarget = await ThreadFront.recordingTargetWaiter.promise;
       dispatch(actions.setRecordingTarget(recordingTarget));
 

--- a/src/ui/components/shared/UserSettingsModal/UserSettingsModal.tsx
+++ b/src/ui/components/shared/UserSettingsModal/UserSettingsModal.tsx
@@ -128,6 +128,8 @@ function Advanced() {
     useBoolPref("logTelemetryEvent");
   const { value: protocolTimeline, update: updateProtocolTimeline } =
     useFeature("protocolTimeline");
+  const { value: chromiumRepaints, update: updateChromiumRepaints } =
+    useFeature("chromiumRepaints");
   const { value: logProtocol, update: updateLogProtocol } = useFeature("logProtocol");
   const { value: newControllerOnRefresh, update: updateNewControllerOnRefresh } =
     useFeature("newControllerOnRefresh");
@@ -167,6 +169,15 @@ function Advanced() {
           onChange={() => updateNewControllerOnRefresh(!newControllerOnRefresh)}
           checked={newControllerOnRefresh}
           label={"Get a new controller upon each page refresh"}
+          description={""}
+        />
+      </div>
+      <div className="mb-4">
+        <CheckboxRow
+          id={"chromium-repaints"}
+          onChange={() => updateChromiumRepaints(!chromiumRepaints)}
+          checked={chromiumRepaints}
+          label={"Allow DOM.repaintGraphics inside of Chromium recordings"}
           description={""}
         />
       </div>

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -42,6 +42,7 @@ pref("devtools.features.protocolTimeline", false);
 pref("devtools.features.repaintEvaluations", false);
 pref("devtools.features.resolveRecording", false);
 pref("devtools.features.chromiumNetMonitor", true);
+pref("devtools.features.chromiumRepaints", false);
 pref("devtools.features.brokenSourcemapWorkaround", true);
 pref("devtools.features.trackRecordingAssetsInDatabase", false);
 
@@ -81,9 +82,12 @@ export const features = new PrefsHelper("devtools.features", {
   resolveRecording: ["Bool", "resolveRecording"],
   rerunRoutines: ["Bool", "rerunRoutines"],
   chromiumNetMonitor: ["Bool", "chromiumNetMonitor"],
+  chromiumRepaints: ["Bool", "chromiumRepaints"],
   brokenSourcemapWorkaround: ["Bool", "brokenSourcemapWorkaround"],
   trackRecordingAssetsInDatabase: ["Bool", "trackRecordingAssetsInDatabase"],
 });
+
+export type Features = typeof features;
 
 export const asyncStore = asyncStoreHelper("devtools", {
   replaySessions: ["Json", "replay-sessions", {} as Record<string, ReplaySession>],


### PR DESCRIPTION
This fails constantly, and it can take a while and block other (possibly successful) manifests.