### PR TITLE
Adjust tooltip color

### DIFF
--- a/packages/replay-next/components/Tooltip.module.css
+++ b/packages/replay-next/components/Tooltip.module.css
@@ -2,6 +2,7 @@
   position: absolute;
   z-index: var(--z-index-1--tooltip);
   background-color: var(--tooltip-bgcolor);
+  border: var(--tooltip-border);
   color: var(--tooltip-color);
   padding: 0.25rem 0.5rem;
   border-radius: 0.25rem;
@@ -9,9 +10,9 @@
   font-family: var(--font-family-default);
   font-size: var(--font-size-regular);
   white-space: nowrap;
-
   animation: tooltip-pop-in 100ms ease;
   transition: margin 200ms ease;
+  filter: drop-shadow(0 1px 1px rgb(0 0 0 / 0.05));
 }
 
 @keyframes tooltip-pop-in {

--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -182,8 +182,9 @@
   --theme-text-field-bgcolor-hover: var(--theme-base-95);
   --theme-text-field-bgcolor: var(--theme-base-85);
   --theme-text-field-color: #fff;
-  --tooltip-bgcolor: var(--theme-base-85);
+  --tooltip-bgcolor: var(--theme-base-100);
   --tooltip-color: #fff;
+  --tooltip-border: 1px solid rgba(43, 46, 49, 1);
 
   --event-row-hover-background-color: rgba(8, 17, 32, 0.5);
 
@@ -519,7 +520,7 @@
   --theme-toggle-handle-bgcolor: var(--theme-base-100);
   --timejump-text: var(--buttontext-color);
   --title-hover-bgcolor: var(--theme-toggle-bgcolor);
-  --toolbarbutton-focus-bgcolor: var(--theme-toggle-bgcolor);
+  --toolbarbutton-focus-bgcolor: var(--theme-base-95);
   --unloaded-region-img: url("/images/dotted-mask-dark.svg");
 
   /* Toolbar (Dark) */
@@ -687,6 +688,7 @@
   --theme-text-field-color: var(--theme-body-color);
   --tooltip-bgcolor: #38383d;
   --tooltip-color: white;
+  --tooltip-border: 1px solid transparent;
 
   --event-row-hover-background-color: rgba(232, 234, 237, 0.5);
 


### PR DESCRIPTION
Dark theme had a bit of a contrast issue when the tooltip was aligned on top of other elements.

![Tooltip color alignment](https://user-images.githubusercontent.com/9154902/218633370-fcae1651-b6b0-4cde-bc40-00cc43f563b5.png)
