### PR TITLE
Fix flaky screenshot test

### DIFF
--- a/packages/replay-next/playwright/tests/source-and-console.ts
+++ b/packages/replay-next/playwright/tests/source-and-console.ts
@@ -52,6 +52,7 @@ test.beforeEach(async ({ page }) => {
   page.setDefaultTimeout(5000);
 
   await page.goto(getTestUrl("source-and-console"));
+  await page.locator('[data-test-id="ConsoleRoot"]').waitFor();
   await openSourceFile(page, sourceId);
 });
 


### PR DESCRIPTION
The test "should render search results properly for lines with multiple breakable column positions" has been failing in my PRs recently (even though it never failed for me locally).
This is an attempt to fix it.