### PR TITLE
Refactor sidebar button logic and fix collapsed persistence

### DIFF
--- a/src/devtools/client/debugger/src/actions/ui.ts
+++ b/src/devtools/client/debugger/src/actions/ui.ts
@@ -22,7 +22,6 @@ import {
   sourcesPanelExpanded,
   toggleActiveSearch,
   toggleSources,
-  toggleStartPanel,
 } from "../reducers/ui";
 import { getActiveSearch, getContext, getQuickOpenEnabled } from "../selectors";
 import { selectSource } from "./sources/select";
@@ -42,7 +41,6 @@ export {
   sourcesPanelExpanded,
   toggleActiveSearch,
   toggleFrameworkGrouping,
-  toggleStartPanel,
   toggleSources,
 } from "../reducers/ui";
 
@@ -63,7 +61,6 @@ export function setActiveSearch(activeSearch: ActiveSearchType): UIThunkAction {
 
 // Preserve existing export names
 export const ensureSourcesIsVisible = sourcesDisplayed;
-export const togglePaneCollapse = toggleStartPanel;
 export const toggleSourcesCollapse = toggleSources;
 export const expandSourcesPane = sourcesPanelExpanded;
 export const updateCursorPosition = setCursorPosition;

--- a/src/devtools/client/debugger/src/reducers/ui.ts
+++ b/src/devtools/client/debugger/src/reducers/ui.ts
@@ -28,8 +28,6 @@ export interface UISliceState {
   fullTextSearchQuery: string;
   fullTextSearchFocus: boolean;
   shownSource?: SourceDetails | null;
-  startPanelCollapsed: boolean;
-  endPanelCollapsed: boolean;
   sourcesCollapsed: boolean;
   frameworkGroupingOn: boolean;
   viewport?: Range | null;
@@ -43,8 +41,6 @@ export const createUIState = (): UISliceState => ({
   fullTextSearchQuery: "",
   fullTextSearchFocus: false,
   shownSource: null,
-  startPanelCollapsed: prefs.startPanelCollapsed as boolean,
-  endPanelCollapsed: prefs.endPanelCollapsed as boolean,
   sourcesCollapsed: prefs.sourcesCollapsed as boolean,
   frameworkGroupingOn: prefs.frameworkGroupingOn as boolean,
   highlightedLineRange: undefined,
@@ -64,9 +60,6 @@ const uiSlice = createSlice({
     },
     setShownSource(state, action: PayloadAction<SourceDetails | null>) {
       state.shownSource = action.payload;
-    },
-    toggleStartPanel(state) {
-      state.startPanelCollapsed = !state.startPanelCollapsed;
     },
     toggleSources(state) {
       state.sourcesCollapsed = !state.sourcesCollapsed;
@@ -110,18 +103,13 @@ const uiSlice = createSlice({
     // Here: pause info panel is open, sources are open
     // Layout reducer: selected primary panel is "explorer"
     sourcesDisplayed(state) {
-      state.startPanelCollapsed = false;
       state.sourcesCollapsed = false;
     },
   },
   extraReducers: builder => {
-    builder
-      .addCase("set_selected_primary_panel", state => {
-        state.startPanelCollapsed = false;
-      })
-      .addCase(closeQuickOpen, state => {
-        state.highlightedLineRange = {};
-      });
+    builder.addCase(closeQuickOpen, state => {
+      state.highlightedLineRange = {};
+    });
   },
 });
 
@@ -139,7 +127,6 @@ export const {
   sourcesPanelExpanded,
   toggleActiveSearch,
   toggleFrameworkGrouping,
-  toggleStartPanel,
   toggleSources,
 } = uiSlice.actions;
 
@@ -153,7 +140,6 @@ export const getSelectedPrimaryPaneTab = (state: UIState) => state.ui.selectedPr
 export const getActiveSearch = (state: UIState) => state.ui.activeSearch;
 export const getFrameworkGroupingState = (state: UIState) => state.ui.frameworkGroupingOn;
 export const getShownSource = (state: UIState) => state.ui.shownSource;
-export const getPaneCollapse = (state: UIState) => state.ui.startPanelCollapsed;
 export const getSourcesCollapsed = (state: UIState) => state.ui.sourcesCollapsed;
 export const getHighlightedLineRange = (state: UIState) => state.ui.highlightedLineRange;
 export const getViewport = (state: UIState) => state.ui.viewport;

--- a/src/devtools/client/debugger/src/utils/prefs.ts
+++ b/src/devtools/client/debugger/src/utils/prefs.ts
@@ -18,8 +18,6 @@ pref("devtools.debugger.scopes-visible", true);
 pref("devtools.debugger.breakpoints-visible", true);
 pref("devtools.debugger.logpoints-visible", true);
 pref("devtools.debugger.event-listeners-visible", false);
-pref("devtools.debugger.start-panel-collapsed", false);
-pref("devtools.debugger.end-panel-collapsed", false);
 pref("devtools.debugger.ui.framework-grouping-on", true);
 pref("devtools.debugger.pending-selected-location", "{}");
 pref("devtools.debugger.features.column-breakpoints", true);
@@ -27,8 +25,6 @@ pref("devtools.debugger.features.column-breakpoints", true);
 export const prefs = new PrefsHelper("devtools", {
   outlineExpanded: ["Bool", "debugger.outline-expanded"],
   sourcesCollapsed: ["Bool", "debugger.sources-collapsed"],
-  startPanelCollapsed: ["Bool", "debugger.start-panel-collapsed"],
-  endPanelCollapsed: ["Bool", "debugger.end-panel-collapsed"],
   frameworkGroupingOn: ["Bool", "debugger.ui.framework-grouping-on"],
   pendingSelectedLocation: ["Json", "debugger.pending-selected-location"],
   debuggerPrefsSchemaVersion: ["Int", "debugger.prefs-schema-version"],

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -11,6 +11,7 @@ import InspectorContextReduxAdapter from "devtools/client/debugger/src/component
 import { ThreadFront } from "protocol/thread";
 import { PointsContextRoot } from "replay-next/src/contexts/PointsContext";
 import { SelectedFrameContextRoot } from "replay-next/src/contexts/SelectedFrameContext";
+import useLocalStorage from "replay-next/src/hooks/useLocalStorage";
 import usePreferredFontSize from "replay-next/src/hooks/usePreferredFontSize";
 import { clearTrialExpired, createSocket } from "ui/actions/session";
 import TerminalContextAdapter from "ui/components/SecondaryToolbox/TerminalContextAdapter";
@@ -78,7 +79,8 @@ function Body() {
 
   const sidePanelRef = useRef<ImperativePanelHandle>(null);
 
-  const [sidePanelCollapsed, setSidePanelCollapsed] = useState(false);
+  const sidePanelStorageKey = "Replay:SidePanelCollapsed";
+  const [sidePanelCollapsed, setSidePanelCollapsed] = useLocalStorage(sidePanelStorageKey, false);
 
   const onSidePanelCollapse = (isCollapsed: boolean) => {
     setSidePanelCollapsed(isCollapsed);

--- a/src/ui/components/KeyboardShortcuts.tsx
+++ b/src/ui/components/KeyboardShortcuts.tsx
@@ -48,7 +48,6 @@ function KeyboardShortcuts({
   setViewMode,
   toggleCommandPalette,
   toggleFocusMode,
-  togglePaneCollapse,
   viewMode,
   toggleThemeAction,
   toggleQuickOpen,
@@ -80,13 +79,6 @@ function KeyboardShortcuts({
 
     const toggleFunctionQuickOpenModal = (e: KeyboardEvent) => {
       toggleQuickOpenModal(e, "@");
-    };
-
-    const toggleLeftSidebar = (e: KeyboardEvent) => {
-      e.preventDefault();
-
-      trackEvent("key_shortcut.toggle_left_sidebar");
-      togglePaneCollapse();
     };
 
     const togglePalette = (e: KeyboardEvent) => {
@@ -146,7 +138,6 @@ function KeyboardShortcuts({
 
     const shortcuts: Record<string, (e: KeyboardEvent) => void> = {
       "CmdOrCtrl+Shift+F": openFullTextSearch,
-      "CmdOrCtrl+B": toggleLeftSidebar,
       "CmdOrCtrl+K": togglePalette,
 
       // Should be ignored when an editable element is focused
@@ -176,7 +167,6 @@ function KeyboardShortcuts({
     setViewMode,
     toggleCommandPalette,
     toggleFocusMode,
-    togglePaneCollapse,
     updateProtocolTimeline,
     viewMode,
     toggleThemeAction,
@@ -211,7 +201,6 @@ const connector = connect(
     focusFullTextInput: dbgActions.focusFullTextInput,
     setSelectedPrimaryPanel: actions.setSelectedPrimaryPanel,
     setViewMode: actions.setViewMode,
-    togglePaneCollapse: actions.togglePaneCollapse,
     toggleCommandPalette: actions.toggleCommandPalette,
     toggleFocusMode: actions.toggleFocusMode,
     toggleThemeAction: actions.toggleTheme,

--- a/src/ui/setup/prefs.ts
+++ b/src/ui/setup/prefs.ts
@@ -73,13 +73,6 @@ export const updatePrefs = (state: UIState, oldState: UIState) => {
       state => state.ui.frameworkGroupingOn
     );
 
-    updateDebuggerPrefs(
-      state,
-      oldState,
-      "startPanelCollapsed",
-      state => state.ui.startPanelCollapsed
-    );
-
     updateDebuggerPrefs(state, oldState, "sourcesCollapsed", state => state.ui.sourcesCollapsed);
 
     updateDebuggerPrefs(


### PR DESCRIPTION
The state of the sidebar panel was originally completely kept in Redux, in a `startPanelCollapsed` field. At some point, with the migration to the new "resizeable panels" library, we stopped using that field to drive the UI.  However, it was still getting persisted and read in one place: `<ToolbarButton>`

Somehow we ended up with two different sets of checks inside the the click handler in `ToolbarButton`. The mismatched logic led to the click handler thinking that the panel was already open when it was actually closed, so sometimes a click on a button wouldn't do anything.

I've refactored the logic to pull the toggle handling up into `<Toolbar>`, removed the Redux `start/endPanelCollapsed` fields and all the persistence related to those, and added persistence of the component state `sidePanelCollapsed` field via `useLocalStorage`.

Also found out that we had a keyboard shortcut ( `CTRL-B` ) that used to toggle the sidebar, but that broke with the panel migration.  Per discussion, killing that.