### PR TITLE
Defer subject node pauses until needed

### DIFF
--- a/src/ui/hooks/useTestStepActions.ts
+++ b/src/ui/hooks/useTestStepActions.ts
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 
 import { selectLocation } from "devtools/client/debugger/src/actions/sources";
 import { getContext } from "devtools/client/debugger/src/selectors";
@@ -47,33 +47,39 @@ export const useTestStepActions = (testStep: AnnotatedTestStep | null) => {
     return test.relativeStartTime != null && test.duration != null;
   };
 
-  const playFromStep = (test: TestItem) => {
-    if (!testStep || !canPlayback(test)) {
-      return;
-    }
+  const playFromStep = useCallback(
+    (test: TestItem) => {
+      if (!testStep || !canPlayback(test)) {
+        return;
+      }
 
-    dispatch(
-      startPlayback({
-        beginTime: testStep.absoluteStartTime,
-        endTime: test.relativeStartTime + test.duration,
-      })
-    );
-  };
+      dispatch(
+        startPlayback({
+          beginTime: testStep.absoluteStartTime,
+          endTime: test.relativeStartTime + test.duration,
+        })
+      );
+    },
+    [dispatch, testStep]
+  );
 
-  const playToStep = (test: TestItem) => {
-    if (!testStep || !canPlayback(test)) {
-      return;
-    }
-    dispatch(
-      startPlayback({
-        beginTime: test.relativeStartTime || 0,
-        endTime: testStep.annotations.end?.time || testStep.absoluteEndTime,
-        endPoint: testStep.annotations.end?.point,
-      })
-    );
-  };
+  const playToStep = useCallback(
+    (test: TestItem) => {
+      if (!testStep || !canPlayback(test)) {
+        return;
+      }
+      dispatch(
+        startPlayback({
+          beginTime: test.relativeStartTime || 0,
+          endTime: testStep.annotations.end?.time || testStep.absoluteEndTime,
+          endPoint: testStep.annotations.end?.point,
+        })
+      );
+    },
+    [dispatch, testStep]
+  );
 
-  const seekToStepStart = () => {
+  const seekToStepStart = useCallback(() => {
     if (!canJumpToBefore) {
       return;
     }
@@ -84,9 +90,9 @@ export const useTestStepActions = (testStep: AnnotatedTestStep | null) => {
     } else {
       dispatch(seekToTime(testStep.absoluteStartTime));
     }
-  };
+  }, [dispatch, testStep, canJumpToBefore]);
 
-  const seekToStepEnd = () => {
+  const seekToStepEnd = useCallback(() => {
     if (!canJumpToAfter) {
       return;
     }
@@ -97,9 +103,9 @@ export const useTestStepActions = (testStep: AnnotatedTestStep | null) => {
     } else {
       dispatch(seekToTime(testStep.absoluteEndTime - 1));
     }
-  };
+  }, [dispatch, testStep, canJumpToAfter]);
 
-  const showStepSource = async () => {
+  const showStepSource = useCallback(async () => {
     if (!canShowStepSource) {
       return;
     }
@@ -119,19 +125,34 @@ export const useTestStepActions = (testStep: AnnotatedTestStep | null) => {
     }
 
     dispatch(setSourcesUserActionPending(false));
-  };
+  }, [dispatch, testStep, canShowStepSource, client, cx, info.metadata]);
 
-  return {
-    canPlayback,
-    canJumpToAfter,
-    canJumpToBefore,
-    isAtStepEnd: stepEnd,
-    isAtStepStart: stepStart,
-    playFromStep,
-    playToStep,
-    seekToStepEnd,
-    seekToStepStart,
-    showStepSource,
-    canShowStepSource,
-  };
+  return useMemo(
+    () => ({
+      canPlayback,
+      canJumpToAfter,
+      canJumpToBefore,
+      isAtStepEnd: stepEnd,
+      isAtStepStart: stepStart,
+      playFromStep,
+      playToStep,
+      seekToStepEnd,
+      seekToStepStart,
+      showStepSource,
+      canShowStepSource,
+    }),
+    [
+      canPlayback,
+      canJumpToAfter,
+      canJumpToBefore,
+      stepEnd,
+      stepStart,
+      playFromStep,
+      playToStep,
+      seekToStepEnd,
+      seekToStepStart,
+      showStepSource,
+      canShowStepSource,
+    ]
+  );
 };

--- a/src/ui/hooks/useTestStepActions.ts
+++ b/src/ui/hooks/useTestStepActions.ts
@@ -16,6 +16,12 @@ import { getTestStepSourceLocationAsync } from "../suspense/testStepCache";
 import { isStepEnd, isStepStart } from "./useStepState";
 import { useTestInfo } from "./useTestInfo";
 
+const canPlayback = (
+  test: TestItem
+): test is TestItem & { relativeStartTime: number; duration: number } => {
+  return test.relativeStartTime != null && test.duration != null;
+};
+
 export const useTestStepActions = (testStep: AnnotatedTestStep | null) => {
   const dispatch = useAppDispatch();
   const currentTime = useAppSelector(getCurrentTime);
@@ -40,12 +46,6 @@ export const useTestStepActions = (testStep: AnnotatedTestStep | null) => {
   const isChaiAssertion = testStep?.name === "assert" && !testStep.annotations.enqueue;
   const annotation = isChaiAssertion ? testStep.annotations.start : testStep?.annotations.enqueue;
   const canShowStepSource = !!cypressVersion && !sourcesLoading && annotation;
-
-  const canPlayback = (
-    test: TestItem
-  ): test is TestItem & { relativeStartTime: number; duration: number } => {
-    return test.relativeStartTime != null && test.duration != null;
-  };
 
   const playFromStep = useCallback(
     (test: TestItem) => {
@@ -142,7 +142,6 @@ export const useTestStepActions = (testStep: AnnotatedTestStep | null) => {
       canShowStepSource,
     }),
     [
-      canPlayback,
       canJumpToAfter,
       canJumpToBefore,
       stepEnd,


### PR DESCRIPTION
## Issue

We're currently proactively creating pauses and running evaluations for each test step to retrieve the subject DOM node IDs so we can highlight the nodes on hover and show the step details as soon as possible. This is causing some consternation on the backend for tests with many steps.

## Resolution

As a first step, this defers creating that pause until it's required by either clicking or hovering a step.