### PR TITLE
Replay Tour: Add logged out experience

### DIFF
--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -14,7 +14,7 @@
   --theme-body-font-size: 12px;
   --theme-code-font-size: 11px;
   --theme-code-line-height: calc(15 / 11);
-  --theme-tab-font-size: 15px;
+  --theme-tab-font-size: var(--font-size-large);
 
   /* Toolbar size (excluding borders) */
   --theme-toolbar-height: 24px;

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -204,7 +204,7 @@ export function TestStepItem({
         className="flex w-0 flex-grow items-start space-x-2 text-start"
         title={`Step ${index + 1}: ${step.name} ${argString || ""}`}
       >
-        <div className={`flex-grow font-medium break-all ${state === "paused" ? "font-bold" : ""}`}>
+        <div className={`flex-grow break-all font-medium ${state === "paused" ? "font-bold" : ""}`}>
           {step.parentId ? "- " : ""}{" "}
           <span className={`${styles.step} ${styles[step.name]}`}>{step.name}</span>
           <span className="opacity-70">{argString}</span>

--- a/src/devtools/client/debugger/src/components/shared/Accordion.css
+++ b/src/devtools/client/debugger/src/components/shared/Accordion.css
@@ -20,7 +20,7 @@
 
 .accordion ._header {
   display: flex;
-  font-size: 15px;
+  font-size: var(--font-size-large);
   line-height: calc(16 / 12);
   padding: 8px;
   width: 100%;

--- a/src/ui/components/Accordion.module.css
+++ b/src/ui/components/Accordion.module.css
@@ -29,7 +29,7 @@
 .accordionItemContainer .header {
   background: var(--tab-bgcolor);
   cursor: pointer;
-  font-size: 15px;
+  font-size: var(--font-size-large);
   line-height: 1.25;
   padding: 8px;
   position: sticky;

--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -12,8 +12,8 @@ import { UIState } from "ui/state";
 import { ModalType } from "ui/state/app";
 import { isTest } from "ui/utils/environment";
 import { trackEvent } from "ui/utils/telemetry";
-import useAuth0 from "ui/utils/useAuth0";
 import { shouldShowNag } from "ui/utils/tour";
+import useAuth0 from "ui/utils/useAuth0";
 
 import { ConfirmRenderer } from "./shared/Confirm";
 import AppErrors from "./shared/Error";

--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -13,7 +13,7 @@ import { ModalType } from "ui/state/app";
 import { isTest } from "ui/utils/environment";
 import { trackEvent } from "ui/utils/telemetry";
 import useAuth0 from "ui/utils/useAuth0";
-import { shouldShowNag } from "ui/utils/user";
+import { shouldShowNag } from "ui/utils/tour";
 
 import { ConfirmRenderer } from "./shared/Confirm";
 import AppErrors from "./shared/Error";

--- a/src/ui/components/Events/ReplayInfo.tsx
+++ b/src/ui/components/Events/ReplayInfo.tsx
@@ -10,7 +10,6 @@ import { formatRelativeTime } from "ui/utils/comments";
 import { getDisplayedUrl } from "ui/utils/environment";
 import { getRecordingId, showDurationWarning } from "ui/utils/recording";
 import useAuth0 from "ui/utils/useAuth0";
-import { shouldShowNag } from "ui/utils/tour";
 
 import { AvatarImage } from "../Avatar";
 import Icon from "../shared/Icon";

--- a/src/ui/components/Events/ReplayInfo.tsx
+++ b/src/ui/components/Events/ReplayInfo.tsx
@@ -50,8 +50,8 @@ function ReplayInfo({ setModal }: PropsFromRedux) {
   };
 
   const isTest = recording.metadata?.test;
-  return (      
-    <div className="flex-column flex items-center overflow-hidden border-splitter bg-bodyBgcolor">     
+  return (
+    <div className="flex-column flex items-center overflow-hidden border-splitter bg-bodyBgcolor">
       <div className="mt-.5 mb-2 flex w-full cursor-default flex-col self-stretch overflow-hidden px-1.5 pb-0 text-xs">
         {recording.user ? (
           <Row>

--- a/src/ui/components/Events/ReplayInfo.tsx
+++ b/src/ui/components/Events/ReplayInfo.tsx
@@ -10,6 +10,7 @@ import { formatRelativeTime } from "ui/utils/comments";
 import { getDisplayedUrl } from "ui/utils/environment";
 import { getRecordingId, showDurationWarning } from "ui/utils/recording";
 import useAuth0 from "ui/utils/useAuth0";
+import { shouldShowNag } from "ui/utils/tour";
 
 import { AvatarImage } from "../Avatar";
 import Icon from "../shared/Icon";
@@ -50,8 +51,8 @@ function ReplayInfo({ setModal }: PropsFromRedux) {
   };
 
   const isTest = recording.metadata?.test;
-  return (
-    <div className="flex-column flex items-center overflow-hidden border-splitter bg-bodyBgcolor">
+  return (      
+    <div className="flex-column flex items-center overflow-hidden border-splitter bg-bodyBgcolor">     
       <div className="mt-.5 mb-2 flex w-full cursor-default flex-col self-stretch overflow-hidden px-1.5 pb-0 text-xs">
         {recording.user ? (
           <Row>

--- a/src/ui/components/Header/UserOptions.tsx
+++ b/src/ui/components/Header/UserOptions.tsx
@@ -19,9 +19,7 @@ function UserOptions({ setModal, noBrowserItem }: UserOptionsProps) {
   const [expanded, setExpanded] = useState(false);
   const { isAuthenticated } = useAuth0();
 
-  if (!isAuthenticated) {
-    return <LoginButton />;
-  }
+
 
   const onDocsClick: React.MouseEventHandler = event => {
     trackEvent("user_options.select_docs");

--- a/src/ui/components/Header/ViewToggle.tsx
+++ b/src/ui/components/Header/ViewToggle.tsx
@@ -61,7 +61,7 @@ export default function ViewToggle() {
   }
 
   return (
-    <div className="flex">     
+    <div className="flex">
       <div className="view-toggle" role="button">
         <div
           className="handle"

--- a/src/ui/components/Header/ViewToggle.tsx
+++ b/src/ui/components/Header/ViewToggle.tsx
@@ -8,7 +8,7 @@ import { getViewMode } from "ui/reducers/layout";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { ViewMode } from "ui/state/layout";
 import { isTest } from "ui/utils/environment";
-import { shouldShowNag } from "ui/utils/user";
+import { shouldShowNag } from "ui/utils/tour";
 
 import MaterialIcon from "../shared/MaterialIcon";
 
@@ -61,20 +61,7 @@ export default function ViewToggle() {
   }
 
   return (
-    <div className="flex">
-      {showDevtoolsNag && (
-        <button
-          type="button"
-          onClick={() => handleToggle("dev")}
-          className="mr-3 flex items-center space-x-1.5 rounded-lg bg-primaryAccent text-sm text-buttontextColor hover:bg-primaryAccentHover"
-          style={{ padding: "5px 12px" }}
-        >
-          <div className="overflow-hidden whitespace-nowrap">
-            Welcome to Replay ❤️ Check out DevTools!
-          </div>
-          <MaterialIcon style={{ fontSize: "16px" }}>arrow_forward</MaterialIcon>
-        </button>
-      )}
+    <div className="flex">     
       <div className="view-toggle" role="button">
         <div
           className="handle"

--- a/src/ui/components/LoginButton.tsx
+++ b/src/ui/components/LoginButton.tsx
@@ -1,9 +1,13 @@
-import React from "react";
-
+import React, { FC } from "react";
 import Avatar from "ui/components/Avatar";
 import useAuth0 from "ui/utils/useAuth0";
+import MaterialIcon from "ui/components/shared/MaterialIcon";
 
-const LoginButton = () => {
+interface LoginButtonProps {
+  variant?: string;
+}
+
+const LoginButton: FC<LoginButtonProps> = ({ variant }) => {
   const { loginAndReturn, isAuthenticated, logout, user } = useAuth0();
 
   if (isAuthenticated) {
@@ -14,6 +18,15 @@ const LoginButton = () => {
       >
         <Avatar player={user} isFirstPlayer={true} />
         <span>Sign Out</span>
+      </button>
+    );
+  }
+
+  if (variant === "Tour") {
+    return (
+      <button type="button" onClick={() => loginAndReturn()} style={{ padding: "4px 8px" }}>
+        <div className="mr-1">Sign in</div>
+        <MaterialIcon style={{ fontSize: "16px" }}>arrow_forward</MaterialIcon>
       </button>
     );
   }
@@ -29,3 +42,4 @@ const LoginButton = () => {
 };
 
 export default LoginButton;
+

--- a/src/ui/components/LoginButton.tsx
+++ b/src/ui/components/LoginButton.tsx
@@ -20,11 +20,10 @@ const LoginButton = () => {
 
   return (
     <button
-      className="inline-flex items-center rounded-md border border-transparent bg-primaryAccent px-3 py-1.5 text-sm font-medium leading-4 text-buttontextColor hover:bg-primaryAccentHover focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+      className="row logout"
       onClick={() => loginAndReturn()}
-      color="blue"
     >
-      Sign In
+      <span className="inline-flex items-center rounded-md border border-transparent bg-primaryAccent px-3 py-1.5 text-sm font-medium leading-4 text-buttontextColor hover:bg-primaryAccentHover focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 w-full justify-center">Sign In</span>
     </button>
   );
 };

--- a/src/ui/components/SidePanel.module.css
+++ b/src/ui/components/SidePanel.module.css
@@ -65,6 +65,7 @@
 {
  font-size: var(--font-size-large);
  margin-bottom: .25em;
+ font-weight: bold;
 }
 
 .TourBox p

--- a/src/ui/components/SidePanel.module.css
+++ b/src/ui/components/SidePanel.module.css
@@ -35,40 +35,37 @@
   color: var(--testsuites-error-icon-bgcolor);
 }
 
-.TourBox
-{
-  padding: .5em;  
+.TourBox {
+  padding: 0.5em;
   color: #fff;
-  background: linear-gradient(116.71deg, #FF2F86 21.74%, #EC275D 83.58%), linear-gradient(133.71deg, #01ACFD 3.31%, #F155FF 106.39%, #F477F8 157.93%, #F33685 212.38%), #007AFF;
+  background: linear-gradient(116.71deg, #ff2f86 21.74%, #ec275d 83.58%),
+    linear-gradient(133.71deg, #01acfd 3.31%, #f155ff 106.39%, #f477f8 157.93%, #f33685 212.38%),
+    #007aff;
   border-radius: 4px;
 }
 
-.TourBox button
-{
+.TourBox button {
   background-color: #fff;
-  color: #F33685;
-  display: flex; 
-  margin-top: 0.75rem; 
+  color: #f33685;
+  display: flex;
+  margin-top: 0.75rem;
   font-size: 0.875rem;
-  line-height: 1.25rem; 
-  align-items: center; 
-  border-radius: 0.5rem; 
+  line-height: 1.25rem;
+  align-items: center;
+  border-radius: 0.5rem;
 }
 
-.TourBox button:hover
-{
+.TourBox button:hover {
   background-color: #fee;
-  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05); 
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
 }
 
-.TourBox h2
-{
- font-size: var(--font-size-large);
- margin-bottom: .25em;
- font-weight: bold;
+.TourBox h2 {
+  font-size: var(--font-size-large);
+  margin-bottom: 0.25em;
+  font-weight: bold;
 }
 
-.TourBox p
-{
- font-size: var(--font-size-regular);
+.TourBox p {
+  font-size: var(--font-size-regular);
 }

--- a/src/ui/components/SidePanel.module.css
+++ b/src/ui/components/SidePanel.module.css
@@ -2,7 +2,7 @@
   display: flex;
   border-bottom: 1px;
   flex-shrink: 0;
-  font-size: 15px;
+  font-size: var(--font-size-large);
   line-height: 19px;
   font-weight: 400;
   color: var(--body-color);
@@ -33,4 +33,41 @@
 
 .ErrorTextLighter {
   color: var(--testsuites-error-icon-bgcolor);
+}
+
+.TourBox
+{
+  padding: .5em;  
+  color: #fff;
+  background: linear-gradient(116.71deg, #FF2F86 21.74%, #EC275D 83.58%), linear-gradient(133.71deg, #01ACFD 3.31%, #F155FF 106.39%, #F477F8 157.93%, #F33685 212.38%), #007AFF;
+  border-radius: 4px;
+}
+
+.TourBox button
+{
+  background-color: #fff;
+  color: #F33685;
+  display: flex; 
+  margin-top: 0.75rem; 
+  font-size: 0.875rem;
+  line-height: 1.25rem; 
+  align-items: center; 
+  border-radius: 0.5rem; 
+}
+
+.TourBox button:hover
+{
+  background-color: #fee;
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05); 
+}
+
+.TourBox h2
+{
+ font-size: var(--font-size-large);
+ margin-bottom: .25em;
+}
+
+.TourBox p
+{
+ font-size: var(--font-size-regular);
 }

--- a/src/ui/components/SidePanel.module.css
+++ b/src/ui/components/SidePanel.module.css
@@ -41,18 +41,18 @@
   background: linear-gradient(116.71deg, #ff2f86 21.74%, #ec275d 83.58%),
     linear-gradient(133.71deg, #01acfd 3.31%, #f155ff 106.39%, #f477f8 157.93%, #f33685 212.38%),
     #007aff;
-  border-radius: 4px;
+  border-radius: 6px;
 }
 
 .TourBox button {
   background-color: #fff;
   color: #f33685;
   display: flex;
-  margin-top: 0.75rem;
+  margin-top: 0.50rem;
   font-size: 0.875rem;
   line-height: 1.25rem;
   align-items: center;
-  border-radius: 0.5rem;
+  border-radius: 0.25rem;
 }
 
 .TourBox button:hover {

--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -4,31 +4,27 @@ import PrimaryPanes from "devtools/client/debugger/src/components/PrimaryPanes";
 import SecondaryPanes from "devtools/client/debugger/src/components/SecondaryPanes";
 import Accordion from "devtools/client/debugger/src/components/shared/Accordion";
 import { setSelectedPrimaryPanel } from "ui/actions/layout";
+import { setViewMode } from "ui/actions/layout";
 import Events from "ui/components/Events";
 import { shouldShowDevToolsNag } from "ui/components/Header/ViewToggle";
 import SearchFilesReduxAdapter from "ui/components/SearchFilesReduxAdapter";
+import MaterialIcon from "ui/components/shared/MaterialIcon";
 import hooks from "ui/hooks";
 import { useFeature } from "ui/hooks/settings";
 import { Nag } from "ui/hooks/users";
 import { useTestInfo } from "ui/hooks/useTestInfo";
 import { getFlatEvents } from "ui/reducers/app";
 import { getSelectedPrimaryPanel } from "ui/reducers/layout";
-import { setViewMode } from "ui/actions/layout";
 import { getViewMode } from "ui/reducers/layout";
-import { ViewMode } from "ui/state/layout";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
-import styles from "src/ui/components/SidePanel.module.css";
-import MaterialIcon from "ui/components/shared/MaterialIcon";
+import { ViewMode } from "ui/state/layout";
+
 import CommentCardsList from "./Comments/CommentCardsList";
 import ReplayInfo from "./Events/ReplayInfo";
 import ProtocolViewer from "./ProtocolViewer";
 import StatusDropdown from "./shared/StatusDropdown";
 import { TestSuitePanel } from "./TestSuitePanel";
-
-
-
-
-
+import styles from "src/ui/components/SidePanel.module.css";
 
 function useInitialPrimaryPanel() {
   const dispatch = useAppDispatch();
@@ -59,14 +55,14 @@ export default function SidePanel() {
   const showDevtoolsNag = shouldShowDevToolsNag(nags, viewMode);
   const dispatch = useAppDispatch();
   const dismissNag = hooks.useDismissNag();
-  
-const handleToggle = async (mode: ViewMode) => {
+
+  const handleToggle = async (mode: ViewMode) => {
     dispatch(setViewMode(mode));
     if (showDevtoolsNag) {
       dismissNag(Nag.VIEW_DEVTOOLS);
     }
   };
-  
+
   const items: any[] = [];
 
   // if (recording?.metadata?.test?.tests?.length) {
@@ -95,23 +91,15 @@ const handleToggle = async (mode: ViewMode) => {
       {shouldShowDevToolsNag(nags, viewMode) && (
         <div className={styles.TourBox}>
           <h2>Welcome to Replay!</h2>
-            <p>
-              To get started, click into DevTools so we can show off some time travel features!
-            </p>
-            <button
-               type="button"
-               onClick={() => handleToggle("dev")}               
-               style={{ padding: "5px 12px" }}
-             >
-               <div>
-                 Open DevTools
-               </div>
-               <MaterialIcon style={{ fontSize: "16px" }}>arrow_forward</MaterialIcon>
-             </button>
-            </div>
+          <p>To get started, click into DevTools so we can show off some time travel features!</p>
+          <button type="button" onClick={() => handleToggle("dev")} style={{ padding: "5px 12px" }}>
+            <div>Open DevTools</div>
+            <MaterialIcon style={{ fontSize: "16px" }}>arrow_forward</MaterialIcon>
+          </button>
+        </div>
       )}
 
-      <div className="w-full overflow-hidden rounded-lg bg-bodyBgcolor text-xs h-full">
+      <div className="h-full w-full overflow-hidden rounded-lg bg-bodyBgcolor text-xs">
         {selectedPrimaryPanel === "explorer" && <PrimaryPanes />}
         {selectedPrimaryPanel === "debugger" && <SecondaryPanes />}
         {selectedPrimaryPanel === "comments" && <CommentCardsList />}

--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -99,7 +99,7 @@ export default function SidePanel() {
         </div>
       )}
 
-      <div className="h-full w-full overflow-hidden rounded-lg bg-bodyBgcolor text-xs">
+      <div className="h-0 flex-grow w-full overflow-hidden rounded-lg bg-bodyBgcolor text-xs">
         {selectedPrimaryPanel === "explorer" && <PrimaryPanes />}
         {selectedPrimaryPanel === "debugger" && <SecondaryPanes />}
         {selectedPrimaryPanel === "comments" && <CommentCardsList />}

--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -5,11 +5,15 @@ import SecondaryPanes from "devtools/client/debugger/src/components/SecondaryPan
 import Accordion from "devtools/client/debugger/src/components/shared/Accordion";
 import { setSelectedPrimaryPanel } from "ui/actions/layout";
 import Events from "ui/components/Events";
+import { shouldShowDevToolsNag } from "ui/components/Header/ViewToggle";
 import SearchFilesReduxAdapter from "ui/components/SearchFilesReduxAdapter";
+import hooks from "ui/hooks";
 import { useFeature } from "ui/hooks/settings";
+import { Nag } from "ui/hooks/users";
 import { useTestInfo } from "ui/hooks/useTestInfo";
 import { getFlatEvents } from "ui/reducers/app";
 import { getSelectedPrimaryPanel } from "ui/reducers/layout";
+import { getViewMode } from "ui/reducers/layout";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 
 import CommentCardsList from "./Comments/CommentCardsList";
@@ -41,6 +45,11 @@ export default function SidePanel() {
   const [eventsCollapsed, setEventsCollapsed] = useState(false);
   const events = useAppSelector(getFlatEvents);
 
+  const viewMode = useAppSelector(getViewMode);
+  const { nags } = hooks.useGetUserInfo();
+
+  const showDevtoolsNag = shouldShowDevToolsNag(nags, viewMode);
+
   const items: any[] = [];
 
   // if (recording?.metadata?.test?.tests?.length) {
@@ -65,14 +74,11 @@ export default function SidePanel() {
   }
 
   return (
-    <div className="flex flex-col w-full gap-1">
-      
-      {1 == 1 && (
-      <div className="p-2 rounded-md bg-primaryAccent">
-        This is where we will say things!
-      </div>
-    )}
-      
+    <div className="flex w-full flex-col gap-1">
+      {shouldShowDevToolsNag(nags, viewMode) && (
+        <div className="rounded-md bg-primaryAccent p-2">Welcome to Replay!</div>
+      )}
+
       <div className="w-full overflow-hidden rounded-lg bg-bodyBgcolor text-xs">
         {selectedPrimaryPanel === "explorer" && <PrimaryPanes />}
         {selectedPrimaryPanel === "debugger" && <SecondaryPanes />}

--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -13,14 +13,22 @@ import { Nag } from "ui/hooks/users";
 import { useTestInfo } from "ui/hooks/useTestInfo";
 import { getFlatEvents } from "ui/reducers/app";
 import { getSelectedPrimaryPanel } from "ui/reducers/layout";
+import { setViewMode } from "ui/actions/layout";
 import { getViewMode } from "ui/reducers/layout";
+import { ViewMode } from "ui/state/layout";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
-
+import styles from "src/ui/components/SidePanel.module.css";
+import MaterialIcon from "ui/components/shared/MaterialIcon";
 import CommentCardsList from "./Comments/CommentCardsList";
 import ReplayInfo from "./Events/ReplayInfo";
 import ProtocolViewer from "./ProtocolViewer";
 import StatusDropdown from "./shared/StatusDropdown";
 import { TestSuitePanel } from "./TestSuitePanel";
+
+
+
+
+
 
 function useInitialPrimaryPanel() {
   const dispatch = useAppDispatch();
@@ -49,7 +57,16 @@ export default function SidePanel() {
   const { nags } = hooks.useGetUserInfo();
 
   const showDevtoolsNag = shouldShowDevToolsNag(nags, viewMode);
-
+  const dispatch = useAppDispatch();
+  const dismissNag = hooks.useDismissNag();
+  
+const handleToggle = async (mode: ViewMode) => {
+    dispatch(setViewMode(mode));
+    if (showDevtoolsNag) {
+      dismissNag(Nag.VIEW_DEVTOOLS);
+    }
+  };
+  
   const items: any[] = [];
 
   // if (recording?.metadata?.test?.tests?.length) {
@@ -74,12 +91,27 @@ export default function SidePanel() {
   }
 
   return (
-    <div className="flex w-full flex-col gap-1">
-      {shouldShowDevToolsNag(nags, viewMode) && (
-        <div className="rounded-md bg-primaryAccent p-2">Welcome to Replay!</div>
+    <div className="flex w-full flex-col gap-2">
+      {!shouldShowDevToolsNag(nags, viewMode) && (
+        <div className={styles.TourBox}>
+          <h2>Welcome to Replay!</h2>
+            <p>
+              To get started, click into DevTools so we can show off some time travel features!
+            </p>
+            <button
+               type="button"
+               onClick={() => handleToggle("dev")}               
+               style={{ padding: "5px 12px" }}
+             >
+               <div>
+                 Open DevTools
+               </div>
+               <MaterialIcon style={{ fontSize: "16px" }}>arrow_forward</MaterialIcon>
+             </button>
+            </div>
       )}
 
-      <div className="w-full overflow-hidden rounded-lg bg-bodyBgcolor text-xs">
+      <div className="w-full overflow-hidden rounded-lg bg-bodyBgcolor text-xs h-full">
         {selectedPrimaryPanel === "explorer" && <PrimaryPanes />}
         {selectedPrimaryPanel === "debugger" && <SecondaryPanes />}
         {selectedPrimaryPanel === "comments" && <CommentCardsList />}

--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -18,7 +18,7 @@ import { getSelectedPrimaryPanel } from "ui/reducers/layout";
 import { getViewMode } from "ui/reducers/layout";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { ViewMode } from "ui/state/layout";
-
+import useAuth0 from "ui/utils/useAuth0";
 import CommentCardsList from "./Comments/CommentCardsList";
 import ReplayInfo from "./Events/ReplayInfo";
 import ProtocolViewer from "./ProtocolViewer";
@@ -48,19 +48,25 @@ export default function SidePanel() {
   const [replayInfoCollapsed, setReplayInfoCollapsed] = useState(false);
   const [eventsCollapsed, setEventsCollapsed] = useState(false);
   const events = useAppSelector(getFlatEvents);
-
+  const { isAuthenticated } = useAuth0();
   const viewMode = useAppSelector(getViewMode);
   const { nags } = hooks.useGetUserInfo();
-
   const showDevtoolsNag = shouldShowDevToolsNag(nags, viewMode);
   const dispatch = useAppDispatch();
   const dismissNag = hooks.useDismissNag();
-
   const handleToggle = async (mode: ViewMode) => {
     dispatch(setViewMode(mode));
     if (showDevtoolsNag) {
       dismissNag(Nag.VIEW_DEVTOOLS);
     }
+  };
+  
+  const launchQuickstart = () => {
+    console.log("launch quickstart");
+  };
+  
+  const signIn = () => {
+    console.log("signIn");
   };
 
   const items: any[] = [];
@@ -86,6 +92,7 @@ export default function SidePanel() {
     });
   }
 
+  
   return (
     <div className="flex w-full flex-col gap-2">
       {shouldShowDevToolsNag(nags, viewMode) && (
@@ -98,6 +105,22 @@ export default function SidePanel() {
           </button>
         </div>
       )}
+      
+      {!isAuthenticated && (
+        <div className={styles.TourBox}>
+          <h2>Welcome to Replay!</h2>
+          <p>To get started with Replay, please sign in or read our quickstart guide.</p>
+          <button type="button" onClick={() => signIn()} style={{ padding: "5px 12px" }}>
+            <div className="mr-1">Sign in</div>
+            <MaterialIcon style={{ fontSize: "16px" }}>arrow_forward</MaterialIcon>
+          </button>
+          <button type="button" onClick={() => launchQuickstart()} style={{ padding: "5px 12px" }}>
+            <div className="mr-1">Quickstart guide</div>
+            <MaterialIcon style={{ fontSize: "16px" }}>arrow_forward</MaterialIcon>
+          </button>
+        </div>
+      )}
+      
 
       <div className="h-0 flex-grow w-full overflow-hidden rounded-lg bg-bodyBgcolor text-xs">
         {selectedPrimaryPanel === "explorer" && <PrimaryPanes />}

--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -92,7 +92,7 @@ const handleToggle = async (mode: ViewMode) => {
 
   return (
     <div className="flex w-full flex-col gap-2">
-      {!shouldShowDevToolsNag(nags, viewMode) && (
+      {shouldShowDevToolsNag(nags, viewMode) && (
         <div className={styles.TourBox}>
           <h2>Welcome to Replay!</h2>
             <p>

--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -25,6 +25,7 @@ import ProtocolViewer from "./ProtocolViewer";
 import StatusDropdown from "./shared/StatusDropdown";
 import { TestSuitePanel } from "./TestSuitePanel";
 import styles from "src/ui/components/SidePanel.module.css";
+import LoginButton from "ui/components/LoginButton";
 
 function useInitialPrimaryPanel() {
   const dispatch = useAppDispatch();
@@ -62,7 +63,7 @@ export default function SidePanel() {
   };
   
   const launchQuickstart = () => {
-    console.log("launch quickstart");
+    window.open('https://docs.replay.io/recording-a-web-app/viewing-and-collaborating', '_blank');
   };
   
   const signIn = () => {
@@ -99,8 +100,8 @@ export default function SidePanel() {
         <div className={styles.TourBox}>
           <h2>Welcome to Replay!</h2>
           <p>To get started, click into DevTools so we can show off some time travel features!</p>
-          <button type="button" onClick={() => handleToggle("dev")} style={{ padding: "5px 12px" }}>
-            <div>Open DevTools</div>
+          <button type="button" onClick={() => handleToggle("dev")} style={{ padding: "4px 8px" }}>
+            <div className="mr-1">Open DevTools</div>
             <MaterialIcon style={{ fontSize: "16px" }}>arrow_forward</MaterialIcon>
           </button>
         </div>
@@ -110,11 +111,10 @@ export default function SidePanel() {
         <div className={styles.TourBox}>
           <h2>Welcome to Replay!</h2>
           <p>To get started with Replay, please sign in or read our quickstart guide.</p>
-          <button type="button" onClick={() => signIn()} style={{ padding: "5px 12px" }}>
-            <div className="mr-1">Sign in</div>
-            <MaterialIcon style={{ fontSize: "16px" }}>arrow_forward</MaterialIcon>
-          </button>
-          <button type="button" onClick={() => launchQuickstart()} style={{ padding: "5px 12px" }}>
+          
+          <LoginButton variant="Tour" />
+                      
+          <button type="button" onClick={() => launchQuickstart()} style={{ padding: "4px 8px" }}>
             <div className="mr-1">Quickstart guide</div>
             <MaterialIcon style={{ fontSize: "16px" }}>arrow_forward</MaterialIcon>
           </button>

--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -65,17 +65,23 @@ export default function SidePanel() {
   }
 
   return (
-    <div
-      className="w-full overflow-hidden rounded-lg bg-bodyBgcolor text-xs"
-      data-test-id="leftSidebar"
-    >
-      {selectedPrimaryPanel === "explorer" && <PrimaryPanes />}
-      {selectedPrimaryPanel === "debugger" && <SecondaryPanes />}
-      {selectedPrimaryPanel === "comments" && <CommentCardsList />}
-      {selectedPrimaryPanel === "events" && <EventsPane items={items} />}
-      {selectedPrimaryPanel === "cypress" && <TestSuitePanel />}
-      {selectedPrimaryPanel === "protocol" && <ProtocolViewer />}
-      {selectedPrimaryPanel === "search" && <SearchFilesReduxAdapter />}
+    <div className="flex flex-col w-full gap-1">
+      
+      {1 == 1 && (
+      <div className="p-2 rounded-md bg-primaryAccent">
+        This is where we will say things!
+      </div>
+    )}
+      
+      <div className="w-full overflow-hidden rounded-lg bg-bodyBgcolor text-xs">
+        {selectedPrimaryPanel === "explorer" && <PrimaryPanes />}
+        {selectedPrimaryPanel === "debugger" && <SecondaryPanes />}
+        {selectedPrimaryPanel === "comments" && <CommentCardsList />}
+        {selectedPrimaryPanel === "events" && <EventsPane items={items} />}
+        {selectedPrimaryPanel === "cypress" && <TestSuitePanel />}
+        {selectedPrimaryPanel === "protocol" && <ProtocolViewer />}
+        {selectedPrimaryPanel === "search" && <SearchFilesReduxAdapter />}
+      </div>
     </div>
   );
 }

--- a/src/ui/components/shared/Nags/Nags.tsx
+++ b/src/ui/components/shared/Nags/Nags.tsx
@@ -4,7 +4,7 @@ import React, { useContext } from "react";
 import { LoggablesContext } from "replay-next/components/console/LoggablesContext";
 import hooks from "ui/hooks";
 import { Nag } from "ui/hooks/users";
-import { shouldShowNag } from "ui/utils/user";
+import { shouldShowNag } from "ui/utils/tour";
 
 import MaterialIcon from "../MaterialIcon";
 

--- a/src/ui/utils/onboarding.ts
+++ b/src/ui/utils/onboarding.ts
@@ -1,7 +1,7 @@
 import { Nag } from "ui/hooks/users";
 import { isReplayBrowser } from "ui/utils/environment";
 
-import { shouldShowNag } from "./user";
+import { shouldShowNag } from "./tour";
 
 function queryParams() {
   return new URL(window.location.href).searchParams;

--- a/src/ui/utils/telemetry.ts
+++ b/src/ui/utils/telemetry.ts
@@ -37,7 +37,7 @@ export function setupTelemetry() {
     // sporadic errors from Next.js
     "Failed to execute 'measure' on 'Performance'",
     "Cannot read properties of undefined (reading 'digest')",
-    "can't access property \"digest\", t is undefined",
+    'can\'t access property "digest", t is undefined',
   ];
   // We always initialize mixpanel here. This allows us to force enable mixpanel events even if
   // telemetry events are being skipped for any reason, e.g. development, test, etc.

--- a/src/ui/utils/tour.ts
+++ b/src/ui/utils/tour.ts
@@ -1,0 +1,5 @@
+import { Nag } from "ui/hooks/users";
+
+export function shouldShowNag(nags: Nag[], key: Nag) {
+  return nags && !nags.includes(key);
+}

--- a/src/ui/utils/user.ts
+++ b/src/ui/utils/user.ts
@@ -1,13 +1,7 @@
-import { Nag } from "ui/hooks/users";
-
 export function getAvatarColor(avatarID?: number) {
   if (!avatarID) {
     return "#696969";
   }
   const avatarColors = ["#2D4551", "#509A8F", "#E4C478", "#E9A56C", "#D97559"];
   return avatarColors[avatarID % avatarColors.length];
-}
-
-export function shouldShowNag(nags: Nag[], key: Nag) {
-  return nags && !nags.includes(key);
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9154902/219206986-014d62bb-4f5e-487f-8eed-1d9c0b9358e5.png)

Addresses [DES-291](https://linear.app/replay/issue/DES-291/2-our-logged-out-state-needs-a-welcome-to-replay-box) and is related to https://github.com/replayio/devtools/pull/8753 .

Right now the links are going to our standard login and https://docs.replay.io/recording-a-web-app/viewing-and-collaborating. I've filed https://linear.app/replay/issue/DES-328/create-a-better-quickstart-guide-link to come up with better quickstart content. (And we'd want different Quickstart content based on whether or not you're using testsuites)