### PR TITLE
Make the loading screen less flickery

### DIFF
--- a/src/ui/components/Account/index.tsx
+++ b/src/ui/components/Account/index.tsx
@@ -31,5 +31,5 @@ export default function Account() {
     return <Login returnToPath={window.location.pathname + window.location.search} />;
   }
 
-  return <LoadingScreen fallbackMessage="Loading account details..." />;
+  return null;
 }

--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -151,7 +151,7 @@ function App({ children, hideModal, modal, quickOpenEnabled }: AppProps) {
   }, [theme]);
 
   if (auth.isLoading || userInfo.loading) {
-    return <LoadingScreen fallbackMessage="Authenticating..." />;
+    return;
   }
 
   if (

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -223,7 +223,7 @@ function _DevTools({
   }, [recording]);
 
   if (!loadingFinished) {
-    return <LoadingScreen fallbackMessage="Starting your session..." />;
+    return <LoadingScreen fallbackMessage="Loading replay..." />;
   }
 
   if (loadedRegions === null) {

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -223,11 +223,11 @@ function _DevTools({
   }, [recording]);
 
   if (!loadingFinished) {
-    return <LoadingScreen fallbackMessage="Loading replay..." />;
+    return <LoadingScreen fallbackMessage="Loading..." />;
   }
 
   if (loadedRegions === null) {
-    return <LoadingScreen fallbackMessage="Loading timeline..." />;
+    return <LoadingScreen fallbackMessage="Loading..." />;
   }
 
   return (

--- a/src/ui/components/Library/Library.tsx
+++ b/src/ui/components/Library/Library.tsx
@@ -87,7 +87,7 @@ function Library({
   }, [teamId, isValidTeamId, redirectToTeam]);
 
   if (!teamId) {
-    return <LoadingScreen fallbackMessage="Loading team information..." />;
+    return null;
   }
 
   return (

--- a/src/ui/components/Library/Library.tsx
+++ b/src/ui/components/Library/Library.tsx
@@ -56,7 +56,7 @@ export default function LibraryLoader() {
   const { loading: userInfoLoading, ...userInfo } = hooks.useGetUserInfo();
 
   if (userSettingsLoading || userInfoLoading) {
-    return <LoadingScreen fallbackMessage="Reloading team details..." />;
+    return;
   }
 
   return <Library userSettings={userSettings} userInfo={userInfo} />;

--- a/src/ui/components/shared/LoadingTips.tsx
+++ b/src/ui/components/shared/LoadingTips.tsx
@@ -48,13 +48,13 @@ export const LoadingTips: FC = () => {
   const currentTipIdx = Math.floor(seed * TIPS.length);
   const { title, description, icon: Icon } = TIPS[currentTipIdx];
   return (
-    <div className="h-32 w-96 space-y-8">
+    <div className="h-16 w-96 space-y-2">
       <div className="flex max-w-lg items-center space-x-4 rounded-lg bg-loadingBoxes px-8 py-4 align-middle text-bodyColor shadow-sm">
         <div className="h-16 w-16">
           <Icon />
         </div>
         <div className="flex flex-col space-y-2">
-          <div className="text-sm font-bold">{title}</div>
+          <div className="text-xs font-bold">{title}</div>
           <div className="text-xs">{description}</div>
         </div>
       </div>


### PR DESCRIPTION
When we go to the library, the loading screen is called several times, and oftentimes each load is only for a split second. This leads to a very flickery and heavy experience.

Old on the left, new on the right:
![Better library load-v1](https://user-images.githubusercontent.com/9154902/223962553-ed16cb89-a6c4-44c9-baa9-2789d4b7a921.gif)

Here are the four small changes to loading messaging to get this effect:

* We used to say "Reloading team details" but it's not necessary.
* Same with "Loading account details"
* We changed the default from "Starting your session..." to the more user-friendly + standard "Loading..."
* We changed "Loading timeline..." to "Loading..." because that distinction isn't important enough for a flicker

* And: a small change to make the tips text a bit smaller.

--

Of note, we still have our standard messaging on devtools. That's where different states (and stalls) are much more relevant to show the user, and aren't as flickery.