### PR TITLE
Fix rounded edges in Pause Info panel

### DIFF
--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointHeading.module.css
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointHeading.module.css
@@ -11,6 +11,7 @@
   position: relative;
   cursor: pointer;
   overflow: hidden;
+  border-radius: 1px;
 }
 
 .Label {

--- a/src/ui/components/TestSuitePanel.tsx
+++ b/src/ui/components/TestSuitePanel.tsx
@@ -131,7 +131,7 @@ export function TestSuitePanel() {
         <TestInfo testCases={testCases} />
       ) : (
         <div className="flex flex-grow flex-col overflow-hidden">
-          <div className="flex flex-grow flex-col space-y-1 overflow-auto px-2">Loading...</div>
+          <div className="flex flex-grow flex-col space-y-1 overflow-auto px-4">Loading...</div>
         </div>
       )}
     </div>


### PR DESCRIPTION
![Rounded edges fix](https://user-images.githubusercontent.com/9154902/218621275-a301704a-ca35-4620-b596-9b1fc00a7c6b.png)

(I also did a small tweak to the positioning for the loading text in testsuites)