### PR TITLE
FE-1291

### DIFF
--- a/packages/replay-next/src/contexts/points/hooks/useLocalPoints.tsx
+++ b/packages/replay-next/src/contexts/points/hooks/useLocalPoints.tsx
@@ -3,7 +3,7 @@ import { useContext, useEffect, useMemo } from "react";
 
 import { SessionContext } from "replay-next/src/contexts/SessionContext";
 import useIndexedDB from "replay-next/src/hooks/useIndexedDB";
-import { Badge, PointBehavior } from "shared/client/types";
+import { Badge, PartialUser, PointBehavior } from "shared/client/types";
 import { createPointKey } from "shared/graphql/Points";
 
 import { POINTS_DATABASE } from "../constants";
@@ -58,6 +58,16 @@ export default function useLocalPoints({
       valueOld.forEach(point => {
         const key = createPointKey(point.recordingId, currentUserInfo?.id ?? null, point.location);
 
+        // Assume legacy log points were created by the current user.
+        // See https://github.com/replayio/devtools/pull/8837
+        const user: PartialUser | null = currentUserInfo
+          ? {
+              id: currentUserInfo.id,
+              name: currentUserInfo.name,
+              picture: currentUserInfo.picture,
+            }
+          : null;
+
         migrated[key] = {
           badge: point.badge,
           condition: point.condition,
@@ -66,13 +76,7 @@ export default function useLocalPoints({
           key,
           location: point.location,
           recordingId: point.recordingId,
-          user: point.createdByUserId
-            ? {
-                id: point.createdByUserId,
-                name: null,
-                picture: null,
-              }
-            : null,
+          user,
         };
       });
       return migrated;


### PR DESCRIPTION
## Backstory

About a month ago (#8647) I added the `createdByUserId` attribute to log points to track the _owner_ of a point. This was done as  pre-requisite for supporting _shared_ log points. After that change, the shape of points data we saved to IndexedDB looked like this:

https://github.com/replayio/devtools/blob/aaf4e3e6f65deb3ce52c5a2acc8310cb345f99b7/packages/shared/client/types.ts#L83-L94

Two weeks later (#8676) I landed another change– this time to the way we persist log points. I changed the _structure_ of log point objects such that "behaviors" (whether or not breaking or logging were enabled) were now stored _separately_ from the core content (e.g. content, conditional, location, and user). This allowed points content to be shared between users while also enabling users to toggle shared points on/off. After that change, the shape of points data we saved to IndexedDB looked like this:

https://github.com/replayio/devtools/blob/5d758318656f7ea0281e53188386d8ea26e13c2f/packages/shared/client/types.ts#L97-L112

Because of the differences in the structure of the data, I saved the new points format in a different IndexedDB table and added a temporary in-place migration to copy _legacy_ points over to that new table and data structure:

https://github.com/replayio/devtools/blob/97963a57e456282a4e2e0ccc52a99e86ee023e09/packages/replay-next/src/contexts/points/hooks/useLocalPoints.tsx#L52-L80

Unfortunately this migration did not account for an _even older format_ that points data may have been saved to. For example, this point object copied from @jonbell-lot23's IndexedDB:
```json
{
  "{\"column\":9,\"line\":305,\"sourceId\":\"pp7\",\"userId\":\"…=\"}": {
    "badge": null,
    "condition": null,
    "content": "\"p\", 305",
    "createdAt": "2023-01-18T21:13:51.471Z",
    "key": "{\"column\":9,\"line\":305,\"sourceId\":\"pp7\",\"userId\":\"…=\"}",
    "location": {
      "column": 9,
      "line": 305,
      "sourceId": "pp7"
    },
    "user": null
  }
}
```

Note that point has no `createdByUserId` attribute. Instead it has a key consisting of a serialized JSON value which has a `userId` field. This migration miss would probably not be a big deal _except_ that it now results in a log point that is owned by no one (no avatar badge) and– more importantly– cannot be edited or deleted by Jon when viewing the Replay.

## The fix

There are two possible "fixes" for this:
1. Try to detect this earlier legacy format and extract the "userId" from the serialized key.
2. Assume that any legacy points without a `createdByUserId` _must_ belong to the current user (because shared print statements didn't exist at that point).

This PR takes the second approach which is probably the simplest/safest.

Note that in a few weeks we can delete this temporary migration code entirely (see FE-1138).

## Verification

To verify this fix I...
1. Deleted my local IndexedDB (otherwise it would have thrown a "version is too new" error)
1. Checked out revision 68c054d6318e2016718723d8100a321f245f4a8f (before the `createdByUserId` attributed was added)
1. Created a new Replay (b7db9322-708a-451c-b0c5-2a128b06d28b) and added a few log points
1. Verified they were saved to IndexedDB in the _older_ legacy format (see below)
1. Checked out HEAD of this branch and opened the same Replay
1. Opened that same Replay (b7db9322-708a-451c-b0c5-2a128b06d28b)
1. Verified the legacy log point format was migrated correctly

The legacy format of the log points:
```js
[
  {
    badge: null,
    condition: null,
    content: '"7228", 9',
    createdAtTime: 1677535139601,
    id: "pp2166:9:65",
    location: { column: 65, line: 9, sourceId: "pp2166" },
    shouldBreak: "disabled",
    shouldLog: "enabled",
  },
  {
    badge: "green",
    condition: null,
    content: '"modified"',
    createdAtTime: 1677535140740,
    id: "pp2166:14:65",
    location: { column: 65, line: 14, sourceId: "pp2166" },
    shouldBreak: "disabled",
    shouldLog: "enabled",
  },
];
```

I tested the above as both an _authenticated_ user and an _unauthenticated_ user. Both correctly migrated the older legacy points format (including giving me the ability to delete the old points)