### PR TITLE
Fix searching for the first meaningful paint (FE-1207)

### DIFF
--- a/packages/protocol/graphics.ts
+++ b/packages/protocol/graphics.ts
@@ -106,12 +106,6 @@ const gMouseClickEvents: MouseEvent[] = [];
 // Device pixel ratio used by the current screenshot.
 let gDevicePixelRatio = 1;
 
-let gAllNecessaryPaintDataReceived = false;
-
-export const videoReady: Deferred<void> = defer();
-
-const gPaintPromises: Promise<ScreenShot | undefined>[] = [];
-
 function onPaints(paints: PaintPoint[]) {
   if (typeof onPointsReceived === "function") {
     onPointsReceived(paints);
@@ -120,32 +114,6 @@ function onPaints(paints: PaintPoint[]) {
   paints.forEach(async ({ point, time, screenShots }) => {
     const paintHash = screenShots.find(desc => desc.mimeType == "image/jpeg")!.hash;
     insertEntrySorted(gPaintPoints, { point, time, paintHash });
-
-    if (gAllNecessaryPaintDataReceived) {
-      // We are all set on the loading front, no need to proactively grab these
-      // paints
-      return;
-    }
-
-    let loadTarget = MINIMUM_VIDEO_CONTENT;
-    if (hasAllPaintPoints) {
-      const lastPaintTime = gPaintPoints[gPaintPoints.length - 1].time;
-      // if we have all of the paints, and the last one happens before the 5
-      // second mark, make that the new goal for considering the video ready
-      if (lastPaintTime < MINIMUM_VIDEO_CONTENT) {
-        loadTarget = lastPaintTime;
-      }
-    }
-
-    if (time < loadTarget) {
-      const screenShotPromise = screenshotCache.getScreenshotForPlayback(point, paintHash);
-      gPaintPromises.push(screenShotPromise);
-    }
-    if (time >= loadTarget) {
-      gAllNecessaryPaintDataReceived = true;
-      await Promise.all(gPaintPromises);
-      videoReady.resolve();
-    }
   });
 }
 
@@ -189,15 +157,16 @@ export function setupGraphics() {
 
     const { client } = await import("./socket");
     client.Graphics.findPaints({}, sessionId).then(async () => {
+      initialPaintsReceivedWaiter.resolve(null);
       hasAllPaintPoints = true;
       onAllPaintsReceived(true);
-
-      await Promise.all(gPaintPromises);
       maybePaintGraphics();
-      videoReady.resolve();
     });
     client.Graphics.addPaintPointsListener(async ({ paints }) => {
       onPaints(paints);
+      if (gPaintPoints.length >= INITIAL_PAINT_COUNT) {
+        initialPaintsReceivedWaiter.resolve(null);
+      }
       const latestPaint = BigInt(maxBy(paints, p => BigInt(p.point))?.point || 0);
       const currentPoint = BigInt(ThreadFront.currentPoint);
       if (currentPoint && latestPaint >= currentPoint) {
@@ -607,8 +576,13 @@ async function getScreenshotDimensions(screen: ScreenShot) {
   return { width: img.width, height: img.height };
 }
 
-export async function getFirstMeaningfulPaint(limit: number = 10) {
-  for (const paintPoint of gPaintPoints.slice(0, limit)) {
+// the maximum number of paints to be considered when looking for the first meaningful paint
+const INITIAL_PAINT_COUNT = 10;
+const initialPaintsReceivedWaiter = defer();
+
+export async function getFirstMeaningfulPaint() {
+  await initialPaintsReceivedWaiter.promise;
+  for (const paintPoint of gPaintPoints.slice(0, INITIAL_PAINT_COUNT)) {
     const { screen } = await getGraphicsAtTime(paintPoint.time);
     if (!screen) {
       continue;

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -33,7 +33,7 @@ import {
 } from "ui/reducers/protocolMessages";
 import type { ExpectedError, UnexpectedError } from "ui/state/app";
 import { extractGraphQLError } from "ui/utils/apolloClient";
-import { isMock, isTest } from "ui/utils/environment";
+import { getPausePointParams, isMock, isTest } from "ui/utils/environment";
 import LogRocket from "ui/utils/logrocket";
 import { endMixpanelSession } from "ui/utils/mixpanel";
 import { features, prefs } from "ui/utils/prefs";
@@ -43,7 +43,7 @@ import { subscriptionExpired } from "ui/utils/workspace";
 
 import { setExpectedError, setUnexpectedError } from "./errors";
 import { setViewMode } from "./layout";
-import { getInitialPausePoint, jumpToInitialPausePoint } from "./timeline";
+import { jumpToInitialPausePoint } from "./timeline";
 
 export { setUnexpectedError, setExpectedError };
 
@@ -231,12 +231,7 @@ export function createSocket(
         }
       }
 
-      const initialPausePoint = await getInitialPausePoint(ThreadFront.recordingId!);
-      const focusRegion =
-        initialPausePoint && "focusRegion" in initialPausePoint
-          ? initialPausePoint.focusRegion
-          : undefined;
-
+      const focusRegion = getPausePointParams()?.focusRegion;
       const focusRange = focusRegion
         ? {
             begin: focusRegion.begin.time,

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -143,7 +143,7 @@ export async function getInitialPausePoint(recordingId: string) {
     return { point, time };
   }
 
-  const firstMeaningfulPaint = await getFirstMeaningfulPaint(10);
+  const firstMeaningfulPaint = await getFirstMeaningfulPaint();
   if (firstMeaningfulPaint) {
     const { point, time } = firstMeaningfulPaint;
     return { point, time };


### PR DESCRIPTION
`getFirstMeaningfulPaint()` had a timing issue: it did not wait for sufficient paint points to be received from the backend.
Furthermore I've removed some logic waiting for the paints from the first 5 seconds of the recording because it isn't used anymore. And I've removed the call to `getFirstMeaningfulPaint()` in `createSocket()` because that function was only interested in a focus region potentially defined in the URL parameters, so now I fetch that directly.