### PR TITLE
Improve "Jump to Code" precision by finding first hit in functions

### DIFF
--- a/packages/replay-next/src/suspense/createGenericCache.ts
+++ b/packages/replay-next/src/suspense/createGenericCache.ts
@@ -30,6 +30,7 @@ export interface GenericCache<TExtraParams extends Array<any>, TParams extends A
   getValueAsync(...args: [...TParams, ...TExtraParams]): Thennable<TValue> | TValue;
   getValueIfCached(...args: TParams): { value: TValue } | undefined;
   getValueSuspense(...args: [...TParams, ...TExtraParams]): TValue;
+  remove(...args: TParams): void;
   subscribeToStatus: (
     callback: SubscribeCallback,
     ...args: TParams
@@ -173,6 +174,11 @@ export function createGenericCache<
     getStatus,
 
     getCacheKey,
+
+    remove(...args) {
+      const cacheKey = getCacheKey(...args);
+      recordMap.delete(cacheKey);
+    },
 
     subscribeToStatus,
   };

--- a/src/ui/actions/event-listeners.ts
+++ b/src/ui/actions/event-listeners.ts
@@ -6,7 +6,10 @@ import type { Location, ObjectPreview, Object as ProtocolObject } from "@replayi
 import type { ThreadFront as TF } from "protocol/thread";
 import { createGenericCache } from "replay-next/src/suspense/createGenericCache";
 import { getTopFrameAsync } from "replay-next/src/suspense/FrameCache";
-import { getObjectWithPreviewHelper } from "replay-next/src/suspense/ObjectPreviews";
+import {
+  getObjectPropertyHelper,
+  getObjectWithPreviewHelper,
+} from "replay-next/src/suspense/ObjectPreviews";
 import { cachePauseData } from "replay-next/src/suspense/PauseCache";
 import { getScopeMapAsync } from "replay-next/src/suspense/ScopeMapCache";
 import { ReplayClientInterface } from "shared/client/types";
@@ -17,6 +20,7 @@ import {
   getSourceDetailsEntities,
 } from "ui/reducers/sources";
 import { UIState } from "ui/state";
+import { getJSON } from "ui/utils/objectFetching";
 
 import { UIThunkAction } from "./index";
 
@@ -270,7 +274,10 @@ function shouldIgnoreEventFromSource(sourceDetails?: SourceDetails) {
   return IGNORABLE_PARTIAL_SOURCE_URLS.some(partialUrl => url.includes(partialUrl));
 }
 
-export const { getValueAsync: getEventListenerLocationAsync } = createGenericCache<
+export const {
+  getValueAsync: getEventListenerLocationAsync,
+  remove: removeEventListenerLocationEntry,
+} = createGenericCache<
   [ThreadFront: typeof TF, replayClient: ReplayClientInterface, getState: () => UIState],
   [pauseId: string, replayEventType: SEARCHABLE_EVENT_TYPES],
   Location | undefined
