### PR TITLE
use UTCMinutes to convert duration into mm : ss

### DIFF
--- a/src/ui/utils/timeline.ts
+++ b/src/ui/utils/timeline.ts
@@ -123,9 +123,9 @@ export function getNewZoomRegion({
 // Format a time value to mm:ss
 export function getFormattedTime(time: number, showMilliseconds: boolean = false) {
   const date = new Date(time);
-  let minutes = date.getMinutes();
-  let seconds = date.getSeconds();
-  const milliseconds = date.getMilliseconds();
+  let minutes = date.getUTCMinutes();
+  let seconds = date.getUTCSeconds();
+  const milliseconds = date.getUTCMilliseconds();
 
   if (!showMilliseconds) {
     if (milliseconds >= 500) {


### PR DESCRIPTION
Fix #8889 

### Replay [After Fix](https://app.replay.io/recording/clock-within-a-clock-within-a-clock--ca4937d8-22da-4db0-a202-0c4a2bc2a33f)
<img width="617" alt="image" src="https://user-images.githubusercontent.com/63918341/223804508-795cc7ae-1366-4861-9f0c-407a819cf278.png">
(timestamp starts from 0:00)


 ### Unit tests after fix
<img width="331" alt="image" src="https://user-images.githubusercontent.com/63918341/224614161-d4b1438e-9c1f-4e39-a1e7-1699afbd62f0.png">



### Replay [Before Fix ](https://app.replay.io/recording/clockreplay--1a13a10a-356c-45ce-aad3-f39e42d58f99) (taken from the issue)



<img width="1098" alt="image" src="https://user-images.githubusercontent.com/63918341/223804849-b0ca0fc1-9332-4c37-b854-e4dd0da2f577.png">

### Unit tests before fix
<img width="557" alt="image" src="https://user-images.githubusercontent.com/63918341/224614742-14ca02f4-4464-41b4-95a6-42587dc98c42.png">

**Note: you can set your timezone to IST to get these tests failing before the fix**

run `TZ=Asia/Calcutta yarn test`  to run tests with IST timezone

### Tests 
Although unit test for the function is already present it would be better if we can run tests in (two ?) different timezones ? 🤔 
TZ environment variable can be modified to change timezone but not sure if it's worth it.

### TODO
there are one or two other places with same issue
e.g when we hover over the timeline the tooltip still shows different minutes elapsed a/c to locale, will be fixing it soon.

### Alternate Solution
credits : copilot
```js
 let minutes = Math.floor(time / 1000 / 60);
 let seconds = Math.floor(time / 1000) % 60;
 const milliseconds = time % 1000;
```

also our current implementation works upto 1 hour only, that is a safe upper limit for replays ?
`3600000` milliseconds convert into `0:00`