### PR TITLE
Fix console freezing when there are too many event filter hits

### DIFF
--- a/packages/replay-next/src/suspense/EventsCache.ts
+++ b/packages/replay-next/src/suspense/EventsCache.ts
@@ -5,6 +5,7 @@ import {
   Location,
   PauseData,
   PauseId,
+  Value as ProtocolValue,
   Object as RecordReplayObject,
 } from "@replayio/protocol";
 
@@ -14,7 +15,7 @@ import { ReplayClientInterface } from "shared/client/types";
 import { STANDARD_EVENT_CATEGORIES } from "../constants";
 import { createWakeable } from "../utils/suspense";
 import { cachePauseData } from "./PauseCache";
-import { Record, STATUS_PENDING, STATUS_RESOLVED, Wakeable } from "./types";
+import { Record, STATUS_PENDING, STATUS_REJECTED, STATUS_RESOLVED, Wakeable } from "./types";
 
 export type Event = {
   count: number;
@@ -37,7 +38,7 @@ export type EventLog = {
   point: ExecutionPoint;
   time: number;
   type: "EventLog";
-  values: any[];
+  values: ProtocolValue[];
 };
 
 let eventTypeToEntryPointMap = new Map<EventHandlerType, Record<EventLog[]>>();
@@ -110,27 +111,52 @@ async function fetchEventTypeEntryPoints(
   eventType: EventHandlerType,
   record: Record<EventLog[]>
 ) {
-  const entryPoints = await client.runAnalysis<EventLog>({
-    effectful: false,
-    eventHandlerEntryPoints: [{ eventType }],
-    mapper: getFunctionBody(eventsMapper),
-  });
-
-  // Pre-cache object previews that came back with our new analysis data.
-  // This will avoid us having to turn around and request them again when rendering the logs.
-  entryPoints.forEach(entryPoint => cachePauseData(client, entryPoint.pauseId, entryPoint.data));
-
-  const eventLogs: EventLog[] = entryPoints.map(entryPoint => ({
-    ...entryPoint,
-    type: "EventLog",
-  }));
-
   const wakeable = record.value;
+  try {
+    const entryPoints = await client.runAnalysis<EventLog>({
+      effectful: false,
+      eventHandlerEntryPoints: [{ eventType }],
+      mapper: getFunctionBody(eventsMapper),
+    });
 
-  record.status = STATUS_RESOLVED;
-  record.value = eventLogs;
+    // Pre-cache object previews that came back with our new analysis data.
+    // This will avoid us having to turn around and request them again when rendering the logs.
+    entryPoints.forEach(entryPoint => cachePauseData(client, entryPoint.pauseId, entryPoint.data));
 
-  wakeable.resolve(eventLogs);
+    const eventLogs: EventLog[] = entryPoints.map(entryPoint => ({
+      ...entryPoint,
+      type: "EventLog",
+    }));
+
+    record.status = STATUS_RESOLVED;
+    record.value = eventLogs;
+  } catch (err) {
+    // Handle any analysis errors (such as "too many hits found") by resolving the record with
+    // a dummy `EventLog` entry that will get shown as a single console message at the top of
+    // the list.  That way we at least communicate to the user what happened.
+    // TODO [FE-1257] Show a better indicator that there were too many events found, like an overlay.
+    record.status = STATUS_RESOLVED;
+    record.value = [
+      {
+        data: {
+          frames: [],
+          objects: [],
+        },
+        location: [],
+        pauseId: "",
+        point: "",
+        time: 0,
+        type: "EventLog",
+        values: [
+          {
+            value: `❗Too many messages of type "${eventType}" found!`,
+          },
+        ],
+      },
+    ];
+  } finally {
+    wakeable.resolve(record.value);
+  }
 }
 
 // Variables in scope in an analysis

--- a/src/ui/utils/preferredLocation.ts
+++ b/src/ui/utils/preferredLocation.ts
@@ -14,7 +14,7 @@ import {
 let store: UIStore;
 
 export function getPreferredLocation(locations: MappedLocation | undefined) {
-  if (!locations) {
+  if (!locations || locations.length === 0) {
     return;
   }
   const state = store.getState();


### PR DESCRIPTION
Per FE-1206, the console freezes and is stuck in a loading state if you try to show events like `mousemove` that have too many hits.

The root cause was our analysis API throwing an error when >200 hits, but the real error was that `EventsCache.ts` didn't handle that case and never resolved the wakeable.  

I've added a `try/catch` there to at least resolve it.

In addition, we don't have any messaging that there were too many hits.  I've cobbled together a bandaid by creating a fake `EventLog` entry with an appropriate message and a timestamp of `0`, so it will end up at the top of the messages list:

![image](https://user-images.githubusercontent.com/1128784/218875590-568cba63-0523-49f1-b73e-be6fbb5fbc70.png)

We should come up with a better UX later, but this at least fixes the freezing and indicates what happened.