### PR TITLE
Add generic cache subscribe API, createInfallibleSuspenseCache util, and tests

### DIFF
--- a/packages/replay-next/src/suspense/createGenericCache.test.ts
+++ b/packages/replay-next/src/suspense/createGenericCache.test.ts
@@ -1,43 +1,289 @@
 import { isThennable } from "shared/proxy/utils";
 
-import { createGenericCache } from "./createGenericCache";
+import {
+  GenericCache,
+  STATUS_PENDING,
+  STATUS_REJECTED,
+  STATUS_RESOLVED,
+  createGenericCache,
+} from "./createGenericCache";
 
-describe("Generic suspense cache", () => {
-  it("should suspend on async values", async () => {
-    const cache = createTestCache();
-    try {
-      cache.getValueSuspense(1);
-      throw new Error("should have suspended");
-    } catch (thennable) {
+describe("createGenericCache", () => {
+  let fetchValue: jest.Mock;
+  let cache: GenericCache<[], [string], string>;
+  let getCacheKey: jest.Mock;
+
+  beforeEach(() => {
+    fetchValue = jest.fn();
+    fetchValue.mockImplementation((key: string) => {
+      if (key.startsWith("async")) {
+        return Promise.resolve(key);
+      } else if (key.startsWith("error")) {
+        return Promise.reject(key);
+      } else {
+        return key;
+      }
+    });
+
+    getCacheKey = jest.fn();
+    getCacheKey.mockImplementation(key => key.toString());
+
+    cache = createGenericCache<[], [string], string>("test", 0, fetchValue, getCacheKey);
+  });
+
+  describe("addValue", () => {
+    it("should cache and return pre-fetched values without reloading", () => {
+      cache.addValue("SYNC", "sync-1");
+      cache.addValue("ASYNC", "async-1");
+
+      expect(cache.getValueIfCached("sync-1")).toEqual({ value: "SYNC" });
+      expect(cache.getValueIfCached("async-1")).toEqual({ value: "ASYNC" });
+
+      expect(fetchValue).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getStatus", () => {
+    it("should return undefined for keys that have not been loaded", () => {
+      expect(cache.getStatus("nope")).toBeUndefined();
+    });
+
+    it("should transition from pending to resolved", async () => {
+      const willResolve = cache.getValueAsync("async");
+
+      expect(cache.getStatus("async")).toBe(STATUS_PENDING);
+
+      await willResolve;
+
+      expect(cache.getStatus("async")).toBe(STATUS_RESOLVED);
+    });
+
+    it("should transition from pending to rejected", async () => {
+      fetchValue.mockReturnValue(Promise.reject("Expected"));
+
+      const willReject = cache.getValueAsync("error");
+
+      expect(cache.getStatus("error")).toBe(STATUS_PENDING);
+
+      try {
+        await willReject;
+      } catch (error) {}
+
+      expect(cache.getStatus("error")).toBe(STATUS_REJECTED);
+    });
+
+    it("should return resolved or rejected for keys that have already been loaded", async () => {
+      const willResolve = cache.getValueAsync("sync");
+      await willResolve;
+      expect(cache.getStatus("sync")).toBe(STATUS_RESOLVED);
+
+      const willReject = cache.getValueAsync("error");
+      try {
+        await willReject;
+      } catch (error) {}
+      expect(cache.getStatus("error")).toBe(STATUS_REJECTED);
+    });
+  });
+
+  describe("getValueAsync", () => {
+    it("should return async values", async () => {
+      const thennable = cache.getValueAsync("async");
+
       expect(isThennable(thennable)).toBe(true);
+
+      await expect(await thennable).toBe("async");
+    });
+
+    it("should return sync values", () => {
+      expect(cache.getValueAsync("sync")).toBe("sync");
+    });
+
+    it("should only load the same value once (per key)", () => {
+      expect(cache.getValueAsync("sync")).toBe("sync");
+      expect(cache.getValueAsync("sync")).toBe("sync");
+
+      expect(fetchValue).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("getValueIfCached", () => {
+    it("should return undefined for values not yet loaded", () => {
+      expect(cache.getValueIfCached("sync")).toBeUndefined();
+    });
+
+    it("should not trigger a fetch", () => {
+      expect(cache.getValueIfCached("sync")).toBeUndefined();
+      expect(fetchValue).not.toHaveBeenCalled();
+    });
+
+    it("should return undefined for values that are pending", () => {
+      cache.getValueAsync("async");
+      expect(cache.getValueIfCached("async")).toBeUndefined();
+    });
+
+    it("should return a cached value for values that have resolved", () => {
+      cache.getValueAsync("sync");
+      expect(cache.getValueIfCached("sync")).toEqual({ value: "sync" });
+    });
+
+    it("should return a cached error for values that have rejected", async () => {
+      cache.getValueAsync("error");
+      await Promise.resolve();
+      expect(() => cache.getValueIfCached("error")).toThrow("error");
+    });
+  });
+
+  describe("getValueSuspense", () => {
+    it("should suspend on async values", async () => {
+      try {
+        cache.getValueSuspense("async");
+
+        throw new Error("should have suspended");
+      } catch (thennable) {
+        expect(isThennable(thennable)).toBe(true);
+
+        await thennable;
+
+        expect(cache.getValueSuspense("async")).toBe("async");
+      }
+    });
+
+    it("should not suspend on sync values", () => {
+      expect(cache.getValueSuspense("sync")).toBe("sync");
+    });
+
+    it("should only fetch the same value once (per key)", () => {
+      expect(cache.getValueSuspense("sync")).toBe("sync");
+      expect(cache.getValueSuspense("sync")).toBe("sync");
+
+      expect(fetchValue).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("subscribeToStatus", () => {
+    let callbackA: jest.Mock;
+    let callbackB: jest.Mock;
+
+    beforeEach(() => {
+      callbackA = jest.fn();
+      callbackB = jest.fn();
+    });
+
+    it("should subscribe to keys that have not been loaded", async () => {
+      cache.subscribeToStatus(callbackA, "sync");
+
+      expect(callbackA).toHaveBeenCalledTimes(1);
+      expect(callbackA).toHaveBeenCalledWith(undefined);
+
+      await Promise.resolve();
+
+      expect(callbackA).toHaveBeenCalledTimes(1);
+    });
+
+    it("should notify of the transition from undefined to resolved for synchronous caches", async () => {
+      cache.subscribeToStatus(callbackA, "sync");
+
+      expect(callbackA).toHaveBeenCalledTimes(1);
+      expect(callbackA).toHaveBeenCalledWith(undefined);
+
+      cache.getValueAsync("sync");
+
+      expect(callbackA).toHaveBeenCalledTimes(3);
+      expect(callbackA).toHaveBeenCalledWith(STATUS_PENDING);
+      expect(callbackA).toHaveBeenCalledWith(STATUS_RESOLVED);
+    });
+
+    it("should notify of the transition from undefined to from pending to resolved for async caches", async () => {
+      cache.subscribeToStatus(callbackA, "async");
+
+      expect(callbackA).toHaveBeenCalledTimes(1);
+      expect(callbackA).toHaveBeenCalledWith(undefined);
+
+      const thennable = cache.getValueAsync("async");
+
+      expect(callbackA).toHaveBeenCalledTimes(2);
+      expect(callbackA).toHaveBeenCalledWith(STATUS_PENDING);
+
       await thennable;
-      expect(cache.getValueSuspense(1)).toBe(1);
-    }
-  });
 
-  it("should not suspend on sync values", () => {
-    const cache = createTestCache();
-    expect(cache.getValueSuspense(2)).toBe(2);
-  });
+      expect(callbackA).toHaveBeenCalledTimes(3);
+      expect(callbackA).toHaveBeenCalledWith(STATUS_RESOLVED);
+    });
 
-  it("should return async values", async () => {
-    const cache = createTestCache();
-    const thennable = cache.getValueAsync(1);
-    expect(isThennable(thennable)).toBe(true);
-    await expect(await thennable).toBe(1);
-  });
+    it("should only notify each subscriber once", async () => {
+      cache.subscribeToStatus(callbackA, "sync");
+      cache.subscribeToStatus(callbackB, "sync");
 
-  it("should return sync values", () => {
-    const cache = createTestCache();
-    expect(cache.getValueAsync(2)).toBe(2);
+      expect(callbackA).toHaveBeenCalledTimes(1);
+      expect(callbackA).toHaveBeenCalledWith(undefined);
+
+      expect(callbackB).toHaveBeenCalledTimes(1);
+      expect(callbackB).toHaveBeenCalledWith(undefined);
+
+      cache.getValueAsync("sync");
+
+      expect(callbackA).toHaveBeenCalledTimes(3);
+      expect(callbackA).toHaveBeenCalledWith(STATUS_PENDING);
+      expect(callbackA).toHaveBeenCalledWith(STATUS_RESOLVED);
+
+      expect(callbackB).toHaveBeenCalledTimes(3);
+      expect(callbackB).toHaveBeenCalledWith(STATUS_PENDING);
+      expect(callbackB).toHaveBeenCalledWith(STATUS_RESOLVED);
+    });
+
+    it("should not notify after a subscriber unsubscribes", async () => {
+      const unsubscribe = cache.subscribeToStatus(callbackA, "sync");
+
+      expect(callbackA).toHaveBeenCalledTimes(1);
+      expect(callbackA).toHaveBeenCalledWith(undefined);
+
+      unsubscribe();
+
+      cache.getValueAsync("sync");
+
+      expect(callbackA).toHaveBeenCalledTimes(1);
+    });
+
+    it("should track subscribers separately, per key", async () => {
+      cache.subscribeToStatus(callbackA, "sync-1");
+      cache.subscribeToStatus(callbackB, "sync-2");
+
+      callbackA.mockReset();
+      callbackB.mockReset();
+
+      cache.getValueAsync("sync-2");
+
+      expect(callbackA).not.toHaveBeenCalled();
+      expect(callbackB).toHaveBeenCalledTimes(2);
+    });
+
+    it("should track unsubscriptions separately, per key", async () => {
+      const unsubscribeA = cache.subscribeToStatus(callbackA, "sync-1");
+      cache.subscribeToStatus(callbackB, "sync-2");
+
+      callbackA.mockReset();
+      callbackB.mockReset();
+
+      unsubscribeA();
+
+      cache.getValueAsync("sync-1");
+      cache.getValueAsync("sync-2");
+
+      expect(callbackA).not.toHaveBeenCalled();
+      expect(callbackB).toHaveBeenCalledTimes(2);
+    });
+
+    it("should return the correct value for keys that have already been resolved or rejected", async () => {
+      cache.getValueAsync("async");
+      cache.getValueAsync("error");
+
+      await Promise.resolve();
+
+      cache.subscribeToStatus(callbackA, "async");
+      cache.subscribeToStatus(callbackB, "error");
+
+      expect(callbackA).toHaveBeenCalledWith(STATUS_RESOLVED);
+      expect(callbackB).toHaveBeenCalledWith(STATUS_REJECTED);
+    });
   });
 });
-
-function createTestCache() {
-  return createGenericCache<[], [number], number>(
-    "test",
-    0,
-    n => (n % 2 === 0 ? n : Promise.resolve(n)),
-    n => `${n}`
-  );
-}

--- a/packages/replay-next/src/suspense/types.ts
+++ b/packages/replay-next/src/suspense/types.ts
@@ -1,6 +1,6 @@
-export const STATUS_PENDING = 0;
-export const STATUS_RESOLVED = 1;
-export const STATUS_REJECTED = 2;
+export const STATUS_PENDING = "pending";
+export const STATUS_RESOLVED = "resolved";
+export const STATUS_REJECTED = "rejected";
 
 export type StatusPending = typeof STATUS_PENDING;
 export type StatusResolved = typeof STATUS_RESOLVED;

--- a/packages/replay-next/src/utils/suspense.test.ts
+++ b/packages/replay-next/src/utils/suspense.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   __setCircularThenableCheckMaxCount,
   createFetchAsyncFromFetchSuspense,
+  createInfallibleSuspenseCache,
   createWakeable,
   suspendInParallel,
 } from "./suspense";
@@ -283,6 +284,27 @@ describe("Suspense util", () => {
       };
       const callback = createFetchAsyncFromFetchSuspense(compositeCache);
       await expect(callback).rejects.toThrowError("Failed");
+    });
+  });
+
+  describe("createInfallibleSuspenseCache", () => {
+    it("should pass through params and return value when Suspense is successful", () => {
+      const cache = jest.fn().mockImplementation(params => {
+        return params * 2;
+      });
+      const infallibleCache = createInfallibleSuspenseCache(cache);
+
+      expect(infallibleCache(1)).toEqual(2);
+      expect(infallibleCache(123)).toEqual(246);
+    });
+
+    it("it should return undefined when the Suspense cache throws", () => {
+      const cache = jest.fn().mockImplementation(() => {
+        throw Error("Expected error");
+      });
+      const infallibleCache = createInfallibleSuspenseCache(cache);
+
+      expect(infallibleCache()).toEqual(undefined);
     });
   });
 

--- a/packages/replay-next/src/utils/suspense.ts
+++ b/packages/replay-next/src/utils/suspense.ts
@@ -129,6 +129,22 @@ export function createFetchAsyncFromFetchSuspense<TParams extends Array<any>, TV
   };
 }
 
+export function createInfallibleSuspenseCache<TParams extends Array<any>, TValue>(
+  suspenseCache: (...params: TParams) => TValue
+): (...params: TParams) => TValue | undefined {
+  return function createInfallibleSuspenseCache(...params) {
+    try {
+      return suspenseCache(...params);
+    } catch (errorOrThennable) {
+      if (isThennable(errorOrThennable)) {
+        throw errorOrThennable;
+      } else {
+        return undefined;
+      }
+    }
+  };
+}
+
 // Helper function to read from multiple Suspense caches in parallel.
 // This method will re-throw any thrown value, but only after also calling subsequent caches.
 export function suspendInParallel<T extends AnyFunction<any>[]>(


### PR DESCRIPTION
Adds a few new Suspense utils along with a bunch of unit tests (for new and old stuff).

### `createInfallibleSuspenseCache`

This util allows components to ignore Suspense failures, treating the data as optional (and supplying their own fallback values). For example:
```js
// Module level
const infallibleCache = createInfallibleSuspenseCache(cache);

// In a component:
const value = infallibleCache(key) ?? fallbackValue;
```

### `subscribeToStatus`

This API can be used with React's `useSyncExternalStore` to render updates when suspense is in progress. For example:
```js
const getStatus = useCallback(() => getValue(...args), args);

const subscribe = useCallback(
  (callback: SubscribeCallback) =>
    subscribeToEventTypeEntryPointsStatus(callback, ...args),
  args
);

const status = useSyncExternalStore(subscribe, getStatus);

// Render UI based on status: undefined, "pending", "resolved", or "rejected"
```

---

Split off of #8767