### PR TITLE
Refactor test into panel UI components

### DIFF
--- a/packages/e2e-tests/jail/cypress-01.test.ts
+++ b/packages/e2e-tests/jail/cypress-01.test.ts
@@ -41,7 +41,7 @@ test(`cypress-01: Test basic cypress reporter functionality`, async ({ page }) =
   await expect(failedRowError).toContainText("Error");
 
   // can open tests
-  await failedRow.locator("button").click();
+  await failedRow.click();
   const selectedRow = await getTestRows(page);
   expect(selectedRow).toHaveCount(1);
   const sections = await getTestCaseSections(selectedRow);

--- a/src/devtools/client/debugger/src/components/TestInfo/MissingSteps.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/MissingSteps.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+
+import { useTestInfo } from "ui/hooks/useTestInfo";
+
+import styles from "./TestInfo.module.css";
+
+export function MissingSteps() {
+  const info = useTestInfo();
+
+  return (
+    <aside className={styles.aside}>
+      <div>
+        <strong>👋 Hey there!</strong>
+      </div>
+      <div>
+        You seem to be missing test steps for this replay. You'll still be able to use the core
+        Replay tools but adding test steps will give you a much better debugging experience.
+      </div>
+      {info.runner === "cypress" ? (
+        <div>
+          This usually means you need to include the <code>@replayio/cypress/support</code> module
+          in your project's support file. More information is available in our{" "}
+          <a
+            className="underline"
+            href="https://docs.replay.io/recording-browser-tests-(beta)/cypress-instructions"
+            target="_blank"
+            rel="noreferrer"
+          >
+            docs
+          </a>
+          .
+        </div>
+      ) : null}
+      <div>
+        If you're stuck, reach out to us over{" "}
+        <a className="underline" href="mailto:support@replay.io" target="_blank" rel="noreferrer">
+          email
+        </a>{" "}
+        or{" "}
+        <a href="https://replay.io/discord" className="underline" target="_blank" rel="noreferrer">
+          discord
+        </a>{" "}
+        and we can help you get set up.
+      </div>
+    </aside>
+  );
+}

--- a/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
@@ -24,19 +24,6 @@ export type TestCaseContextType = {
   onPlayFromHere: (startTime: number) => void;
 };
 
-export function formatStepError(step?: TestStep) {
-  if (!step || !step.error || !step.args) {
-    return null;
-  }
-
-  return (
-    <>
-      <strong className="bold">Error:</strong>&nbsp;
-      {step.args.map((e, i) => (typeof e === "string" ? <span key={i}>{e}&nbsp;</span> : null))}
-    </>
-  );
-}
-
 export const TestCaseContext = createContext<TestCaseContextType>(null as any);
 
 export function TestCase({ test }: { test: TestItem }) {

--- a/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestCase.tsx
@@ -1,4 +1,3 @@
-import classnames from "classnames";
 import { createContext, useCallback, useEffect, useState } from "react";
 
 import { TestItem, TestResult, TestStep } from "shared/graphql/types";
@@ -11,12 +10,7 @@ import {
   updateFocusRegionParam,
 } from "ui/actions/timeline";
 import Icon from "ui/components/shared/Icon";
-import MaterialIcon from "ui/components/shared/MaterialIcon";
-import {
-  getReporterAnnotationsForTitleEnd,
-  getSelectedTest,
-  setSelectedTest,
-} from "ui/reducers/reporter";
+import { getReporterAnnotationsForTitleEnd, getSelectedTest } from "ui/reducers/reporter";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 
 import { TestSteps } from "./TestSteps";
@@ -30,7 +24,7 @@ export type TestCaseContextType = {
   onPlayFromHere: (startTime: number) => void;
 };
 
-function formatStepError(step?: TestStep) {
+export function formatStepError(step?: TestStep) {
   if (!step || !step.error || !step.args) {
     return null;
   }
@@ -45,12 +39,8 @@ function formatStepError(step?: TestStep) {
 
 export const TestCaseContext = createContext<TestCaseContextType>(null as any);
 
-export function TestCase({ test, index }: { test: TestItem; index: number }) {
-  const [expandSteps, setExpandSteps] = useState(false);
+export function TestCase({ test }: { test: TestItem }) {
   const dispatch = useAppDispatch();
-  const expandable = !!test.steps;
-  const selectedTest = useAppSelector(getSelectedTest);
-  const isSelected = selectedTest === index;
   const annotationsEnd = useAppSelector(getReporterAnnotationsForTitleEnd);
 
   const testStartTime = test.relativeStartTime || 0;
@@ -69,10 +59,6 @@ export function TestCase({ test, index }: { test: TestItem; index: number }) {
     dispatch(updateFocusRegionParam());
   }, [testStartTime, testEndTime, dispatch]);
 
-  const toggleExpand = () => {
-    dispatch(setSelectedTest({ index, title: test.title }));
-  };
-
   const seekToFirstStep = useCallback(() => {
     const firstStep = test.steps?.[0];
     if (test.relativeStartTime != null) {
@@ -90,14 +76,9 @@ export function TestCase({ test, index }: { test: TestItem; index: number }) {
   }, [test, annotationsEnd, dispatch]);
 
   useEffect(() => {
-    if (isSelected) {
-      setExpandSteps(true);
-      seekToFirstStep();
-      onFocus();
-    } else {
-      setExpandSteps(false);
-    }
-  }, [isSelected, seekToFirstStep, onFocus]);
+    seekToFirstStep();
+    onFocus();
+  }, [seekToFirstStep, onFocus]);
 
   const onReplay = () => {
     dispatch(startPlayback({ beginTime: testStartTime, endTime: testEndTime - 1 }));
@@ -111,41 +92,7 @@ export function TestCase({ test, index }: { test: TestItem; index: number }) {
       value={{ startTime: testStartTime, endTime: testEndTime, onReplay, onPlayFromHere, test }}
     >
       <div className="flex flex-col" data-test-id="TestSuite-TestCaseRow">
-        {!isSelected && (
-          <button
-            className={classnames(
-              "flex flex-row items-center justify-between gap-1 rounded-lg p-1 transition",
-              {
-                "group hover:cursor-pointer": expandable,
-              }
-            )}
-            onClick={toggleExpand}
-            disabled={!expandable}
-          >
-            <div className="flex flex-grow flex-row gap-1 overflow-hidden">
-              <Status result={test.result} />
-              <div className="flex flex-col items-start text-bodyColor">
-                <div
-                  className={`overflow-hidden overflow-ellipsis whitespace-pre ${"group-hover:underline"}`}
-                >
-                  {test.title}
-                </div>
-                {test.error ? (
-                  <div
-                    className="mt-2 overflow-hidden rounded-lg bg-testsuitesErrorBgcolor px-3 py-2 text-left font-mono"
-                    data-test-id="TestSuite-TestCaseRow-Error"
-                  >
-                    {formatStepError(test.steps?.find(s => s.error)) || test.error.message}
-                  </div>
-                ) : null}
-              </div>
-            </div>
-            <div className="invisible flex self-start group-hover:visible">
-              <MaterialIcon>chevron_right</MaterialIcon>
-            </div>
-          </button>
-        )}
-        {expandSteps ? <TestSteps test={test} /> : null}
+        <TestSteps test={test} />
       </div>
     </TestCaseContext.Provider>
   );

--- a/src/devtools/client/debugger/src/components/TestInfo/TestCaseRow.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestCaseRow.tsx
@@ -30,6 +30,7 @@ export function TestCaseRow({ test, index }: { test: TestItem; index: number }) 
 
   return (
     <button
+      data-test-id="TestSuite-TestCaseRow"
       className={classnames(
         "flex flex-row items-center justify-between gap-1 rounded-lg p-1 transition",
         {

--- a/src/devtools/client/debugger/src/components/TestInfo/TestCaseRow.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestCaseRow.tsx
@@ -1,0 +1,52 @@
+import classnames from "classnames";
+
+import { TestItem } from "shared/graphql/types";
+import MaterialIcon from "ui/components/shared/MaterialIcon";
+import { setSelectedTest } from "ui/reducers/reporter";
+import { useAppDispatch } from "ui/setup/hooks";
+
+import { Status, formatStepError } from "./TestCase";
+
+export function TestCaseRow({ test, index }: { test: TestItem; index: number }) {
+  const dispatch = useAppDispatch();
+  const expandable = !!test.steps;
+
+  const toggleExpand = () => {
+    dispatch(setSelectedTest({ index, title: test.title }));
+  };
+
+  return (
+    <button
+      className={classnames(
+        "flex flex-row items-center justify-between gap-1 rounded-lg p-1 transition",
+        {
+          "group hover:cursor-pointer": expandable,
+        }
+      )}
+      onClick={toggleExpand}
+      disabled={!expandable}
+    >
+      <div className="flex flex-grow flex-row gap-1 overflow-hidden">
+        <Status result={test.result} />
+        <div className="flex flex-col items-start text-bodyColor">
+          <div
+            className={`overflow-hidden overflow-ellipsis whitespace-pre ${"group-hover:underline"}`}
+          >
+            {test.title}
+          </div>
+          {test.error ? (
+            <div
+              className="mt-2 overflow-hidden rounded-lg bg-testsuitesErrorBgcolor px-3 py-2 text-left font-mono"
+              data-test-id="TestSuite-TestCaseRow-Error"
+            >
+              {formatStepError(test.steps?.find(s => s.error)) || test.error.message}
+            </div>
+          ) : null}
+        </div>
+      </div>
+      <div className="invisible flex self-start group-hover:visible">
+        <MaterialIcon>chevron_right</MaterialIcon>
+      </div>
+    </button>
+  );
+}

--- a/src/devtools/client/debugger/src/components/TestInfo/TestCaseRow.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestCaseRow.tsx
@@ -1,11 +1,24 @@
 import classnames from "classnames";
 
-import { TestItem } from "shared/graphql/types";
+import { TestItem, TestStep } from "shared/graphql/types";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
 import { setSelectedTest } from "ui/reducers/reporter";
 import { useAppDispatch } from "ui/setup/hooks";
 
-import { Status, formatStepError } from "./TestCase";
+import { Status } from "./TestCase";
+
+function formatStepError(step?: TestStep) {
+  if (!step || !step.error || !step.args) {
+    return null;
+  }
+
+  return (
+    <>
+      <strong className="bold">Error:</strong>&nbsp;
+      {step.args.map((e, i) => (typeof e === "string" ? <span key={i}>{e}&nbsp;</span> : null))}
+    </>
+  );
+}
 
 export function TestCaseRow({ test, index }: { test: TestItem; index: number }) {
   const dispatch = useAppDispatch();

--- a/src/devtools/client/debugger/src/components/TestInfo/TestCaseTree.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestCaseTree.tsx
@@ -1,0 +1,65 @@
+import React, { useMemo } from "react";
+
+import { TestItem } from "shared/graphql/types";
+
+import { TestCaseRow } from "./TestCaseRow";
+
+interface TestTree {
+  branches: Record<string, TestTree>;
+  tests: { index: number; test: TestItem }[];
+}
+
+function createTree(): TestTree {
+  return {
+    branches: {},
+    tests: [],
+  };
+}
+
+function TestCaseBranch({ name, tree }: { name?: string; tree: TestTree }) {
+  const branchNames = Object.keys(tree.branches);
+  const hasBranches = branchNames.length > 0;
+  const hasTests = tree.tests.length > 0;
+
+  if (!hasBranches && !hasTests) {
+    return null;
+  }
+
+  return (
+    <>
+      {name ? <li className="p-1">{name}</li> : null}
+      <ol className={name ? "ml-3" : undefined}>
+        {branchNames.map(name => (
+          <TestCaseBranch key={"branch-" + name} tree={tree.branches[name]} name={name} />
+        ))}
+        {tree.tests.map(t => (
+          <TestCaseRow key={t.index} test={t.test} index={t.index} />
+        ))}
+      </ol>
+    </>
+  );
+}
+export function TestCaseTree({ testCases }: { testCases: TestItem[] }) {
+  const tree = useMemo(
+    () =>
+      testCases.reduce((acc, t, i) => {
+        let branch = acc;
+        const describes = t.path?.slice(3, t.path.length - 1);
+
+        describes?.forEach(d => {
+          if (!branch.branches[d]) {
+            branch.branches[d] = createTree();
+          }
+
+          branch = branch.branches[d];
+        });
+
+        branch.tests.push({ index: i, test: t });
+
+        return acc;
+      }, createTree()),
+    [testCases]
+  );
+
+  return <TestCaseBranch tree={tree} />;
+}

--- a/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
@@ -14,23 +14,9 @@ import { TestCase } from "./TestCase";
 import { TestCaseTree } from "./TestCaseTree";
 import { TestInfoContextMenuContextRoot } from "./TestInfoContextMenuContext";
 
-type TestInfoContextType = {
-  consoleProps?: ProtocolObject;
-  setConsoleProps: (obj?: ProtocolObject) => void;
-  loading: boolean;
-  setLoading: (loading: boolean) => void;
-  pauseId: string | null;
-  setPauseId: (id: string | null) => void;
-};
-
-export const TestInfoContext = createContext<TestInfoContextType>(null as any);
-
 export default function TestInfo({ testCases }: { testCases: TestItem[] }) {
   const dispatch = useAppDispatch();
   const selectedTest = useAppSelector(getSelectedTest);
-  const [consoleProps, setConsoleProps] = useState<ProtocolObject>();
-  const [loading, setLoading] = useState<boolean>(true);
-  const [pauseId, setPauseId] = useState<string | null>(null);
   const info = useTestInfo();
 
   const missingSteps =
@@ -52,23 +38,19 @@ export default function TestInfo({ testCases }: { testCases: TestItem[] }) {
   }, [testCases, dispatch]);
 
   return (
-    <TestInfoContext.Provider
-      value={{ loading, setLoading, consoleProps, setConsoleProps, pauseId, setPauseId }}
-    >
-      <TestInfoContextMenuContextRoot>
-        <div className="flex flex-grow flex-col overflow-hidden">
-          <div className="relative flex flex-grow flex-col space-y-1 overflow-auto border-t border-splitter px-2 pt-3">
-            {missingSteps ? <MissingSteps /> : null}
-            {selectedTest == null ? (
-              <TestCaseTree testCases={testCases} />
-            ) : (
-              <TestCase test={testCases[selectedTest]} />
-            )}
-          </div>
-          {selectedTest !== null && info.supportsStepAnnotations ? <StepDetails /> : null}
-          <ContextMenuWrapper />
+    <TestInfoContextMenuContextRoot>
+      <div className="flex flex-grow flex-col overflow-hidden">
+        <div className="relative flex flex-grow flex-col space-y-1 overflow-auto border-t border-splitter px-2 pt-3">
+          {missingSteps ? <MissingSteps /> : null}
+          {selectedTest == null ? (
+            <TestCaseTree testCases={testCases} />
+          ) : (
+            <TestCase test={testCases[selectedTest]} />
+          )}
         </div>
-      </TestInfoContextMenuContextRoot>
-    </TestInfoContext.Provider>
+        {selectedTest !== null && info.supportsStepAnnotations ? <StepDetails /> : null}
+        <ContextMenuWrapper />
+      </div>
+    </TestInfoContextMenuContextRoot>
   );
 }


### PR DESCRIPTION
* Mostly breaking up components into separate files so they're easier to find.
* Split `TestCase` into `TestCaseRow` and `TestCase` because the same component was used for both rendering the list and rendering the item
  * `TestCaseRow` is only used to render the entry for the test case in the list
  * `TestCase` is only used to render the selected test case