### PR TITLE
Sort by point instead of time (FE-1229)

### DIFF
--- a/src/ui/utils/timeline.ts
+++ b/src/ui/utils/timeline.ts
@@ -336,10 +336,10 @@ export function mergeSortedPointLists(
     if (destinationIndexPoint == null) {
       destination.push(sourcePoint);
       sourceIndex++;
-    } else if (sourcePoint.time === destinationIndexPoint.time) {
+    } else if (sourcePoint.point === destinationIndexPoint.point) {
       // Don't add duplicates.
       sourceIndex++;
-    } else if (sourcePoint.time < destinationIndexPoint.time) {
+    } else if (BigInt(sourcePoint.point) < BigInt(destinationIndexPoint.point)) {
       destination.splice(destinationIndex, 0, sourcePoint);
       sourceIndex++;
       destinationIndex++;


### PR DESCRIPTION
`mergeSortedPointLists()` asserted that the lists were sorted by `point` and then merged them sorted by `time`, so it's no surprise that this fails sometimes (e.g. https://app.replay.io/recording/unsorted-points-assertion--8732a7ee-c197-4ac0-a24c-938dd187e824).
`time` should not be used for *anything* other than user display, it's simply not precise and reliable enough for anything else!