### PR TITLE
[testsuites] Fix Cypress icon in dark theme

### DIFF
--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -34,7 +34,7 @@ function CypressIcon() {
       <path
         d="M128 2C197.645 2 254 58.3555 254 128C254 197.645 197.645 254 128 254C58.3555 254 2 197.645 2 128C2 58.3555 58.3555 2 128 2Z"
         fill="currentColor"
-        stroke="white"
+        stroke="transparent"
         strokeWidth="4"
       />
       <path


### PR DESCRIPTION
![Cypress icon improvement](https://user-images.githubusercontent.com/9154902/220214016-74b4cf0f-71b3-4368-b579-33502b685bbc.png)
