### PR TITLE
Hide delete-all button if all break/log points are shared

### DIFF
--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointHeading.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointHeading.tsx
@@ -17,9 +17,10 @@ import { CloseButton } from "../../shared/Button";
 import styles from "./BreakpointHeading.module.css";
 
 type BHExtraProps = {
-  sourceId: SourceId;
   breakpoint: Point;
+  allBreakpointsAreShared: boolean;
   onRemoveBreakpoints: (cx: Context, source: MiniSource) => void;
+  sourceId: SourceId;
 };
 
 const mapStateToProps = (state: UIState, { sourceId }: BHExtraProps) => {
@@ -72,7 +73,7 @@ class BreakpointHeading extends PureComponent<BreakpointsProps> {
   };
 
   render() {
-    const { source, hasSiblingOfSameName } = this.props;
+    const { allBreakpointsAreShared, source, hasSiblingOfSameName } = this.props;
 
     const query = hasSiblingOfSameName ? getSourceQueryString(source) : "";
     const fileName = getTruncatedFileName(source, query);
@@ -85,10 +86,12 @@ class BreakpointHeading extends PureComponent<BreakpointsProps> {
         onClick={this.onClick}
       >
         <Redacted className={styles.Label}>{fileName}</Redacted>
-        <CloseButton
-          handleClick={this.removeBreakpoint}
-          tooltip={"Remove all breakpoint from this source"}
-        />
+        {allBreakpointsAreShared || (
+          <CloseButton
+            handleClick={this.removeBreakpoint}
+            tooltip={"Remove all breakpoint from this source"}
+          />
+        )}
       </div>
     );
   }

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/Breakpoints.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/Breakpoints.tsx
@@ -91,13 +91,17 @@ export default function Breakpoints({
   return (
     <div className={styles.Breakpoints}>
       {entries.map(([sourceId, points]) => {
+        const allBreakpointsAreShared =
+          points.filter(point => point.user?.id == currentUserInfo?.id).length === 0;
+
         return (
           <div className={styles.List} data-test-name="BreakpointsList" key={sourceId}>
             <BreakpointHeading
-              key="header"
+              allBreakpointsAreShared={allBreakpointsAreShared}
               breakpoint={points[0]}
-              sourceId={sourceId}
+              key="header"
               onRemoveBreakpoints={() => deletePoints(...points.map(point => point.key))}
+              sourceId={sourceId}
             />
             {points.map(point => {
               const pointBehavior = pointBehaviors[point.key];


### PR DESCRIPTION
Doesn't fix the issue Mark reported (because I wasn't able to repro that issue) but is probably a nice UX improvement anyway.