### PR TITLE
Adjust the comments to be on a consistent grid

### DIFF
--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -720,7 +720,7 @@
   --color-contrast: #ffffff;
   --color-current: #f02d5e;
   --color-default: #223344;
-  --color-dim: #666666;
+  --color-dim: rgba(135, 135, 137, 0.9);  
   --color-dimmer: #aaaaaa;
   --color-disabled-button: #ffffff;
   --color-error: #ff0000;

--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -720,7 +720,7 @@
   --color-contrast: #ffffff;
   --color-current: #f02d5e;
   --color-default: #223344;
-  --color-dim: rgba(135, 135, 137, 0.9);  
+  --color-dim: rgba(135, 135, 137, 0.9);
   --color-dimmer: #aaaaaa;
   --color-disabled-button: #ffffff;
   --color-error: #ff0000;

--- a/src/ui/components/Comments/CommentCardsList.module.css
+++ b/src/ui/components/Comments/CommentCardsList.module.css
@@ -24,7 +24,7 @@
   white-space: nowrap;
   text-overflow: ellipsis;
   padding: 8px;
-  padding-left: .75em;
+  padding-left: 0.75em;
 }
 
 .List {

--- a/src/ui/components/Comments/CommentCardsList.module.css
+++ b/src/ui/components/Comments/CommentCardsList.module.css
@@ -24,6 +24,7 @@
   white-space: nowrap;
   text-overflow: ellipsis;
   padding: 8px;
+  padding-left: .75em;
 }
 
 .List {

--- a/src/ui/components/Comments/CommentReplyButton.module.css
+++ b/src/ui/components/Comments/CommentReplyButton.module.css
@@ -6,7 +6,7 @@
 }
 
 .Button {
-  padding: 0 0.5rem;
+  padding: 0 0.25rem;
   color: var(--theme-icon-dimmed-color);
   text-align: left;
 }

--- a/src/ui/components/Comments/EditableRemark.module.css
+++ b/src/ui/components/Comments/EditableRemark.module.css
@@ -56,7 +56,7 @@
 
 .Editing {
   background-color: var(--background-color-inputs);
-  margin-left: .5em;
+  margin-left: 0.5em;
 }
 
 .Content p {

--- a/src/ui/components/Comments/EditableRemark.module.css
+++ b/src/ui/components/Comments/EditableRemark.module.css
@@ -56,10 +56,12 @@
 
 .Editing {
   background-color: var(--background-color-inputs);
+  margin-left: 1em;
 }
 
 .Content p {
   margin: 0;
+  margin-left: 0.25em;
 }
 
 .Icon {

--- a/src/ui/components/Comments/EditableRemark.module.css
+++ b/src/ui/components/Comments/EditableRemark.module.css
@@ -56,7 +56,7 @@
 
 .Editing {
   background-color: var(--background-color-inputs);
-  margin-left: 1em;
+  margin-left: .5em;
 }
 
 .Content p {


### PR DESCRIPTION
Some small alignment tweaks:

![Comment alignment - dark theme](https://user-images.githubusercontent.com/9154902/218247014-b923dc67-9d82-448d-8aa8-88485e92f01d.png)
![Comment alignment - light theme](https://user-images.githubusercontent.com/9154902/218247016-c7ad91b3-6e6f-47c8-af24-99b2dfd89ea1.png)
