### PR TITLE
refact:  to function component

### DIFF
--- a/src/devtools/client/debugger/src/components/A11yIntention.js
+++ b/src/devtools/client/debugger/src/components/A11yIntention.js
@@ -3,28 +3,22 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 //
-import React from "react";
+import React, { useState } from "react";
 
-export default class A11yIntention extends React.Component {
-  state = { keyboard: false };
+export default function A11yIntention({ children }) {
+  const [isKeyboard, setIsKeyboard] = useState(false);
 
-  handleKeyDown = () => {
-    this.setState({ keyboard: true });
-  };
+  handleKeyDown = () => setIsKeyboard(true);
 
-  handleMouseDown = () => {
-    this.setState({ keyboard: false });
-  };
+  handleMouseDown = () => setIsKeyboard(false);
 
-  render() {
-    return (
-      <div
-        className={this.state.keyboard ? "A11y-keyboard" : "A11y-mouse"}
-        onKeyDown={this.handleKeyDown}
-        onMouseDown={this.handleMouseDown}
-      >
-        {this.props.children}
-      </div>
-    );
-  }
+  return (
+    <div
+      className={isKeyboard ? "A11y-keyboard" : "A11y-mouse"}
+      onKeyDown={handleKeyDown}
+      onMouseDown={handleMouseDown}
+    >
+      {children}
+    </div>
+  );
 }

--- a/src/devtools/client/debugger/src/components/A11yIntention.tsx
+++ b/src/devtools/client/debugger/src/components/A11yIntention.tsx
@@ -5,12 +5,12 @@
 //
 import React, { useState } from "react";
 
-export default function A11yIntention({ children }) {
+export default function A11yIntention({ children }: { children: React.ReactNode }) {
   const [isKeyboard, setIsKeyboard] = useState(false);
 
-  handleKeyDown = () => setIsKeyboard(true);
+  const handleKeyDown = () => setIsKeyboard(true);
 
-  handleMouseDown = () => setIsKeyboard(false);
+  const handleMouseDown = () => setIsKeyboard(false);
 
   return (
     <div


### PR DESCRIPTION
This PR is part of a larger block of work #8769 to migrate away from `connect` to use React hooks.

This PR is refactoring the `A11yIntention` component from a class-based component to function component.