### PR TITLE
Add bigger click target for code comments

### DIFF
--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -764,7 +764,7 @@
 
   --comment-card-preview-background-color-hover: #e6e6e6;
   --comment-card-preview-background-color: #f2f3f2;
-  --comment-card-source-preview-background-color-hover: #E3ECF9;
+  --comment-card-source-preview-background-color-hover: #e3ecf9;
   --comment-card-source-preview-background-color: var(--background-color-current-execution-point);
   --comment-reply-unpublished-background-color: var(--point-panel-background-color);
   --comment-reply-unpublished-textfield-background-color: #fff;

--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -258,8 +258,10 @@
   --context-menu-bgcolor-divider: var(--background-color-contrast-3);
   --context-menu-bgcolor-hover: var(--theme-base-95);
 
-  --comment-card-source-preview-background-color: #081221;
-  --comment-card-source-preview-background-color-hover: #000;
+  --comment-card-preview-background-color-hover: #2d3c4f;
+  --comment-card-preview-background-color: #253446;
+  --comment-card-source-preview-background-color: var(--background-color-current-execution-point);
+  --comment-card-source-preview-background-color-hover: #364052;
   --comment-reply-unpublished-background-color: var(--point-panel-background-color);
   --comment-reply-unpublished-textfield-background-color: #000;
   --comment-reply-unpublished-textfield-color: #fff;
@@ -760,8 +762,10 @@
   --context-menu-bgcolor-hover: var(--theme-base-95);
   --context-menu-bgcolor: #f8f8f9;
 
-  --comment-card-source-preview-background-color-hover: #e6e6e6;
-  --comment-card-source-preview-background-color: #f2f3f2;
+  --comment-card-preview-background-color-hover: #e6e6e6;
+  --comment-card-preview-background-color: #f2f3f2;
+  --comment-card-source-preview-background-color-hover: #E3ECF9;
+  --comment-card-source-preview-background-color: var(--background-color-current-execution-point);
   --comment-reply-unpublished-background-color: var(--point-panel-background-color);
   --comment-reply-unpublished-textfield-background-color: #fff;
   --comment-reply-unpublished-textfield-color: #000;

--- a/src/ui/components/Comments/CommentCard.tsx
+++ b/src/ui/components/Comments/CommentCard.tsx
@@ -1,32 +1,55 @@
 import classNames from "classnames";
 import { MouseEvent } from "react";
-
+import { selectLocation } from "devtools/client/debugger/src/actions/sources";
+import { trackEvent } from "ui/utils/telemetry";
 import { getExecutionPoint } from "devtools/client/debugger/src/selectors";
 import { seekToComment } from "ui/actions/comments";
 import { getViewMode } from "ui/reducers/layout";
+
+import SourceCodePreview from "./TranscriptComments/SourceCodePreview";
+import { isSourceCodeCommentTypeData } from "replay-next/components/sources/utils/comments";
 import { getCurrentTime } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { Comment } from "ui/state/comments";
 import { isCommentContentEmpty } from "ui/utils/comments";
-
+import { getThreadContext } from "devtools/client/debugger/src/selectors";
 import CommentPreview from "./CommentPreview";
 import CommentReplyButton from "./CommentReplyButton";
 import EditableRemark from "./EditableRemark";
 import ReplyCard from "./ReplyCard";
 import styles from "./CommentCard.module.css";
