### PR TITLE
Improve "ready when you are!" in dark theme

### DIFF
--- a/src/ui/components/shared/Dialog.css
+++ b/src/ui/components/shared/Dialog.css
@@ -1,11 +1,11 @@
 .dialog {
   border-radius: 8px;
-  background: var(--modal-bgcolor);
-  color: var(--modal-color);
+  background: #fff;
+  color: #38383d;
   border-radius: 8px;
   box-shadow: 0px 20px 25px -5px rgba(0, 0, 0, 0.1), 0px 10px 10px -5px rgba(0, 0, 0, 0.04);
   height: max-content;
-  padding: 16px;
+  padding: 8px;
   padding-bottom: 32px;
   width: max-content;
   backdrop-filter: blur(8px);

--- a/src/ui/components/shared/Dialog.tsx
+++ b/src/ui/components/shared/Dialog.tsx
@@ -92,10 +92,7 @@ export const DialogDescription = ({
   ...props
 }: HTMLProps<HTMLParagraphElement>) => {
   return (
-    <p
-      {...props}
-      className="break-word mb-2 whitespace-pre-wrap text-center text-sm text-themeBase-70"
-    >
+    <p {...props} className="break-word mb-2 whitespace-pre-wrap text-center text-sm">
       {children}
     </p>
   );


### PR DESCRIPTION
Old on left, new on right:
<img width="1029" alt="image" src="https://user-images.githubusercontent.com/9154902/216850837-2c3b3095-f650-4210-bf57-ec52082ffc2a.png">

These bright pastel colors don't work very well in dark theme. And even when we move beyond these illustrations, it's hard to make every illustration look equally as good in light and dark theme.

We've always had a strange contrast problem in our dark theme, so this addresses a more long term concern, independent of illustrations. 