### PR TITLE
Show cypress commands with failed assert as errored

### DIFF
--- a/packages/shared/graphql/types.ts
+++ b/packages/shared/graphql/types.ts
@@ -288,6 +288,8 @@ export type TestStep = {
   alias?: string;
   error?: TestItemError;
   hook?: "beforeEach" | "afterEach";
+  commandId?: string;
+  assertIds?: string[];
 };
 
 export type AnnotatedTestStep = TestStep & {

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -8,6 +8,7 @@ import { AnnotatedTestStep } from "shared/graphql/types";
 import { seek, seekToTime, setTimelineToPauseTime, setTimelineToTime } from "ui/actions/timeline";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
 import { getStepRanges, useStepState } from "ui/hooks/useStepState";
+import { useTestInfo } from "ui/hooks/useTestInfo";
 import { useTestStepActions } from "ui/hooks/useTestStepActions";
 import { getViewMode } from "ui/reducers/layout";
 import { getSelectedStep, setSelectedStep } from "ui/reducers/reporter";
@@ -80,6 +81,7 @@ export function TestStepItem({ step, argString, index, id }: TestStepItemProps) 
   const client = useContext(ReplayClientContext);
   const state = useStepState(step);
   const actions = useTestStepActions(step);
+  const info = useTestInfo();
 
   useEffect(() => {
     setSubjectNodePauseData(getCypressSubjectNodeIdsAsync(client, step));
@@ -178,12 +180,13 @@ export function TestStepItem({ step, argString, index, id }: TestStepItemProps) 
   const displayedProgress =
     (step.duration === 1 && state === "paused") || progress == 100 ? 0 : progress;
   const isSelected = selectedStep?.id === id;
+  const error = !!(step.error || info.getStepAsserts(step).some(s => !!s.error));
 
   return (
     <TestStepRow
       active={state === "paused"}
       pending={state === "pending"}
-      error={!!step.error}
+      error={error}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       ref={ref}

--- a/src/ui/hooks/useTestInfo.ts
+++ b/src/ui/hooks/useTestInfo.ts
@@ -1,3 +1,4 @@
+import { AnnotatedTestStep } from "shared/graphql/types";
 import {
   getReporterAnnotationsComplete,
   getSelectedStep,
@@ -29,6 +30,9 @@ export function useTestInfo() {
 
   const isLoading = loading || (supportsStepAnnotations && !annotationsComplete);
 
+  const getStepAsserts = (step: AnnotatedTestStep) =>
+    selectedTest?.steps?.filter(s => step.assertIds?.includes(s.id)) || [];
+
   return {
     loading: isLoading,
     metadata,
@@ -41,5 +45,6 @@ export function useTestInfo() {
     pluginVersion,
     supportsSteps,
     supportsStepAnnotations,
+    getStepAsserts,
   };
 }


### PR DESCRIPTION
https://app.replay.io/recording/scs-734-flag-commands-with-failed-assertions-as-errored--062935c0-6ed1-4aa1-b829-d2e17d2d0080