-
+import { setViewMode } from "ui/actions/layout";
 export default function CommentCard({ comment }: { comment: Comment }) {
   const currentTime = useAppSelector(getCurrentTime);
   const executionPoint = useAppSelector(getExecutionPoint);
   const viewMode = useAppSelector(getViewMode);
   const isPaused = currentTime === comment.time && executionPoint === comment.point;
 
+  const context = useAppSelector(getThreadContext);
   const dispatch = useAppDispatch();
 
   const onClick = (event: MouseEvent) => {
     event.stopPropagation();
     const openSource = viewMode === "dev";
     dispatch(seekToComment(comment, comment.sourceLocation, openSource));
+    
+    
+    const { type, typeData } = comment;
+    if (openSource && isSourceCodeCommentTypeData(type, typeData)) {
+    
+    dispatch(setViewMode("dev"));
+    trackEvent("comments.select_location");      
+      
+    dispatch(
+      selectLocation(context, {
+        column: typeData.columnIndex,
+        line: typeData.lineNumber,
+        sourceId: typeData.sourceId,
+        sourceUrl: typeData.sourceUrl || undefined,
+      })
+    );    
+  }
+  
   };
 
   const onPreviewClick = (event: MouseEvent) => {

--- a/src/ui/components/Comments/CommentCard.tsx
+++ b/src/ui/components/Comments/CommentCard.tsx
@@ -1,24 +1,26 @@
 import classNames from "classnames";
 import { MouseEvent } from "react";
-import { selectLocation } from "devtools/client/debugger/src/actions/sources";
-import { trackEvent } from "ui/utils/telemetry";
-import { getExecutionPoint } from "devtools/client/debugger/src/selectors";
-import { seekToComment } from "ui/actions/comments";
-import { getViewMode } from "ui/reducers/layout";
 
-import SourceCodePreview from "./TranscriptComments/SourceCodePreview";
+import { selectLocation } from "devtools/client/debugger/src/actions/sources";
+import { getExecutionPoint } from "devtools/client/debugger/src/selectors";
+import { getThreadContext } from "devtools/client/debugger/src/selectors";
 import { isSourceCodeCommentTypeData } from "replay-next/components/sources/utils/comments";
+import { seekToComment } from "ui/actions/comments";
+import { setViewMode } from "ui/actions/layout";
+import { getViewMode } from "ui/reducers/layout";
 import { getCurrentTime } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { Comment } from "ui/state/comments";
 import { isCommentContentEmpty } from "ui/utils/comments";
-import { getThreadContext } from "devtools/client/debugger/src/selectors";
+import { trackEvent } from "ui/utils/telemetry";
+
 import CommentPreview from "./CommentPreview";
 import CommentReplyButton from "./CommentReplyButton";
 import EditableRemark from "./EditableRemark";
 import ReplyCard from "./ReplyCard";
+import SourceCodePreview from "./TranscriptComments/SourceCodePreview";
 import styles from "./CommentCard.module.css";
-import { setViewMode } from "ui/actions/layout";
+
 export default function CommentCard({ comment }: { comment: Comment }) {
   const currentTime = useAppSelector(getCurrentTime);
   const executionPoint = useAppSelector(getExecutionPoint);
@@ -32,24 +34,21 @@ export default function CommentCard({ comment }: { comment: Comment }) {
     event.stopPropagation();
     const openSource = viewMode === "dev";
     dispatch(seekToComment(comment, comment.sourceLocation, openSource));
-    
-    
+
     const { type, typeData } = comment;
     if (openSource && isSourceCodeCommentTypeData(type, typeData)) {
-    
-    dispatch(setViewMode("dev"));
-    trackEvent("comments.select_location");      
-      
-    dispatch(
-      selectLocation(context, {
-        column: typeData.columnIndex,
-        line: typeData.lineNumber,
-        sourceId: typeData.sourceId,
-        sourceUrl: typeData.sourceUrl || undefined,
-      })
-    );    
-  }
-  
+      dispatch(setViewMode("dev"));
+      trackEvent("comments.select_location");
+
+      dispatch(
+        selectLocation(context, {
+          column: typeData.columnIndex,
+          line: typeData.lineNumber,
+          sourceId: typeData.sourceId,
+          sourceUrl: typeData.sourceUrl || undefined,
+        })
+      );
+    }
   };
 
   const onPreviewClick = (event: MouseEvent) => {

--- a/src/ui/components/Comments/CommentReplyButton.tsx
+++ b/src/ui/components/Comments/CommentReplyButton.tsx
@@ -24,7 +24,7 @@ export default function CommentReplyButton({ comment }: { comment: Comment }) {
     return null;
   }
 
-  const addReply: MouseEventHandler = async (event) => {
+  const addReply: MouseEventHandler = async event => {
     event.stopPropagation();
     setIsPending(true);
 

--- a/src/ui/components/Comments/CommentReplyButton.tsx
+++ b/src/ui/components/Comments/CommentReplyButton.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { MouseEventHandler, useState } from "react";
 
 import { setModal } from "ui/actions/app";
 import useAddCommentReply from "ui/hooks/comments/useAddCommentReply";
@@ -24,7 +24,8 @@ export default function CommentReplyButton({ comment }: { comment: Comment }) {
     return null;
   }
 
-  const addReply = async () => {
+  const addReply: MouseEventHandler = async (event) => {
+    event.stopPropagation();
     setIsPending(true);
 
     // By default, a Reply is a new unpublished comment.

--- a/src/ui/components/Comments/EditableRemark.tsx
+++ b/src/ui/components/Comments/EditableRemark.tsx
@@ -1,5 +1,5 @@
 import { SerializedEditorState } from "lexical";
-import { useState } from "react";
+import { MouseEventHandler, useState } from "react";
 
 import CommentEditor from "replay-next/components/lexical/CommentEditor";
 import useCommentContextMenu from "ui/components/Comments/useCommentContextMenu";
@@ -92,6 +92,11 @@ export default function EditableRemark({
     classNames.push(styles.Editing);
   }
 
+  const onContextMenuClick: MouseEventHandler = (event) => {
+  event.stopPropagation();
+  onContextMenu(event);
+  }
+  
   const { contextMenu, onContextMenu } = useCommentContextMenu({
     deleteRemark: deleteRemark,
     editRemark: startEditing,
@@ -109,7 +114,7 @@ export default function EditableRemark({
         </div>
         <div className={styles.Time}>{formatRelativeTime(new Date(remark.createdAt))}</div>
 
-        <MaterialIcon className={styles.Icon} disabled={isPending} outlined onClick={onContextMenu}>
+        <MaterialIcon className={styles.Icon} disabled={isPending} outlined onClick={onContextMenuClick}>
           more_vert
         </MaterialIcon>
       </div>

--- a/src/ui/components/Comments/EditableRemark.tsx
+++ b/src/ui/components/Comments/EditableRemark.tsx
@@ -92,11 +92,11 @@ export default function EditableRemark({
     classNames.push(styles.Editing);
   }
 
-  const onContextMenuClick: MouseEventHandler = (event) => {
-  event.stopPropagation();
-  onContextMenu(event);
-  }
-  
+  const onContextMenuClick: MouseEventHandler = event => {
+    event.stopPropagation();
+    onContextMenu(event);
+  };
+
   const { contextMenu, onContextMenu } = useCommentContextMenu({
     deleteRemark: deleteRemark,
     editRemark: startEditing,
@@ -114,7 +114,12 @@ export default function EditableRemark({
         </div>
         <div className={styles.Time}>{formatRelativeTime(new Date(remark.createdAt))}</div>
 
-        <MaterialIcon className={styles.Icon} disabled={isPending} outlined onClick={onContextMenuClick}>
+        <MaterialIcon
+          className={styles.Icon}
+          disabled={isPending}
+          outlined
+          onClick={onContextMenuClick}
+        >
           more_vert
         </MaterialIcon>
       </div>

--- a/src/ui/components/Comments/TranscriptComments/SourceCodePreview.tsx
+++ b/src/ui/components/Comments/TranscriptComments/SourceCodePreview.tsx
@@ -3,13 +3,13 @@ import { ReactNode, useEffect, useState } from "react";
 import { selectLocation } from "devtools/client/debugger/src/actions/sources";
 import { getThreadContext } from "devtools/client/debugger/src/selectors";
 import Icon from "replay-next/components/Icon";
-import useTooltip from "replay-next/src/hooks/useTooltip";
-import Tooltip from "replay-next/components/Tooltip";
 import {
   SourceCodeCommentTypeData,
   createTypeDataForSourceCodeComment,
 } from "replay-next/components/sources/utils/comments";
 import { isSourceCodeCommentTypeData } from "replay-next/components/sources/utils/comments";
+import Tooltip from "replay-next/components/Tooltip";
+import useTooltip from "replay-next/src/hooks/useTooltip";
 import { ParsedToken, parsedTokensToHtml } from "replay-next/src/suspense/SyntaxParsingCache";
 import { getSourceFileNameFromUrl } from "replay-next/src/utils/source";
 import { replayClient } from "shared/client/ReplayClientContext";
@@ -126,7 +126,6 @@ function ModernSourceCodePreview({
   sourceId: string;
   sourceUrl: string | null;
 }) {
-    
   const context = useAppSelector(getThreadContext);
   const dispatch = useAppDispatch();
 
@@ -155,7 +154,7 @@ function ModernSourceCodePreview({
       </div>
     );
   }
-  
+
   const { onMouseEnter, onMouseLeave, tooltip } = useTooltip({
     position: "above",
     tooltip: location,
@@ -177,9 +176,7 @@ function ModernSourceCodePreview({
     <div className={styles.LabelGroup} onClick={onSelectSource}>
       <div className={styles.Labels} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
         {codePreview}
-        <Tooltip>
-          {tooltip}
-        </Tooltip>
+        <Tooltip>{tooltip}</Tooltip>
       </div>
       <Icon className={styles.Icon} type="chevron-right" />
     </div>

--- a/src/ui/components/Comments/TranscriptComments/SourceCodePreview.tsx
+++ b/src/ui/components/Comments/TranscriptComments/SourceCodePreview.tsx
@@ -167,7 +167,6 @@ function ModernSourceCodePreview({
   return (
     <div className={styles.LabelGroup} onClick={onSelectSource} title="Show in the Editor">
       <div className={styles.Labels}>
-        {location}
         {codePreview}
       </div>
       <Icon className={styles.Icon} type="chevron-right" />

--- a/src/ui/components/Comments/TranscriptComments/SourceCodePreview.tsx
+++ b/src/ui/components/Comments/TranscriptComments/SourceCodePreview.tsx
@@ -3,6 +3,8 @@ import { ReactNode, useEffect, useState } from "react";
 import { selectLocation } from "devtools/client/debugger/src/actions/sources";
 import { getThreadContext } from "devtools/client/debugger/src/selectors";
 import Icon from "replay-next/components/Icon";
+import useTooltip from "replay-next/src/hooks/useTooltip";
+import Tooltip from "replay-next/components/Tooltip";
 import {
   SourceCodeCommentTypeData,
   createTypeDataForSourceCodeComment,
@@ -124,6 +126,7 @@ function ModernSourceCodePreview({
   sourceId: string;
   sourceUrl: string | null;
 }) {
+    
   const context = useAppSelector(getThreadContext);
   const dispatch = useAppDispatch();
 
@@ -147,11 +150,17 @@ function ModernSourceCodePreview({
     const fileName = getSourceFileNameFromUrl(sourceUrl);
 
     location = (
-      <div className={styles.PrimaryLabel}>
+      <div>
         ${fileName}:{lineNumber}
       </div>
     );
   }
+  
+  const { onMouseEnter, onMouseLeave, tooltip } = useTooltip({
+    position: "above",
+    tooltip: location,
+    delay: 200,
+  });
 
   let codePreview: ReactNode | null = null;
   if (parsedTokens) {
@@ -165,9 +174,12 @@ function ModernSourceCodePreview({
   }
 
   return (
-    <div className={styles.LabelGroup} onClick={onSelectSource} title="Show in the Editor">
-      <div className={styles.Labels}>
+    <div className={styles.LabelGroup} onClick={onSelectSource}>
+      <div className={styles.Labels} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
         {codePreview}
+        <Tooltip>
+          {tooltip}
+        </Tooltip>
       </div>
       <Icon className={styles.Icon} type="chevron-right" />
     </div>

--- a/src/ui/components/Comments/TranscriptComments/styles.module.css
+++ b/src/ui/components/Comments/TranscriptComments/styles.module.css
@@ -69,10 +69,10 @@
   margin: 0.25rem;
   padding: 0.25rem;
   border-radius: 0.25rem;
-  background-color: var(--comment-card-source-preview-background-color);
+  background-color: var(--comment-card-preview-background-color);
 }
 .OuterImageContainer:hover {
-  background-color: var(--comment-card-source-preview-background-color-hover);
+  background-color: var(--comment-card-preview-background-color-hover);
 }
 
 .InnerImageContainer {
@@ -111,5 +111,5 @@
 .PreviewIcon {
   width: 1rem;
   height: 1rem;
-  color: var(--color-dimmer);
+  color: var(--color-dim);
 }

--- a/src/ui/components/Comments/TranscriptComments/styles.module.css
+++ b/src/ui/components/Comments/TranscriptComments/styles.module.css
@@ -26,7 +26,7 @@
   flex-direction: column;
   flex: 1 1 auto;
   overflow: hidden;
-  padding: 0.125rem 0.5rem;
+  padding: 0.25rem 0.5rem;
   gap: 0.125rem;
 }
 

--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -99,7 +99,7 @@ export default function SidePanel() {
         </div>
       )}
 
-      <div className="h-0 flex-grow w-full overflow-hidden rounded-lg bg-bodyBgcolor text-xs">
+      <div className="h-0 w-full flex-grow overflow-hidden rounded-lg bg-bodyBgcolor text-xs">
         {selectedPrimaryPanel === "explorer" && <PrimaryPanes />}
         {selectedPrimaryPanel === "debugger" && <SecondaryPanes />}
         {selectedPrimaryPanel === "comments" && <CommentCardsList />}


### PR DESCRIPTION
**Summary**

When you're in DevTools and you click on a comment, we should load the line of code in Source Viewer. Before this change, we only took you to code when you clicked the small code callout, but now it's the whole region.

<img width="662" alt="image" src="https://user-images.githubusercontent.com/9154902/220444168-86ebb820-6a19-4a32-9109-27812d096957.png">
