### PR TITLE
Allow seeking to unloaded points (FE-1217)

### DIFF
--- a/packages/protocol/socket.ts
+++ b/packages/protocol/socket.ts
@@ -97,7 +97,6 @@ const noCallerStackTracesForErrorCodes = new Set<ProtocolError>([
   ProtocolError.GraphicsUnavailableAtPoint,
   ProtocolError.InternalError,
   ProtocolError.InvalidRecording,
-  ProtocolError.RecordingUnloaded,
   ProtocolError.SessionCreationFailure,
   ProtocolError.SessionDestroyed,
   ProtocolError.ServiceUnavailable,

--- a/packages/replay-next/src/utils/testing.tsx
+++ b/packages/replay-next/src/utils/testing.tsx
@@ -189,7 +189,7 @@ export function createMockReplayClient() {
     findMessages: jest.fn().mockImplementation(async () => ({ messages: [], overflow: false })),
     findNavigationEvents: jest.fn().mockImplementation(async () => []),
     findSources: jest.fn().mockImplementation(async () => []),
-    getAllFrames: jest.fn().mockImplementation(async () => []),
+    getAllFrames: jest.fn().mockImplementation(async () => ({ frames: [], data: {} })),
     getAnnotationKinds: jest.fn().mockImplementation(async () => []),
     getBreakpointPositions: jest.fn().mockImplementation(async () => []),
     getCorrespondingSourceIds: jest.fn().mockImplementation(() => []),

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/index.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/index.tsx
@@ -6,9 +6,10 @@
 
 import React from "react";
 
+import { getCurrentPoint } from "ui/actions/app";
+import { getCurrentTime } from "ui/reducers/timeline";
 import { useAppSelector } from "ui/setup/hooks";
 
-import { getPauseErrored, getPauseId } from "../../reducers/pause";
 import { useDebuggerPrefs } from "../../utils/prefs";
 import BreakpointsPane from "./BreakpointsPane";
 import CommandBar from "./CommandBar";
@@ -20,8 +21,9 @@ import NewScopes from "./NewScopes";
 import { Accordion, AccordionPane } from "@recordreplay/accordion";
 
 export default function SecondaryPanes() {
-  const pauseId = useAppSelector(getPauseId);
-  const pauseErrored = useAppSelector(getPauseErrored);
+  const currentPoint = useAppSelector(getCurrentPoint);
+  const currentTime = useAppSelector(getCurrentTime);
+
   const { value: scopesExpanded, update: updateScopesExpanded } =
     useDebuggerPrefs("scopes-visible");
   const { value: callstackVisible, update: updateCallstackVisible } =
@@ -58,12 +60,7 @@ export default function SecondaryPanes() {
           expanded={callstackVisible}
           onToggle={() => updateCallstackVisible(!callstackVisible)}
         >
-          {pauseId && <NewFrames pauseId={pauseId} panel="debugger" />}
-          {pauseErrored && (
-            <div className="pane frames" data-test-id="FramesPanel">
-              <div className="pane-info empty">Error loading frames</div>
-            </div>
-          )}
+          {currentPoint && <NewFrames point={currentPoint} time={currentTime} panel="debugger" />}
         </AccordionPane>
         <AccordionPane
           header="Scopes"

--- a/src/devtools/client/inspector/components/App.tsx
+++ b/src/devtools/client/inspector/components/App.tsx
@@ -1,11 +1,15 @@
 import "ui/setup/dynamic/inspector";
-import classnames from "classnames";
+import { useContext } from "react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 
 import ComputedApp from "devtools/client/inspector/computed/components/ComputedApp";
 import LayoutApp from "devtools/client/inspector/layout/components/LayoutApp";
 import MarkupApp from "devtools/client/inspector/markup/components/MarkupApp";
 import { RulesApp } from "devtools/client/inspector/rules/components/RulesApp";
+import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
+import { isPointInRegions } from "shared/utils/time";
+import { enterFocusMode } from "ui/actions/timeline";
+import { getLoadedRegions } from "ui/reducers/app";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 
 import { ResponsiveTabs, Tab } from "../../shared/components/ResponsiveTabs";
@@ -30,6 +34,20 @@ const availableTabs: readonly InspectorActiveTab[] = [
 export default function InspectorApp() {
   const dispatch = useAppDispatch();
   const activeTab = useAppSelector(state => state.inspector.activeTab);
+  const { executionPoint } = useContext(TimelineContext);
+  const loadedRegions = useAppSelector(getLoadedRegions);
+
+  if (!isPointInRegions(executionPoint, loadedRegions?.loaded ?? [])) {
+    return (
+      <div className="inspector-responsive-container bg-bodyBgcolor p-2">
+        Elements are unavailable because you're paused at a point outside{" "}
+        <span className="cursor-pointer underline" onClick={() => dispatch(enterFocusMode())}>
+          your debugging window
+        </span>
+        .
+      </div>
+    );
+  }
 
   return (
     <div className="inspector-responsive-container theme-body inspector">

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -259,18 +259,7 @@ export function seek(
     if (pauseId) {
       ThreadFront.timeWarpToPause({ point, time, pauseId }, openSource);
     } else {
-      const regions = getLoadedRegions(getState());
-      const focusRegion = getFocusRegion(getState());
-      const isTimeInLoadedRegion = regions !== null && isTimeInRegions(time, regions.loaded);
-      if (isTimeInLoadedRegion) {
-        ThreadFront.timeWarp(point, time, openSource);
-      } else {
-        // We can't time-wrap in this case because trying to pause outside of a loaded region will throw.
-        // In this case the best we can do is update the current time and the "video" frame.
-        dispatch(setTimelineState({ currentTime: time }));
-        dispatch(setTimelineToTime(time, true));
-        updatePausePointParams({ point, time, focusRegion });
-      }
+      ThreadFront.timeWarp(point, time, openSource);
     }
     return true;
   };

--- a/src/ui/components/NetworkMonitor/StackTrace.tsx
+++ b/src/ui/components/NetworkMonitor/StackTrace.tsx
@@ -1,19 +1,15 @@
-import React, { Suspense, useContext } from "react";
+import React, { Suspense } from "react";
 
 import Frames from "devtools/client/debugger/src/components/SecondaryPanes/Frames/NewFrames";
-import { getPauseIdSuspense } from "replay-next/src/suspense/PauseCache";
-import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
 import { RequestSummary } from "./utils";
 
 function StackTrace({ request }: { request: RequestSummary }) {
-  const client = useContext(ReplayClientContext);
-  const pauseId = getPauseIdSuspense(client, request.point.point, request.point.time);
   return (
     <div className="call-stack-pane">
       <h1 className="py-2 px-4 font-bold">Stack Trace</h1>
       <div className="px-2">
-        <Frames pauseId={pauseId} panel="networkmonitor" />
+        <Frames point={request.point.point} time={request.point.time} panel="networkmonitor" />
       </div>
     </div>
   );


### PR DESCRIPTION
Currently when the user tries to seek to an unloaded point, we update the current time but not the current point, resulting in an inconsistent and confusing UI (see FE-1217).
This PR:
- always updates current time *and* point even if they're in an unloaded region
- disables the Elements, ReactDevTools and ConsoleInput panels and the PreviewPopup if the current point is unloaded (Frames and Scopes were already disabled in that case)
- fixes the Frames panel so that it doesn't try to create a pause in an unloaded region and then shows "Error loading frames"
- reenables caller stacktraces for CommandErrors that are due to unloaded regions - this should help finding any other places that may try to create or use a pause in an unloaded region