### PR TITLE
Clear timers on component unmount to prevent memory leaks

### DIFF
--- a/packages/design/AddCommentButton/index.tsx
+++ b/packages/design/AddCommentButton/index.tsx
@@ -1,6 +1,6 @@
 import classNames from "classnames";
 import type { MouseEventHandler } from "react";
-import { forwardRef, useRef, useState } from "react";
+import { forwardRef, useRef, useState, useEffect } from "react";
 import mergeRefs from "react-merge-refs";
 import { Transition } from "react-transition-group";
 
@@ -47,6 +47,12 @@ export const AddCommentButton = forwardRef<HTMLButtonElement, AddCommentButtonPr
       },
       className
     );
+
+    useEffect(() => {
+      return () => {
+        clearTimeout(hoverRef.current);
+      };
+    }, []);
 
     return (
       <div className={styles.Root}>

--- a/packages/design/PrefixBadgePicker/Picker.tsx
+++ b/packages/design/PrefixBadgePicker/Picker.tsx
@@ -1,6 +1,6 @@
 import classNames from "classnames";
 import { motion } from "framer-motion";
-import type { ComponentProps, ReactNode } from "react";
+import type { ComponentProps, ReactNode, useEffect } from "react";
 import { Children, cloneElement, isValidElement, useRef, useState } from "react";
 
 import styles from "./Picker.module.css";
@@ -20,6 +20,7 @@ export function Picker<Values extends any>({
   style?: React.CSSProperties;
   title?: string;
 }) {
+  const timeOutID: any = useRef(null);
   const previousId = useRef(null);
   const transitioning = useRef(false);
   const [isActive, setIsActive] = useState(false);
@@ -28,6 +29,12 @@ export function Picker<Values extends any>({
     duration: isOpen ? 0.16 : 0.2,
     opacity: { duration: isOpen ? 0.1 : 0.04 },
   };
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(timeOutID.current);
+    };
+  }, []);
 
   return (
     <motion.div
@@ -85,7 +92,7 @@ export function Picker<Values extends any>({
             setIsActive(true);
           } else {
             /** Wait until the fill is finished animating before removing the active background color. */
-            setTimeout(() => {
+            timeOutID.current = setTimeout(() => {
               setIsActive(false);
               transitioning.current = false;
             }, transition.duration * 1000);

--- a/packages/replay-next/components/lexical/CommentEditor.tsx
+++ b/packages/replay-next/components/lexical/CommentEditor.tsx
@@ -155,18 +155,23 @@ export default function CommentEditor({
 
   // Toggle editor's enabled state when the prop changes.
   useEffect(() => {
+    let timeOutID: any = null;
     const editor = editorRef.current;
     if (editor != null) {
       if (editor.isEditable() !== editable) {
         editor.setEditable(editable);
 
         if (editable) {
-          setTimeout(() => {
+          timeOutID = setTimeout(() => {
             editor.focus();
           });
         }
       }
     }
+
+    return () => {
+      clearTimeout(timeOutID);
+    };
   }, [editable]);
 
   // Save a backup of the editor state in case we need to cancel/discard pending changes.

--- a/packages/replay-next/src/hooks/useDebouncedCallback.ts
+++ b/packages/replay-next/src/hooks/useDebouncedCallback.ts
@@ -1,9 +1,15 @@
-import { useRef } from "react";
+import { useRef, useEffect } from "react";
 
 export default function useDebouncedCallback<T extends (...args: any[]) => void>(
   callback: T,
   duration: number
 ): T {
+  useEffect(() => {
+    return () => {
+      clearTimeout(timeoutIdRef.current);
+    };
+  }, []);
+
   const timeoutIdRef = useRef<NodeJS.Timeout | null>(null);
 
   // @ts-ignore I don't know how to make TypeScript happy with the inner function signature.

--- a/src/devtools/client/inspector/markup/components/Node.tsx
+++ b/src/devtools/client/inspector/markup/components/Node.tsx
@@ -32,6 +32,7 @@ interface NodeProps {
 type FinalNodeProps = NodeProps & PropsFromRedux;
 
 class _Node extends PureComponent<FinalNodeProps> {
+  private static timeOutID: any;
   onExpanderToggle = (event: MouseEvent) => {
     event.stopPropagation();
     const { node } = this.props;
@@ -72,6 +73,7 @@ class _Node extends PureComponent<FinalNodeProps> {
       // Chrome sometimes ignores element.scrollIntoView() here,
       // calling it with a little delay fixes it
       setTimeout(() => el.scrollIntoView({ behavior: "smooth", block: "center" }));
+      _Node.timeOutID = setTimeout(() => el.scrollIntoView({ behavior: "smooth", block: "center" }));
     }
   };
 
@@ -208,6 +210,10 @@ class _Node extends PureComponent<FinalNodeProps> {
         {this.renderClosingTag()}
       </li>
     );
+  }
+
+  componentWillUnmount() {
+    clearTimeout(_Node.timeOutID);
   }
 }
 

--- a/src/ui/components/Header/Header.tsx
+++ b/src/ui/components/Header/Header.tsx
@@ -82,6 +82,7 @@ function HeaderTitle({
   recording: Recording;
   recordingId: RecordingId;
 }) {
+  const timeOutID: any = useRef(null);
   const [editState, setEditState] = useState(EditState.Inactive);
   const contentEditableRef = useRef<HTMLSpanElement>(null);
   const updateRecordingTitle = hooks.useUpdateRecordingTitle();
@@ -104,6 +105,10 @@ function HeaderTitle({
     } else if (editState === EditState.Saving && !contentEditableRef.current.innerText) {
       contentEditableRef.current.innerText = "Untitled";
     }
+
+    return () => {
+      clearTimeout(timeOutID.current);
+    };
   }, [editState, hasTitle, title]);
 
   if (!canEditTitle) {
@@ -126,7 +131,7 @@ function HeaderTitle({
 
       // HACK
       // Waiting until the end of the microtask queue works around a selection bug in Safari.
-      setTimeout(() => {
+      timeOutID.current = setTimeout(() => {
         const selection = window.getSelection();
         if (selection) {
           const range = document.createRange();

--- a/src/ui/components/NetworkMonitor/BodyDownload.tsx
+++ b/src/ui/components/NetworkMonitor/BodyDownload.tsx
@@ -1,10 +1,11 @@
 import classNames from "classnames";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, useRef } from "react";
 
 import MaterialIcon from "../shared/MaterialIcon";
 import { RawBody } from "./content";
 
 const BodyDownload = ({ raw, filename }: { raw: RawBody; filename: string }) => {
+  const timeOutID: any = useRef(null);
   const [downloaded, setDownloaded] = useState(false);
   const dataURL = useMemo(
     () => URL.createObjectURL(new Blob([raw.content.buffer], { type: raw.contentType })),
@@ -12,7 +13,10 @@ const BodyDownload = ({ raw, filename }: { raw: RawBody; filename: string }) => 
   );
 
   useEffect(() => {
-    return () => URL.revokeObjectURL(dataURL);
+    return () => {
+      URL.revokeObjectURL(dataURL);
+      clearTimeout(timeOutID.current);
+    };
   }, [dataURL]);
 
   return (
@@ -24,7 +28,7 @@ const BodyDownload = ({ raw, filename }: { raw: RawBody; filename: string }) => 
       rel="noreferrer noopener"
       onClick={() => {
         setDownloaded(true);
-        setTimeout(() => {
+        timeOutID.current = setTimeout(() => {
           setDownloaded(false);
         }, 2000);
       }}

--- a/src/ui/components/NetworkMonitor/HttpBody.tsx
+++ b/src/ui/components/NetworkMonitor/HttpBody.tsx
@@ -1,7 +1,7 @@
 import { BodyData } from "@replayio/protocol";
 import classNames from "classnames";
 import dynamic from "next/dynamic";
-import { useMemo, useState } from "react";
+import { useMemo, useState, useRef, useEffect } from "react";
 
 import { getTheme } from "ui/reducers/app";
 import { useAppSelector } from "ui/setup/hooks";
@@ -25,7 +25,14 @@ const ReactJson = dynamic(() => import("react-json-view"), {
 });
 
 const TextBodyComponent = ({ raw, text }: { raw: RawBody; text: string }) => {
+  const timeOutID: any = useRef(null);
   const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(timeOutID.current);
+    };
+  }, []);
 
   return (
     <div
@@ -41,7 +48,7 @@ const TextBodyComponent = ({ raw, text }: { raw: RawBody; text: string }) => {
             const blob = new Blob([asString.content], { type: "text/plain" });
             navigator.clipboard.write([new ClipboardItem({ "text/plain": blob })]);
             setCopied(true);
-            setTimeout(() => setCopied(false), 2000);
+            timeOutID.current = setTimeout(() => setCopied(false), 2000);
           }}
         >
           <MaterialIcon

--- a/src/ui/components/SecondaryToolbox/SourcesTabLabel.tsx
+++ b/src/ui/components/SecondaryToolbox/SourcesTabLabel.tsx
@@ -28,6 +28,10 @@ export default function TabSpotlight() {
       timeoutKey.current = null;
     }, 2000);
     // eslint-disable-next-line react-hooks/exhaustive-deps
+
+    return () => {
+      clearTimeout(timeoutKey.current);
+    };
   }, [selectedSource?.sourceId]);
 
   return (

--- a/src/ui/components/UploadScreen/UploadScreen.tsx
+++ b/src/ui/components/UploadScreen/UploadScreen.tsx
@@ -30,9 +30,13 @@ function DeletedScreen({ url }: { url: string }) {
     window.location.href = url;
   };
   useEffect(() => {
-    setTimeout(() => {
+    const timeOutID = setTimeout(() => {
       navigateToUrl();
     }, 1200);
+
+    return () => {
+      clearTimeout(timeOutID);
+    };
   });
 
   return (

--- a/src/ui/components/shared/APIKeys.tsx
+++ b/src/ui/components/shared/APIKeys.tsx
@@ -15,9 +15,14 @@ function NewApiKey({ keyValue, onDone }: { keyValue: string; onDone: () => void 
   const [copied, setCopied] = useState(false);
 
   useEffect(() => {
+    let timeOutID: any = null;
     if (copied) {
-      setTimeout(() => setCopied(false), 2000);
+      timeOutID = setTimeout(() => setCopied(false), 2000);
     }
+
+    return () => {
+      clearTimeout(timeOutID);
+    };
   }, [copied, setCopied]);
 
   return (

--- a/src/ui/components/shared/IconWithTooltip.tsx
+++ b/src/ui/components/shared/IconWithTooltip.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useRef, useState, useEffect } from "react";
 import ReactDOM from "react-dom";
 
 interface IconWithTooltipProps {
@@ -27,6 +27,12 @@ export default function IconWithTooltip({
     setHovered(false);
     clearTimeout(timeoutKey.current);
   };
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(timeoutKey.current);
+    };
+  }, []);
 
   return (
     <div className="icon-with-tooltip text-sm">

--- a/src/ui/components/shared/NewWorkspaceModal/InvitationLink.tsx
+++ b/src/ui/components/shared/NewWorkspaceModal/InvitationLink.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import React, { useRef, useState } from "react";
+import React, { useRef, useState, useEffect } from "react";
 
 import { Workspace } from "shared/graphql/types";
 import hooks from "ui/hooks";
@@ -26,6 +26,12 @@ export function TextInputCopy({
     setShowCopied(true);
     timeoutKey.current = setTimeout(() => setShowCopied(false), 2000);
   };
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(timeoutKey.current);
+    };
+  }, []);
 
   return (
     <div className="relative flex w-full flex-col items-center p-0.5">

--- a/src/ui/components/shared/SharingModal/EmailForm.tsx
+++ b/src/ui/components/shared/SharingModal/EmailForm.tsx
@@ -1,6 +1,6 @@
 import { CheckCircleIcon, ExclamationCircleIcon, PaperAirplaneIcon } from "@heroicons/react/solid";
 import { RecordingId } from "@replayio/protocol";
-import React, { Dispatch, SetStateAction, useState } from "react";
+import React, { Dispatch, SetStateAction, useState, useRef, useEffect } from "react";
 
 import hooks from "ui/hooks";
 import { validateEmail } from "ui/utils/helpers";
@@ -61,6 +61,7 @@ function AutocompleteAction({
 }
 
 export default function EmailForm({ recordingId }: { recordingId: RecordingId }) {
+  const timeOutID: any = useRef(null);
   const [inputValue, setInputValue] = useState("");
   const [showAutocomplete, setShowAutocomplete] = useState(false);
   const [status, setStatus] = useState<ActionStatus>("pending");
@@ -76,7 +77,7 @@ export default function EmailForm({ recordingId }: { recordingId: RecordingId })
   );
 
   const delayedReset = () => {
-    setTimeout(() => {
+    timeOutID.current = setTimeout(() => {
       setStatus("pending");
       setShowAutocomplete(false);
       setInputValue("");
@@ -109,6 +110,12 @@ export default function EmailForm({ recordingId }: { recordingId: RecordingId })
     });
     setStatus("loading");
   };
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(timeOutID.current);
+    };
+  }, []);
 
   return (
     <form className="new-collaborator-form" onSubmit={handleSubmit}>

--- a/src/ui/components/shared/SharingModal/ReplayLink.tsx
+++ b/src/ui/components/shared/SharingModal/ReplayLink.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useRef, useState, useEffect } from "react";
 
 import { Recording } from "shared/graphql/types";
 import { getRecordingURL } from "ui/utils/recording";
@@ -23,6 +23,12 @@ export function CopyButton({ recording }: { recording: Recording }) {
     setShowCopied(true);
     timeoutKey.current = setTimeout(() => setShowCopied(false), 2000);
   };
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(timeoutKey.current);
+    };
+  }, []);
 
   return (
     <div className="copy-link relative flex flex-shrink-0 flex-col items-center">
@@ -55,6 +61,12 @@ export function UrlCopy({ url }: { url: string }) {
     setShowCopied(true);
     timeoutKey.current = setTimeout(() => setShowCopied(false), 2000);
   };
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(timeoutKey.current);
+    };
+  }, []);
 
   return (
     <div className="copy-link relative flex flex-col items-center">

--- a/src/ui/components/shared/StatusDropdown.tsx
+++ b/src/ui/components/shared/StatusDropdown.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from "react";
+import React, { ReactNode, useState, useRef, useEffect } from "react";
 
 import { Dropdown, DropdownItem, DropdownItemContent } from "ui/components/Library/LibraryDropdown";
 import {
@@ -25,6 +25,7 @@ function DropdownButton({ disabled, children }: { disabled?: boolean; children: 
 }
 
 export default function StatusDropdown() {
+  const timeOutID: any = useRef(null);
   const recordingId = useGetRecordingId();
   const { recording } = useGetRecording(recordingId!);
   const [expanded, setExpanded] = useState(false);
@@ -36,6 +37,12 @@ export default function StatusDropdown() {
   }
 
   const isResolved = recording.resolution?.resolvedAt;
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(timeOutID.current);
+    };
+  }, []);
 
   return (
     <div className="rounded-md px-2 py-1">
@@ -68,7 +75,7 @@ export default function StatusDropdown() {
               setShowConfetti(true);
               setExpanded(false);
               setIsResolved(true);
-              setTimeout(() => setShowConfetti(false), 6000);
+              timeOutID.current = setTimeout(() => setShowConfetti(false), 6000);
             }}
           >
             <DropdownItemContent icon="resolved" selected={false}>

--- a/src/ui/components/shared/WorkspaceSettingsModal/useDebounceState.ts
+++ b/src/ui/components/shared/WorkspaceSettingsModal/useDebounceState.ts
@@ -5,6 +5,12 @@ export default function useDebounceState<T>(
   callback: (value: T) => void,
   timeout = 500
 ): [T | undefined, (value: T) => void, (value: T) => void] {
+  useEffect(() => {
+    return () => {
+      clearTimeout(ref.current);
+    };
+  }, []);
+
   const [value, updateValue] = useState(original); // nosemgrep typescript.react.best-practice.react-props-in-state.react-props-in-state
   const ref = useRef<NodeJS.Timeout | undefined>();
 

--- a/src/ui/utils/tokenManager.tsx
+++ b/src/ui/utils/tokenManager.tsx
@@ -41,6 +41,7 @@ function unstable_getAuth0Token() {
 }
 
 class TokenManager {
+  private static timeOutID: any;
   auth0Client: Auth0ContextInterface | undefined;
   private deferredState = defer<TokenState>();
   private currentState?: TokenState;
@@ -109,7 +110,7 @@ class TokenManager {
               return;
             }
 
-            setTimeout(() => {
+            TokenManager.timeOutID = setTimeout(() => {
               if (apiKey) {
                 this.setExternalAuth(apiKey);
               } else if (
@@ -252,6 +253,11 @@ class TokenManager {
       0
     );
     this.refreshTimeout = window.setTimeout(() => this.update(true), refreshDelay);
+  }
+
+  componentWillUnmount() {
+    clearTimeout(this.refreshTimeout);
+    clearTimeout(TokenManager.timeOutID);
   }
 }
 


### PR DESCRIPTION
Hello 👋 
As part of our project, we are using Facebook's new Memlab tool to detect memory leaks in SPA applications and their libraries. While running the tool and analyzing the code of replayio's devtools, we saw that your project does a very good job of ensuring that all async operations are cancelled when components destroy. However, as per Memlab execution results, we found some uncleared timers, causing the memory to leak (screenshots below).

[before]
<img width="1380" alt="before Screen Shot 2023-02-10 at 5 12 11 AM" src="https://user-images.githubusercontent.com/56495631/217937173-29cb8905-2ac4-44f7-a03b-32d54ec24b1a.png">

Hence we added the fix by clearing the timers on component unload, and you can see the heap size and # of leaks reducing noticeably:
 <br />
<img width="1392" alt="Screen Shot 2023-02-10 at 5 00 13 AM" src="https://user-images.githubusercontent.com/56495631/217937883-91a81535-85d9-4821-9f06-ac7623dbefa4.png">


Note. Static properties are used in classes to avoid losing the context of the correct ‘this’ in case any nesting changes are made to the enclosing functions in future.

We executed the unit test suite after the fixes and it successfully passed 43 of 43 (in non-watch mode) and 14 of 14 (in watch mode) respectively. 

You can analyze this and other potential leak sources, if you like, by running [Memlab](https://facebook.github.io/memlab/) with a scenario file covering the maximum # of use cases.

Following is a sample of the scenario file we used (it needs to be a .js file but attaching here in .txt form):
[devtools-scenario-memlab.txt](https://github.com/replayio/devtools/files/10701446/devtools-scenario-memlab.txt)

Note that some other reported leaks (in Memlab) originated from React's internal objects, and hence were ignored.