### PR TITLE
Ensure React and DOM node picker usage doesn't add a comment

### DIFF
--- a/src/ui/components/NodePicker.tsx
+++ b/src/ui/components/NodePicker.tsx
@@ -101,9 +101,6 @@ export function NodePicker() {
           dispatch(unhighlightNode());
         },
         async onPicked(nodeId) {
-          setGlobalNodePickerActive(false);
-          dispatch(setIsNodePickerActive(false));
-          dispatch(setMouseTargetsLoading(false));
           nodePickerRemoveTime.current = Date.now();
 
           if (nodeId) {
@@ -111,6 +108,10 @@ export function NodePicker() {
           } else {
             dispatch(unhighlightNode());
           }
+
+          setGlobalNodePickerActive(false);
+          dispatch(setIsNodePickerActive(false));
+          dispatch(setMouseTargetsLoading(false));
         },
         onCheckNodeBounds: async (x, y, nodeIds) => {
           const boundingRects = await dispatch(fetchMouseTargetsForPause());

--- a/src/ui/components/SecondaryToolbox/index.tsx
+++ b/src/ui/components/SecondaryToolbox/index.tsx
@@ -1,6 +1,15 @@
 import "ui/setup/dynamic/inspector";
 import classnames from "classnames";
-import React, { FC, ReactNode, RefObject, Suspense, useContext, useEffect, useState } from "react";
+import React, {
+  FC,
+  ReactNode,
+  RefObject,
+  Suspense,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useState,
+} from "react";
 import { ImperativePanelHandle } from "react-resizable-panels";
 
 import { EditorPane } from "devtools/client/debugger/src/components/Editor/EditorPane";
@@ -165,9 +174,11 @@ function SecondaryToolbox({
   const hasReactComponents = kindsSet.has("react-devtools-hook");
   const hasReduxAnnotations = kindsSet.has("redux-devtools-data");
 
-  if (selectedPanel === "react-components" && !hasReactComponents) {
-    dispatch(setSelectedPanel("console"));
-  }
+  useLayoutEffect(() => {
+    if (selectedPanel === "react-components" && !hasReactComponents) {
+      dispatch(setSelectedPanel("console"));
+    }
+  }, [selectedPanel, hasReactComponents, dispatch]);
 
   useEffect(() => {
     async function fetchKinds() {

--- a/src/ui/components/Video.tsx
+++ b/src/ui/components/Video.tsx
@@ -40,7 +40,13 @@ export default function Video() {
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
-  const { onClick, onMouseEnter, onMouseLeave, onMouseMove, tooltip } = useVideoCommentTool({
+  const {
+    onClick: onVideoCommentClick,
+    onMouseEnter,
+    onMouseLeave,
+    onMouseMove,
+    tooltip,
+  } = useVideoCommentTool({
     areMouseTargetsLoading: mouseTargetsLoading,
     canvasRef,
     recordingId: recordingId!,
@@ -75,6 +81,14 @@ export default function Video() {
     if (isNodePickerActive || isNodePickerInitializing) {
       return;
     }
+  };
+
+  const onClick = (e: React.MouseEvent) => {
+    if (isNodePickerActive || isNodePickerInitializing) {
+      return;
+    }
+
+    onVideoCommentClick(e);
   };
 
   const showCommentTool =


### PR DESCRIPTION
Made several changes. Actually not 100% sure all of them are _necessary_, but the combination seems to prevent the "Add comment" tooltip from showing up when a node picker is active and you hover over the video preview, and also prevents adding a new comment when you click to select a node:

- Changed `utils/nodePicker` to set its DOM event listeners on the canvas directly, listen for `"click"` instead of `"mouseup"`, and use `e.stopPropagation/preventDefault()` in its click handler
- Rearranged the order of when `isNodePickerActive` gets set to `false`
- Added a `if (isNodePickerActive) return` bailout in `useVideoCommentTool`'s "add comment" handler and `<Video>`'s click handler

Also fixed a case where `<SecondaryToolbox>` was doing a dispatch while rendering when the "React" tab was selected but no React data is available.