### PR TITLE
Focus mode UX tweak

### DIFF
--- a/src/ui/components/Timeline/CurrentTimeIndicator.tsx
+++ b/src/ui/components/Timeline/CurrentTimeIndicator.tsx
@@ -14,8 +14,8 @@ export default function CurrentTimeIndicator({ editMode }: { editMode: EditMode 
 
   // When the focus region is being resized, the video preview updates to track its drag handle.
   // During this time, the currentTime indicator should be de-emphasized.
-  const isResizingFocusRegion =
-    editMode?.type === "resize-end" || editMode?.type === "resize-start";
+  // Same for when the region is being dragged.
+  const isResizingFocusRegion = editMode !== null;
 
   return (
     <div


### PR DESCRIPTION
## [Loom demo](https://www.loom.com/share/741fcd11788b42f985ec7f364122a9ba)

While dragging, or resizing, the current time indicator changes from _red_ to _blue_ (to indicate that the preview does not match the current time).

cc @jonbell-lot23 
