### PR TITLE
Initialize focus region from URL parameters (FE-1268)

### DIFF
--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -29,7 +29,7 @@ import {
 import { DownloadCancelledError } from "protocol/screenshot-cache";
 import { ThreadFront } from "protocol/thread";
 import { PauseEventArgs } from "protocol/thread/thread";
-import { Deferred, defer, waitForTime } from "protocol/utils";
+import { waitForTime } from "protocol/utils";
 import { getPointsBoundingTimeAsync } from "replay-next/src/suspense/ExecutionPointsCache";
 import { ReplayClientInterface } from "shared/client/types";
 import { getFirstComment } from "ui/hooks/comments/comments";
@@ -123,11 +123,6 @@ export function jumpToInitialPausePoint(): UIThunkAction {
     const initialPausePoint = await getInitialPausePoint(ThreadFront.recordingId!);
 
     if (initialPausePoint) {
-      const focusRegion =
-        "focusRegion" in initialPausePoint ? initialPausePoint.focusRegion : undefined;
-      if (focusRegion) {
-        dispatch(newFocusRegion(focusRegion));
-      }
       point = initialPausePoint.point;
       time = initialPausePoint.time;
     }

--- a/src/ui/components/FocusContextReduxAdapter.tsx
+++ b/src/ui/components/FocusContextReduxAdapter.tsx
@@ -26,7 +26,7 @@ export default function FocusContextReduxAdapter({ children }: PropsWithChildren
   const { endpoint } = useContext(SessionContext);
 
   const [isPending, startTransition] = useTransition();
-  const [deferredFocusRegion, setDeferredFocusRegion] = useState<FocusRegion | null>(null);
+  const [deferredFocusRegion, setDeferredFocusRegion] = useState<FocusRegion | null>(focusRegion);
 
   useEffect(() => {
     startTransition(() => {

--- a/src/ui/reducers/timeline.ts
+++ b/src/ui/reducers/timeline.ts
@@ -2,17 +2,17 @@ import { PayloadAction, createSlice } from "@reduxjs/toolkit";
 import { TimeRange, TimeStampedPoint } from "@replayio/protocol";
 import sortBy from "lodash/sortBy";
 
-import { UIThunkAction } from "ui/actions";
 import { MAX_FOCUS_REGION_DURATION } from "ui/actions/timeline";
 import { UIState } from "ui/state";
 import { FocusRegion, HoveredItem, TimelineState } from "ui/state/timeline";
+import { getPausePointParams } from "ui/utils/environment";
 import { mergeSortedPointLists } from "ui/utils/timeline";
 
 function initialTimelineState(): TimelineState {
   return {
     allPaintsReceived: false,
     currentTime: 0,
-    focusRegion: null,
+    focusRegion: getPausePointParams()?.focusRegion || null,
     focusRegionBackup: null,
     displayedFocusRegion: null,
     hoverTime: null,


### PR DESCRIPTION
We used to initialize the focus region to `null` and then set it to the focus region found in the URL parameters during the initialization sequence. As a result, logpoints that were saved from a previous session would kick off an analysis for the recording's entire range (because the focus region was still set to `null`). That analysis would then wait for the recording's entire range to be loaded, which never happens unless the user explicitly resets the focus region. The blocked analysis would then freeze the console.
