### PR TITLE
Restructure Source Viewer to not block on hit counts or breakable positions

### DIFF
--- a/packages/replay-next/src/suspense/FrameStepsCache.ts
+++ b/packages/replay-next/src/suspense/FrameStepsCache.ts
@@ -10,6 +10,7 @@ export const {
   getValueSuspense: getFrameStepsSuspense,
   getValueAsync: getFrameStepsAsync,
   getValueIfCached: getFrameStepsIfCached,
+  getCacheKey,
 } = createGenericCache<
   [replayClient: ReplayClientInterface],
   [pauseId: PauseId, frameId: FrameId],
@@ -42,5 +43,5 @@ export const useGetFrameSteps = createUseGetValue<
     pauseId && frameId ? await getFrameStepsAsync(replayClient, pauseId, frameId) : undefined,
   (replayClient, pauseId, frameId) =>
     pauseId && frameId ? getFrameStepsIfCached(pauseId, frameId) : { value: undefined },
-  (replayClient, pauseId, frameId) => `${pauseId}:${frameId}`
+  (replayClient, pauseId, frameId) => getCacheKey(pauseId!, frameId!)
 );

--- a/packages/replay-next/src/suspense/ObjectPreviews.ts
+++ b/packages/replay-next/src/suspense/ObjectPreviews.ts
@@ -1,7 +1,7 @@
 import { Object, ObjectId, PauseId, Value as ProtocolValue } from "@replayio/protocol";
 
 import { ReplayClientInterface } from "../../../shared/client/types";
-import { createWakeable } from "../utils/suspense";
+import { createFetchAsyncFromFetchSuspense, createWakeable } from "../utils/suspense";
 import { cachePauseData } from "./PauseCache";
 import { Record, STATUS_PENDING, STATUS_REJECTED, STATUS_RESOLVED, Wakeable } from "./types";
 
