### PR TITLE
Revamp "Protocol Viewer" to always enable for devs and show messages from recordings of Replay

### DIFF
--- a/packages/replay-next/src/suspense/AnalysisCache.ts
+++ b/packages/replay-next/src/suspense/AnalysisCache.ts
@@ -19,13 +19,13 @@ import {
 } from "protocol/evaluation-utils";
 import { ReplayClientInterface } from "shared/client/types";
 
-import { createWakeable } from "../utils/suspense";
+import { createFetchAsyncFromFetchSuspense, createWakeable } from "../utils/suspense";
 import { cachePauseData } from "./PauseCache";
 import { Record, STATUS_PENDING, STATUS_REJECTED, STATUS_RESOLVED, Wakeable } from "./types";
 
 type Value = any;
 
-type AnalysisResult = {
+export type AnalysisResult = {
   executionPoint: ExecutionPoint;
   isRemote: boolean;
   pauseId: PauseId | null;
@@ -33,7 +33,7 @@ type AnalysisResult = {
   values: Value[];
 };
 
-export type AnalysisResults = (timeStampedPoint: TimeStampedPoint) => AnalysisResult | null;
+export type GetAnalysisResult = (timeStampedPoint: TimeStampedPoint) => AnalysisResult | null;
 
 export type RemoteAnalysisResult = {
   data: { frames: Frame[]; objects: ProtocolObject[]; scopes: Scope[] };
@@ -56,7 +56,7 @@ function getKey(
   }`;
 }
 
-const locationAndTimeToValueMap: Map<string, Record<AnalysisResults>> = new Map();
+const locationAndTimeToValueMap: Map<string, Record<GetAnalysisResult>> = new Map();
 
 // TODO (FE-469) Filter in-memory if the range gets smaller (and we haven't overflowed)
 // Currently we re-run the analysis which seems wasteful.
@@ -67,12 +67,12 @@ export function runAnalysisSuspense(
   location: Location,
   code: string,
   condition: string | null
-): AnalysisResults {
+): GetAnalysisResult {
   const key = getKey(focusRange, location, code, condition);
 
   let record = locationAndTimeToValueMap.get(key);
   if (record == null) {
-    const wakeable = createWakeable<AnalysisResults>(`runAnalysisSuspense: ${key}`);
+    const wakeable = createWakeable<GetAnalysisResult>(`runAnalysisSuspense: ${key}`);
 
     record = {
       status: STATUS_PENDING,
@@ -147,11 +147,11 @@ export function canRunLocalAnalysis(code: string): boolean {
 
 async function runLocalAnalysis(
   code: string,
-  record: Record<AnalysisResults>,
-  wakeable: Wakeable<AnalysisResults>
+  record: Record<GetAnalysisResult>,
+  wakeable: Wakeable<GetAnalysisResult>
 ) {
   try {
-    const analysisResults = await new Promise<AnalysisResults>((resolve, reject) => {
+    const analysisResults = await new Promise<GetAnalysisResult>((resolve, reject) => {
       if (code === "location") {
         reject();
       }
@@ -167,7 +167,7 @@ async function runLocalAnalysis(
       const worker = new Worker(objectURL);
       worker.addEventListener("message", event => {
         const values = event.data;
-        const analysisResults: AnalysisResults = (timeStampedPoint: TimeStampedPoint) => ({
+        const analysisResults: GetAnalysisResult = (timeStampedPoint: TimeStampedPoint) => ({
           executionPoint: timeStampedPoint.point,
           isRemote: false,
           pauseId: null,
@@ -207,8 +207,8 @@ async function runRemoteAnalysis(
   location: Location,
   code: string,
   condition: string | null,
-  record: Record<AnalysisResults>,
-  wakeable: Wakeable<AnalysisResults>
+  record: Record<GetAnalysisResult>,
+  wakeable: Wakeable<GetAnalysisResult>
 ) {
   try {
     const results = await client.runAnalysis<RemoteAnalysisResult>({

--- a/packages/replay-next/src/suspense/AnalysisCache.ts
+++ b/packages/replay-next/src/suspense/AnalysisCache.ts
@@ -95,6 +95,8 @@ export function runAnalysisSuspense(
   }
 }
 
+export const runAnalysisAsync = createFetchAsyncFromFetchSuspense(runAnalysisSuspense);
+
 export function canRunLocalAnalysis(code: string): boolean {
   const tokens = jsTokens(code);
   // @ts-ignore

--- a/packages/replay-next/src/suspense/ExecutionPointsCache.ts
+++ b/packages/replay-next/src/suspense/ExecutionPointsCache.ts
@@ -9,7 +9,7 @@ import {
 import { HitPointsAndStatusTuple, ReplayClientInterface } from "shared/client/types";
 import { ProtocolError, isCommandError } from "shared/utils/error";
 
-import { createWakeable } from "../utils/suspense";
+import { createFetchAsyncFromFetchSuspense, createWakeable } from "../utils/suspense";
 import { isExecutionPointsLessThan } from "../utils/time";
 import { createGenericCache } from "./createGenericCache";
 import { Record, STATUS_PENDING, STATUS_REJECTED, STATUS_RESOLVED, Wakeable } from "./types";
@@ -308,6 +308,10 @@ export function getHitPointsForLocationSuspense(
     throw record.value;
   }
 }
+
+export const getHitPointsForLocationAsync = createFetchAsyncFromFetchSuspense(
+  getHitPointsForLocationSuspense
+);
 
 function getKey(
   location: Location,

--- a/src/devtools/client/debugger/src/reducers/ast.ts
+++ b/src/devtools/client/debugger/src/reducers/ast.ts
@@ -6,7 +6,12 @@ import { EntityState, createAsyncThunk, createEntityAdapter, createSlice } from 
 import { SourceLocation } from "@replayio/protocol";
 
 import { getSourceIDsToSearch } from "devtools/client/debugger/src/utils/sourceVisualizations";
-import { MiniSource, SourceDetails, getSourceDetailsEntities } from "ui/reducers/sources";
+import {
+  MiniSource,
+  SourceDetails,
+  getAllSourceDetails,
+  getSourceDetailsEntities,
+} from "ui/reducers/sources";
 import { UIState } from "ui/state";
 import { getSymbolsAsync } from "ui/suspense/sourceCaches";
 import { LoadingStatus } from "ui/utils/LoadingStatus";
@@ -109,10 +114,12 @@ export const fetchSymbolsForSource = createAsyncThunk<
   { state: UIState; extra: ThunkExtraArgs }
 >(
   "ast/fetchSymbolsForSource",
-  async (sourceId, { extra }) => {
+  async (sourceId, { extra, getState }) => {
     const { replayClient } = extra;
 
-    const symbols = await getSymbolsAsync(replayClient, sourceId);
+    const sourceDetails = getAllSourceDetails(getState());
+
+    const symbols = await getSymbolsAsync(replayClient, sourceId, sourceDetails);
     return symbols!;
   },
   {

--- a/src/devtools/client/inspector/components/App.tsx
+++ b/src/devtools/client/inspector/components/App.tsx
@@ -8,7 +8,7 @@ import MarkupApp from "devtools/client/inspector/markup/components/MarkupApp";
 import { RulesApp } from "devtools/client/inspector/rules/components/RulesApp";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 
-import { ResponsiveTabs } from "../../shared/components/ResponsiveTabs";
+import { ResponsiveTabs, Tab } from "../../shared/components/ResponsiveTabs";
 import { setActiveTab } from "../actions";
 import { EventListenersApp } from "../event-listeners/EventListenersApp";
 import { InspectorActiveTab } from "../reducers";
@@ -55,22 +55,13 @@ export default function InspectorApp() {
                           {availableTabs.map(panelId => {
                             const isPanelSelected = activeTab === panelId;
                             return (
-                              <span
+                              <Tab
                                 key={panelId}
-                                className={classnames("tabs-menu-item", {
-                                  "is-active": isPanelSelected,
-                                })}
-                              >
-                                <span className="devtools-tab-line"></span>
-                                <button
-                                  id={`${panelId}-tab`}
-                                  title={INSPECTOR_TAB_TITLES[panelId]}
-                                  role="tab"
-                                  onClick={() => dispatch(setActiveTab(panelId))}
-                                >
-                                  {INSPECTOR_TAB_TITLES[panelId]}
-                                </button>
-                              </span>
+                                id={panelId}
+                                active={isPanelSelected}
+                                text={INSPECTOR_TAB_TITLES[panelId]}
+                                onClick={() => dispatch(setActiveTab(panelId))}
+                              />
                             );
                           })}
                         </ResponsiveTabs>

--- a/src/devtools/client/shared/components/ResponsiveTabs.tsx
+++ b/src/devtools/client/shared/components/ResponsiveTabs.tsx
@@ -9,6 +9,28 @@ import React, {
   useState,
 } from "react";
 
+interface TabProps {
+  id: string;
+  text: string;
+  active?: boolean;
+  onClick?: () => void;
+}
+
+export function Tab({ id, text, active, onClick }: TabProps) {
+  return (
+    <span
+      className={cx("tabs-menu-item", {
+        "is-active": active,
+      })}
+    >
+      <span className="devtools-tab-line"></span>
+      <button id={`${id}-tab`} title={text} role="tab" onClick={onClick}>
+        {text}
+      </button>
+    </span>
+  );
+}
+
 type ResponsiveTabsProps = {
   className?: string;
   dropdownButton?: ReactNode;

--- a/src/devtools/client/shared/components/Tabs.css
+++ b/src/devtools/client/shared/components/Tabs.css
@@ -5,7 +5,6 @@
 /* Tabs General Styles */
 
 .tabs {
-  height: 100%;
   background: var(--theme-sidebar-background);
   display: flex;
   flex-direction: column;

--- a/src/ui/components/ProtocolViewer.tsx
+++ b/src/ui/components/ProtocolViewer.tsx
@@ -510,7 +510,7 @@ const { getValueSuspense: getRecordedProtocolMessagesSuspense } = createGenericC
       replayClient,
       sessionSource.id
     );
-    const symbols = await getSymbolsAsync(replayClient, sessionSource.id);
+    const symbols = await getSymbolsAsync(replayClient, sessionSource.id, sourceDetails);
 
     const mapNamesToCallbackNames: Record<keyof AllProtocolMessages, string> = {
       requestMap: "onRequest",

--- a/src/ui/components/shared/UserSettingsModal/UserSettingsModal.tsx
+++ b/src/ui/components/shared/UserSettingsModal/UserSettingsModal.tsx
@@ -233,10 +233,6 @@ export function UserSettingsModal(props: PropsFromRedux) {
     if (!user.features.library) {
       hiddenTabs.push("API Keys");
     }
-
-    if (!user.internal) {
-      hiddenTabs.push("Advanced");
-    }
   }
 
   return (

--- a/src/ui/reducers/protocolMessages.ts
+++ b/src/ui/reducers/protocolMessages.ts
@@ -20,11 +20,15 @@ export type RequestSummary = Omit<CommandRequest, "method"> & {
   recordedAt: number;
 };
 
+export type ProtocolResponseMap = { [id: number]: CommandResponse & Recorded };
+export type ProtocolRequestMap = { [id: number]: RequestSummary };
+export type ProtocolErrorMap = { [id: number]: CommandResponse & Recorded };
+
 export interface ProtocolMessagesState {
   events: (ProtocolEvent & Recorded)[];
-  idToResponseMap: { [id: number]: CommandResponse & Recorded };
-  idToRequestMap: { [id: number]: RequestSummary };
-  idToErrorMap: { [id: number]: CommandResponse & Recorded };
+  idToResponseMap: ProtocolResponseMap;
+  idToRequestMap: ProtocolRequestMap;
+  idToErrorMap: ProtocolErrorMap;
 }
 
 const protocolMessagesSlice = createSlice({

--- a/src/ui/suspense/sourceCaches.ts
+++ b/src/ui/suspense/sourceCaches.ts
@@ -2,6 +2,29 @@ import type { SymbolDeclarations } from "devtools/client/debugger/src/reducers/a
 import { createGenericCache } from "replay-next/src/suspense/createGenericCache";
 import { getSourceContentsAsync } from "replay-next/src/suspense/SourcesCache";
 import { ReplayClientInterface } from "shared/client/types";
+import { SourceDetails } from "ui/reducers/sources";
+
+// Based on similar logic in `replay-next/src/suspense/SourcesCache`
+function urlToContentType(fileName: string): string {
+  const extension = fileName.split(".").pop()!.split("?").shift()!;
+  switch (extension) {
+    case "js":
+      return "text/javascript";
+    case "jsx":
+      return "text/jsx";
+    case "ts":
+    case "tsx":
+      return "text/typescript";
+    case "json":
+      return "text/json";
+    case "html":
+      return "text/html";
+    case "vue":
+      return "text/vue";
+    default:
+      return "text/javascript";
+  }
+}
 
 export const {
   getValueAsync: getSymbolsAsync,
@@ -9,17 +32,21 @@ export const {
   getValueSuspense: getSymbolsSuspense,
 } = createGenericCache<
   [replayClient: ReplayClientInterface],
-  [sourceId: string],
+  [sourceId: string, sourceDetails: SourceDetails[]],
   SymbolDeclarations | undefined
 >(
   "sourceSymbolsCache",
   1,
-  async (replayClient, sourceId) => {
+  async (replayClient, sourceId, sourceDetails) => {
     const { parser } = await import("devtools/client/debugger/src/utils/bootstrap");
     const sourceContents = await getSourceContentsAsync(replayClient, sourceId);
 
     if (sourceContents !== undefined) {
-      const { contents, contentType } = sourceContents;
+      const { contents, sourceId } = sourceContents;
+
+      const matchingSource = sourceDetails.find(sd => sd.id === sourceId);
+
+      const contentType = urlToContentType(matchingSource?.url ?? "");
 
       // Our Babel parser worker requires a copy of the source text be sent over first
       parser.setSource(sourceId, {

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -31,7 +31,7 @@ pref("devtools.features.disableStableQueryCache", false);
 pref("devtools.features.enableUnstableQueryCache", false);
 pref("devtools.features.enableLargeText", false);
 pref("devtools.features.hitCounts", true);
-pref("devtools.features.logProtocol", false);
+pref("devtools.features.logProtocol", true);
 pref("devtools.features.logProtocolEvents", false);
 pref("devtools.features.newControllerOnRefresh", false);
 pref("devtools.features.originalClassNames", false);


### PR DESCRIPTION
Per FE-1214, I recently had a brainstorm. We have a "Protocol Viewer" panel that is only usable by Replay devs, and shows a neatly-formatted log of all the protocol requests and responses in the current open session.

We spend a lot of time debugging _recordings_ of Replay itself.  Wouldn't it be great if we could reuse the same `<ProtocolViewer>` component to visualize the protocol messages _from the copy of Replay we recorded_?  That would be really useful for debugging our own app.

So... I did that :)

Along the way I got a bit sidetracked and noted that we have 3.5 different implementations of tabs in this codebase in terms of CSS classes, and _no_ prebuilt components for any of those.

I ended up componentizing some of the HTML used by the tabs in the "Elements" and "Network" sub-panels.  I also noted that we have `@headlessui/react` in our codebase already, which has prebuilt headless tab management logic: https://headlessui.com/react/tabs .  So, I opted to try using that to switch between the "Live" and "Recorded" versions of the panel.

This first pass requires that you click to fetch the recorded data, doesn't cache any of it, and doesn't persist those results if you switch to a different tab or panel.  Also need to figure out how to handle cases where there's >200 analysis hits. Wanted to get what I have working up as a PR.

Overall, this PR:

- Removes the existing internal-user-only feature checkbox for enabling the `<ProtocolViewer>` ( accessible from the console as `window.app.features.logProtocol` ), and instead just checks if the current user is a Replay dev. (Brian and I agreed there's no reason to make this optional for us devs.)
- Extracts a reusable `<Tab>` component out of the HTML from those couple panels
- Updates the Protocol Viewer file to split it into:
  - `<ProtocolViewerPanel>`
    - `<LiveAppProtocolViewer>`, which reads from Redux
      - `<ProtocolViewer>`, which is now a "presentational" component
    - `<RecordedAppProtocolViewer>`, which fetches messages via analysis
- Updates `AnalysisCache.ts` to rename the `AnalysisResults` type, which is actually a callback function that returns a result and _not_ an array, to `GetAnalysisResult` for clarity
- Uses more analysis wizardry to find the protocol messages from the recording:
  - Checks the list of sources for our known `actions/session.ts` file
  - Finds the `onRequest`, `onResponse`, and `onResponseError` callback functions in that file
  - Finds the first breakable position in each function
  - Queries for all hit points of those positions
  - Uses analysis to fetch the `event` object in scope in each callback
  - Recursively downloads the `event` object to turn it into a POJO
  - Reformats the fetched event objects to match the normalized structure needed by `<ProtocolViewer>`

Here's how the "Protocol Viewer" panel looks with the "Recorded" tab selected:

![image](https://user-images.githubusercontent.com/1128784/217960319-ab7a8592-8c91-455a-941d-59b6ef3602b0.png)