@@ -305,7 +312,6 @@ export const { getValueAsync: getEventListenerLocationAsync } = createGenericCac
 
     if (res.returned?.object) {
       const preview = await getObjectWithPreviewHelper(replayClient, pauseId, res.returned.object);
-
       // The evaluation may have found a React prop function somewhere.
       const handlerProp = preview?.preview?.properties?.find(p => p.name === "handlerProp");
 
@@ -331,6 +337,7 @@ export const { getValueAsync: getEventListenerLocationAsync } = createGenericCac
       }
     } else if (res.exception?.object) {
       const error = await getObjectWithPreviewHelper(replayClient, pauseId, res.exception.object);
+      console.error("Error fetching event listener location: ", error);
     }
 
     if (!sourceLocation) {
@@ -359,10 +366,19 @@ interface InjectedValues {
   possibleReactPropNames: string[];
   args: any[];
 }
+
+interface SearchedNode {
+  name: string;
+  searchPropKeys?: string[];
+  propKeys?: string[];
+}
+
 interface EventMapperResult {
   target: HTMLElement;
+  fieldName?: string;
   handlerProp?: Function;
   handlerNode?: HTMLElement;
+  searchedNodes: SearchedNode[];
 }
 
 function createReactEventMapper(eventType: SEARCHABLE_EVENT_TYPES) {
@@ -379,16 +395,40 @@ function createReactEventMapper(eventType: SEARCHABLE_EVENT_TYPES) {
     );
 
     if (matchingEvent) {
-      // We _could_ probably just return the prop function or undefined here
+      const searchedNodes: SearchedNode[] = [];
       const res: EventMapperResult = {
         target: event.target as HTMLElement,
+        searchedNodes,
       };
+
+      // Debugging: trace nodes we've looked at, like `"input#id.classname"`
+      function stringifyNode(node: HTMLElement) {
+        const tokens = [node.nodeName];
+
+        if (node.id) {
+          tokens.push("#" + node.id);
+        }
+
+        if (typeof node.className === "string") {
+          for (let className of node.className.split(" ")) {
+            tokens.push("." + className);
+          }
+        }
+
+        return tokens.join("").toLowerCase();
+      }
 
       // Search the event target node and all of its ancestors
       // for React internal props data, and specifically look
       // for the nearest node with a relevant React event handler prop if any.
-      let currentNode = event.target as HTMLElement;
+      const startingNode = event.target as HTMLElement;
+      let currentNode = startingNode;
       while (currentNode) {
+        const searchedNode: SearchedNode = {
+          name: stringifyNode(currentNode),
+        };
+        searchedNodes.push(searchedNode);
+
         const keys = Object.keys(currentNode);
         const reactPropsKey = keys.find(key => {
           return (
@@ -402,6 +442,7 @@ function createReactEventMapper(eventType: SEARCHABLE_EVENT_TYPES) {
           if (reactPropsKey in currentNode) {
             // @ts-ignore
             props = currentNode[reactPropsKey];
+            searchedNode.propKeys = Object.keys(props);
           }
 
           // Depending on the type of event, there could be different
@@ -409,15 +450,28 @@ function createReactEventMapper(eventType: SEARCHABLE_EVENT_TYPES) {
           // For example, an input is likely to have "onChange",
           // whereas some other element might have "onKeyPress".
           let handler = undefined;
-          for (let possibleReactProp of injectedValues.possibleReactPropNames) {
+          let name: string | undefined = undefined;
+          let possibleReactPropNames = injectedValues.possibleReactPropNames;
+
+          // `<input>` tags often have an `onChange` prop, including checkboxes;
+          // _If_ the original target DOM node is an input, add that to the list of prop names.
+          if (currentNode === startingNode && currentNode.nodeName.toLowerCase() === "input") {
+            possibleReactPropNames = possibleReactPropNames.concat("onChange");
+          }
+
+          searchedNode.searchPropKeys = possibleReactPropNames;
+
+          for (let possibleReactProp of possibleReactPropNames) {
             if (possibleReactProp in props) {
               handler = props[possibleReactProp];
+              name = possibleReactProp;
             }
           }
 
           if (handler) {
             res.handlerProp = handler;
             res.handlerNode = currentNode as HTMLElement;
+            res.fieldName = name;
             break;
           }
         }


### PR DESCRIPTION
The original "Jump to Code" implementation limited itself to finding the function _declaration_ that handled the event, and opening that location.  This was good, but it's even nicer if we can get you to the _time_ that the function actually ran.

This means that we need to find the first breakable location _inside_ the function after its declaration, and then do hit point analysis to find the next time that breakable position was hit.

And I've got that working!

Tested this out on several recordings and it works pretty consistently.

I've also added some additional logic to the evaluated introspection logic to handle cases where a click event might be on an `<input>` that has an `onChange` (such as an `<input type="checkbox">`, even though that wouldn't normally be a prop name you'd associate with a click event otherwise.

Example:

Open up https://devtools-git-feature-fe-1228-jump-location-recordreplay.vercel.app/recording/redux-todos-app-with-events--8835992a-2708-4c59-928e-85ea1f0216a5 , click the "Info" panel icon on the left, hover over one of the events list items like "Click" and click the "Jump to Code" flyout button on the right side of the list item:

![image](https://user-images.githubusercontent.com/1128784/220810778-978f9871-7242-4470-a7db-3e8faee7a62e.png)
