### PR TITLE
Do not block loading on endpoint

### DIFF
--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -332,8 +332,8 @@ export function createSocket(
       ThreadFront.on("paused", ({ point }) => dispatch(setCurrentPoint(point)));
 
       await ThreadFront.waitForSession();
-      await dispatch(jumpToInitialPausePoint());
 
+      dispatch(jumpToInitialPausePoint());
       dispatch(actions.setLoadingFinished(true));
 
       if (!focusRegion) {


### PR DESCRIPTION
In this Replay we wait for the endpoint for four minutes:

https://app.replay.io/recording/super-duper-never-loads-wtf--bcbb8ecc-36d6-4199-a43e-cade7a4433a1?point=157391498534412048370684558846197892&time=54376.98606502986&focusRegion=eyJiZWdpbiI6eyJwb2ludCI6IjUwNDYyNjM1MDk2ODYxMzE2NjYyOTcxNzEzMDg5NjAxNzY0NSIsInRpbWUiOjE3OTE4OX0sImVuZCI6eyJwb2ludCI6IjY4NDQwOTYyOTcwNTYzOTU0MTMyMjEwNzg4Mzc2NzIwMTc5MiIsInRpbWUiOjIzOTIwM319

We should make that faster. But also, in the meantime, let's just not await it.