### PR TITLE
Log point panel: Don't show 0/0 while hit points are loading

### DIFF
--- a/packages/replay-next/components/sources/log-point-panel/Capsule.module.css
+++ b/packages/replay-next/components/sources/log-point-panel/Capsule.module.css
@@ -12,6 +12,14 @@
   font-variant-numeric: tabular-nums;
 }
 
+.Capsule[data-loading] {
+  padding: 0 2ch;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-dimmer);
+}
+
 .Label,
 .Denominator {
   flex: 1 0 auto;

--- a/packages/replay-next/components/sources/log-point-panel/Capsule.tsx
+++ b/packages/replay-next/components/sources/log-point-panel/Capsule.tsx
@@ -122,6 +122,20 @@ export default function Capsule({
 
   const inputDefaultValue = tooManyPointsToFind ? "10k+" : `${closestHitPointIndex + 1}`;
 
+  // Don't show "0/0" while hit points are loading.
+  if (hitPointStatus === null) {
+    return (
+      <div
+        className={styles.Capsule}
+        data-loading
+        data-test-name="LogPointCapsule"
+        style={badgeStyle as CSSProperties}
+      >
+        –
+      </div>
+    );
+  }
+
   return (
     <>
       <div


### PR DESCRIPTION
Show loading text "–" instead (for lack of anything better).

### Before

![Kapture 2023-02-14 at 23 09 33](https://user-images.githubusercontent.com/29597/218927449-a38c5af3-46e2-45b7-b1e9-eb5631471e9b.gif)

### After

![Kapture 2023-02-14 at 23 03 36](https://user-images.githubusercontent.com/29597/218926717-51e31b9f-01fc-419a-8b43-20a4ea81efeb.gif)

---

Ignore the timing differences above as they are somewhat arbitrary. The key difference is showing "0/0" vs "–" when hit points data is still loading.

Unfortunately we can't prevent some amount of size jumping (without knowing how many hits to allow space for). I could perhaps estimate more closely than I'm currently doing (e.g. assume single digits) but it didn't seem worth it for a temporary fix.

cc @jonbell-lot23 