### PR TITLE
Removed required length param from createGenericCache

### DIFF
--- a/packages/replay-next/components/sources/SourceSearchContext.tsx
+++ b/packages/replay-next/components/sources/SourceSearchContext.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, createContext, useContext, useEffect, useMemo } from "react";
 
 import { SourcesContext } from "replay-next/src/contexts/SourcesContext";
-import { getStreamingSourceContentsHelper } from "replay-next/src/suspense/SourcesCache";
+import { getStreamingSourceContentsAsync } from "replay-next/src/suspense/SourcesCache";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
 import useSourceSearch, { Actions, SetScope, State } from "./hooks/useSourceSearch";
@@ -35,7 +35,7 @@ export function SourceSearchContextRoot({ children }: { children: ReactNode }) {
   useEffect(() => {
     async function updateSourceContents(focusedSourceId: string | null, setScope: SetScope) {
       if (focusedSourceId) {
-        const { resolver } = await getStreamingSourceContentsHelper(client, focusedSourceId);
+        const { resolver } = await getStreamingSourceContentsAsync(client, focusedSourceId);
         const { contents: code } = await resolver;
         setScope(focusedSourceId, code || "");
       } else {

--- a/packages/replay-next/playwright/tests/console.ts
+++ b/packages/replay-next/playwright/tests/console.ts
@@ -15,14 +15,7 @@ import {
   toggleSideMenu,
   verifyTypeAheadContainsSuggestions,
 } from "./utils/console";
-import {
-  delay,
-  getCommandKey,
-  getElementCount,
-  getTestUrl,
-  stopHovering,
-  takeScreenshot,
-} from "./utils/general";
+import { delay, getElementCount, getTestUrl, stopHovering, takeScreenshot } from "./utils/general";
 import testSetup from "./utils/testSetup";
 
 testSetup("4ccc9f9f-f0d3-4418-ac21-1b316e462a44");

--- a/packages/replay-next/playwright/tests/source-search.ts
+++ b/packages/replay-next/playwright/tests/source-search.ts
@@ -1,7 +1,7 @@
 import { test } from "@playwright/test";
 
 import { getTestUrl, takeScreenshot } from "./utils/general";
-import { addLogPoint, getSourceLineLocator, verifyCurrentSearchResult } from "./utils/source";
+import { verifyCurrentSearchResult } from "./utils/source";
 import {
   clickSearchResultRow,
   getSourceSearchResultsLocator,

--- a/packages/replay-next/src/hooks/useIndexedDB.ts
+++ b/packages/replay-next/src/hooks/useIndexedDB.ts
@@ -47,7 +47,6 @@ export const {
   getValueIfCached: getIDBInstanceIfCached,
 } = createGenericCache<[], [dbOptions: IDBOptions], IDBPDatabase>(
   "useIndexedDB: getIDBInstance",
-  0,
   async dbOptions => {
     const { databaseName, databaseVersion, storeNames } = dbOptions;
     // Create a single shared IDB instance for this DB definition
@@ -74,7 +73,6 @@ export const {
   addValue: setLatestIDBValue,
 } = createGenericCache<[], [dbOptions: IDBOptions, storeName: string, recordName: string], any>(
   "MappedLocationCache: getLatestIDBValue",
-  0,
   async (dbOptions, storeName, recordName) => {
     // Only look up this initial stored value once
     const dbInstance = await getIDBInstanceAsync(dbOptions);

--- a/packages/replay-next/src/suspense/CommentsCache.ts
+++ b/packages/replay-next/src/suspense/CommentsCache.ts
@@ -16,7 +16,6 @@ export const {
   Comment[]
 >(
   "CommentsCache: getCommentsGraphQL",
-  2,
   async (
     graphQLClient: GraphQLClientInterface,
     accessToken: string | null,

--- a/packages/replay-next/src/suspense/EventsCache.ts
+++ b/packages/replay-next/src/suspense/EventsCache.ts
@@ -53,7 +53,6 @@ export const {
   EventCategory[]
 >(
   "getEventCategoryCounts",
-  1,
   async (client, range) => {
     const allEvents = await client.getEventCountForTypes(
       Object.values(STANDARD_EVENT_CATEGORIES)

--- a/packages/replay-next/src/suspense/ExecutionPointsCache.ts
+++ b/packages/replay-next/src/suspense/ExecutionPointsCache.ts
@@ -397,7 +397,6 @@ export const {
   getValueIfCached: getPointsBoundingTimeIfCached,
 } = createGenericCache<[replayClient: ReplayClientInterface], [time: number], PointsBoundingTime>(
   "PointsCache: getPointsBoundingTime",
-  1,
   async (client, time) => client.getPointsBoundingTime(time),
   time => `${time}`
 );

--- a/packages/replay-next/src/suspense/FrameCache.ts
+++ b/packages/replay-next/src/suspense/FrameCache.ts
@@ -17,7 +17,6 @@ export const {
   Frame[] | undefined
 >(
   "FrameCache: getFrames",
-  1,
   async (client, pauseId) => {
     const framesResult = await client.getAllFrames(pauseId);
     await client.waitForLoadedSources();

--- a/packages/replay-next/src/suspense/FrameStepsCache.ts
+++ b/packages/replay-next/src/suspense/FrameStepsCache.ts
@@ -17,7 +17,6 @@ export const {
   PointDescription[] | undefined
 >(
   "FrameStepsCache: getFrameSteps",
-  1,
   async (client, pauseId, frameId) => {
     try {
       const frameSteps = await client.getFrameSteps(pauseId, frameId);

--- a/packages/replay-next/src/suspense/MappedLocationCache.ts
+++ b/packages/replay-next/src/suspense/MappedLocationCache.ts
@@ -17,7 +17,6 @@ export const {
   ProtocolMappedLocation
 >(
   "MappedLocationCache: getMappedLocation",
-  1,
   (client, location) => client.getMappedLocation(location),
   location => `${location.sourceId}:${location.line}:${location.column}`
 );

--- a/packages/replay-next/src/suspense/PauseCache.ts
+++ b/packages/replay-next/src/suspense/PauseCache.ts
@@ -27,7 +27,6 @@ const {
   PauseId
 >(
   "PauseCache: getPauseIdForExecutionPoint",
-  1,
   async (client, executionPoint) => {
     const createPauseResult = await client.createPause(executionPoint);
     await client.waitForLoadedSources();
@@ -80,7 +79,6 @@ export const {
   Omit<Result, "data">
 >(
   "PauseCache: evaluate",
-  1,
   async (client, pauseId, frameId, expression) => {
     const result = await client.evaluateExpression(pauseId, expression, frameId);
     await client.waitForLoadedSources();

--- a/packages/replay-next/src/suspense/PauseCache.ts
+++ b/packages/replay-next/src/suspense/PauseCache.ts
@@ -79,13 +79,13 @@ export const {
   Omit<Result, "data">
 >(
   "PauseCache: evaluate",
-  async (client, pauseId, frameId, expression) => {
+  async (client, pauseId, frameId, expression, uid) => {
     const result = await client.evaluateExpression(pauseId, expression, frameId);
     await client.waitForLoadedSources();
     cachePauseData(client, pauseId, result.data);
     return { exception: result.exception, failed: result.failed, returned: result.returned };
   },
-  (pauseId, frameId, expression, uid = "") => `${pauseId}:${frameId}:${expression}:${uid}`
+  (pauseId, frameId, expression, uid) => `${pauseId}:${frameId}:${expression}:${uid || ""}`
 );
 
 export function cachePauseData(

--- a/packages/replay-next/src/suspense/PointsCache.ts
+++ b/packages/replay-next/src/suspense/PointsCache.ts
@@ -17,7 +17,6 @@ export const {
   Point[]
 >(
   "PointsCache: getPointsGraphQL",
-  2,
   async (
     graphQLClient: GraphQLClientInterface,
     accessToken: string | null,

--- a/packages/replay-next/src/suspense/ScopeCache.ts
+++ b/packages/replay-next/src/suspense/ScopeCache.ts
@@ -24,7 +24,6 @@ export const {
   Scope
 >(
   "ScopeCache: getScope",
-  1,
   async (client, pauseId, scopeId) => {
     const result = await client.getScope(pauseId, scopeId);
     await client.waitForLoadedSources();
@@ -46,7 +45,6 @@ export const {
   FrameScopes
 >(
   "ScopeCache: getFrameScopes",
-  1,
   async (client, pauseId, frameId) => {
     const frame = (await getFramesAsync(client, pauseId))?.find(
       frame => frame.frameId === frameId

--- a/packages/replay-next/src/suspense/ScopeMapCache.ts
+++ b/packages/replay-next/src/suspense/ScopeMapCache.ts
@@ -14,7 +14,6 @@ export const {
   VariableMapping[] | undefined
 >(
   "ScopeMapCache: getScopeMap",
-  1,
   (client, location) => client.getScopeMap(location),
   location => `${location.sourceId}:${location.line}:${location.column}`
 );

--- a/packages/replay-next/src/suspense/SearchCache.ts
+++ b/packages/replay-next/src/suspense/SearchCache.ts
@@ -57,7 +57,6 @@ export const {
   StreamingSourceSearchResults
 >(
   "SearchCache: searchSources",
-  1,
   async (
     client: ReplayClientInterface,
     query: string,

--- a/packages/replay-next/src/suspense/SearchCache.ts
+++ b/packages/replay-next/src/suspense/SearchCache.ts
@@ -61,8 +61,12 @@ export const {
     client: ReplayClientInterface,
     query: string,
     includeNodeModules: boolean,
-    limit: number = MAX_SEARCH_RESULTS_TO_DISPLAY
+    limit?: number
   ) => {
+    if (limit === undefined) {
+      limit = MAX_SEARCH_RESULTS_TO_DISPLAY;
+    }
+
     const subscribers: Set<Subscriber> = new Set();
 
     const orderedResults: SourceSearchResult[] = [];

--- a/packages/replay-next/src/suspense/SourcesCache.ts
+++ b/packages/replay-next/src/suspense/SourcesCache.ts
@@ -294,7 +294,6 @@ export const {
   BreakpointPositionsResult
 >(
   "SourcesCache: getBreakpointPositions",
-  1,
   async (client, sourceId) => {
     const breakablePositions = await client.getBreakpointPositions(sourceId, null);
 
@@ -644,7 +643,6 @@ export const {
   StreamingSourceContents | undefined
 >(
   "sourceContentsCache",
-  1,
   async (replayClient, sourceId) => {
     const res = await getStreamingSourceContentsHelper(replayClient, sourceId);
     if (res) {

--- a/packages/replay-next/src/suspense/SyntaxParsingCache.ts
+++ b/packages/replay-next/src/suspense/SyntaxParsingCache.ts
@@ -51,7 +51,7 @@ export const { getValueSuspense: parse } = createGenericCache<
   [],
   [code: string, fileName: string],
   Array<ParsedToken[]> | null
->("SyntaxParsingCache: parse", highlighter, identity);
+>("SyntaxParsingCache: parse", highlighter, (code, fileName) => code);
 
 export const {
   getValueAsync: parseStreamingAsync,
@@ -59,9 +59,13 @@ export const {
   getValueIfCached: getParsedValueIfCached,
 } = createGenericCache<
   [],
-  [source: StreamingSourceContents, maxTime?: number],
+  [source: StreamingSourceContents, maxCharacters?: number, maxTime?: number],
   StreamingParser | null
->("SyntaxParsingCache: parseStreaming", streamingSourceContentsToStreamingParser, identity);
+>(
+  "SyntaxParsingCache: parseStreaming",
+  streamingSourceContentsToStreamingParser,
+  (source, maxCharacters, maxTime) => source.contents || ""
+);
 
 async function streamingSourceContentsToStreamingParser(
   source: StreamingSourceContents,
@@ -288,10 +292,6 @@ function highlighter(code: string, fileName: string): Array<ParsedToken[]> | nul
   parser.parseChunk(code, true);
 
   return parser.parsedTokensByLine;
-}
-
-function identity(any: any) {
-  return any;
 }
 
 function contentTypeToLanguage(contentType: ContentType): LRLanguage {

--- a/packages/replay-next/src/suspense/SyntaxParsingCache.ts
+++ b/packages/replay-next/src/suspense/SyntaxParsingCache.ts
@@ -51,7 +51,11 @@ export const { getValueSuspense: parse } = createGenericCache<
   [],
   [code: string, fileName: string],
   Array<ParsedToken[]> | null
->("SyntaxParsingCache: parse", highlighter, (code, fileName) => code);
+>(
+  "SyntaxParsingCache: parse",
+  (code, fileName) => highlighter(code, fileName),
+  (code, fileName) => code
+);
 
 export const {
   getValueAsync: parseStreamingAsync,
@@ -63,7 +67,8 @@ export const {
   StreamingParser | null
 >(
   "SyntaxParsingCache: parseStreaming",
-  streamingSourceContentsToStreamingParser,
+  (source, maxCharacters, maxTime) =>
+    streamingSourceContentsToStreamingParser(source, maxCharacters, maxTime),
   (source, maxCharacters, maxTime) => source.contents || ""
 );
 

--- a/packages/replay-next/src/suspense/SyntaxParsingCache.ts
+++ b/packages/replay-next/src/suspense/SyntaxParsingCache.ts
@@ -51,7 +51,7 @@ export const { getValueSuspense: parse } = createGenericCache<
   [],
   [code: string, fileName: string],
   Array<ParsedToken[]> | null
->("SyntaxParsingCache: parse", 0, highlighter, identity);
+>("SyntaxParsingCache: parse", highlighter, identity);
 
 export const {
   getValueAsync: parseStreamingAsync,
@@ -61,7 +61,7 @@ export const {
   [],
   [source: StreamingSourceContents, maxTime?: number],
   StreamingParser | null
->("SyntaxParsingCache: parseStreaming", 0, streamingSourceContentsToStreamingParser, identity);
+>("SyntaxParsingCache: parseStreaming", streamingSourceContentsToStreamingParser, identity);
 
 async function streamingSourceContentsToStreamingParser(
   source: StreamingSourceContents,

--- a/packages/replay-next/src/suspense/createGenericCache.test.ts
+++ b/packages/replay-next/src/suspense/createGenericCache.test.ts
@@ -28,7 +28,7 @@ describe("createGenericCache", () => {
     getCacheKey = jest.fn();
     getCacheKey.mockImplementation(key => key.toString());
 
-    cache = createGenericCache<[], [string], string>("test", 0, fetchValue, getCacheKey);
+    cache = createGenericCache<[], [string], string>("test", fetchValue, getCacheKey);
   });
 
   describe("addValue", () => {

--- a/packages/replay-next/src/suspense/createGenericCache.ts
+++ b/packages/replay-next/src/suspense/createGenericCache.ts
@@ -50,6 +50,11 @@ export function createGenericCache<
 
   const extraParamsLength = fetchValue.length - getCacheKey.length;
 
+  if (process.env.NODE_ENV === "development") {
+    verifyNoDefaultParametersInDev(fetchValue, debugLabel);
+    verifyNoDefaultParametersInDev(getCacheKey, debugLabel);
+  }
+
   function getOrCreateRecord(...args: [...TExtraParams, ...TParams]): Record<TValue> {
     const cacheKey = getCacheKey(...(args.slice(extraParamsLength) as TParams));
 
@@ -225,4 +230,15 @@ export function createUseGetValue<TParams extends Array<any>, TValue>(
 
     return { loading: !cachedValue && !caught, value: cachedValue?.value, error: caught?.error };
   };
+}
+
+function verifyNoDefaultParametersInDev(func: Function, debugLabel: string) {
+  const source = func.toString();
+  const index = source.indexOf(")");
+  const signature = source.slice(1, index);
+  if (signature.includes("=")) {
+    throw new Error(
+      `Default parameters disallowed for generic cache methods (${debugLabel})\n\n${signature}`
+    );
+  }
 }

--- a/packages/replay-next/src/suspense/createGenericCache.ts
+++ b/packages/replay-next/src/suspense/createGenericCache.ts
@@ -42,12 +42,13 @@ export function createGenericCache<
   TValue
 >(
   debugLabel: string,
-  extraParamsLength: TExtraParams["length"],
   fetchValue: (...args: [...TExtraParams, ...TParams]) => Thennable<TValue> | TValue,
   getCacheKey: (...args: TParams) => string
 ): GenericCache<TExtraParams, TParams, TValue> {
   const recordMap = new Map<string, Record<TValue>>();
   const subscriberMap = new Map<string, Set<SubscribeCallback>>();
+
+  const extraParamsLength = fetchValue.length - getCacheKey.length;
 
   function getOrCreateRecord(...args: [...TExtraParams, ...TParams]): Record<TValue> {
     const cacheKey = getCacheKey(...(args.slice(extraParamsLength) as TParams));

--- a/src/ui/actions/event-listeners.ts
+++ b/src/ui/actions/event-listeners.ts
@@ -276,7 +276,6 @@ export const { getValueAsync: getEventListenerLocationAsync } = createGenericCac
   Location | undefined
 >(
   "eventListenerLocationCache",
-  3,
   async (ThreadFront, replayClient, getState, pauseId, replayEventType) => {
     const stackFrames = await getFramesAsync(replayClient, pauseId);
     if (!stackFrames) {

--- a/src/ui/components/Events/Event.tsx
+++ b/src/ui/components/Events/Event.tsx
@@ -48,7 +48,6 @@ const { getValueAsync: getNextInteractionEventAsync } = createGenericCache<
   EventLog | undefined
 >(
   "nextInteractionEventCache",
-  2,
   async (replayClient, ThreadFront, point, replayEventType, endTime) => {
     const pointNearEndTime = await replayClient.getPointNearTime(endTime);
 

--- a/src/ui/components/ProtocolViewer.tsx
+++ b/src/ui/components/ProtocolViewer.tsx
@@ -499,7 +499,6 @@ const { getValueSuspense: getRecordedProtocolMessagesSuspense } = createGenericC
   AllProtocolMessages
 >(
   "recordedPotocolMessagesCache",
-  1,
   async (replayClient, sourceDetails) => {
     const sessionSource = sourceDetails.find(source => source.url?.includes("ui/actions/session"));
 

--- a/src/ui/components/SecondaryToolbox/redux-devtools/injectReduxDevtoolsProcessing.ts
+++ b/src/ui/components/SecondaryToolbox/redux-devtools/injectReduxDevtoolsProcessing.ts
@@ -131,7 +131,6 @@ export const { getValueAsync: getActionStateValuesAsync } = createGenericCache<
   ReduxActionStateValues | undefined
 >(
   "reduxDevtools: getActionStateValues",
-  1,
   async (replayClient, point, time) => {
     const pauseId = await getPauseIdAsync(replayClient, point, time);
     if (!pauseId) {
@@ -173,7 +172,6 @@ export const { getValueAsync: getDiffAsync } = createGenericCache<
   Delta | undefined
 >(
   "reduxDevtools: getDiff",
-  1,
   async (replayClient, point, time) => {
     const pauseId = await getPauseIdAsync(replayClient, point, time);
     if (!pauseId) {

--- a/src/ui/suspense/nodeCaches.ts
+++ b/src/ui/suspense/nodeCaches.ts
@@ -52,7 +52,6 @@ export const {
   ProtocolObject[]
 >(
   "nodeCaches: getNodeData",
-  3,
   async (client, replayClient, sessionId, pauseId, options) => {
     let nodeIds: string[] = [];
     let pauseData = null as PauseData | null;
@@ -174,7 +173,6 @@ export const {
   EventListener[] | undefined
 >(
   "nodeCaches: getNodeEventListeners",
-  3,
   async (client, replayClient, sessionId, pauseId, nodeId) => {
     const { listeners, data } = await client.DOM.getEventListeners(
       {
@@ -200,7 +198,6 @@ export const {
   NodeBounds[]
 >(
   "nodeCaches: getBoundingRects",
-  2,
   async (client, sessionId, pauseId) => {
     const { elements } = await client.DOM.getAllBoundingClientRects({}, sessionId, pauseId);
     return elements;
@@ -218,7 +215,6 @@ export const {
   BoxModel
 >(
   "nodeCaches: getBoxModel",
-  2,
   async (client, sessionId, pauseId, nodeId) => {
     const { model: nodeBoxModel } = await client.DOM.getBoxModel(
       {

--- a/src/ui/suspense/sourceCaches.ts
+++ b/src/ui/suspense/sourceCaches.ts
@@ -36,7 +36,6 @@ export const {
   SymbolDeclarations | undefined
 >(
   "sourceSymbolsCache",
-  1,
   async (replayClient, sourceId, sourceDetails) => {
     const { parser } = await import("devtools/client/debugger/src/utils/bootstrap");
     const sourceContents = await getSourceContentsAsync(replayClient, sourceId);
@@ -64,7 +63,6 @@ export const {
 export const { getValueAsync: getSourceLinesAsync, getValueSuspense: getSourceLinesSuspense } =
   createGenericCache<[replayClient: ReplayClientInterface], [sourceId: string], string[]>(
     "sourceLinesCache",
-    1,
     async (replayClient, sourceId) => {
       const sourceContents = await getSourceContentsAsync(replayClient, sourceId);
       if (!sourceContents) {

--- a/src/ui/suspense/styleCaches.ts
+++ b/src/ui/suspense/styleCaches.ts
@@ -22,7 +22,6 @@ export const {
   WiredAppliedRule[]
 >(
   "styleCaches: getAppliedRules",
-  3,
   async (client, replayClient, sessionId, pauseId, nodeId) => {
     const { rules, data } = await client.CSS.getAppliedRules({ node: nodeId }, sessionId, pauseId);
 
@@ -81,7 +80,6 @@ export const {
   Map<string, string> | undefined
 >(
   "styleCaches: getComputedStyle",
-  2,
   async (client, sessionId, pauseId, nodeId) => {
     try {
       const { computedStyle } = await client.CSS.getComputedStyle(
@@ -115,7 +113,6 @@ export const {
   DOMRect | undefined
 >(
   "styleCaches: getBoundingRect",
-  2,
   async (client, sessionId, pauseId, nodeId) => {
     try {
       const { rect } = await client.DOM.getBoundingClientRect(


### PR DESCRIPTION
Makes use of [`Function.prototype.length`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/length) to programmatically determine the number of "extra args" passed to the _fetch_ function vs the _key_ function. The previous `extraParamsLength` param can be calculated and cached like:
```js
const extraParamsLength = fetchValue.length - getCacheKey.length;
```

This is a much smaller/nicer approach than #8773.