### PR TITLE
Set Protocol Viewer back to default false, and only show in devtools

### DIFF
--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -196,7 +196,7 @@ export default function Toolbar() {
             />
           </>
         ) : null}
-        {logProtocol ? (
+        {logProtocol && viewMode === "dev" ? (
           <ToolbarButton icon="code" label="Protocol" name="protocol" onClick={handleButtonClick} />
         ) : null}
         <div className="grow"></div>

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -31,7 +31,7 @@ pref("devtools.features.disableStableQueryCache", false);
 pref("devtools.features.enableUnstableQueryCache", false);
 pref("devtools.features.enableLargeText", false);
 pref("devtools.features.hitCounts", true);
-pref("devtools.features.logProtocol", true);
+pref("devtools.features.logProtocol", false);
 pref("devtools.features.logProtocolEvents", false);
 pref("devtools.features.newControllerOnRefresh", false);
 pref("devtools.features.originalClassNames", false);


### PR DESCRIPTION
Per discussion in FE-1267, I'm defaulting the Protocol Viewer pref back to false. Can't really do much with a `user.internal` check because the pref is going to end up overriding that anyway.