### PR TITLE
Remember state of Expandables in the Scopes panel (FE-939)

### DIFF
--- a/packages/e2e-tests/helpers/pause-information-panel.ts
+++ b/packages/e2e-tests/helpers/pause-information-panel.ts
@@ -352,7 +352,12 @@ export async function waitForPaused(page: Page, line?: number): Promise<void> {
   }
 }
 
-export async function waitForScopeValue(page: Page, name: string, expectedValue: Expected) {
+export async function waitForScopeValue(
+  page: Page,
+  name: string,
+  expectedValue: Expected,
+  expandScopes = true
+) {
   await debugPrint(
     page,
     `Waiting for scope with variable "${chalk.bold(name)}" to have value "${chalk.bold(
@@ -364,7 +369,9 @@ export async function waitForScopeValue(page: Page, name: string, expectedValue:
   const escapedValue =
     typeof expectedValue === "string" ? expectedValue.replace(/"/g, '\\"') : expectedValue;
 
-  await expandAllScopesBlocks(page);
+  if (expandScopes) {
+    await expandAllScopesBlocks(page);
+  }
 
   const scopesPanel = getScopesPanel(page);
   const scopeValue = scopesPanel

--- a/packages/e2e-tests/tests/object_preview-03.test.ts
+++ b/packages/e2e-tests/tests/object_preview-03.test.ts
@@ -37,8 +37,8 @@ test(`object_preview-03: Test previews when switching between frames and steppin
   const blockScope = getScopeChildren(page, "Block");
 
   await toggleExpandable(page, { scope: blockScope, text: "barobj" });
-  await waitForScopeValue(page, "barprop1", 2);
-  await waitForScopeValue(page, "barprop2", 3);
+  await waitForScopeValue(page, "barprop1", 2, false);
+  await waitForScopeValue(page, "barprop2", 3, false);
 
   await waitForFrameTimeline(page, target == "gecko" ? "42%" : "75%");
 
@@ -46,21 +46,17 @@ test(`object_preview-03: Test previews when switching between frames and steppin
   await selectFrame(page, 1);
   await expandAllScopesBlocks(page);
   await toggleExpandable(page, { scope: blockScope, text: "fooobj" });
-  await waitForScopeValue(page, "fooprop1", 0);
-  await waitForScopeValue(page, "fooprop2", 1);
+  await waitForScopeValue(page, "fooprop1", 0, false);
+  await waitForScopeValue(page, "fooprop2", 1, false);
 
   await selectFrame(page, 0);
   await stepOverToLine(page, 18);
   await waitForFrameTimeline(page, target == "gecko" ? "71%" : "100%");
-  await expandAllScopesBlocks(page);
-  await toggleExpandable(page, { scope: blockScope, text: "barobj" });
-  await waitForScopeValue(page, "barprop1", '"updated"');
-  await waitForScopeValue(page, "barprop2", 3);
+  await waitForScopeValue(page, "barprop1", '"updated"', false);
+  await waitForScopeValue(page, "barprop2", 3, false);
 
   await reverseStepOverToLine(page, 17);
-  await expandAllScopesBlocks(page);
-  await toggleExpandable(page, { scope: blockScope, text: "barobj" });
-  await waitForScopeValue(page, "barprop1", "2");
+  await waitForScopeValue(page, "barprop1", "2", false);
 
   await stepInToLine(page, 21);
   await stepOverToLine(page, 22);

--- a/packages/replay-next/components/Expandable.tsx
+++ b/packages/replay-next/components/Expandable.tsx
@@ -3,9 +3,12 @@ import React, {
   KeyboardEvent,
   MouseEvent,
   ReactNode,
+  useContext,
   useState,
   useTransition,
 } from "react";
+
+import { ExpandablesContext } from "replay-next/src/contexts/ExpandablesContext";
 
 import Icon from "./Icon";
 import LazyOffscreen from "./LazyOffscreen";
@@ -24,6 +27,7 @@ export default function Expandable({
   header,
   headerClassName = "",
   onChange = noopOnChange,
+  persistenceKey,
   style,
   useBlockLayoutWhenExpanded = true,
 }: {
@@ -35,10 +39,15 @@ export default function Expandable({
   header: ReactNode;
   headerClassName?: string;
   onChange?: (value: boolean) => void;
+  persistenceKey?: string;
   style?: CSSProperties;
   useBlockLayoutWhenExpanded?: boolean;
 }) {
   const [isPending, startTransition] = useTransition();
+  const { isExpanded, setIsExpanded } = useContext(ExpandablesContext);
+  if (persistenceKey !== undefined) {
+    defaultOpen = isExpanded(persistenceKey) ?? defaultOpen;
+  }
   const [isOpen, setIsOpen] = useState(defaultOpen);
 
   const onClick = (event: MouseEvent) => {
@@ -58,6 +67,9 @@ export default function Expandable({
     startTransition(() => {
       onChange(newIsOpen);
       setIsOpen(newIsOpen);
+      if (persistenceKey !== undefined) {
+        setIsExpanded(persistenceKey, newIsOpen);
+      }
     });
   };
 
@@ -71,6 +83,9 @@ export default function Expandable({
 
         onChange(newIsOpen);
         setIsOpen(newIsOpen);
+        if (persistenceKey !== undefined) {
+          setIsExpanded(persistenceKey, newIsOpen);
+        }
         break;
     }
   };

--- a/packages/replay-next/components/inspector/GetterRenderer.tsx
+++ b/packages/replay-next/components/inspector/GetterRenderer.tsx
@@ -2,7 +2,6 @@ import {
   PauseId,
   Object as ProtocolObject,
   Property as ProtocolProperty,
-  Value as ProtocolValue,
 } from "@replayio/protocol";
 import classNames from "classnames";
 import {
@@ -25,7 +24,6 @@ import {
 import { Value as ClientValue, protocolValueToClientValue } from "replay-next/src/utils/protocol";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
-import HTMLExpandable from "./HTMLExpandable";
 import PropertiesRenderer from "./PropertiesRenderer";
 import useClientValue from "./useClientValue";
 import ValueRenderer from "./ValueRenderer";
@@ -33,10 +31,12 @@ import styles from "./GetterRenderer.module.css";
 
 export default function GetterRenderer({
   parentObjectId,
+  path,
   pauseId,
   protocolProperty,
 }: {
   parentObjectId: string;
+  path?: string;
   pauseId: PauseId;
   protocolProperty: ProtocolProperty;
 }) {
@@ -134,11 +134,12 @@ export default function GetterRenderer({
       <Expandable
         children={
           <Suspense fallback={<Loader />}>
-            <PropertiesRenderer object={getterValueWithPreview!} pauseId={pauseId} />
+            <PropertiesRenderer object={getterValueWithPreview!} path={path} pauseId={pauseId} />
           </Suspense>
         }
         header={header}
         onChange={setIsExpanded}
+        persistenceKey={path}
       />
     );
   } else {

--- a/packages/replay-next/components/inspector/HTMLChildrenRenderer.tsx
+++ b/packages/replay-next/components/inspector/HTMLChildrenRenderer.tsx
@@ -9,6 +9,7 @@ import { getObjectWithPreviewSuspense } from "replay-next/src/suspense/ObjectPre
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
 import KeyValueRenderer from "./KeyValueRenderer";
+import { addPathSegment } from "./PropertiesRenderer";
 
 // HTML entries are a special case.
 // Unlike the other property lists, HTML entries only display child nodes:
@@ -20,9 +21,11 @@ import KeyValueRenderer from "./KeyValueRenderer";
 //         </li>
 export default function HTMLChildrenRenderer({
   object,
+  path,
   pauseId,
 }: {
   object: ProtocolObject;
+  path?: string;
   pauseId: ProtocolPauseId;
 }) {
   const childNodes = object.preview?.node?.childNodes ?? [];
@@ -33,7 +36,12 @@ export default function HTMLChildrenRenderer({
   return (
     <>
       {childNodes.map((objectId: ProtocolObjectId, index: number) => (
-        <HTMLChildRenderer key={index} objectId={objectId} pauseId={pauseId} />
+        <HTMLChildRenderer
+          key={index}
+          objectId={objectId}
+          path={addPathSegment(path, `${index}`)}
+          pauseId={pauseId}
+        />
       ))}
     </>
   );
@@ -41,9 +49,11 @@ export default function HTMLChildrenRenderer({
 
 function HTMLChildRenderer({
   objectId,
+  path,
   pauseId,
 }: {
   objectId: ProtocolObjectId;
+  path?: string;
   pauseId: ProtocolPauseId;
 }) {
   const client = useContext(ReplayClientContext);
@@ -61,6 +71,7 @@ function HTMLChildRenderer({
     <KeyValueRenderer
       context="nested"
       layout="vertical"
+      path={path}
       pauseId={pauseId}
       protocolValue={protocolValue}
     />

--- a/packages/replay-next/components/inspector/HTMLExpandable.tsx
+++ b/packages/replay-next/components/inspector/HTMLExpandable.tsx
@@ -3,7 +3,9 @@ import {
   PauseId as ProtocolPauseId,
   Value as ProtocolValue,
 } from "@replayio/protocol";
-import { ReactNode, Suspense, useState } from "react";
+import { ReactNode, Suspense, useContext, useState } from "react";
+
+import { ExpandablesContext } from "replay-next/src/contexts/ExpandablesContext";
 
 import Icon from "../Icon";
 import LazyOffscreen from "../LazyOffscreen";
@@ -22,20 +24,29 @@ export default function HTMLExpandable({
   before = null,
   defaultOpen = false,
   object,
+  path,
   pauseId,
   protocolValue,
 }: {
   before?: ReactNode;
   defaultOpen?: boolean;
   object: ProtocolObject;
+  path?: string;
   pauseId: ProtocolPauseId;
   protocolValue: ProtocolValue;
 }) {
-  const [isOpen, setIsOpen] = useState(false);
+  const { isExpanded, setIsExpanded } = useContext(ExpandablesContext);
+  if (path !== undefined) {
+    defaultOpen = isExpanded(path) ?? defaultOpen;
+  }
+  const [isOpen, setIsOpen] = useState(defaultOpen);
 
   const toggle = (event: React.MouseEvent) => {
     event.stopPropagation();
     setIsOpen(!isOpen);
+    if (path !== undefined) {
+      setIsExpanded(path, !isOpen);
+    }
   };
 
   return (
@@ -66,7 +77,7 @@ export default function HTMLExpandable({
       <LazyOffscreen mode={isOpen ? "visible" : "hidden"}>
         <span className={styles.Children} data-test-name="ExpandableChildren">
           <Suspense fallback={<Loader />}>
-            <HTMLChildrenRenderer object={object} pauseId={pauseId} />
+            <HTMLChildrenRenderer object={object} path={path} pauseId={pauseId} />
           </Suspense>
 
           <HTMLElementRenderer

--- a/packages/replay-next/components/inspector/Inspector.tsx
+++ b/packages/replay-next/components/inspector/Inspector.tsx
@@ -11,12 +11,14 @@ export default function Inspector({
   className,
   context,
   expandByDefault,
+  path,
   pauseId,
   protocolValue,
 }: {
   className?: string;
   context: "console" | "default";
   expandByDefault?: boolean;
+  path?: string;
   pauseId: PauseId;
   protocolValue: ProtocolValue | ProtocolNamedValue;
 }) {
@@ -25,6 +27,7 @@ export default function Inspector({
       context={context}
       expandByDefault={expandByDefault}
       layout="horizontal"
+      path={path}
       pauseId={pauseId}
       protocolValue={protocolValue}
     />

--- a/packages/replay-next/components/inspector/KeyValueRenderer.tsx
+++ b/packages/replay-next/components/inspector/KeyValueRenderer.tsx
@@ -20,6 +20,7 @@ export type Props = {
   expandByDefault?: boolean;
   layout?: "horizontal" | "vertical";
   onContextMenu?: (event: MouseEvent) => void;
+  path?: string;
   pauseId: PauseId;
   protocolValue: ProtocolValue;
 };
@@ -40,6 +41,7 @@ export default function KeyValueRenderer({
   expandByDefault = false,
   layout = "horizontal",
   onContextMenu,
+  path,
   pauseId,
   protocolValue,
 }: Props) {
@@ -100,6 +102,7 @@ export default function KeyValueRenderer({
                   }
                   defaultOpen={expandByDefault}
                   object={objectWithPreview!}
+                  path={path}
                   pauseId={pauseId}
                   protocolValue={protocolValue}
                 />
@@ -173,12 +176,13 @@ export default function KeyValueRenderer({
       <Expandable
         children={
           <Suspense fallback={<Loader />}>
-            <PropertiesRenderer object={objectWithPreview!} pauseId={pauseId} />
+            <PropertiesRenderer object={objectWithPreview!} path={path} pauseId={pauseId} />
           </Suspense>
         }
         defaultOpen={expandByDefault}
         header={header}
         onChange={setIsExpanded}
+        persistenceKey={path}
       />
     );
   } else {

--- a/packages/replay-next/components/inspector/PropertiesRenderer.tsx
+++ b/packages/replay-next/components/inspector/PropertiesRenderer.tsx
@@ -7,7 +7,7 @@ import {
   Property as ProtocolProperty,
 } from "@replayio/protocol";
 import sortBy from "lodash/sortBy";
-import { FC, Fragment, Suspense, useContext, useMemo } from "react";
+import { FC, Fragment, ReactNode, Suspense, useContext, useMemo } from "react";
 
 import Expandable from "replay-next/components/Expandable";
 import Loader from "replay-next/components/Loader";
@@ -28,9 +28,11 @@ const PROPERTY_BUCKET_SIZE = 100;
 // https://static.replay.io/protocol/tot/Pause/#type-Property
 export default function PropertiesRenderer({
   object,
+  path,
   pauseId,
 }: {
   object: ProtocolObject;
+  path?: string;
   pauseId: ProtocolPauseId;
 }) {
   const client = useContext(ReplayClientContext);
@@ -100,81 +102,99 @@ export default function PropertiesRenderer({
     }
   }
 
+  let renderedPrototype: ReactNode = null;
+  if (prototype != null) {
+    const prototypePath = addPathSegment(path, "[[Prototype]]");
+    renderedPrototype = (
+      <Expandable
+        children={<PropertiesRenderer object={prototype} path={prototypePath} pauseId={pauseId} />}
+        header={
+          <span className={styles.Prototype}>
+            <span className={styles.PrototypeName}>[[Prototype]]: </span>
+            {prototype.className}
+          </span>
+        }
+        persistenceKey={prototypePath}
+      />
+    );
+  }
+
   return (
     <>
       <EntriesRenderer containerEntries={containerEntries} pauseId={pauseId} />
 
-      {buckets.map((bucket, index) => (
-        <Expandable
-          key={`bucketed-properties-${index}`}
-          children={
-            <Suspense fallback={<Loader />}>
-              {bucket.properties.map((property, index) => (
-                <Fragment key={index}>
-                  {property.hasOwnProperty("get") && (
-                    <GetterRenderer
-                      parentObjectId={objectId}
+      {buckets.map((bucket, index) => {
+        const bucketPath = addPathSegment(path, bucket.header);
+        return (
+          <Expandable
+            key={`bucketed-properties-${index}`}
+            children={
+              <Suspense fallback={<Loader />}>
+                {bucket.properties.map((property, index) => (
+                  <Fragment key={index}>
+                    {property.hasOwnProperty("get") && (
+                      <GetterRenderer
+                        parentObjectId={objectId}
+                        path={addPathSegment(bucketPath, `get ${property.name}`)}
+                        pauseId={pauseId}
+                        protocolProperty={property}
+                      />
+                    )}
+                    <KeyValueRenderer
+                      context="default"
+                      layout="vertical"
+                      path={addPathSegment(bucketPath, property.name)}
                       pauseId={pauseId}
-                      protocolProperty={property}
+                      protocolValue={property}
                     />
-                  )}
-                  <KeyValueRenderer
-                    context="default"
-                    layout="vertical"
-                    pauseId={pauseId}
-                    protocolValue={property}
-                  />
-                </Fragment>
-              ))}
-            </Suspense>
-          }
-          header={<span className={styles.Bucket}>{bucket.header}</span>}
-        />
-      ))}
+                  </Fragment>
+                ))}
+              </Suspense>
+            }
+            header={<span className={styles.Bucket}>{bucket.header}</span>}
+            persistenceKey={bucketPath}
+          />
+        );
+      })}
 
       {buckets.length === 0 && (
         <Suspense fallback={<Loader />}>
-          {properties.map((property, index) => (
-            <Fragment key={index}>
-              {property.hasOwnProperty("get") && (
-                <GetterRenderer
-                  parentObjectId={objectId}
+          {properties.map((property, index) => {
+            return (
+              <Fragment key={index}>
+                {property.hasOwnProperty("get") && (
+                  <GetterRenderer
+                    parentObjectId={objectId}
+                    path={addPathSegment(path, `get ${property.name}`)}
+                    pauseId={pauseId}
+                    protocolProperty={property}
+                  />
+                )}
+                <KeyValueRenderer
+                  context="default"
+                  layout="vertical"
+                  path={addPathSegment(path, property.name)}
                   pauseId={pauseId}
-                  protocolProperty={property}
+                  protocolValue={property}
                 />
-              )}
-              <KeyValueRenderer
-                context="default"
-                layout="vertical"
-                pauseId={pauseId}
-                protocolValue={property}
-              />
-            </Fragment>
-          ))}
+              </Fragment>
+            );
+          })}
         </Suspense>
       )}
 
-      {prototype != null && (
-        <Expandable
-          children={<PropertiesRenderer object={prototype} pauseId={pauseId} />}
-          header={
-            <span className={styles.Prototype}>
-              <span className={styles.PrototypeName}>[[Prototype]]: </span>
-              {prototype !== null ? prototype.className : null}
-            </span>
-          }
-        />
-      )}
+      {renderedPrototype}
     </>
   );
 }
 
 type EntriesRendererProps = {
   containerEntries: ProtocolContainerEntry[];
+  path?: string;
   pauseId: PauseId;
 };
 
-function ContainerEntriesRenderer({ containerEntries, pauseId }: EntriesRendererProps) {
+function ContainerEntriesRenderer({ containerEntries, path, pauseId }: EntriesRendererProps) {
   if (containerEntries.length === 0) {
     return null;
   }
@@ -183,14 +203,23 @@ function ContainerEntriesRenderer({ containerEntries, pauseId }: EntriesRenderer
     <Expandable
       defaultOpen={true}
       children={
-        <ContainerEntriesChildrenRenderer containerEntries={containerEntries} pauseId={pauseId} />
+        <ContainerEntriesChildrenRenderer
+          containerEntries={containerEntries}
+          path={path}
+          pauseId={pauseId}
+        />
       }
       header={<span className={styles.BucketLabel}>[[Entries]]</span>}
+      persistenceKey={path}
     />
   );
 }
 
-function ContainerEntriesChildrenRenderer({ containerEntries, pauseId }: EntriesRendererProps) {
+function ContainerEntriesChildrenRenderer({
+  containerEntries,
+  path,
+  pauseId,
+}: EntriesRendererProps) {
   return (
     <Suspense fallback={<Loader />}>
       {containerEntries.map(({ key, value }, index) => (
@@ -199,6 +228,7 @@ function ContainerEntriesChildrenRenderer({ containerEntries, pauseId }: Entries
           context="nested"
           layout="vertical"
           pauseId={pauseId}
+          path={addPathSegment(path, `${key?.value ?? index}`)}
           protocolValue={value}
         />
       ))}
@@ -210,14 +240,99 @@ function ContainerEntriesChildrenRenderer({ containerEntries, pauseId }: Entries
 // Unlike the other property lists, Map entries are formatted like:
 //   ▼ <index>: {"<key>" -> <value>}
 //        key: "<key>"
-//        key: <value>
-function MapContainerEntriesRenderer({ containerEntries, pauseId }: EntriesRendererProps) {
+//        value: <value>
+function MapContainerEntriesRenderer({ containerEntries, path, pauseId }: EntriesRendererProps) {
   return (
     <Expandable
       defaultOpen={true}
       children={
         <MapContainerEntriesChildrenRenderer
           containerEntries={containerEntries}
+          path={path}
+          pauseId={pauseId}
+        />
+      }
+      header={<span className={styles.BucketLabel}>[[Entries]]</span>}
+      persistenceKey={path}
+    />
+  );
+}
+
+function MapContainerEntriesChildrenRenderer({
+  containerEntries,
+  path,
+  pauseId,
+}: EntriesRendererProps) {
+  if (containerEntries.length === 0) {
+    return <span className={styles.NoEntries}>No properties</span>;
+  }
+
+  return (
+    <Suspense fallback={<Loader />}>
+      {containerEntries.map(({ key, value }, index) => {
+        const entryPath = addPathSegment(path, `${key?.value ?? index}`);
+        return (
+          <Expandable
+            key={index}
+            children={
+              <>
+                <KeyValueRenderer
+                  before={
+                    <>
+                      <span className={styles.MapEntryPrefix}>key</span>
+                      <span className={styles.Separator}>: </span>
+                    </>
+                  }
+                  context="nested"
+                  layout="vertical"
+                  path={addPathSegment(entryPath, "key")}
+                  pauseId={pauseId}
+                  protocolValue={key!}
+                />
+                <KeyValueRenderer
+                  before={
+                    <>
+                      <span className={styles.MapEntryPrefix}>value</span>
+                      <span className={styles.Separator}>: </span>
+                    </>
+                  }
+                  context="nested"
+                  layout="vertical"
+                  path={addPathSegment(entryPath, "value")}
+                  pauseId={pauseId}
+                  protocolValue={value}
+                />
+              </>
+            }
+            header={
+              <>
+                <span className={styles.MapIndex}>{index}</span>: {"{"}
+                <ValueRenderer context="nested" pauseId={pauseId} protocolValue={key!} />
+                &nbsp;{"→"}&nbsp;
+                <ValueRenderer context="nested" pauseId={pauseId} protocolValue={value} />
+                {"}"}
+              </>
+            }
+            persistenceKey={entryPath}
+          />
+        );
+      })}
+    </Suspense>
+  );
+}
+
+// Set entries are a special case.
+// Unlike the other property lists, Set entries are formatted like:
+//   ▼ <index>: <value>
+//        key: <value>
+function SetContainerEntriesRenderer({ containerEntries, path, pauseId }: EntriesRendererProps) {
+  return (
+    <Expandable
+      defaultOpen={true}
+      children={
+        <SetContainerEntriesChildrenRenderer
+          containerEntries={containerEntries}
+          path={path}
           pauseId={pauseId}
         />
       }
@@ -226,30 +341,23 @@ function MapContainerEntriesRenderer({ containerEntries, pauseId }: EntriesRende
   );
 }
 
-function MapContainerEntriesChildrenRenderer({ containerEntries, pauseId }: EntriesRendererProps) {
+function SetContainerEntriesChildrenRenderer({
+  containerEntries,
+  path,
+  pauseId,
+}: EntriesRendererProps) {
   if (containerEntries.length === 0) {
     return <span className={styles.NoEntries}>No properties</span>;
   }
 
   return (
     <Suspense fallback={<Loader />}>
-      {containerEntries.map(({ key, value }, index) => (
-        <Expandable
-          key={index}
-          children={
-            <>
-              <KeyValueRenderer
-                before={
-                  <>
-                    <span className={styles.MapEntryPrefix}>key</span>
-                    <span className={styles.Separator}>: </span>
-                  </>
-                }
-                context="nested"
-                layout="vertical"
-                pauseId={pauseId}
-                protocolValue={key!}
-              />
+      {containerEntries.map(({ value }, index) => {
+        const entryPath = addPathSegment(path, `${index}`);
+        return (
+          <Expandable
+            key={index}
+            children={
               <KeyValueRenderer
                 before={
                   <>
@@ -259,78 +367,29 @@ function MapContainerEntriesChildrenRenderer({ containerEntries, pauseId }: Entr
                 }
                 context="nested"
                 layout="vertical"
+                path={entryPath}
                 pauseId={pauseId}
                 protocolValue={value}
               />
-            </>
-          }
-          header={
-            <>
-              <span className={styles.MapIndex}>{index}</span>: {"{"}
-              <ValueRenderer context="nested" pauseId={pauseId} protocolValue={key!} />
-              &nbsp;{"→"}&nbsp;
-              <ValueRenderer context="nested" pauseId={pauseId} protocolValue={value} />
-              {"}"}
-            </>
-          }
-        />
-      ))}
+            }
+            header={
+              <>
+                <span className={styles.MapIndex}>{index}</span>: {"{"}
+                <ValueRenderer context="nested" pauseId={pauseId} protocolValue={value} />
+                {"}"}
+              </>
+            }
+            persistenceKey={entryPath}
+          />
+        );
+      })}
     </Suspense>
   );
 }
 
-// Set entries are a special case.
-// Unlike the other property lists, Set entries are formatted like:
-//   ▼ <index>: <value>
-//        key: <value>
-function SetContainerEntriesRenderer({ containerEntries, pauseId }: EntriesRendererProps) {
-  return (
-    <Expandable
-      defaultOpen={true}
-      children={
-        <SetContainerEntriesChildrenRenderer
-          containerEntries={containerEntries}
-          pauseId={pauseId}
-        />
-      }
-      header={<span className={styles.BucketLabel}>[[Entries]]</span>}
-    />
-  );
-}
-
-function SetContainerEntriesChildrenRenderer({ containerEntries, pauseId }: EntriesRendererProps) {
-  if (containerEntries.length === 0) {
-    return <span className={styles.NoEntries}>No properties</span>;
+export function addPathSegment(path: string | undefined, segment: string): string | undefined {
+  if (path === undefined) {
+    return undefined;
   }
-
-  return (
-    <Suspense fallback={<Loader />}>
-      {containerEntries.map(({ value }, index) => (
-        <Expandable
-          key={index}
-          children={
-            <KeyValueRenderer
-              before={
-                <>
-                  <span className={styles.MapEntryPrefix}>value</span>
-                  <span className={styles.Separator}>: </span>
-                </>
-              }
-              context="nested"
-              layout="vertical"
-              pauseId={pauseId}
-              protocolValue={value}
-            />
-          }
-          header={
-            <>
-              <span className={styles.MapIndex}>{index}</span>: {"{"}
-              <ValueRenderer context="nested" pauseId={pauseId} protocolValue={value} />
-              {"}"}
-            </>
-          }
-        />
-      ))}
-    </Suspense>
-  );
+  return `${path}/${segment}`;
 }

--- a/packages/replay-next/components/inspector/ScopesInspector.tsx
+++ b/packages/replay-next/components/inspector/ScopesInspector.tsx
@@ -1,20 +1,23 @@
-import { PauseId, Value as ProtocolValue } from "@replayio/protocol";
+import { NamedValue, PauseId } from "@replayio/protocol";
 import { Suspense } from "react";
 
 import Expandable from "replay-next/components/Expandable";
 import Loader from "replay-next/components/Loader";
 
 import Inspector from "./Inspector";
+import { addPathSegment } from "./PropertiesRenderer";
 import styles from "./ScopesInspector.module.css";
 
 export default function ScopesInspector({
   name,
+  path,
   pauseId,
   protocolValues,
 }: {
   name: string;
+  path?: string;
   pauseId: PauseId;
-  protocolValues: ProtocolValue[];
+  protocolValues: NamedValue[];
 }) {
   return (
     <div className={styles.ScopesInspector} data-test-name="ScopesInspector">
@@ -25,11 +28,13 @@ export default function ScopesInspector({
             <Inspector
               context="default"
               key={index}
+              path={addPathSegment(path, protocolValue.name)}
               pauseId={pauseId}
               protocolValue={protocolValue}
             />
           ))}
           header={name}
+          persistenceKey={path}
         />
       </Suspense>
     </div>

--- a/packages/replay-next/src/contexts/ExpandablesContext.tsx
+++ b/packages/replay-next/src/contexts/ExpandablesContext.tsx
@@ -1,0 +1,24 @@
+import { PropsWithChildren, createContext, useCallback, useMemo } from "react";
+
+export type InspectorContextType = {
+  isExpanded(key: string): boolean | undefined;
+  setIsExpanded(key: string, expanded: boolean): void;
+};
+
+export const ExpandablesContext = createContext<InspectorContextType>({
+  isExpanded: () => undefined,
+  setIsExpanded: () => {},
+});
+
+export function ExpandablesContextRoot({ children }: PropsWithChildren) {
+  const expandedKeys = useMemo(() => new Map<string, boolean>(), []);
+  const isExpanded = useCallback((key: string) => expandedKeys.get(key), [expandedKeys]);
+  const setIsExpanded = useCallback(
+    (key: string, expanded: boolean) => expandedKeys.set(key, expanded),
+    [expandedKeys]
+  );
+
+  const context = useMemo(() => ({ isExpanded, setIsExpanded }), [isExpanded, setIsExpanded]);
+
+  return <ExpandablesContext.Provider value={context}>{children}</ExpandablesContext.Provider>;
+}

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -9,6 +9,7 @@ import {
 
 import InspectorContextReduxAdapter from "devtools/client/debugger/src/components/shared/InspectorContextReduxAdapter";
 import { ThreadFront } from "protocol/thread";
+import { ExpandablesContextRoot } from "replay-next/src/contexts/ExpandablesContext";
 import { PointsContextRoot } from "replay-next/src/contexts/PointsContext";
 import { SelectedFrameContextRoot } from "replay-next/src/contexts/SelectedFrameContext";
 import usePreferredFontSize from "replay-next/src/hooks/usePreferredFontSize";
@@ -226,12 +227,14 @@ function _DevTools({
               <SelectedFrameContextRoot SelectedFrameContextAdapter={SelectedFrameContextAdapter}>
                 <TerminalContextAdapter>
                   <InspectorContextReduxAdapter>
-                    <KeyModifiers>
-                      <Header />
-                      <Body />
-                      {showCommandPalette ? <CommandPaletteModal /> : null}
-                      <KeyboardShortcuts />
-                    </KeyModifiers>
+                    <ExpandablesContextRoot>
+                      <KeyModifiers>
+                        <Header />
+                        <Body />
+                        {showCommandPalette ? <CommandPaletteModal /> : null}
+                        <KeyboardShortcuts />
+                      </KeyModifiers>
+                    </ExpandablesContextRoot>
                   </InspectorContextReduxAdapter>
                 </TerminalContextAdapter>
               </SelectedFrameContextRoot>


### PR DESCRIPTION
This uses the `functionLocation` that we get for call frames from the backend in the `persistenceKey` for which the state is saved. So the Scopes panel remembers the expandable states when stepping within a function and when coming back to it after stepping into a different function.