### PR TITLE
Remove unused screenshot logic that led to modal crash in library

### DIFF
--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -7,7 +7,7 @@ import { prefs } from "devtools/client/debugger/src/utils/prefs";
 import { ThreadFront as ThreadFrontType } from "protocol/thread";
 import { ReplayClientInterface } from "shared/client/types";
 import { CommandKey } from "ui/components/CommandPalette/CommandPalette";
-import * as selectors from "ui/reducers/app";
+import { getEventsForType } from "ui/reducers/app";
 import { getTheme } from "ui/reducers/app";
 import { Canvas, EventKind, ReplayEvent, ReplayNavigationEvent } from "ui/state/app";
 import { getBoundingRectsAsync } from "ui/suspense/nodeCaches";
@@ -146,10 +146,7 @@ function loadReceivedKeyboardEvents(): UIThunkAction {
 
 function onNavigationEvents(events: ReplayNavigationEvent[], store: UIStore) {
   const currentNavEvents: ReplayNavigationEvent[] = events.map(e => ({ ...e, kind: "navigation" }));
-  const newNavEvents = [
-    ...selectors.getEventsForType(store.getState(), "navigation"),
-    ...currentNavEvents,
-  ];
+  const newNavEvents = [...getEventsForType(store.getState(), "navigation"), ...currentNavEvents];
   newNavEvents.sort((a, b) => compareBigInt(BigInt(a.point), BigInt(b.point)));
 
   store.dispatch(loadReceivedEvents({ navigation: newNavEvents }));

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -23,7 +23,7 @@ import {
   setCurrentPoint,
   setTrialExpired,
 } from "ui/reducers/app";
-import * as selectors from "ui/reducers/app";
+import { getUnexpectedError } from "ui/reducers/app";
 import {
   ProtocolEvent,
   errorReceived,
@@ -331,7 +331,7 @@ export function createSocket(
       await ThreadFront.loadingHasBegun.promise;
       dispatch(jumpToInitialPausePoint());
     } catch (e: any) {
-      const currentError = selectors.getUnexpectedError(getState());
+      const currentError = getUnexpectedError(getState());
 
       // Don't overwrite an existing error.
       if (!currentError) {

--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, createContext, useEffect } from "react";
+import React, { ReactNode, useEffect } from "react";
 import { ConnectedProps, connect } from "react-redux";
 
 import QuickOpenModal from "devtools/client/debugger/src/components/QuickOpenModal";
@@ -6,8 +6,8 @@ import { getQuickOpenEnabled } from "devtools/client/debugger/src/selectors";
 import { actions } from "ui/actions";
 import hooks from "ui/hooks";
 import { Nag, useGetUserInfo } from "ui/hooks/users";
-import * as selectors from "ui/reducers/app";
-import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
+import { getLoadingFinished, getModal, getTheme } from "ui/reducers/app";
+import { useAppSelector } from "ui/setup/hooks";
 import { UIState } from "ui/state";
 import { ModalType } from "ui/state/app";
 import { isTest } from "ui/utils/environment";
@@ -39,7 +39,7 @@ const SingleInviteModal = React.lazy(() => import("./shared/OnboardingModal/Sing
 const FirstReplayModal = React.lazy(() => import("./shared/FirstReplayModal"));
 
 function AppModal({ hideModal, modal }: { hideModal: () => void; modal: ModalType }) {
-  const loadingFinished = useAppSelector(selectors.getLoadingFinished);
+  const loadingFinished = useAppSelector(getLoadingFinished);
 
   // Dismiss modal if the "Escape" key is pressed.
   useEffect(() => {
@@ -114,7 +114,7 @@ function App({ children, hideModal, modal, quickOpenEnabled }: AppProps) {
   const auth = useAuth0();
   const dismissNag = hooks.useDismissNag();
   const userInfo = useGetUserInfo();
-  const theme = useAppSelector(selectors.getTheme);
+  const theme = useAppSelector(getTheme);
 
   useEffect(() => {
     if (userInfo.nags && shouldShowNag(userInfo.nags, Nag.FIRST_LOG_IN)) {
@@ -180,7 +180,7 @@ function App({ children, hideModal, modal, quickOpenEnabled }: AppProps) {
 
 const connector = connect(
   (state: UIState) => ({
-    modal: selectors.getModal(state),
+    modal: getModal(state),
 
     // Only read quick open state if it exists, to ensure safe loads
     quickOpenEnabled: !!state.quickOpen && getQuickOpenEnabled(state),

--- a/src/ui/components/shared/Error.tsx
+++ b/src/ui/components/shared/Error.tsx
@@ -8,7 +8,7 @@ import { useGetTeamIdFromRoute } from "ui/components/Library/Team/utils";
 import Modal from "ui/components/shared/NewModal";
 import hooks from "ui/hooks";
 import { useRequestRecordingAccess } from "ui/hooks/recordings";
-import * as selectors from "ui/reducers/app";
+import { getExpectedError, getTrialExpired, getUnexpectedError } from "ui/reducers/app";
 import { useAppDispatch } from "ui/setup/hooks";
 import { UIState } from "ui/state";
 import { ErrorActions, ExpectedError, UnexpectedError } from "ui/state/app";
@@ -215,9 +215,9 @@ function _AppErrors({ expectedError, unexpectedError, trialExpired }: PropsFromR
 }
 
 const connector = connect((state: UIState) => ({
-  expectedError: selectors.getExpectedError(state),
-  unexpectedError: selectors.getUnexpectedError(state),
-  trialExpired: selectors.getTrialExpired(state),
+  expectedError: getExpectedError(state),
+  unexpectedError: getUnexpectedError(state),
+  trialExpired: getTrialExpired(state),
 }));
 type PropsFromRedux = ConnectedProps<typeof connector>;
 export default connector(_AppErrors);

--- a/src/ui/components/shared/SharingModal/SharingModal.tsx
+++ b/src/ui/components/shared/SharingModal/SharingModal.tsx
@@ -14,10 +14,8 @@ import {
   getUniqueDomains,
 } from "ui/components/UploadScreen/Privacy";
 import hooks from "ui/hooks";
-import { getRecording, useHasNoRole } from "ui/hooks/recordings";
-import * as selectors from "ui/reducers/app";
-import { getRecordingTarget } from "ui/reducers/app";
-import { getCurrentTime } from "ui/reducers/timeline";
+import { useHasNoRole } from "ui/hooks/recordings";
+import { getModalOptions, getRecordingTarget } from "ui/reducers/app";
 import { useAppSelector } from "ui/setup/hooks";
 import { UIState } from "ui/state";
 import useToken from "ui/utils/useToken";
@@ -318,7 +316,7 @@ function SharingModal({ recording, hideModal }: SharingModalProps) {
 
 const connector = connect(
   (state: UIState) => ({
-    modalOptions: selectors.getModalOptions(state),
+    modalOptions: getModalOptions(state),
   }),
   {
     hideModal: actions.hideModal,

--- a/src/ui/components/shared/SharingModal/SharingModal.tsx
+++ b/src/ui/components/shared/SharingModal/SharingModal.tsx
@@ -222,16 +222,10 @@ function Header({
 
 function DownloadSection({ recording }: { recording: Recording }) {
   const token = useToken();
-  const currentTime = useAppSelector(getCurrentTime);
-  const [screen, setScreen] = useState<ScreenShot | null>(null);
 
   const [downloadState, setDownloadState] = useState<
     "not-started" | "downloading" | "success" | "error"
   >("not-started");
-
-  useEffect(() => {
-    getGraphicsAtTime(currentTime).then(res => res.screen && setScreen(res.screen));
-  }, [currentTime]);
 
   const buttonStates = {
     "not-started": {

--- a/src/ui/components/shared/UserSettingsModal/UserSettingsModal.tsx
+++ b/src/ui/components/shared/UserSettingsModal/UserSettingsModal.tsx
@@ -6,7 +6,7 @@ import { AvatarImage } from "ui/components/Avatar";
 import hooks from "ui/hooks";
 import { useBoolPref, useFeature } from "ui/hooks/settings";
 import { UserInfo, useGetUserInfo } from "ui/hooks/users";
-import * as selectors from "ui/reducers/app";
+import { getDefaultSettingsTab, getModalOptions } from "ui/reducers/app";
 import { UIState } from "ui/state";
 import { SettingsTabTitle } from "ui/state/app";
 import useAuth0 from "ui/utils/useAuth0";
@@ -248,10 +248,10 @@ export function UserSettingsModal(props: PropsFromRedux) {
 
 const connector = connect(
   (state: UIState) => {
-    const opts = selectors.getModalOptions(state);
+    const opts = getModalOptions(state);
     const view = opts && "view" in opts ? opts.view : null;
     return {
-      defaultSettingsTab: selectors.getDefaultSettingsTab(state),
+      defaultSettingsTab: getDefaultSettingsTab(state),
       view,
     };
   },

--- a/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSettingsModal.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSettingsModal.tsx
@@ -5,7 +5,7 @@ import * as actions from "ui/actions/app";
 import { useRedirectToTeam } from "ui/components/Library/Team/utils";
 import { useGetTeamIdFromRoute } from "ui/components/Library/Team/utils";
 import hooks from "ui/hooks";
-import * as selectors from "ui/reducers/app";
+import { getModalOptions } from "ui/reducers/app";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { validateEmail } from "ui/utils/helpers";
 import { trackEvent } from "ui/utils/telemetry";
@@ -232,7 +232,7 @@ const tabNameForView = {
 
 export default function WorkspaceSettingsModal() {
   const selectedTab = useAppSelector(state => {
-    const opts = selectors.getModalOptions(state);
+    const opts = getModalOptions(state);
     const view = opts && "view" in opts ? opts.view : null;
     return view && tabNameForView[view as keyof typeof tabNameForView];
   });


### PR DESCRIPTION
- `<DownloadSection>` in `<SharingModal>` was using a selector that read `state.timeline.currentTime`, but that doesn't exist in the library because we lazy-load most of our reducers when DevTools boots up, so the modal crashes when used in the library.  Looks like this "show a screenshot" functionality wasn't even being used, so I removed it.
- Replaced uses of `import * as selectors` with specific named imports for clarity.