### PR TITLE
When pressing replay, don't play back the timeline until we've finished getting the corresponding point

### DIFF
--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -387,8 +387,7 @@ export function replayPlayback(): UIThunkAction {
   return (dispatch, getState) => {
     const beginTime = 0;
 
-    dispatch(seekToTime(beginTime));
-    dispatch(startPlayback());
+    dispatch(seekToTime(beginTime, true));
   };
 }
 


### PR DESCRIPTION
This uses `seekToTime`'s autoplay flag to play the timeline after hitting replay, instead of playing it back separately.