### PR TITLE
Adds feature run-time override

### DIFF
--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -15,7 +15,7 @@ import { Recording } from "shared/graphql/types";
 import { UIThunkAction } from "ui/actions";
 import * as actions from "ui/actions/app";
 import { getRecording } from "ui/hooks/recordings";
-import { getUserSettings } from "ui/hooks/settings";
+import { getFeature, getUserSettings } from "ui/hooks/settings";
 import { getUserId, getUserInfo } from "ui/hooks/users";
 import {
   clearExpectedError,
@@ -247,17 +247,17 @@ export function createSocket(
         focusRange,
         {
           onEvent: (event: ProtocolEvent) => {
-            if (features.logProtocolEvents) {
+            if (getFeature("logProtocolEvents")) {
               queueAction(eventReceived({ ...event, recordedAt: window.performance.now() }));
             }
           },
           onRequest: (request: CommandRequest) => {
-            if (features.logProtocol) {
+            if (getFeature("logProtocol")) {
               queueAction(requestSent({ ...request, recordedAt: window.performance.now() }));
             }
           },
           onResponse: (response: CommandResponse) => {
-            if (features.logProtocol) {
+            if (getFeature("logProtocol")) {
               const clonedResponse = { ...response, recordedAt: window.performance.now() };
 
               if (isSourceContentsCommandResponse(clonedResponse)) {
@@ -273,7 +273,7 @@ export function createSocket(
             }
           },
           onResponseError: (error: CommandResponse) => {
-            if (features.logProtocol) {
+            if (getFeature("logProtocol")) {
               queueAction(errorReceived({ ...error, recordedAt: window.performance.now() }));
             }
           },

--- a/src/ui/reducers/protocolMessages.ts
+++ b/src/ui/reducers/protocolMessages.ts
@@ -3,6 +3,7 @@ import { EventMethods, EventParams } from "@replayio/protocol";
 import cloneDeep from "lodash/cloneDeep";
 
 import { CommandRequest, CommandResponse } from "protocol/socket";
+import { getFeature } from "ui/hooks/settings";
 import { UIState } from "ui/state";
 import { features } from "ui/utils/prefs";
 
@@ -86,7 +87,7 @@ export const { errorReceived, eventReceived, requestSent, responseReceived } =
 export default protocolMessagesSlice.reducer;
 
 export const getProtocolEvents = (_state: UIState) => {
-  if (!features.logProtocolEvents) {
+  if (!getFeature("logProtocolEvents")) {
     console.log("protocol events are disabled");
   }
 


### PR DESCRIPTION
Adds support for `features` query string parameter accepting a comma-separated list of devtools features which will be force-enabled for the session (not permanently for the user).