### PR TITLE
Fixed an error caused by accessing an empty ref

### DIFF
--- a/src/ui/components/Header/Header.tsx
+++ b/src/ui/components/Header/Header.tsx
@@ -127,10 +127,11 @@ function HeaderTitle({
     }
   };
   const onBlur = () => {
-    if (editState !== EditState.Active) {
+    const contentEditable = contentEditableRef.current;
+    if (editState !== EditState.Active || !contentEditable) {
       return;
     }
-    const currentValue = contentEditableRef.current!.textContent || "";
+    const currentValue = contentEditable.textContent || "";
 
     setEditState(EditState.Saving);
     updateRecordingTitle(recordingId, currentValue).then(() => {


### PR DESCRIPTION
I'm not sure when this can actually be `null` since React's `onBlur` shouldn't be fired when unmounting (see the long-standing issue~ [here](https://github.com/facebook/react/issues/12363)).

However, I noticed this error in the console and it was pointing to this exact line:
<img width="605" alt="Call stack of an error in the browser devtools. Stating that: 'Uncaught TypeError: Cannot read properties of null (reading textContent)'" src="https://user-images.githubusercontent.com/9800850/221805162-4ff5e966-779f-49da-8473-c2b203d5e11f.png">
