### PR TITLE
Shortcuts to jump back to previous and next pause

### DIFF
--- a/src/devtools/client/debugger/src/actions/pause/index.ts
+++ b/src/devtools/client/debugger/src/actions/pause/index.ts
@@ -14,3 +14,4 @@ export { resumed } from "../../reducers/pause";
 export { paused } from "./paused";
 export { selectFrame } from "./selectFrame";
 export * from "./previewPausedLocation";
+export { jumpToNextPause, jumpToLastPause } from "./jumps";

--- a/src/devtools/client/debugger/src/actions/pause/jumps.ts
+++ b/src/devtools/client/debugger/src/actions/pause/jumps.ts
@@ -1,0 +1,33 @@
+import { UIThunkAction } from "ui/actions";
+import { seek } from "ui/actions/timeline";
+
+import { pauseHistoryDecremented, pauseHistoryIncremented } from "../../reducers/pause";
+import { getPauseHistory, getPauseHistoryIndex } from "../../selectors";
+
+export function jumpToLastPause(): UIThunkAction {
+  return (dispatch, getState) => {
+    const pauseHistory = getPauseHistory(getState());
+    const pauseHistoryIndex = getPauseHistoryIndex(getState());
+    if (pauseHistoryIndex !== 0) {
+      const pause = pauseHistory[pauseHistoryIndex - 1];
+      if (pause) {
+        dispatch(pauseHistoryDecremented());
+        dispatch(seek(pause.executionPoint, pause.time, pause.hasFrames, pause.pauseId));
+      }
+    }
+  };
+}
+
+export function jumpToNextPause(): UIThunkAction {
+  return (dispatch, getState) => {
+    const pauseHistory = getPauseHistory(getState());
+    const pauseHistoryIndex = getPauseHistoryIndex(getState());
+    if (pauseHistoryIndex !== pauseHistory.length) {
+      const pause = pauseHistory[pauseHistoryIndex + 1];
+      if (pause) {
+        dispatch(pauseHistoryIncremented());
+        dispatch(seek(pause.executionPoint, pause.time, pause.hasFrames, pause.pauseId));
+      }
+    }
+  };
+}

