### PR TITLE
Fix RDT prop fetching (FE-1274)

### DIFF
--- a/src/ui/utils/objectFetching.ts
+++ b/src/ui/utils/objectFetching.ts
@@ -28,7 +28,7 @@ export async function loadObjectProperties(
   pauseId: string,
   objectId: string
 ) {
-  const obj = await getObjectWithPreviewHelper(replayClient, pauseId, objectId);
+  const obj = await getObjectWithPreviewHelper(replayClient, pauseId, objectId, true);
 
   const properties = obj.preview?.properties ?? [];
   const objectProperties = properties.filter(entry => "object" in entry) ?? [];


### PR DESCRIPTION
Our ReactDevTools panel uses the `getJSON()` helper when forwarding a message from the RDT backend to the RDT frontend. That helper allowed the object previews to overflow, so the message properties could be incomplete.