### PR TITLE
Hide test step alias when the panel is narrow

### DIFF
--- a/src/devtools/client/debugger/src/components/TestInfo/TestInfo.module.css
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestInfo.module.css
@@ -49,3 +49,8 @@
 .aside div {
   margin-bottom: 5px;
 }
+
+/* TestInfo adds a narrow class when the panel is < 300px */
+.narrow .alias {
+  display: none;
+}

--- a/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
@@ -1,11 +1,12 @@
-import { Object as ProtocolObject } from "@replayio/protocol";
-import React, { createContext, useEffect, useState } from "react";
+import classNamesBind from "classnames/bind";
+import React, { useEffect, useRef } from "react";
 
 import { TestItem } from "shared/graphql/types";
 import { useTestInfo } from "ui/hooks/useTestInfo";
 import { getSelectedTest, setSelectedTest } from "ui/reducers/reporter";
 import { setPlaybackFocusRegion } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
+import useWidthObserver from "ui/utils/useWidthObserver";
 
 import ContextMenuWrapper from "./ContextMenu";
 import { MissingSteps } from "./MissingSteps";
@@ -13,11 +14,16 @@ import { StepDetails } from "./StepDetails";
 import { TestCase } from "./TestCase";
 import { TestCaseTree } from "./TestCaseTree";
 import { TestInfoContextMenuContextRoot } from "./TestInfoContextMenuContext";
+import styles from "./TestInfo.module.css";
+
+const classNames = classNamesBind.bind(styles);
 
 export default function TestInfo({ testCases }: { testCases: TestItem[] }) {
+  const ref = useRef<HTMLDivElement>(null);
   const dispatch = useAppDispatch();
   const selectedTest = useAppSelector(getSelectedTest);
   const info = useTestInfo();
+  const widthObserver = useWidthObserver(ref);
 
   const missingSteps =
     !info.loading && info.supportsSteps && !testCases.some(t => t.steps && t.steps.length > 0);
@@ -39,7 +45,12 @@ export default function TestInfo({ testCases }: { testCases: TestItem[] }) {
 
   return (
     <TestInfoContextMenuContextRoot>
-      <div className="flex flex-grow flex-col overflow-hidden">
+      <div
+        ref={ref}
+        className={classNames("flex flex-grow flex-col overflow-hidden", {
+          narrow: !widthObserver || widthObserver < 300,
+        })}
+      >
         <div className="relative flex flex-grow flex-col space-y-1 overflow-auto border-t border-splitter px-2 pt-3">
           {missingSteps ? <MissingSteps /> : null}
           {selectedTest == null ? (

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -1,4 +1,4 @@
-import classNames from "classnames";
+import classNamesBind from "classnames/bind";
 import React, { useCallback, useContext, useEffect, useRef, useState } from "react";
 
 import { highlightNodes, unhighlightNode } from "devtools/client/inspector/markup/actions/markup";
@@ -24,6 +24,8 @@ import { TestCaseContext } from "./TestCase";
 import { TestInfoContextMenuContext } from "./TestInfoContextMenuContext";
 import { TestStepRow } from "./TestStepRow";
 import styles from "./TestInfo.module.css";
+
+const classNames = classNamesBind.bind(styles);
 
 function preventClickFromSpaceBar(ev: React.KeyboardEvent<HTMLButtonElement>) {
   if (ev.key === " ") {
@@ -214,6 +216,8 @@ export function TestStepItem({
       {step.alias ? (
         <span
           className={classNames(
+            "alias",
+            // TODO [ryanjduffy]: Migrate these into the CSS module class
             "-my-1 flex-shrink rounded p-1 text-xs text-gray-800",
             isSelected ? "bg-gray-300" : "bg-gray-200"
           )}


### PR DESCRIPTION
Hides the test step alias badge when the test info panel is narrow by using `useWidthObserver` to observe the width and a module-scoped CSS class, `.narrow`, to trigger hiding the badge.

https://app.replay.io/recording/cypresse2ecast-alias-spects--943a622e-16bb-4318-9504-46380aa5adbf