### PR TITLE
AvatarImage uses useTooltip hook to show user's names as Replay tooltips

### DIFF
--- a/packages/replay-next/components/AvatarImage.tsx
+++ b/packages/replay-next/components/AvatarImage.tsx
@@ -15,6 +15,7 @@ export default function AvatarImage({ className, name, src, title, ...rest }: Pr
   const tooltipOrTitle = title ?? name ?? "";
 
   const { onMouseEnter, onMouseLeave, tooltip } = useTooltip({
+    position: "above",
     tooltip: tooltipOrTitle,
   });
 

--- a/packages/replay-next/components/AvatarImage.tsx
+++ b/packages/replay-next/components/AvatarImage.tsx
@@ -1,5 +1,7 @@
 import { ImgHTMLAttributes, useState } from "react";
 
+import useTooltip from "replay-next/src/hooks/useTooltip";
+
 import styles from "./AvatarImage.module.css";
 
 type Props = {
@@ -10,21 +12,28 @@ export default function AvatarImage({ className, name, src, title, ...rest }: Pr
   const [source, setSource] = useState(src);
   const [showNameBadge, setShowNameBadge] = useState(name && !src);
 
+  const tooltipOrTitle = title ?? name ?? "";
+
+  const { onMouseEnter, onMouseLeave, tooltip } = useTooltip({
+    tooltip: tooltipOrTitle,
+  });
+
   // If the user has no image, their initials can be shown as a fallback.
   if (name && showNameBadge) {
     const initials = name
       .split(" ")
       .map(n => n.charAt(0))
       .join("");
+
     return (
-      <div className={`${styles.Name} ${className}`} title={title || name}>
+      <div className={`${styles.Name} ${className}`} title={tooltipOrTitle}>
         {initials}
       </div>
     );
   }
 
   // If a user image fails to load, show a fallback.
-  const onError = ({ currentTarget }: any) => {
+  const onError = () => {
     if (name) {
       setShowNameBadge(true);
     } else {
@@ -33,13 +42,17 @@ export default function AvatarImage({ className, name, src, title, ...rest }: Pr
   };
 
   return (
-    <img
-      {...rest}
-      className={`${styles.Image} ${className}`}
-      data-private
-      onError={onError}
-      src={source}
-      title={title || name}
-    />
+    <>
+      <img
+        {...rest}
+        className={`${styles.Image} ${className}`}
+        data-private
+        onError={onError}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+        src={source}
+      />
+      {tooltip}
+    </>
   );
 }


### PR DESCRIPTION
This finishes out the UI spec in FE-1201 and I think is probably a good general change for anywhere we have a user avatar:

<img width="461" alt="Screen Shot 2023-02-13 at 2 24 24 PM" src="https://user-images.githubusercontent.com/29597/218554428-8c69e258-91d8-4b05-8df8-33163d96c076.png">

<img width="240" alt="Screen Shot 2023-02-13 at 2 24 28 PM" src="https://user-images.githubusercontent.com/29597/218554431-fa7c2948-79d2-4cdb-99e0-20404fa25794.png">

cc @jonbell-lot23 