### PR TITLE
Wait for the secondary toolbox in node e2e tests (FE-1264)

### DIFF
--- a/packages/e2e-tests/helpers/index.ts
+++ b/packages/e2e-tests/helpers/index.ts
@@ -47,7 +47,9 @@ export async function startTest(page: Page, example: string) {
   await page.goto(url);
 
   // Wait for the recording basic information to load such that the primary tabs are visible.
-  if (!example.startsWith("node")) {
+  if (example.startsWith("node")) {
+    await page.locator('[data-panel-id="Panel-SecondaryToolbox"]').waitFor();
+  } else {
     // Node recordings don't have the "Viewer/DevTools" toggle
     await page.locator('[data-test-id="ViewToggle-Viewer"]').waitFor();
     await page.locator('[data-test-id="ViewToggle-DevTools"]').waitFor();


### PR DESCRIPTION
In e2e tests we wait for the Viewer/Devtools toggle to appear before starting the test - except if the example recording is a node recording (and hence the toggle isn't shown), in that case we didn't wait at all.
Now we're waiting for the secondary toolbox in that case.