### PR TITLE
Render assertion error next to failing step

### DIFF
--- a/packages/shared/graphql/types.ts
+++ b/packages/shared/graphql/types.ts
@@ -258,7 +258,7 @@ export type TestItem = {
   error?: TestItemError;
 };
 
-type TestItemError = {
+export type TestItemError = {
   message: string;
   line?: number;
   column?: number;


### PR DESCRIPTION
If we have step errors, render the error after the error. If not (because the test runner/plugin doesn't support steps yet), render it at the end as we did before.

<img width="488" alt="image" src="https://user-images.githubusercontent.com/788456/218821759-d0c5e94d-f053-4125-8c47-bc6e6b72294b.png">
