### PR TITLE
[Testsuites] Improve wrapping

### DIFF
--- a/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestInfo.tsx
@@ -48,7 +48,7 @@ export default function TestInfo({ testCases }: { testCases: TestItem[] }) {
       <div
         ref={ref}
         className={classNames("flex flex-grow flex-col overflow-hidden", {
-          narrow: !widthObserver || widthObserver < 300,
+          narrow: !widthObserver || widthObserver < 400,
         })}
       >
         <div className="relative flex flex-grow flex-col space-y-1 overflow-auto border-t border-splitter px-2 pt-3">

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -204,7 +204,7 @@ export function TestStepItem({
         className="flex w-0 flex-grow items-start space-x-2 text-start"
         title={`Step ${index + 1}: ${step.name} ${argString || ""}`}
       >
-        <div className={`flex-grow font-medium ${state === "paused" ? "font-bold" : ""}`}>
+        <div className={`flex-grow font-medium break-all ${state === "paused" ? "font-bold" : ""}`}>
           {step.parentId ? "- " : ""}{" "}
           <span className={`${styles.step} ${styles[step.name]}`}>{step.name}</span>
           <span className="opacity-70">{argString}</span>


### PR DESCRIPTION
We have a lot of lines that have no spaces, so we can't get by with word-wrap. I made some changes to make this read better across long lines:

![Wrapping before and after-1](https://user-images.githubusercontent.com/9154902/218628387-c541e0bb-0d42-47ac-98a0-60d5a473b77a.png)
![Wrapping before and after-2](https://user-images.githubusercontent.com/9154902/218628426-3584b4cd-bf8f-439b-8a41-67889eb7e6ad.png)
