### PR TITLE
Add telemetry and fallback when failing to set role

### DIFF
--- a/pages/browser/choose-role.tsx
+++ b/pages/browser/choose-role.tsx
@@ -11,13 +11,24 @@ import {
   OnboardingModalContainer,
 } from "ui/components/shared/Onboarding";
 import { useUpdateUserSetting } from "ui/hooks/settings";
+import { sendTelemetryEvent } from "ui/utils/telemetry";
 
 export default function ImportSettings() {
   const router = useRouter();
   const updateUserSetting = useUpdateUserSetting("role");
   const setRole = (role: string) => {
     // TODO [ryanjduffy]: Should this route to the tutorial app?
-    updateUserSetting({ variables: { role } }).then(() => router.push("/"));
+    updateUserSetting({ variables: { role } })
+      .then(() => router.push("/"))
+      .catch(e => {
+        sendTelemetryEvent("DevtoolsGraphQLError", {
+          source: "updateUserSetting",
+          role,
+          message: e,
+        });
+
+        router.push("/");
+      });
   };
 
   return (


### PR DESCRIPTION
Redirects to root after failing to set role since that failure shouldn't block usage of the product.