### PR TITLE
Defer loading Pause and Frame info for print statement and console inputs

### DIFF
--- a/packages/replay-next/components/console/ConsoleInput.tsx
+++ b/packages/replay-next/components/console/ConsoleInput.tsx
@@ -129,7 +129,7 @@ function ConsoleInputSuspends({ inputRef }: { inputRef?: RefObject<ImperativeHan
       }
     }
 
-    if (!frameId || !pauseId) {
+    if (!pauseId) {
       // Unexpected edge case.
       // In this case, the getPauseAndFrameIdSuspends() will log Error info to the console.
       return;
@@ -138,8 +138,8 @@ function ConsoleInputSuspends({ inputRef }: { inputRef?: RefObject<ImperativeHan
     if (expression.trim() !== "") {
       addMessage({
         expression,
-        frameId: frameId!,
-        pauseId: pauseId!,
+        frameId,
+        pauseId,
         point: executionPoint || "",
         time: time || 0,
       });

--- a/packages/replay-next/components/console/ConsoleInput.tsx
+++ b/packages/replay-next/components/console/ConsoleInput.tsx
@@ -5,16 +5,13 @@ import ErrorBoundary from "replay-next/components/ErrorBoundary";
 import Icon from "replay-next/components/Icon";
 import CodeEditor, { ImperativeHandle } from "replay-next/components/lexical/CodeEditor";
 import Loader from "replay-next/components/Loader";
+import { getPauseAndFrameIdAsync } from "replay-next/components/sources/utils/getPauseAndFrameId";
 import { SelectedFrameContext } from "replay-next/src/contexts/SelectedFrameContext";
 import { SessionContext } from "replay-next/src/contexts/SessionContext";
 import { TerminalContext } from "replay-next/src/contexts/TerminalContext";
 import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
 import useLoadedRegions from "replay-next/src/hooks/useRegions";
-import { getFramesSuspense } from "replay-next/src/suspense/FrameCache";
-import { getPauseIdSuspense } from "replay-next/src/suspense/PauseCache";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
-import { isThennable } from "shared/proxy/utils";
-import { isPointInRegions } from "shared/utils/time";
 
 import { ConsoleSearchContext } from "./ConsoleSearchContext";
 import EagerEvaluationResult from "./EagerEvaluationResult";
@@ -33,11 +30,12 @@ export default function ConsoleInput({ inputRef }: { inputRef?: RefObject<Impera
 }
 
 function ConsoleInputSuspends({ inputRef }: { inputRef?: RefObject<ImperativeHandle> }) {
-  const replayClient = useContext(ReplayClientContext);
   const [searchState] = useContext(ConsoleSearchContext);
+  const { selectedPauseAndFrameId } = useContext(SelectedFrameContext);
+  const replayClient = useContext(ReplayClientContext);
+  const { recordingId } = useContext(SessionContext);
   const { addMessage } = useContext(TerminalContext);
   const { executionPoint, time } = useContext(TimelineContext);
-  const { recordingId } = useContext(SessionContext);
 
   const loadedRegions = useLoadedRegions(replayClient);
 
@@ -57,28 +55,6 @@ function ConsoleInputSuspends({ inputRef }: { inputRef?: RefObject<ImperativeHan
 
     searchStateVisibleRef.current = searchState.visible;
   }, [searchState.visible]);
-
-  const { selectedPauseAndFrameId } = useContext(SelectedFrameContext);
-  let pauseId: PauseId | null = null;
-  let frameId: FrameId | null = null;
-  if (selectedPauseAndFrameId) {
-    pauseId = selectedPauseAndFrameId.pauseId;
-    frameId = selectedPauseAndFrameId.frameId;
-  } else {
-    const isLoaded =
-      loadedRegions !== null && isPointInRegions(executionPoint, loadedRegions.loaded);
-    if (isLoaded) {
-      pauseId = getPauseIdSuspense(replayClient, executionPoint, time);
-      try {
-        const frames = getFramesSuspense(replayClient, pauseId);
-        frameId = frames?.[0]?.frameId ?? null;
-      } catch (errorOrPromise) {
-        if (isThennable(errorOrPromise)) {
-          throw errorOrPromise;
-        }
-      }
-    }
-  }
 
   const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.defaultPrevented) {
@@ -133,7 +109,32 @@ function ConsoleInputSuspends({ inputRef }: { inputRef?: RefObject<ImperativeHan
     setExpression(newExpression);
   };
 
-  const onSubmit = (expression: string) => {
+  const onSubmit = async (expression: string) => {
+    let pauseId: PauseId | null = null;
+    let frameId: FrameId | null = null;
+    if (selectedPauseAndFrameId) {
+      pauseId = selectedPauseAndFrameId.pauseId;
+      frameId = selectedPauseAndFrameId.frameId;
+    } else {
+      const pauseAndFrameId = await getPauseAndFrameIdAsync(
+        replayClient,
+        executionPoint,
+        time,
+        loadedRegions,
+        false
+      );
+      if (pauseAndFrameId) {
+        pauseId = pauseAndFrameId.pauseId;
+        frameId = pauseAndFrameId.frameId;
+      }
+    }
+
+    if (!frameId || !pauseId) {
+      // Unexpected edge case.
+      // In this case, the getPauseAndFrameIdSuspends() will log Error info to the console.
+      return;
+    }
+
     if (expression.trim() !== "") {
       addMessage({
         expression,
@@ -166,12 +167,13 @@ function ConsoleInputSuspends({ inputRef }: { inputRef?: RefObject<ImperativeHan
             context="console"
             dataTestId="ConsoleTerminalInput"
             editable={true}
+            executionPoint={executionPoint}
             initialValue={expression}
             key={incrementedKey}
             onChange={onChange}
             onSave={onSubmit}
-            pauseAndFrameId={selectedPauseAndFrameId}
             ref={inputRef}
+            time={time}
           />
         </div>
       </div>

--- a/packages/replay-next/components/lexical/CodeEditor.tsx
+++ b/packages/replay-next/components/lexical/CodeEditor.tsx
@@ -8,6 +8,7 @@ import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
 import { $selectAll } from "@lexical/selection";
 import { $rootTextContent } from "@lexical/text";
 import { mergeRegister } from "@lexical/utils";
+import { ExecutionPoint } from "@replayio/protocol";
 import {
   $getRoot,
   $getSelection,
@@ -32,8 +33,6 @@ import {
   useMemo,
   useRef,
 } from "react";
-
-import { PauseAndFrameId } from "replay-next/src/contexts/SelectedFrameContext";
 
 import LexicalEditorRefSetter from "./LexicalEditorRefSetter";
 import CodeCompletionPlugin from "./plugins/code-completion/CodeCompletionPlugin";
@@ -60,13 +59,14 @@ type Props = {
   dataTestId?: string;
   dataTestName?: string;
   editable: boolean;
+  executionPoint: ExecutionPoint;
   forwardedRef?: ForwardedRef<ImperativeHandle>;
   initialValue: string;
   onCancel?: () => void;
   onChange?: (markdown: string, editorState: SerializedEditorState) => void;
   onSave: (markdown: string, editorState: SerializedEditorState) => void;
-  pauseAndFrameId: PauseAndFrameId | null;
   placeholder?: string;
+  time: number;
 };
 
 function CodeEditor({
@@ -77,13 +77,14 @@ function CodeEditor({
   dataTestId,
   dataTestName,
   editable,
+  executionPoint,
   forwardedRef,
   initialValue,
   onCancel,
   onChange,
   onSave,
-  pauseAndFrameId,
   placeholder = "",
+  time,
 }: Props): JSX.Element {
   const historyState = useMemo(() => createEmptyHistoryState(), []);
 
@@ -241,7 +242,8 @@ function CodeEditor({
           context={context}
           dataTestId={dataTestId ? `${dataTestId}-CodeTypeAhead` : undefined}
           dataTestName={dataTestName ? `${dataTestName}-CodeTypeAhead` : undefined}
-          pauseAndFrameId={pauseAndFrameId}
+          executionPoint={executionPoint}
+          time={time}
         />
       </>
     </LexicalComposer>

--- a/packages/replay-next/components/lexical/plugins/code-completion/CodeCompletionPlugin.tsx
+++ b/packages/replay-next/components/lexical/plugins/code-completion/CodeCompletionPlugin.tsx
@@ -1,10 +1,10 @@
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { mergeRegister } from "@lexical/utils";
-import { FrameId, PauseId } from "@replayio/protocol";
+import { ExecutionPoint, FrameId, PauseId } from "@replayio/protocol";
 import { $createTextNode, TextNode } from "lexical";
 import { useContext, useEffect } from "react";
 
-import { PauseAndFrameId } from "replay-next/src/contexts/SelectedFrameContext";
+import useRegions from "replay-next/src/hooks/useRegions";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
 import TypeAheadPlugin from "../typeahead/TypeAheadPlugin";
@@ -18,26 +18,31 @@ export default function CodeCompletionPlugin({
   context,
   dataTestId,
   dataTestName = "CodeTypeAhead",
-  pauseAndFrameId = null,
+  executionPoint,
+  time,
 }: {
   context: Context;
   dataTestId?: string;
   dataTestName?: string;
-  pauseAndFrameId: PauseAndFrameId | null;
+  executionPoint: ExecutionPoint;
+  time: number;
 }): JSX.Element {
   const [editor] = useLexicalComposerContext();
 
   const replayClient = useContext(ReplayClientContext);
 
-  let pauseId: PauseId | null = null;
-  let frameId: FrameId | null = null;
-  if (pauseAndFrameId != null) {
-    pauseId = pauseAndFrameId.pauseId;
-    frameId = pauseAndFrameId.frameId;
-  }
+  const loadedRegions = useRegions(replayClient);
 
   const findMatchesWrapper = (query: string, queryScope: string | null) => {
-    return findMatches(query, queryScope, replayClient, frameId, pauseId, context);
+    return findMatches(
+      query,
+      queryScope,
+      replayClient,
+      executionPoint,
+      time,
+      loadedRegions,
+      context
+    );
   };
 
   useEffect(() => {

--- a/packages/replay-next/components/sources/utils/getPauseAndFrameId.ts
+++ b/packages/replay-next/components/sources/utils/getPauseAndFrameId.ts
@@ -1,0 +1,47 @@
+import { ExecutionPoint, loadedRegions as LoadedRegions } from "@replayio/protocol";
+
+import { PauseAndFrameId } from "replay-next/src/contexts/SelectedFrameContext";
+import { getFramesSuspense } from "replay-next/src/suspense/FrameCache";
+import { getPauseIdSuspense } from "replay-next/src/suspense/PauseCache";
+import { createFetchAsyncFromFetchSuspense } from "replay-next/src/utils/suspense";
+import { ReplayClientInterface } from "shared/client/types";
+import { isThennable } from "shared/proxy/utils";
+import { isPointInRegions } from "shared/utils/time";
+
+export function getPauseAndFrameIdSuspends(
+  replayClient: ReplayClientInterface,
+  executionPoint: ExecutionPoint,
+  time: number,
+  loadedRegions: LoadedRegions | null,
+  throwOnFail: boolean
+): PauseAndFrameId | null {
+  const isLoaded = loadedRegions !== null && isPointInRegions(executionPoint, loadedRegions.loaded);
+  if (!isLoaded) {
+    return null;
+  }
+
+  let pauseAndFrameId: PauseAndFrameId | null = null;
+  try {
+    const pauseId = getPauseIdSuspense(replayClient, executionPoint, time);
+    const frames = getFramesSuspense(replayClient, pauseId);
+    const frameId = frames?.[0]?.frameId ?? null;
+    if (frameId !== null) {
+      pauseAndFrameId = {
+        frameId,
+        pauseId,
+      };
+    }
+  } catch (errorOrThennable) {
+    if (throwOnFail || isThennable(errorOrThennable)) {
+      throw errorOrThennable;
+    }
+
+    console.error(errorOrThennable);
+  }
+
+  return pauseAndFrameId;
+}
+
+export const getPauseAndFrameIdAsync = createFetchAsyncFromFetchSuspense(
+  getPauseAndFrameIdSuspends
+);

--- a/packages/replay-next/src/suspense/types.ts
+++ b/packages/replay-next/src/suspense/types.ts
@@ -2,18 +2,22 @@ export const STATUS_PENDING = 0;
 export const STATUS_RESOLVED = 1;
 export const STATUS_REJECTED = 2;
 
+export type StatusPending = typeof STATUS_PENDING;
+export type StatusResolved = typeof STATUS_RESOLVED;
+export type StatusRejected = typeof STATUS_REJECTED;
+
 export type PendingRecord<T> = {
-  status: 0;
+  status: StatusPending;
   value: Wakeable<T>;
 };
 
 export type ResolvedRecord<T> = {
-  status: 1;
+  status: StatusResolved;
   value: T;
 };
 
 export type RejectedRecord = {
-  status: 2;
+  status: StatusRejected;
   value: any;
 };
 

--- a/packages/replay-next/src/utils/suspense.test.ts
+++ b/packages/replay-next/src/utils/suspense.test.ts
@@ -1,6 +1,19 @@
-import { Wakeable } from "replay-next/src/suspense/types";
+import {
+  STATUS_PENDING,
+  STATUS_REJECTED,
+  STATUS_RESOLVED,
+  StatusPending,
+  StatusRejected,
+  StatusResolved,
+  Wakeable,
+} from "replay-next/src/suspense/types";
 
-import { __setCircularThenableCheckMaxCount, createWakeable, suspendInParallel } from "./suspense";
+import {
+  __setCircularThenableCheckMaxCount,
+  createFetchAsyncFromFetchSuspense,
+  createWakeable,
+  suspendInParallel,
+} from "./suspense";
 
 describe("Suspense util", () => {
   describe("createWakeable", () => {
@@ -205,6 +218,71 @@ describe("Suspense util", () => {
 
       // But Wakeable B should not
       registerSyncListeners(wakeableB, 2);
+    });
+  });
+
+  describe("createFetchAsyncFromFetchSuspense", () => {
+    function createFakeSuspenseCache(): (resolvedValue?: number) => number {
+      const wakeable: Wakeable<number> | null = createWakeable<number>("Fake value");
+
+      let status: StatusPending | StatusRejected | StatusResolved | null = null;
+
+      return function getValue(resolvedValue?: number) {
+        if (status === null) {
+          status = STATUS_PENDING;
+
+          Promise.resolve().then(() => {
+            if (resolvedValue !== undefined) {
+              wakeable?.resolve(resolvedValue);
+            } else {
+              wakeable?.reject(Error("Failed"));
+            }
+          });
+
+          throw wakeable;
+        } else {
+          if (resolvedValue !== undefined) {
+            status = STATUS_RESOLVED;
+            return resolvedValue;
+          } else {
+            status = STATUS_REJECTED;
+            throw Error("Failed");
+          }
+        }
+      };
+    }
+
+    it("awaits the result of a function that suspends", async () => {
+      const cache = createFakeSuspenseCache();
+      const callback = createFetchAsyncFromFetchSuspense(cache);
+      expect(await callback(123)).toBe(123);
+      expect(await callback(234)).toBe(234);
+    });
+
+    it("awaits the result of a function that suspends multiple times", async () => {
+      const cache1 = createFakeSuspenseCache();
+      const cache2 = createFakeSuspenseCache();
+      const compositeCache = (num: number) => {
+        return cache1(100) + cache2(10) + num;
+      };
+      const callback = await createFetchAsyncFromFetchSuspense(compositeCache);
+      expect(await callback(1)).toBe(111);
+    });
+
+    it("re-throws errors", async () => {
+      const cache = createFakeSuspenseCache();
+      const callback = createFetchAsyncFromFetchSuspense(cache);
+      await expect(callback).rejects.toThrowError("Failed");
+    });
+
+    it("re-throws errors after suspending", async () => {
+      const cache1 = createFakeSuspenseCache();
+      const cache2 = createFakeSuspenseCache();
+      const compositeCache = () => {
+        return cache1(100) + cache2();
+      };
+      const callback = createFetchAsyncFromFetchSuspense(compositeCache);
+      await expect(callback).rejects.toThrowError("Failed");
     });
   });
 

--- a/packages/replay-next/src/utils/suspense.ts
+++ b/packages/replay-next/src/utils/suspense.ts
@@ -1,6 +1,10 @@
+import { isThennable } from "shared/proxy/utils";
+
 import { Wakeable } from "../suspense/types";
 
-let CIRCULAR_THENABLE_CHECK_MAX_COUNT = 1_000;
+type AnyFunction<ReturnType> = (...args: any[]) => ReturnType;
+
+let MAX_LOOP_COUNT = 1_000;
 
 // A "thennable" is a subset of the Promise API.
 // We could use a Promise as thennable, but Promises have a downside: they use the microtask queue.
@@ -21,7 +25,7 @@ export function createWakeable<T>(debugLabel: string): Wakeable<T> {
   // Note that our guard counter should be somewhat high to avoid false positives.
   // It is a legitimate use-case to register handlers after a wakeable has been resolved or rejected.
   const checkCircularThenableChain = () => {
-    if (++callbacksRegisteredAfterResolutionCount > CIRCULAR_THENABLE_CHECK_MAX_COUNT) {
+    if (++callbacksRegisteredAfterResolutionCount > MAX_LOOP_COUNT) {
       throw Error(`Circular thenable chain detected (infinite loop) for resource:\n${debugLabel}`);
     }
   };
@@ -98,13 +102,38 @@ export function createWakeable<T>(debugLabel: string): Wakeable<T> {
   return wakeable;
 }
 
-type AnyFunction = (...args: any[]) => any;
+export function createFetchAsyncFromFetchSuspense<TParams extends Array<any>, TValue>(
+  suspenseCache: (...params: TParams) => TValue
+): (...params: TParams) => Promise<TValue> {
+  return async function fetchAsync(...params: TParams): Promise<TValue> {
+    let loopCount = 0;
+
+    // We use a loop because the Suspense callback may suspend to fetch multiple values.
+    while (true) {
+      loopCount++;
+
+      try {
+        return await suspenseCache(...params);
+      } catch (errorOrPromise) {
+        if (isThennable(errorOrPromise)) {
+          await errorOrPromise;
+        } else {
+          throw errorOrPromise;
+        }
+      }
+
+      if (loopCount > MAX_LOOP_COUNT) {
+        throw new Error("Suspense loop exceeded maximum loop count");
+      }
+    }
+  };
+}
 
 // Helper function to read from multiple Suspense caches in parallel.
 // This method will re-throw any thrown value, but only after also calling subsequent caches.
-export function suspendInParallel<T extends AnyFunction[]>(
+export function suspendInParallel<T extends AnyFunction<any>[]>(
   ...callbacks: [...T]
-): { [K in keyof T]: ReturnType<Extract<T[K], AnyFunction>> } {
+): { [K in keyof T]: ReturnType<Extract<T[K], AnyFunction<any>>> } {
   const values: any[] = [];
   let thrownValue = null;
 
@@ -120,32 +149,10 @@ export function suspendInParallel<T extends AnyFunction[]>(
     throw thrownValue;
   }
 
-  return values as { [K in keyof T]: ReturnType<Extract<T[K], AnyFunction>> };
+  return values as { [K in keyof T]: ReturnType<Extract<T[K], AnyFunction<any>>> };
 }
 
 // Expose max circular check count for testing purposes.
 export function __setCircularThenableCheckMaxCount(value: number) {
-  CIRCULAR_THENABLE_CHECK_MAX_COUNT = value;
-}
-
-export function createFetchAsyncFromFetchSuspense<TParams extends Array<any>, TValue>(
-  fetchAsyncMethod: (...params: TParams) => TValue
-) {
-  const fetchAsync = async (...params: TParams) => {
-    try {
-      return fetchAsyncMethod(...params);
-    } catch (errorOrPromise) {
-      if (
-        errorOrPromise != null &&
-        typeof errorOrPromise === "object" &&
-        errorOrPromise.hasOwnProperty("then")
-      ) {
-        return errorOrPromise as Promise<TValue>;
-      } else {
-        throw errorOrPromise;
-      }
-    }
-  };
-
-  return fetchAsync;
+  MAX_LOOP_COUNT = value;
 }


### PR DESCRIPTION
Speeds up various parts of the UI:
* Print statement panels now defer loading Pause and Frame information until _required_ by the type-ahead input (aka when a user actually starts typing)
* Console now defers loading pause and frame info until the user starts typing _or_ enters a terminal expression (at which point the information is needed to evaluate and render the expression)

Here are some before/after demos:
* [Print statements panel](https://www.loom.com/share/24e68cf418ae44e6a5186dd2c23d651a)
* [Console (and input)](https://www.loom.com/share/68b2e42071374ae1bff351bed7e8b343)

cc @jcmorrow 