--- a/src/devtools/client/debugger/src/reducers/pause.ts
+++ b/src/devtools/client/debugger/src/reducers/pause.ts
@@ -188,7 +188,12 @@ const pauseSlice = createSlice({
       state.selectedFrameId = frame ? { pauseId: frame.pauseId, frameId: frame.protocolId } : null;
       state.threadcx.pauseCounter++;
       state.pausePreviewLocation = null;
-      if (time && state.pauseHistoryIndex === state.pauseHistory.length - 1 && ( state.pauseHistory.length >= 1 && state.pauseHistory[state.pauseHistory.length - 1]?.time !== time) ) {
+      if (
+        time &&
+        state.pauseHistoryIndex === state.pauseHistory.length - 1 &&
+        state.pauseHistory.length >= 1 &&
+        state.pauseHistory[state.pauseHistory.length - 1]?.time !== time
+      ) {
         console.log("pause state added", state.pauseHistoryIndex, state.pauseHistory.length);
         state.pauseHistory.push({
           pauseId: id,
@@ -240,8 +245,8 @@ const pauseSlice = createSlice({
     },
     resumed(state) {
       Object.assign(state, resumedPauseState);
-      if( state.pauseHistoryIndex !== state.pauseHistory.length - 1 ){
-        while( state.pauseHistoryIndex !== state.pauseHistory.length - 1 ){
+      if (state.pauseHistoryIndex !== state.pauseHistory.length - 1) {
+        while (state.pauseHistoryIndex !== state.pauseHistory.length - 1) {
           state.pauseHistory.pop();
         }
       }

--- a/src/devtools/client/debugger/src/reducers/pause.ts
+++ b/src/devtools/client/debugger/src/reducers/pause.ts
@@ -191,10 +191,8 @@ const pauseSlice = createSlice({
       if (
         time &&
         state.pauseHistoryIndex === state.pauseHistory.length - 1 &&
-        state.pauseHistory.length >= 1 &&
         state.pauseHistory[state.pauseHistory.length - 1]?.time !== time
       ) {
-        console.log("pause state added", state.pauseHistoryIndex, state.pauseHistory.length);
         state.pauseHistory.push({
           pauseId: id,
           time,

--- a/src/devtools/client/debugger/src/reducers/pause.ts
+++ b/src/devtools/client/debugger/src/reducers/pause.ts
@@ -29,6 +29,13 @@ export interface Context {
   navigateCounter: number;
 }
 
+interface PauseHistoryData {
+  pauseId: string;
+  time: number;
+  executionPoint: string;
+  hasFrames: boolean;
+}
+
 export interface ThreadContext {
   isPaused: boolean;
   navigateCounter: number;
@@ -68,6 +75,8 @@ export interface PauseState {
   executionPoint: string | null;
   command: string | null;
   replayFramePositions?: { positions: UnknownPosition[] } | null;
+  pauseHistory: PauseHistoryData[];
+  pauseHistoryIndex: number;
 }
 
 export type ValidCommand =
@@ -103,6 +112,8 @@ const initialState: PauseState = {
   pausePreviewLocation: null,
   ...resumedPauseState,
   command: null,
+  pauseHistory: [],
+  pauseHistoryIndex: 0,
 };
 
 export const executeCommandOperation = createAsyncThunk<
@@ -164,7 +175,7 @@ const pauseSlice = createSlice({
         time?: number;
       }>
     ) {
-      const { id, frame, why, executionPoint } = action.payload;
+      const { id, frame, why, executionPoint, time } = action.payload;
       Object.assign(state, {
         pauseErrored: false,
         pauseLoading: false,
@@ -177,6 +188,21 @@ const pauseSlice = createSlice({
       state.selectedFrameId = frame ? { pauseId: frame.pauseId, frameId: frame.protocolId } : null;
       state.threadcx.pauseCounter++;
       state.pausePreviewLocation = null;
+      if (time && state.pauseHistoryIndex === state.pauseHistory.length) {
+        state.pauseHistory.push({
+          pauseId: id,
+          time,
+          executionPoint,
+          hasFrames: !!frame,
+        });
+        state.pauseHistoryIndex++;
+      }
+    },
+    pauseHistoryDecremented(state) {
+      state.pauseHistoryIndex--;
+    },
+    pauseHistoryIncremented(state) {
+      state.pauseHistoryIndex++;
     },
     pauseCreationFailed(state, action: PayloadAction<string>) {
       const executionPoint = action.payload;
@@ -251,6 +277,8 @@ export const {
   previewLocationCleared,
   previewLocationUpdated,
   resumed,
+  pauseHistoryDecremented,
+  pauseHistoryIncremented,
 } = pauseSlice.actions;
 
 // Copied to avoid import
@@ -296,6 +324,12 @@ export function getPauseErrored(state: UIState) {
 
 export function getPausePreviewLocation(state: UIState) {
   return state.pause.pausePreviewLocation;
+}
+export function getPauseHistory(state: UIState) {
+  return state.pause.pauseHistory;
+}
+export function getPauseHistoryIndex(state: UIState) {
+  return state.pause.pauseHistoryIndex;
 }
 
 async function getResumePoint(replayClient: ReplayClientInterface, state: UIState, type: string) {

--- a/src/devtools/client/debugger/src/reducers/pause.ts
+++ b/src/devtools/client/debugger/src/reducers/pause.ts
@@ -113,7 +113,7 @@ const initialState: PauseState = {
   ...resumedPauseState,
   command: null,
   pauseHistory: [],
-  pauseHistoryIndex: 0,
+  pauseHistoryIndex: -1,
 };
 
 export const executeCommandOperation = createAsyncThunk<
@@ -188,7 +188,8 @@ const pauseSlice = createSlice({
       state.selectedFrameId = frame ? { pauseId: frame.pauseId, frameId: frame.protocolId } : null;
       state.threadcx.pauseCounter++;
       state.pausePreviewLocation = null;
-      if (time && state.pauseHistoryIndex === state.pauseHistory.length) {
+      if (time && state.pauseHistoryIndex === state.pauseHistory.length - 1 && ( state.pauseHistory.length >= 1 && state.pauseHistory[state.pauseHistory.length - 1]?.time !== time) ) {
+        console.log("pause state added", state.pauseHistoryIndex, state.pauseHistory.length);
         state.pauseHistory.push({
           pauseId: id,
           time,
@@ -239,6 +240,11 @@ const pauseSlice = createSlice({
     },
     resumed(state) {
       Object.assign(state, resumedPauseState);
+      if( state.pauseHistoryIndex !== state.pauseHistory.length - 1 ){
+        while( state.pauseHistoryIndex !== state.pauseHistory.length - 1 ){
+          state.pauseHistory.pop();
+        }
+      }
       state.threadcx.isPaused = false;
     },
   },

--- a/src/devtools/client/debugger/src/reducers/pause.ts
+++ b/src/devtools/client/debugger/src/reducers/pause.ts
@@ -188,18 +188,17 @@ const pauseSlice = createSlice({
       state.selectedFrameId = frame ? { pauseId: frame.pauseId, frameId: frame.protocolId } : null;
       state.threadcx.pauseCounter++;
       state.pausePreviewLocation = null;
-      if (
-        time &&
-        state.pauseHistoryIndex === state.pauseHistory.length - 1 &&
-        state.pauseHistory[state.pauseHistory.length - 1]?.time !== time
-      ) {
-        state.pauseHistory.push({
-          pauseId: id,
-          time,
-          executionPoint,
-          hasFrames: !!frame,
-        });
-        state.pauseHistoryIndex++;
+      if (time) {
+        const filteredPauses = state.pauseHistory.filter(pause => pause.time === time);
+        if (!filteredPauses.length) {
+          state.pauseHistory.push({
+            pauseId: id,
+            time,
+            executionPoint,
+            hasFrames: !!frame,
+          });
+          state.pauseHistoryIndex++;
+        }
       }
     },
     pauseHistoryDecremented(state) {

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -1,6 +1,7 @@
 import { KeyboardEvent, NodeBounds } from "@replayio/protocol";
 import groupBy from "lodash/groupBy";
 
+import { jumpToLastPause, jumpToNextPause } from "devtools/client/debugger/src/actions/pause/jumps";
 import { openQuickOpen } from "devtools/client/debugger/src/actions/quick-open";
 import { shallowEqual } from "devtools/client/debugger/src/utils/compare";
 import { prefs } from "devtools/client/debugger/src/utils/prefs";
@@ -308,6 +309,10 @@ export function executeCommand(key: CommandKey): UIThunkAction {
       dispatch(setToolboxLayout("left"));
     } else if (key === "pin_to_bottom_right") {
       dispatch(setToolboxLayout("ide"));
+    } else if (key === "jump_to_previous_pause") {
+      dispatch(jumpToLastPause());
+    } else if (key === "jump_to_next_pause") {
+      dispatch(jumpToNextPause());
     }
     // else if (key === "copy_points") {
     //   dispatch(copyBreakpointsToClipboard());

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -309,7 +309,7 @@ export function executeCommand(key: CommandKey): UIThunkAction {
       dispatch(setToolboxLayout("left"));
     } else if (key === "pin_to_bottom_right") {
       dispatch(setToolboxLayout("ide"));
-    } else if (key === "jump_to_previous_pause") {
+    } else if (key === "jump_to_last_pause") {
       dispatch(jumpToLastPause());
     } else if (key === "jump_to_next_pause") {
       dispatch(jumpToNextPause());

--- a/src/ui/components/CommandPalette/CommandPalette.tsx
+++ b/src/ui/components/CommandPalette/CommandPalette.tsx
@@ -45,7 +45,7 @@ export type CommandKey =
   | "toggle_dark_mode"
   | "toggle_edit_focus"
   | "jump_to_next_pause"
-  | "jump_to_previous_pause";
+  | "jump_to_last_pause";
 
 const COMMANDS: readonly Command[] = [
   { key: "open_console", label: "Open Console" },

--- a/src/ui/components/CommandPalette/CommandPalette.tsx
+++ b/src/ui/components/CommandPalette/CommandPalette.tsx
@@ -43,7 +43,9 @@ export type CommandKey =
   | "show_replay_info"
   | "show_sharing"
   | "toggle_dark_mode"
-  | "toggle_edit_focus";
+  | "toggle_edit_focus"
+  | "jump_to_next_pause"
+  | "jump_to_previous_pause";
 
 const COMMANDS: readonly Command[] = [
   { key: "open_console", label: "Open Console" },

--- a/src/ui/components/KeyboardShortcuts.tsx
+++ b/src/ui/components/KeyboardShortcuts.tsx
@@ -138,14 +138,14 @@ function KeyboardShortcuts({
       }
     };
 
-    const OverRiddenJumpToLastPause = (e: KeyboardEvent) => {
+    const jumpToLastPauseWrapper = (e: KeyboardEvent) => {
       if (!e.target || !isEditableElement(e.target)) {
         e.preventDefault();
         jumpToLastPause();
       }
     };
 
-    const OverRiddenJumpToNextPause = (e: KeyboardEvent) => {
+    const jumpToNextPauseWrapper = (e: KeyboardEvent) => {
       if (!e.target || !isEditableElement(e.target)) {
         e.preventDefault();
         jumpToNextPause();
@@ -168,8 +168,8 @@ function KeyboardShortcuts({
       // Can pre-fill the dialog with specific filter prefixes
       "CmdOrCtrl+Shift+O": toggleFunctionQuickOpenModal,
       "CmdOrCtrl+O": toggleProjectFunctionQuickOpenModal,
-      "CmdOrCtrl+[": OverRiddenJumpToLastPause,
-      "CmdOrCtrl+]": OverRiddenJumpToNextPause,
+      "CmdOrCtrl+[": jumpToLastPauseWrapper,
+      "CmdOrCtrl+]": jumpToNextPauseWrapper,
       "~": toggleProtocolTimeline,
 
       Escape: closeOpenModalsOnEscape,

--- a/src/ui/components/KeyboardShortcuts.tsx
+++ b/src/ui/components/KeyboardShortcuts.tsx
@@ -138,6 +138,20 @@ function KeyboardShortcuts({
       }
     };
 
+    const OverRiddenJumpToLastPause = (e: KeyboardEvent) => {
+      if( !e.target || !isEditableElement(e.target)){
+        e.preventDefault();
+        jumpToLastPause();
+      }
+    };
+
+    const OverRiddenJumpToNextPause = (e: KeyboardEvent) => {
+      if( !e.target || !isEditableElement(e.target)){
+        e.preventDefault();
+        jumpToNextPause();
+      }
+    };
+
     const shortcuts: Record<string, (e: KeyboardEvent) => void> = {
       "CmdOrCtrl+Shift+F": openFullTextSearch,
       "CmdOrCtrl+K": togglePalette,
@@ -154,8 +168,8 @@ function KeyboardShortcuts({
       // Can pre-fill the dialog with specific filter prefixes
       "CmdOrCtrl+Shift+O": toggleFunctionQuickOpenModal,
       "CmdOrCtrl+O": toggleProjectFunctionQuickOpenModal,
-      "CmdOrCtrl+Z": jumpToLastPause,
-      "Shift+CmdOrCtrl+Z": jumpToNextPause,
+      "CmdOrCtrl+[": OverRiddenJumpToLastPause,
+      "CmdOrCtrl+]": OverRiddenJumpToNextPause,
       "~": toggleProtocolTimeline,
 
       Escape: closeOpenModalsOnEscape,

--- a/src/ui/components/KeyboardShortcuts.tsx
+++ b/src/ui/components/KeyboardShortcuts.tsx
@@ -139,14 +139,14 @@ function KeyboardShortcuts({
     };
 
     const OverRiddenJumpToLastPause = (e: KeyboardEvent) => {
-      if( !e.target || !isEditableElement(e.target)){
+      if (!e.target || !isEditableElement(e.target)) {
         e.preventDefault();
         jumpToLastPause();
       }
     };
 
     const OverRiddenJumpToNextPause = (e: KeyboardEvent) => {
-      if( !e.target || !isEditableElement(e.target)){
+      if (!e.target || !isEditableElement(e.target)) {
         e.preventDefault();
         jumpToNextPause();
       }

--- a/src/ui/components/KeyboardShortcuts.tsx
+++ b/src/ui/components/KeyboardShortcuts.tsx
@@ -52,6 +52,8 @@ function KeyboardShortcuts({
   toggleThemeAction,
   toggleQuickOpen,
   closeOpenModalsOnEscape,
+  jumpToLastPause,
+  jumpToNextPause,
 }: PropsFromRedux) {
   const recordingId = useGetRecordingId();
   const { isAuthenticated } = useAuth0();
@@ -152,7 +154,8 @@ function KeyboardShortcuts({
       // Can pre-fill the dialog with specific filter prefixes
       "CmdOrCtrl+Shift+O": toggleFunctionQuickOpenModal,
       "CmdOrCtrl+O": toggleProjectFunctionQuickOpenModal,
-
+      "CmdOrCtrl+Z": jumpToLastPause,
+      "Shift+CmdOrCtrl+Z": jumpToNextPause,
       "~": toggleProtocolTimeline,
 
       Escape: closeOpenModalsOnEscape,
@@ -174,6 +177,8 @@ function KeyboardShortcuts({
     closeOpenModalsOnEscape,
     createFrameComment,
     recordingId,
+    jumpToLastPause,
+    jumpToNextPause,
   ]);
 
   useEffect(() => {
@@ -206,6 +211,8 @@ const connector = connect(
     toggleThemeAction: actions.toggleTheme,
     toggleQuickOpen,
     closeOpenModalsOnEscape,
+    jumpToLastPause: actions.jumpToLastPause,
+    jumpToNextPause: actions.jumpToNextPause,
   }
 );
 type PropsFromRedux = ConnectedProps<typeof connector>;


### PR DESCRIPTION
#8788 
- Use `Ctrl+[` or `Cmd+[` to jump to previous pause.
- Use `Ctrl+]` or `Cmd+]` to jump to next pause.

# Working
- Have modified the working of the jumps, the jumps work much cleaner there should be not much confusion with the jumps.
- If you have made jumps let's say ( 1,2,3,4 ) in the order without going back and now let's say you jump back to 2 and then resume the replay, the data for jump ( 3,4 ) will be removed. This is because keeping in mind that you have started debugging from point 2 and you will revisit jumps 3 and 4 as u play the replay so have removed it.

# Sample video
Before improvements: 
https://app.replay.io/recording/jump-to-previous-and-next-pause-using-shortcuts--1cbe5a45-9376-4a46-b2a5-564567e12709

After Improvements:
https://app.replay.io/recording/jump-pauses-improved--2d659844-71b2-4cf5-bc90-c28607f1acc4
# Improvement
- Currently its been implemented based on array and array indexing.
- I was thinking to implementation it using Priority Queue or Heaps.