@@ -147,26 +147,9 @@ export function getObjectWithPreviewSuspense(
 // Wrapper method around Suspense method.
 // This method can be used by non-React code to prefetch/prime the Suspense cache by loading preview data.
 // Loaded properties can also be accessed via getCachedObject().
-export async function getObjectWithPreviewHelper(
-  client: ReplayClientInterface,
-  pauseId: PauseId,
-  objectId: ObjectId,
-  noOverflow: boolean = false
-): Promise<Object> {
-  try {
-    return getObjectWithPreviewSuspense(client, pauseId, objectId, noOverflow);
-  } catch (errorOrPromise) {
-    if (
-      errorOrPromise != null &&
-      typeof errorOrPromise === "object" &&
-      errorOrPromise.hasOwnProperty("then")
-    ) {
-      return errorOrPromise as Promise<Object>;
-    } else {
-      throw errorOrPromise;
-    }
-  }
-}
+export const getObjectWithPreviewHelper = createFetchAsyncFromFetchSuspense(
+  getObjectWithPreviewSuspense
+);
 
 export function getObjectPropertySuspense(
   client: ReplayClientInterface,
@@ -204,26 +187,7 @@ export function getObjectPropertySuspense(
 // Wrapper method around Suspense method.
 // This method can be used by non-React code to prefetch/prime the Suspense cache by loading object properties.
 // Loaded properties can also be accessed via getCachedObjectProperty().
-export async function getObjectPropertyHelper(
-  client: ReplayClientInterface,
-  pauseId: PauseId,
-  objectId: ObjectId,
-  propertyName: string
-): Promise<ProtocolValue> {
-  try {
-    return getObjectPropertySuspense(client, pauseId, objectId, propertyName);
-  } catch (errorOrPromise) {
-    if (
-      errorOrPromise != null &&
-      typeof errorOrPromise === "object" &&
-      errorOrPromise.hasOwnProperty("then")
-    ) {
-      return errorOrPromise as Promise<ProtocolValue>;
-    } else {
-      throw errorOrPromise;
-    }
-  }
-}
+export const getObjectPropertyHelper = createFetchAsyncFromFetchSuspense(getObjectPropertySuspense);
 
 export function preCacheObjects(pauseId: PauseId, objects: Object[]): void {
   objects.forEach(object => preCacheObject(pauseId, object));

--- a/packages/replay-next/src/suspense/SourcesCache.ts
+++ b/packages/replay-next/src/suspense/SourcesCache.ts
@@ -15,7 +15,7 @@ import {
 import { ProtocolError, isCommandError } from "shared/utils/error";
 import { isPointRange, toPointRange } from "shared/utils/time";
 
-import { createWakeable } from "../utils/suspense";
+import { createFetchAsyncFromFetchSuspense, createWakeable } from "../utils/suspense";
 import { createGenericCache } from "./createGenericCache";
 import { Record, STATUS_PENDING, STATUS_REJECTED, STATUS_RESOLVED, Wakeable } from "./types";
 
@@ -103,21 +103,7 @@ export function getSourcesByUrlSuspense(client: ReplayClientInterface) {
 
 // Wrapper method around getSources Suspense method.
 // This method can be used by non-React code to prefetch/prime the Suspense cache by loading object properties.
-export async function getSourcesAsync(client: ReplayClientInterface): Promise<ProtocolSource[]> {
-  try {
-    return getSourcesSuspense(client);
-  } catch (errorOrPromise) {
-    if (
-      errorOrPromise != null &&
-      typeof errorOrPromise === "object" &&
-      errorOrPromise.hasOwnProperty("then")
-    ) {
-      return errorOrPromise as Promise<ProtocolSource[]>;
-    } else {
-      throw errorOrPromise;
-    }
-  }
-}
+export const getSourcesAsync = createFetchAsyncFromFetchSuspense(getSourcesSuspense);
 
 export async function getSourceAsync(
   client: ReplayClientInterface,
@@ -150,24 +136,9 @@ export function getCachedSourceContents(
   return record?.status === STATUS_RESOLVED ? record.value : null;
 }
 
-export async function getStreamingSourceContentsAsync(
-  client: ReplayClientInterface,
-  sourceId: ProtocolSourceId
-): Promise<StreamingSourceContents | null> {
-  try {
-    return getStreamingSourceContentsSuspense(client, sourceId);
-  } catch (errorOrPromise) {
-    if (
-      errorOrPromise != null &&
-      typeof errorOrPromise === "object" &&
-      errorOrPromise.hasOwnProperty("then")
-    ) {
-      return errorOrPromise as Promise<StreamingSourceContents>;
-    } else {
-      throw errorOrPromise;
-    }
-  }
-}
+export const getStreamingSourceContentsAsync = createFetchAsyncFromFetchSuspense(
+  getStreamingSourceContentsSuspense
+);
 
 export function getStreamingSourceContentsSuspense(
   client: ReplayClientInterface,
@@ -266,6 +237,7 @@ export const {
   getValueSuspense: getBreakpointPositionsSuspense,
   getValueAsync: getBreakpointPositionsAsync,
   getValueIfCached: getBreakpointPositionsIfCached,
+  getCacheKey: getBreakpointPositionsCacheKey,
 } = createGenericCache<
   [replayClient: ReplayClientInterface],
   [sourceId: ProtocolSourceId],

--- a/packages/replay-next/src/suspense/createGenericCache.ts
+++ b/packages/replay-next/src/suspense/createGenericCache.ts
@@ -23,6 +23,7 @@ export interface GenericCache<TExtraParams extends Array<any>, TParams extends A
   getValueIfCached(...args: TParams): { value: TValue } | undefined;
   addValue(value: TValue, ...args: TParams): void;
   getStatus(...args: TParams): CacheRecordStatus | undefined;
+  getCacheKey(...args: TParams): string;
 }
 
 export function createGenericCache<
@@ -122,6 +123,8 @@ export function createGenericCache<
       const cacheKey = getCacheKey(...args);
       return recordMap.get(cacheKey)?.status;
     },
+
+    getCacheKey,
   };
 }
 

--- a/packages/replay-next/src/utils/suspense.ts
+++ b/packages/replay-next/src/utils/suspense.ts
@@ -127,3 +127,25 @@ export function suspendInParallel<T extends AnyFunction[]>(
 export function __setCircularThenableCheckMaxCount(value: number) {
   CIRCULAR_THENABLE_CHECK_MAX_COUNT = value;
 }
+
+export function createFetchAsyncFromFetchSuspense<TParams extends Array<any>, TValue>(
+  fetchAsyncMethod: (...params: TParams) => TValue
+) {
+  const fetchAsync = async (...params: TParams) => {
+    try {
+      return fetchAsyncMethod(...params);
+    } catch (errorOrPromise) {
+      if (
+        errorOrPromise != null &&
+        typeof errorOrPromise === "object" &&
+        errorOrPromise.hasOwnProperty("then")
+      ) {
+        return errorOrPromise as Promise<TValue>;
+      } else {
+        throw errorOrPromise;
+      }
+    }
+  };
+
+  return fetchAsync;
+}

--- a/packages/replay-next/tsconfig.json
+++ b/packages/replay-next/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
The `<SourceList>` component needs 3 major pieces of data: source contents, hit counts, and breakable positions. It had been fetching all of those using the `getDataSuspense` methods. However, those effectively "block" inside of the component, and won't continue until the data has resolved.  This leads to both waterfall-style behavior, and also the component not actually rendering until all 3 pieces are available.

We saw a case where the hit counts request never resolved, and that kept `<SourceList>` from actually showing the selected file's text. But, hit counts shouldn't be critical-path data for rendering the _text_ of a file. We should always show the text as soon as it's available, and show hit counts and breakable positions in a non-blocking way.

Conveniently, we already had a `createUseGetValue` hook factory, which fetches via one of our "getDataAsync" methods and sets state. This is a homegrown version of the usual hook that kicks off a request in a `useEffect`, and gives you back `{value, loading, error}`.  It needs `(getAsync, getIfCached, getCacheKey)` as its arguments.

Normally, each of those methods gets generated by our `createGenericCache` util.  But the hit counts cache is custom and _not_ a generic cache, so I had to restructure the logic to expose all the same methods as a generic cache would.

As part of that restructuring, I noted that we had 4-5 different places where we were creating manually-defined `getDataAsync` methods by calling `getDataSuspense` and manually check the return value to add the right wrapping.  I extracted that behavior into its own `createFetchAsyncFromFetchSuspense` util and updated those locations.  I also updated `createGenericCache` to re-expose the `getCacheKey` function for reuse.

The actual changes to `<SourceList>` were minimal.  I replaced `getHitCounts/BreakablePositionsSuspense` with their corresponding hooks, and provided default empty fallbacks.  I did some checking with an artificial delay in `fetchHitCounts` and confirmed that the source text renders immediately, and the hit counts fill in later.
