### PR TITLE
Fix off-by-one error in SourceListRow breakpoint column rendering

### DIFF
--- a/packages/replay-next/components/sources/SourceListRow.tsx
+++ b/packages/replay-next/components/sources/SourceListRow.tsx
@@ -247,7 +247,7 @@ const SourceListRow = memo(
         }
 
         if (lastColumnIndex < plainText.length - 1) {
-          renderBetween(lineSegments, lastColumnIndex, plainText.length - 1);
+          renderBetween(lineSegments, lastColumnIndex, plainText.length);
         }
       } else {
         if (tokens !== null) {


### PR DESCRIPTION
## Before

<img width="708" alt="Screen Shot 2023-02-15 at 12 55 49 PM" src="https://user-images.githubusercontent.com/29597/219113046-c1996aba-ae91-483d-afc5-499ff3eaf8bb.png">

## After

<img width="702" alt="Screen Shot 2023-02-15 at 12 55 20 PM" src="https://user-images.githubusercontent.com/29597/219113044-19eff601-1d95-4c4a-ab46-41fd2bd7d646.png">
