### PR TITLE
Expand the side panel when adding comments (FE-1185)

### DIFF
--- a/src/devtools/client/debugger/src/components/shared/InspectorContextReduxAdapter.tsx
+++ b/src/devtools/client/debugger/src/components/shared/InspectorContextReduxAdapter.tsx
@@ -10,7 +10,9 @@ import { selectNode } from "devtools/client/inspector/markup/actions/markup";
 import { onViewSourceInDebugger } from "devtools/client/webconsole/actions";
 import { ThreadFront } from "protocol/thread";
 import { InspectorContext } from "replay-next/src/contexts/InspectorContext";
+import useLocalStorage from "replay-next/src/hooks/useLocalStorage";
 import { setSelectedPanel, setSelectedPrimaryPanel } from "ui/actions/layout";
+import { sidePanelStorageKey } from "ui/components/DevTools";
 import { getSourceDetailsEntities } from "ui/reducers/sources";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 
@@ -18,6 +20,7 @@ import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 export default function InspectorContextReduxAdapter({ children }: { children: ReactNode }) {
   const sourcesById = useAppSelector(getSourceDetailsEntities);
   const dispatch = useAppDispatch();
+  const [, setSidePanelCollapsed] = useLocalStorage(sidePanelStorageKey, false);
 
   const inspectFunctionDefinition = useCallback(
     (mappedLocation: MappedLocation) => {
@@ -41,7 +44,8 @@ export default function InspectorContextReduxAdapter({ children }: { children: R
 
   const showCommentsPanel = useCallback(() => {
     dispatch(setSelectedPrimaryPanel("comments"));
-  }, [dispatch]);
+    setSidePanelCollapsed(false);
+  }, [dispatch, setSidePanelCollapsed]);
 
   const inspectHTMLElement = useCallback(
     (protocolValue: ProtocolValue, pauseId: PauseId, point: ExecutionPoint, time: number) => {

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -54,6 +54,8 @@ const Viewer = React.lazy(() => import("./Viewer"));
 
 type DevToolsProps = PropsFromRedux & { apiKey?: string; uploadComplete: boolean };
 
+export const sidePanelStorageKey = "Replay:SidePanelCollapsed";
+
 function ViewLoader() {
   const [showLoader, setShowLoader] = useState(false);
   const idRef = useRef<ReturnType<typeof setTimeout>>();
@@ -81,17 +83,24 @@ function Body() {
 
   const sidePanelRef = useRef<ImperativePanelHandle>(null);
 
-  const sidePanelStorageKey = "Replay:SidePanelCollapsed";
   const [sidePanelCollapsed, setSidePanelCollapsed] = useLocalStorage(sidePanelStorageKey, false);
 
   const onSidePanelCollapse = (isCollapsed: boolean) => {
     setSidePanelCollapsed(isCollapsed);
   };
 
+  useEffect(() => {
+    if (sidePanelCollapsed) {
+      sidePanelRef.current?.collapse();
+    } else {
+      sidePanelRef.current?.expand();
+    }
+  }, [sidePanelCollapsed]);
+
   return (
     <div className="vertical-panels pr-2">
       <div className="flex h-full flex-row overflow-hidden bg-chrome">
-        <Toolbar sidePanelCollapsed={sidePanelCollapsed} sidePanelRef={sidePanelRef} />
+        <Toolbar />
         <PanelGroup autoSaveId="DevTools-horizontal" className="split-box" direction="horizontal">
           <Panel
             className="flex=1 flex h-full overflow-hidden"

--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -1,9 +1,9 @@
 import classnames from "classnames";
 import classNames from "classnames";
-import React, { ReactNode, RefObject, useContext, useEffect, useState } from "react";
-import { ImperativePanelHandle } from "react-resizable-panels";
+import React, { useContext, useEffect, useState } from "react";
 
 import { getPauseId } from "devtools/client/debugger/src/selectors";
+import useLocalStorage from "replay-next/src/hooks/useLocalStorage";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import IconWithTooltip from "ui/components/shared/IconWithTooltip";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
@@ -19,6 +19,7 @@ import { trackEvent } from "ui/utils/telemetry";
 
 import { actions } from "../actions";
 import { selectors } from "../reducers";
+import { sidePanelStorageKey } from "./DevTools";
 
 function CypressIcon() {
   return (
@@ -106,13 +107,7 @@ function ToolbarButton({
   );
 }
 
-export default function Toolbar({
-  sidePanelCollapsed,
-  sidePanelRef,
-}: {
-  sidePanelCollapsed: boolean;
-  sidePanelRef: RefObject<ImperativePanelHandle>;
-}) {
+export default function Toolbar() {
   const dispatch = useAppDispatch();
   const replayClient = useContext(ReplayClientContext);
   const pauseId = useAppSelector(getPauseId);
@@ -125,6 +120,7 @@ export default function Toolbar({
   const { recording } = useGetRecording(recordingId);
   const { comments, loading } = hooks.useGetComments(recordingId);
   const { value: logProtocol } = useFeature("logProtocol");
+  const [sidePanelCollapsed, setSidePanelCollapsed] = useLocalStorage(sidePanelStorageKey, false);
 
   useEffect(() => {
     if (!loading && comments.length > 0) {
@@ -139,14 +135,7 @@ export default function Toolbar({
   }, [selectedPrimaryPanel, showCommentsBadge]);
 
   const togglePanel = () => {
-    const panel = sidePanelRef.current;
-    if (panel) {
-      if (sidePanelCollapsed) {
-        panel.expand();
-      } else {
-        panel.collapse();
-      }
-    }
+    setSidePanelCollapsed(!sidePanelCollapsed);
   };
 
   const handleButtonClick = (panelName: PrimaryPanelName) => {

--- a/src/ui/components/shared/CommentTool.tsx
+++ b/src/ui/components/shared/CommentTool.tsx
@@ -1,13 +1,13 @@
 import classNames from "classnames";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useContext, useEffect, useRef, useState } from "react";
 
 import {
   VisualCommentTypeData,
   createTypeDataForVisualComment,
 } from "replay-next/components/sources/utils/comments";
+import { InspectorContext } from "replay-next/src/contexts/InspectorContext";
 import { getAreMouseTargetsLoading, getCanvas } from "ui/actions/app";
 import { createFrameComment } from "ui/actions/comments";
-import { setSelectedPrimaryPanel } from "ui/actions/layout";
 import { useGetRecordingId } from "ui/hooks/recordings";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { Canvas } from "ui/state/app";
@@ -68,6 +68,7 @@ export default function CommentTool({ comments }: { comments: (Comment | Reply)[
   const canvas = useAppSelector(getCanvas);
   const areMouseTargetsLoading = useAppSelector(getAreMouseTargetsLoading);
   const { isAuthenticated } = useAuth0();
+  const { showCommentsPanel } = useContext(InspectorContext);
 
   const dispatch = useAppDispatch();
 
@@ -102,7 +103,7 @@ export default function CommentTool({ comments }: { comments: (Comment | Reply)[
           dispatch(createFrameComment(position, recordingId, typeData));
         }
 
-        dispatch(setSelectedPrimaryPanel("comments"));
+        showCommentsPanel?.();
       };
 
       const onMouseMove = (e: MouseEvent) => setMousePosition(mouseEventCanvasPosition(e));
@@ -124,7 +125,7 @@ export default function CommentTool({ comments }: { comments: (Comment | Reply)[
         videoNode.removeEventListener("mouseleave", onMouseLeave);
       };
     }
-  }, [comments, dispatch, isAuthenticated, recordingId]);
+  }, [comments, dispatch, isAuthenticated, recordingId, showCommentsPanel]);
 
   // Un-authenticated users can't comment on Replays.
   if (!isAuthenticated) {


### PR DESCRIPTION
- small refactor: the side panel's `collapse()`/`expand()` methods are now called in an effect whenever the corresponding localStorage value changes, so that other components can expand/collapse the side panel without needing a `ref` for it
- bugfix: before that refactor, if you had 2 replay tabs open and expanded or collapsed the side panel in one of them, you couldn't expand or collapse it in the other tab anymore
- the `InspectorContextReduxAdapter`'s `showCommentsPanel()` function now expands the side panel
- the `CommentTool` component now also uses that function
