### PR TITLE
Fix syntax highlighting for TypeScript and JSX

### DIFF
--- a/packages/replay-next/components/sources/Source.tsx
+++ b/packages/replay-next/components/sources/Source.tsx
@@ -9,6 +9,7 @@ import {
   getStreamingSourceContentsSuspense,
 } from "replay-next/src/suspense/SourcesCache";
 import { StreamingParser, parseStreaming } from "replay-next/src/suspense/SyntaxParsingCache";
+import { getSourceFileName } from "replay-next/src/utils/source";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
 import Loader from "../Loader";
@@ -56,7 +57,8 @@ function SourceLoader({
     return null;
   }
 
-  const streamingParser = parseStreaming(streamingSourceContents);
+  const fileName = getSourceFileName(source);
+  const streamingParser = parseStreaming(streamingSourceContents, fileName);
   if (streamingParser === null) {
     return null;
   }

--- a/packages/replay-next/components/sources/utils/comments.ts
+++ b/packages/replay-next/components/sources/utils/comments.ts
@@ -7,6 +7,7 @@ import {
 import { parseStreamingAsync } from "replay-next/src/suspense/SyntaxParsingCache";
 import { ParsedToken } from "replay-next/src/suspense/SyntaxParsingCache";
 import { getBase64Png } from "replay-next/src/utils/canvas";
+import { getSourceFileName } from "replay-next/src/utils/source";
 import { ReplayClientInterface } from "shared/client/types";
 
 export enum CanonicalRequestType {
@@ -83,11 +84,12 @@ export async function createTypeDataForSourceCodeComment(
 
   const source = await getSourceAsync(replayClient, sourceId);
   const sourceUrl = source?.url ?? null;
+  const fileName = source ? getSourceFileName(source) : null;
 
   // Secondary label is used to store the syntax-highlighted markup for the line
   const streamingSource = await getStreamingSourceContentsAsync(replayClient, sourceId);
   if (streamingSource != null) {
-    const parsedSource = await parseStreamingAsync(streamingSource);
+    const parsedSource = await parseStreamingAsync(streamingSource, fileName);
     if (parsedSource != null) {
       if (parsedSource.rawTextByLine.length < lineNumber) {
         // If the streaming source hasn't finished loading yet, wait for it to load;


### PR DESCRIPTION
If possible, use the file extension to infer the language syntax. Extensions like `*.tsx` or `*.jsx` end up with a `contentType` of `"text/javascript"`, but parsing those files with the JavaScript language extension won't be fully accurate.

### Before
<img width="490" alt="Screen Shot 2023-02-24 at 10 20 56 AM" src="https://user-images.githubusercontent.com/29597/221218232-63c1a60e-4617-4d8c-a570-ae54f5ce45d6.png">


### After
<img width="375" alt="Screen Shot 2023-02-24 at 10 21 03 AM" src="https://user-images.githubusercontent.com/29597/221218234-26ae6580-4712-4048-8799-7476b61fb2a1.png">