### PR TITLE
Remove unprocessedRegions usage

### DIFF
--- a/docs/devtools-setup-sequence.md
+++ b/docs/devtools-setup-sequence.md
@@ -69,7 +69,6 @@ There's also some setting of global variables, like `window.gToolbox` for manipu
 - `ui/actions/app.ts::setupApp(store)`:
   - Auth token setup
   - Waits for thread session, sets session ID, loads various kinds of events (keyboard, nav, etc)
-  - Calls `ThreadFront.ensureProcessed()` for "basic" and "executionIndexed", sets loading actions
   - Listens for loading region changes and dispatches
 - `ui/actions/timeline.ts::setupTimeline(store)`:
   - Dispatches on pause

--- a/packages/protocol/thread/thread.ts
+++ b/packages/protocol/thread/thread.ts
@@ -435,23 +435,23 @@ class _ThreadFront {
     const abilities = await this.recordingCapabilitiesWaiter.promise;
     const { result } = frameId
       ? await client.Pause.evaluateInFrame(
-        {
-          frameId,
-          expression: text,
-          useOriginalScopes: true,
-          pure: abilities.supportsPureEvaluation && pure,
-        },
-        this.sessionId!,
-        pauseId
-      )
+          {
+            frameId,
+            expression: text,
+            useOriginalScopes: true,
+            pure: abilities.supportsPureEvaluation && pure,
+          },
+          this.sessionId!,
+          pauseId
+        )
       : await client.Pause.evaluateInGlobal(
-        {
-          expression: text,
-          pure: abilities.supportsPureEvaluation && pure,
-        },
-        this.sessionId!,
-        pauseId
-      );
+          {
+            expression: text,
+            pure: abilities.supportsPureEvaluation && pure,
+          },
+          this.sessionId!,
+          pauseId
+        );
     cachePauseData(replayClient, pauseId, result.data);
 
     if (repaintAfterEvaluationsExperimentalFlag) {

--- a/pages/recording/[id]/sourcemap/[sourceId].tsx
+++ b/pages/recording/[id]/sourcemap/[sourceId].tsx
@@ -18,13 +18,13 @@ import tokenManager from "ui/utils/tokenManager";
 
 type SourcemapResult =
   | {
-    source: string;
-    map: string | undefined;
-    url: string | undefined;
-  }
+      source: string;
+      map: string | undefined;
+      url: string | undefined;
+    }
   | {
-    error: string;
-  };
+      error: string;
+    };
 
 async function loadSourceMap(
   recordingId: string,

--- a/pages/recording/[id]/sourcemap/[sourceId].tsx
+++ b/pages/recording/[id]/sourcemap/[sourceId].tsx
@@ -7,7 +7,7 @@ import { client, initSocket } from "protocol/socket";
 import { assert } from "protocol/utils";
 import renderSourcemap from "third-party/sourcemap-visualizer/sourcemapVisualizer";
 import { UIStore } from "ui/actions";
-import { onUnprocessedRegions, setAppMode } from "ui/actions/app";
+import { setAppMode } from "ui/actions/app";
 import { getAccessibleRecording } from "ui/actions/session";
 import { ExpectedErrorScreen } from "ui/components/shared/Error";
 import LoadingScreen from "ui/components/shared/LoadingScreen";
@@ -18,13 +18,13 @@ import tokenManager from "ui/utils/tokenManager";
 
 type SourcemapResult =
   | {
-      source: string;
-      map: string | undefined;
-      url: string | undefined;
-    }
+    source: string;
+    map: string | undefined;
+    url: string | undefined;
+  }
   | {
-      error: string;
-    };
+    error: string;
+  };
 
 async function loadSourceMap(
   recordingId: string,
@@ -53,14 +53,6 @@ async function loadSourceMap(
       await client.Authentication.setAccessToken({ accessToken: token.token });
     }
     const { sessionId } = await client.Recording.createSession({ recordingId });
-
-    // this will show a progress bar in the LoadingScreen, note that the
-    // sourcemap visualizer is shown as soon as the requested source and its sourcemap
-    // have been loaded, which may happen before the progress bar reaches 100%
-    client.Session.ensureProcessed({ level: "basic" }, sessionId);
-    client.Session.addUnprocessedRegionsListener(regions =>
-      store.dispatch(onUnprocessedRegions(regions))
-    );
 
     const sources: Map<string, newSource> = new Map();
     client.Debugger.addNewSourceListener(newSource => {

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -1,4 +1,4 @@
-import { KeyboardEvent, NodeBounds, unprocessedRegions } from "@replayio/protocol";
+import { KeyboardEvent, NodeBounds } from "@replayio/protocol";
 import groupBy from "lodash/groupBy";
 
 import { openQuickOpen } from "devtools/client/debugger/src/actions/quick-open";
@@ -15,7 +15,6 @@ import { compareBigInt } from "ui/utils/helpers";
 import { getRecordingId } from "ui/utils/recording";
 
 import {
-  durationSeen,
   getIsIndexed,
   getLoadingStatusSlow,
   loadReceivedEvents,
@@ -68,10 +67,6 @@ export async function setupApp(
     );
   });
 
-  ThreadFront.ensureProcessed("basic", undefined, regions =>
-    store.dispatch(onUnprocessedRegions(regions))
-  );
-
   // The backend doesn't give up on loading and indexing; apparently it keeps trying until the entire session errors.
   // Practically speaking though, there are cases where updates take so long it feels like things are broken.
   // In that case the UI should show a visual indicator that the loading is slow.
@@ -111,15 +106,8 @@ export async function setupApp(
   ThreadFront.listenForLoadChanges(parameters => {
     lastLoadChangeUpdateTime = now();
 
-    store.dispatch(durationSeen(Math.max(...parameters.loading.map(r => r.end.time))));
     store.dispatch(setLoadedRegions(parameters));
   });
-}
-
-export function onUnprocessedRegions({ regions }: unprocessedRegions): UIThunkAction {
-  return dispatch => {
-    dispatch(durationSeen(Math.max(...regions.map(r => r.end.time), 0)));
-  };
 }
 
 const allKeyboardEvents: KeyboardEvent[] = [];

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -235,9 +235,9 @@ export function createSocket(
       const focusRegion = getPausePointParams()?.focusRegion;
       const focusRange = focusRegion
         ? {
-          begin: focusRegion.begin.time,
-          end: focusRegion.end.time,
-        }
+            begin: focusRegion.begin.time,
+            end: focusRegion.end.time,
+          }
         : undefined;
 
       const sessionId = await createSession(

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -235,9 +235,9 @@ export function createSocket(
       const focusRegion = getPausePointParams()?.focusRegion;
       const focusRange = focusRegion
         ? {
-            begin: focusRegion.begin.time,
-            end: focusRegion.end.time,
-          }
+          begin: focusRegion.begin.time,
+          end: focusRegion.end.time,
+        }
         : undefined;
 
       const sessionId = await createSession(
@@ -320,7 +320,6 @@ export function createSocket(
       // We don't want to show the non-dev version of the app for node replays.
       if (recordingTarget === "node") {
         dispatch(setViewMode("dev"));
-        dispatch(onLoadingFinished());
       }
 
       dispatch(onLoadingFinished());

--- a/src/ui/components/Library/Team/View/TestRuns/RunStats.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/RunStats.tsx
@@ -20,7 +20,9 @@ export function RunStats({ testRun }: { testRun: TestRun }) {
   return (
     <div className="flex shrink space-x-2">
       {failed > 0 && <Pill styles="text-chrome bg-[#EB5757]" value={failed} />}
-      {failed == 0 && passed > 0 && <Pill styles="border border-[#219653] border-2 text-[#219653]" value={passed} />}
+      {failed == 0 && passed > 0 && (
+        <Pill styles="border border-[#219653] border-2 text-[#219653]" value={passed} />
+      )}
     </div>
   );
 }

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -64,13 +64,6 @@ const appSlice = createSlice({
     setMouseTargetsLoading(state, action: PayloadAction<boolean>) {
       state.mouseTargetsLoading = action.payload;
     },
-    durationSeen(state, action: PayloadAction<number>) {
-      // If this is the longest duration we have seen yet, we should update the
-      // store
-      if (action.payload > state.recordingDuration) {
-        state.recordingDuration = action.payload;
-      }
-    },
     setUploading(state, action: PayloadAction<UploadInfo | null>) {
       state.uploading = action.payload;
     },
@@ -171,7 +164,6 @@ const appSlice = createSlice({
 
 export const {
   clearExpectedError,
-  durationSeen: durationSeen,
   setAppMode,
   setAwaitingSourcemaps,
   setCanvas,
@@ -303,8 +295,8 @@ export const getFlatEvents = (state: UIState) => {
   // Only show the events in the current focused region
   return focusRegion
     ? filteredEvents.filter(
-        e => e.point >= focusRegion.begin.point && e.point < focusRegion.end.point
-      )
+      e => e.point >= focusRegion.begin.point && e.point < focusRegion.end.point
+    )
     : filteredEvents;
 };
 export const getIsNodePickerActive = (state: UIState) => state.app.isNodePickerActive;

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -295,8 +295,8 @@ export const getFlatEvents = (state: UIState) => {
   // Only show the events in the current focused region
   return focusRegion
     ? filteredEvents.filter(
-      e => e.point >= focusRegion.begin.point && e.point < focusRegion.end.point
-    )
+        e => e.point >= focusRegion.begin.point && e.point < focusRegion.end.point
+      )
     : filteredEvents;
 };
 export const getIsNodePickerActive = (state: UIState) => state.app.isNodePickerActive;

--- a/src/ui/reducers/timeline.ts
+++ b/src/ui/reducers/timeline.ts
@@ -27,7 +27,6 @@ function initialTimelineState(): TimelineState {
     showFocusModeControls: false,
     stalled: false,
     timelineDimensions: { left: 1, top: 1, width: 1 },
-    unprocessedRegions: [],
     /** @deprecated This appears to be obsolete for now? */
     zoomRegion: { beginTime: 0, endTime: 0, scale: 1 },
     dragging: false,
@@ -113,7 +112,6 @@ export const getShowFocusModeControls = (state: UIState) => state.timeline.showF
 export const isDragging = (state: UIState) => state.timeline.dragging;
 export const isPlaying = (state: UIState) => state.timeline.playback !== null;
 export const isPlaybackStalled = (state: UIState) => state.timeline.stalled;
-export const getUnprocessedRegions = (state: UIState) => state.timeline.unprocessedRegions;
 export const getRecordingDuration = (state: UIState) => state.timeline.recordingDuration;
 export const getTimelineDimensions = (state: UIState) => state.timeline.timelineDimensions;
 export const getHoveredItem = (state: UIState) => state.timeline.hoveredItem;

--- a/src/ui/setup/store.ts
+++ b/src/ui/setup/store.ts
@@ -73,7 +73,6 @@ const reduxDevToolsOptions: ReduxDevToolsOptions = {
     "protocolMessages/responseReceived",
     "protocolMessages/errorReceived",
     "protocolMessages/requestSent",
-    "app/durationSeen",
     "timeline/setPlaybackPrecachedTime",
   ],
 };

--- a/src/ui/state/timeline.ts
+++ b/src/ui/state/timeline.ts
@@ -33,7 +33,6 @@ export interface TimelineState {
   showFocusModeControls: boolean;
   stalled?: boolean;
   timelineDimensions: { width: number; left: number; top: number };
-  unprocessedRegions: TimeRange[];
   zoomRegion: ZoomRegion;
   dragging: boolean;
 }


### PR DESCRIPTION
The whole `ensureProcessed` command is probably going to either get deleted or change considerably in the near future. It seems like basically all of this is not really powering any important functionality at the moment. The SourceMap visualizer has a comment about showing a loading bar, but actually removing this has no affect on the source map viewer loading screen.

Blocks https://linear.app/replay/issue/BAC-2871/make-sure-that-the-dispatcher-waiting-on-regions-is-not-a-problem