### PR TITLE
Add POC "React Renders" panel

### DIFF
--- a/packages/shared/graphql/types.ts
+++ b/packages/shared/graphql/types.ts
@@ -102,6 +102,7 @@ export type LocalExperimentalUserSettings = {
   profileWorkerThreads: boolean;
   brokenSourcemapWorkaround: boolean;
   disableRecordingAssetsInDatabase: boolean;
+  reactPanel: boolean;
 };
 
 export type LocalUserSettings = LocalExperimentalUserSettings & {

--- a/src/devtools/client/debugger/src/utils/ast.ts
+++ b/src/devtools/client/debugger/src/utils/ast.ts
@@ -37,7 +37,7 @@ export function containsPosition(a: PositionRange, b: SourceLocation) {
   return startsBefore && endsAfter;
 }
 
-function findClosestofSymbol(
+export function findClosestofSymbol(
   declarations: (FunctionDeclaration | ClassDeclaration)[],
   location: SourceLocation
 ) {

--- a/src/ui/actions/event-listeners.ts
+++ b/src/ui/actions/event-listeners.ts
@@ -15,6 +15,7 @@ import { getScopeMapAsync } from "replay-next/src/suspense/ScopeMapCache";
 import { ReplayClientInterface } from "shared/client/types";
 import {
   SourceDetails,
+  SourcesState,
   getGeneratedLocation,
   getPreferredLocation,
   getSourceDetailsEntities,
@@ -84,17 +85,17 @@ export type FormattedEventListener = Awaited<ReturnType<typeof formatEventListen
 export const formatEventListener = async (
   replayClient: ReplayClientInterface,
   listener: { type: string; capture: boolean },
-  fnPreview: FunctionWithPreview,
-  state: UIState,
+  fnPreview: FunctionWithPreview["preview"],
+  sourcesState: SourcesState,
   sourcesById: Dictionary<SourceDetails>,
   framework?: string
 ) => {
-  const { functionLocation, functionName = "", functionParameterNames = [] } = fnPreview.preview;
+  const { functionLocation, functionName = "", functionParameterNames = [] } = fnPreview;
 
   let location: Location | undefined = undefined;
   let locationUrl: string | undefined = undefined;
   if (functionLocation) {
-    location = getPreferredLocation(state.sources, functionLocation);
+    location = getPreferredLocation(sourcesState, functionLocation);
 
     locationUrl = functionLocation?.length > 0 ? sourcesById[location.sourceId]?.url : undefined;
   }
@@ -161,7 +162,13 @@ export function getNodeEventListeners(
           listener.handler
         ) as FunctionWithPreview;
 
-        return formatEventListener(replayClient, listener, listenerHandler, state, sourcesById);
+        return formatEventListener(
+          replayClient,
+          listener,
+          listenerHandler.preview,
+          state.sources,
+          sourcesById
+        );
       })
     );
 
@@ -228,8 +235,8 @@ export function getNodeEventListeners(
               return formatEventListener(
                 replayClient,
                 { type: obj.name, capture: false },
-                obj.value,
-                state,
+                obj.value.preview,
+                state.sources,
                 sourcesById,
                 // We're only finding React-specific event handlers atm
                 "react"
@@ -329,8 +336,8 @@ export const {
         const formattedEventListener = await formatEventListener(
           replayClient,
           { type: "onClick", capture: false },
-          onClickPreview,
-          state,
+          onClickPreview.preview,
+          state.sources,
           sourcesById,
           "react"
         );

--- a/src/ui/actions/event-listeners.ts
+++ b/src/ui/actions/event-listeners.ts
@@ -261,14 +261,16 @@ const EVENT_CLASS_FOR_EVENT_TYPE: Record<SEARCHABLE_EVENT_TYPES, string> = {
   keypress: "InputEvent",
 };
 
-const IGNORABLE_PARTIAL_SOURCE_URLS = [
+export const IGNORABLE_PARTIAL_SOURCE_URLS = [
   // Don't jump into React internals
   "react-dom",
   // or CodeSandbox
   "webpack:///src/sandbox/",
+  "webpack:///sandpack-core/",
+  "webpack:////home/circleci/codesandbox-client",
 ];
 
-function shouldIgnoreEventFromSource(sourceDetails?: SourceDetails) {
+export function shouldIgnoreEventFromSource(sourceDetails?: SourceDetails) {
   const url = sourceDetails?.url ?? "";
 
   return IGNORABLE_PARTIAL_SOURCE_URLS.some(partialUrl => url.includes(partialUrl));

--- a/src/ui/components/Events/Event.tsx
+++ b/src/ui/components/Events/Event.tsx
@@ -90,9 +90,9 @@ const { getValueAsync: getNextInteractionEventAsync } = createGenericCache<
 );
 
 type EventProps = {
-  currentTime: any;
+  currentTime: number;
   event: ReplayEvent;
-  executionPoint: any;
+  executionPoint: string;
   onSeek: (point: string, time: number) => void;
 };
 
@@ -112,10 +112,10 @@ export const getEventLabel = (event: ReplayEvent) => {
   return label;
 };
 
-type JumpToCodeFailureReason = "not_loaded" | "no_hits";
-type JumpToCodeStatus = JumpToCodeFailureReason | "not_checked" | "loading" | "found";
+export type JumpToCodeFailureReason = "not_loaded" | "no_hits";
+export type JumpToCodeStatus = JumpToCodeFailureReason | "not_checked" | "loading" | "found";
 
-const errorMessages: Record<JumpToCodeFailureReason, string> = {
+export const errorMessages: Record<JumpToCodeFailureReason, string> = {
   not_loaded: "Not loaded",
   no_hits: "No results",
 };

--- a/src/ui/components/Events/Events.tsx
+++ b/src/ui/components/Events/Events.tsx
@@ -42,7 +42,7 @@ function Events({ currentTime, events, executionPoint, seek }: PropsFromRedux) {
                   onSeek={onSeek}
                   event={e}
                   currentTime={currentTime}
-                  executionPoint={executionPoint}
+                  executionPoint={executionPoint!}
                 />
               </div>
             </div>

--- a/src/ui/components/ReactPanel.tsx
+++ b/src/ui/components/ReactPanel.tsx
@@ -1,6 +1,146 @@
+import { Location, SameLineSourceLocations, TimeStampedPointRange } from "@replayio/protocol";
+import { useContext } from "react";
+
 import AccessibleImage from "devtools/client/debugger/src/components/shared/AccessibleImage";
+import { FocusContext } from "replay-next/src/contexts/FocusContext";
+import { getFramesAsync } from "replay-next/src/suspense/FrameCache";
+import { getHitPointsForLocationAsync } from "replay-next/src/suspense/HitPointsCache";
+import { getPauseIdAsync } from "replay-next/src/suspense/PauseCache";
+import { getScopeMapAsync } from "replay-next/src/suspense/ScopeMapCache";
+import { getBreakpointPositionsAsync } from "replay-next/src/suspense/SourcesCache";
+import { UIThunkAction } from "ui/actions";
+import {
+  IGNORABLE_PARTIAL_SOURCE_URLS,
+  shouldIgnoreEventFromSource,
+} from "ui/actions/event-listeners";
+import {
+  getAllSourceDetails,
+  getGeneratedLocation,
+  getPreferredLocation,
+  getSourceDetailsEntities,
+  getSourceIdsByUrl,
+  getSourceToDisplayForUrl,
+} from "ui/reducers/sources";
+import { useAppDispatch } from "ui/setup/hooks";
+import { getSymbolsAsync } from "ui/suspense/sourceCaches";
+
+import { findFirstBreakablePositionForFunction } from "./Events/Event";
+
+const MORE_IGNORABLE_PARTIAL_URLS = IGNORABLE_PARTIAL_SOURCE_URLS.concat(
+  // Ignore _any_ 3rd-party package for now
+  "node_modules"
+);
+
+function findQueuedRendersForRange(range: TimeStampedPointRange): UIThunkAction {
+  return async (dispatch, getState, { replayClient }) => {
+    const sourcesByUrl = getSourceIdsByUrl(getState());
+    const sourcesById = getSourceDetailsEntities(getState());
+    const allSources = getAllSourceDetails(getState());
+    const sourcesState = getState().sources;
+    const reactDomDevUrl = Object.keys(sourcesByUrl).find(key => {
+      return key.includes("react-dom.development");
+    });
+
+    if (!reactDomDevUrl) {
+      return;
+    }
+
+    const preferredSource = getSourceToDisplayForUrl(getState(), reactDomDevUrl);
+    if (!preferredSource) {
+      return;
+    }
+    const [symbols, breakablePositionsResult] = await Promise.all([
+      getSymbolsAsync(preferredSource.id, allSources, replayClient),
+      getBreakpointPositionsAsync(preferredSource.id, replayClient),
+    ]);
+    const [breakablePositions, breakablePositionsByLine] = breakablePositionsResult;
+    const shouldUpdateFiberSymbol = symbols?.functions.find(
+      f => f.name === "scheduleUpdateOnFiber"
+    )!;
+
+    const firstBreakablePosition = findFirstBreakablePositionForFunction(
+      { ...shouldUpdateFiberSymbol.location.start, sourceId: preferredSource.id },
+      breakablePositionsByLine
+    );
+    if (!firstBreakablePosition) {
+      return;
+    }
+    console.log("First breakable position: ", firstBreakablePosition);
+
+    const [hitPoints] = await getHitPointsForLocationAsync(
+      replayClient,
+      firstBreakablePosition,
+      null,
+      { begin: range.begin.point, end: range.end.point }
+    );
+    console.log("Hit points: ", hitPoints);
+
+    const hitPointsToCheck = hitPoints.slice(0, 3);
+    const queuedRenders = await Promise.all(
+      hitPointsToCheck.map(async hitPoint => {
+        const pauseId = await getPauseIdAsync(replayClient, hitPoint.point, hitPoint.time);
+
+        const frames = (await getFramesAsync(pauseId, replayClient)) ?? [];
+
+        const formattedFrames = await Promise.all(
+          frames.map(async frame => {
+            const { functionLocation = [], functionName = "" } = frame;
+            let location: Location | undefined = undefined;
+            let locationUrl: string | undefined = undefined;
+            if (functionLocation) {
+              location = getPreferredLocation(sourcesState, functionLocation);
+
+              locationUrl =
+                functionLocation?.length > 0 ? sourcesById[location.sourceId]?.url : undefined;
+            }
+
+            const scopeMap = await getScopeMapAsync(
+              getGeneratedLocation(sourcesById, functionLocation),
+              replayClient
+            );
+            const originalFunctionName = scopeMap?.find(
+              mapping => mapping[0] === functionName
+            )?.[1];
+            return {
+              location,
+              locationUrl,
+              functionName,
+              originalFunctionName,
+              source: location ? sourcesById[location.sourceId] : undefined,
+            };
+          })
+        );
+
+        const filteredFrames = formattedFrames.filter(entry => {
+          if (!entry.locationUrl) {
+            return false;
+          }
+          return !MORE_IGNORABLE_PARTIAL_URLS.some(partialUrl =>
+            entry.locationUrl!.includes(partialUrl)
+          );
+        });
+
+        return {
+          frames,
+          formattedFrames,
+          filteredFrames,
+        };
+      })
+    );
+
+    console.log("Queued renders: ", queuedRenders);
+  };
+}
 
 export function ReactPanel() {
+  const dispatch = useAppDispatch();
+  const { rangeForDisplay: focusRange } = useContext(FocusContext);
+
+  const handleClick = () => {
+    console.log("Focus range: ", focusRange);
+    dispatch(findQueuedRendersForRange(focusRange!));
+  };
+
   return (
     <div>
       <div
@@ -8,6 +148,16 @@ export function ReactPanel() {
         style={{ display: "flex", alignItems: "center", justifyContent: "center" }}
       >
         React Renders <AccessibleImage className="annotation-logo react" />
+      </div>
+      <div>
+        <button
+          type="button"
+          onClick={handleClick}
+          className="mr-0 flex items-center space-x-1.5 rounded-lg bg-primaryAccent text-buttontextColor hover:bg-primaryAccentHover focus:outline-none focus:ring-2 focus:ring-primaryAccent focus:ring-offset-2"
+          style={{ padding: "5px 12px" }}
+        >
+          Find React Renders
+        </button>
       </div>
     </div>
   );

--- a/src/ui/components/ReactPanel.tsx
+++ b/src/ui/components/ReactPanel.tsx
@@ -5,20 +5,32 @@ import {
   TimeStampedPoint,
   TimeStampedPointRange,
 } from "@replayio/protocol";
-import { useContext, useState } from "react";
+import classnames from "classnames";
+import { ReactNode, useContext, useState } from "react";
 
+import { selectFrame as selectFrameAction } from "devtools/client/debugger/src/actions/pause/selectFrame";
 import AccessibleImage from "devtools/client/debugger/src/components/shared/AccessibleImage";
+import {
+  PauseFrame,
+  getExecutionPoint,
+  getThreadContext,
+} from "devtools/client/debugger/src/reducers/pause";
+import { getFilename } from "devtools/client/debugger/src/utils/source";
+import { AnalysisInput, getFunctionBody } from "protocol/evaluation-utils";
+import Icon from "replay-next/components/Icon";
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
 import { getFramesAsync } from "replay-next/src/suspense/FrameCache";
 import { getHitPointsForLocationAsync } from "replay-next/src/suspense/HitPointsCache";
 import { getPauseIdAsync } from "replay-next/src/suspense/PauseCache";
 import { getScopeMapAsync } from "replay-next/src/suspense/ScopeMapCache";
 import { getBreakpointPositionsAsync } from "replay-next/src/suspense/SourcesCache";
+import { isExecutionPointsGreaterThan } from "replay-next/src/utils/time";
 import { UIThunkAction } from "ui/actions";
 import {
   IGNORABLE_PARTIAL_SOURCE_URLS,
   shouldIgnoreEventFromSource,
 } from "ui/actions/event-listeners";
+import { seek } from "ui/actions/timeline";
 import {
   SourceDetails,
   getAllSourceDetails,
@@ -28,10 +40,18 @@ import {
   getSourceIdsByUrl,
   getSourceToDisplayForUrl,
 } from "ui/reducers/sources";
-import { useAppDispatch } from "ui/setup/hooks";
+import { getCurrentTime } from "ui/reducers/timeline";
+import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
+import { getPauseFramesAsync } from "ui/suspense/frameCache";
 import { getSymbolsAsync } from "ui/suspense/sourceCaches";
 
-import { findFirstBreakablePositionForFunction } from "./Events/Event";
+import {
+  JumpToCodeFailureReason,
+  JumpToCodeStatus,
+  findFirstBreakablePositionForFunction,
+} from "./Events/Event";
+import MaterialIcon from "./shared/MaterialIcon";
+import styles from "./Events/Event.module.css";
 
 const MORE_IGNORABLE_PARTIAL_URLS = IGNORABLE_PARTIAL_SOURCE_URLS.concat(
   // Ignore _any_ 3rd-party package for now
@@ -46,11 +66,25 @@ interface FormattedFrame {
   source: SourceDetails | undefined;
 }
 
-interface ReactQueuedRenderDetails {
-  point: TimeStampedPoint;
-  frames: Frame[];
-  formattedFrames: FormattedFrame[];
-  filteredFrames: FormattedFrame[];
+interface ReactQueuedRenderDetails extends TimeStampedPoint {
+  // frames: Frame[];
+  // formattedFrames: FormattedFrame[];
+  // filteredFrames: FormattedFrame[];
+  pauseFrames: PauseFrame[];
+  filteredPauseFrames: PauseFrame[];
+  userPauseFrame?: PauseFrame;
+  userPauseFrameTime?: TimeStampedPoint;
+}
+
+declare let input: AnalysisInput;
+
+export function hitMapper() {
+  return [
+    {
+      key: input.point,
+      value: input,
+    },
+  ];
 }
 
 function findQueuedRendersForRange(
@@ -66,13 +100,16 @@ function findQueuedRendersForRange(
     });
 
     if (!reactDomDevUrl) {
+      console.error("No ReactDOM url");
       return;
     }
 
     const preferredSource = getSourceToDisplayForUrl(getState(), reactDomDevUrl);
     if (!preferredSource) {
+      console.error("No preferred source");
       return;
     }
+    console.log("Getting symbols and positions");
     const [symbols, breakablePositionsResult] = await Promise.all([
       getSymbolsAsync(preferredSource.id, allSources, replayClient),
       getBreakpointPositionsAsync(preferredSource.id, replayClient),
@@ -82,6 +119,7 @@ function findQueuedRendersForRange(
       f => f.name === "scheduleUpdateOnFiber"
     )!;
 
+    console.log("shouldUpdateFiber: ", shouldUpdateFiberSymbol);
     const firstBreakablePosition = findFirstBreakablePositionForFunction(
       { ...shouldUpdateFiberSymbol.location.start, sourceId: preferredSource.id },
       breakablePositionsByLine
@@ -99,69 +137,214 @@ function findQueuedRendersForRange(
     );
     console.log("Hit points: ", hitPoints);
 
-    const hitPointsToCheck = hitPoints.slice(0, 3);
-    const queuedRenders = await Promise.all(
-      hitPointsToCheck.map(async hitPoint => {
-        const pauseId = await getPauseIdAsync(replayClient, hitPoint.point, hitPoint.time);
+    const hitPointsToCheck = hitPoints.slice(0, 200);
+    try {
+      const queuedRenders = await Promise.all(
+        hitPointsToCheck.map(async (hitPoint): Promise<ReactQueuedRenderDetails> => {
+          const pauseId = await getPauseIdAsync(replayClient, hitPoint.point, hitPoint.time);
 
-        const frames = (await getFramesAsync(pauseId, replayClient)) ?? [];
+          // const frames = (await getFramesAsync(pauseId, replayClient)) ?? [];
 
-        const formattedFrames = await Promise.all(
-          frames.map(async (frame): Promise<FormattedFrame> => {
-            const { functionLocation = [], functionName = "" } = frame;
-            let location: Location | undefined = undefined;
-            let locationUrl: string | undefined = undefined;
-            if (functionLocation) {
-              location = getPreferredLocation(sourcesState, functionLocation);
+          // const formattedFrames = await Promise.all(
+          //   frames.map(async (frame): Promise<FormattedFrame> => {
+          //     const { functionLocation = [], functionName = "" } = frame;
+          //     let location: Location | undefined = undefined;
+          //     let locationUrl: string | undefined = undefined;
+          //     if (functionLocation) {
+          //       location = getPreferredLocation(sourcesState, functionLocation);
 
-              locationUrl =
-                functionLocation?.length > 0 ? sourcesById[location.sourceId]?.url : undefined;
+          //       locationUrl =
+          //         functionLocation?.length > 0 ? sourcesById[location.sourceId]?.url : undefined;
+          //     }
+
+          //     const scopeMap = await getScopeMapAsync(
+          //       getGeneratedLocation(sourcesById, functionLocation),
+          //       replayClient
+          //     );
+          //     const originalFunctionName = scopeMap?.find(
+          //       mapping => mapping[0] === functionName
+          //     )?.[1];
+          //     return {
+          //       location,
+          //       locationUrl,
+          //       functionName,
+          //       originalFunctionName,
+          //       source: location ? sourcesById[location.sourceId] : undefined,
+          //     };
+          //   })
+          // );
+
+          // const filteredFrames = formattedFrames.filter(entry => {
+          //   if (!entry.locationUrl) {
+          //     return false;
+          //   }
+          //   return !MORE_IGNORABLE_PARTIAL_URLS.some(partialUrl =>
+          //     entry.locationUrl!.includes(partialUrl)
+          //   );
+          // });
+
+          const pauseFrames =
+            (await getPauseFramesAsync(replayClient, pauseId, sourcesState)) ?? [];
+          const filteredPauseFrames = pauseFrames.filter(frame => {
+            const { source } = frame;
+            if (!source) {
+              return false;
             }
-
-            const scopeMap = await getScopeMapAsync(
-              getGeneratedLocation(sourcesById, functionLocation),
-              replayClient
+            return !MORE_IGNORABLE_PARTIAL_URLS.some(partialUrl =>
+              source.url?.includes(partialUrl)
             );
-            console.log("Scope map: ", functionName, scopeMap);
-            const originalFunctionName = scopeMap?.find(
-              mapping => mapping[0] === functionName
-            )?.[1];
-            return {
+          });
+
+          const [userPauseFrame] = filteredPauseFrames.slice(-1);
+
+          let userPauseFrameTime: TimeStampedPoint | undefined = undefined;
+
+          if (userPauseFrame) {
+            const arbitraryStartPoint = hitPoint.time - 50;
+            const pointNearTime = await replayClient.getPointNearTime(arbitraryStartPoint);
+            const { location } = userPauseFrame;
+            const functionHits = await replayClient.runAnalysis<AnalysisInput>({
+              effectful: false,
+              mapper: getFunctionBody(hitMapper),
               location,
-              locationUrl,
-              functionName,
-              originalFunctionName,
-              source: location ? sourcesById[location.sourceId] : undefined,
-            };
-          })
-        );
-
-        const filteredFrames = formattedFrames.filter(entry => {
-          if (!entry.locationUrl) {
-            return false;
+              range: {
+                begin: pointNearTime.point,
+                end: hitPoint.point,
+              },
+            });
+            [userPauseFrameTime] = functionHits.slice(-1);
           }
-          return !MORE_IGNORABLE_PARTIAL_URLS.some(partialUrl =>
-            entry.locationUrl!.includes(partialUrl)
-          );
-        });
 
-        return {
-          point: hitPoint,
-          frames,
-          formattedFrames,
-          filteredFrames,
-        };
-      })
-    );
+          return {
+            ...hitPoint,
+            // frames,
+            // formattedFrames,
+            // filteredFrames,
+            pauseFrames,
+            filteredPauseFrames,
+            userPauseFrame,
+            userPauseFrameTime,
+          };
+        })
+      );
 
-    console.log("Queued renders: ", queuedRenders);
+      console.log("Queued renders: ", queuedRenders);
 
-    return queuedRenders;
+      return queuedRenders;
+    } catch (err) {
+      console.error("Error loading frames: ", err);
+    }
   };
+}
+
+const Label = ({ children }: { children: ReactNode }) => (
+  <div className="overflow-hidden overflow-ellipsis whitespace-pre font-normal">{children}</div>
+);
+
+type EventProps = {
+  currentTime: number;
+  renderDetails: ReactQueuedRenderDetails;
+  executionPoint: string;
+  onSeek: (point: string, time: number) => void;
+};
+
+function ReactRenderListItem({ currentTime, renderDetails, executionPoint, onSeek }: EventProps) {
+  const dispatch = useAppDispatch();
+  const { point, time } = renderDetails;
+  const isPaused = time === currentTime && executionPoint === point;
+  const [isHovered, setIsHovered] = useState(false);
+  const cx = useAppSelector(getThreadContext);
+
+  const [jumpToCodeStatus, setJumpToCodeStatus] = useState<JumpToCodeStatus>("not_checked");
+
+  const { userPauseFrame, userPauseFrameTime } = renderDetails;
+  const { source } = userPauseFrame!;
+
+  const filename = source ? getFilename(source) : "Unknown";
+
+  const onClickSeek = () => {
+    if (userPauseFrameTime) {
+      onSeek(userPauseFrameTime.point, userPauseFrameTime.time);
+    }
+  };
+
+  const onClickJumpToCode = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+
+    // Seek to the sidebar event timestamp right away.
+    // That way we're at least _close_ to the right time
+    onClickSeek();
+
+    dispatch(selectFrameAction(cx, userPauseFrame!));
+  };
+
+  const timeLabel =
+    executionPoint === null || isExecutionPointsGreaterThan(point, executionPoint)
+      ? "fast-forward"
+      : "rewind";
+
+  const jumpToCodeButtonAvailable =
+    jumpToCodeStatus === "not_checked" || jumpToCodeStatus === "found";
+
+  const jumpToCodeButtonClassname = classnames(
+    "transition-width flex items-center justify-center rounded-full  duration-100 ease-out h-6",
+    {
+      "bg-primaryAccent": jumpToCodeButtonAvailable,
+      "bg-gray-400 cursor-default": !jumpToCodeButtonAvailable,
+      "px-2 shadow-sm": isHovered,
+      "w-6": !isHovered,
+    }
+  );
+
+  const onJumpButtonMouseEnter = (e: React.MouseEvent) => {
+    setIsHovered(true);
+  };
+
+  const onJumpButtonMouseLeave = (e: React.MouseEvent) => {
+    setIsHovered(false);
+  };
+
+  let jumpButtonText = "Jump to code";
+
+  return (
+    <>
+      <div
+        className={classnames(styles.eventRow, "group block w-full", {
+          "text-lightGrey": currentTime < time,
+          "font-semibold text-primaryAccent": isPaused,
+        })}
+        onClick={onClickSeek}
+      >
+        <div className="flex flex-row items-center space-x-2 overflow-hidden">
+          <MaterialIcon iconSize="xl">ads_click</MaterialIcon>
+          <Label>
+            {filename}: {userPauseFrame.displayName}
+          </Label>
+        </div>
+        <div className="flex space-x-2 opacity-0 group-hover:opacity-100">
+          {
+            <div
+              onClick={jumpToCodeButtonAvailable ? onClickJumpToCode : undefined}
+              onMouseEnter={onJumpButtonMouseEnter}
+              onMouseLeave={onJumpButtonMouseLeave}
+              className={jumpToCodeButtonClassname}
+            >
+              <div className="flex items-center space-x-1">
+                {isHovered && <span className="truncate text-white ">{jumpButtonText}</span>}
+                <Icon type={timeLabel} className="w-3.5 text-white" />
+              </div>
+            </div>
+          }
+        </div>
+      </div>
+    </>
+  );
 }
 
 export function ReactPanel() {
   const dispatch = useAppDispatch();
+  const currentTime = useAppSelector(getCurrentTime);
+  const executionPoint = useAppSelector(getExecutionPoint);
   const { rangeForDisplay: focusRange } = useContext(FocusContext);
   const [renderDetails, setRenderDetails] = useState<ReactQueuedRenderDetails[]>([]);
 
@@ -173,25 +356,31 @@ export function ReactPanel() {
     }
   };
 
-  const renderedRenderEntries = renderDetails.map(entry => {
-    const [firstFrame] = entry.filteredFrames;
+  const onSeek = (point: string, time: number) => {
+    // trackEvent("events_timeline.select");
+    dispatch(seek(point, time, false));
+  };
 
-    if (!firstFrame) {
-      return <li key={entry.point.point}>No function found</li>;
+  const renderedRenderEntries = renderDetails.map(entry => {
+    const [oldestPauseFrame] = entry.filteredPauseFrames.slice(-1);
+
+    if (!oldestPauseFrame) {
+      return null;
     }
 
     return (
-      <li key={entry.point.point}>
-        Function: {firstFrame.functionName}
-        <br />
-        Location: {firstFrame.locationUrl}
-        <br />
-      </li>
+      <ReactRenderListItem
+        currentTime={currentTime}
+        executionPoint={executionPoint!}
+        renderDetails={entry}
+        onSeek={onSeek}
+        key={entry.point}
+      />
     );
   });
 
   return (
-    <div>
+    <div style={{ height: "100%", display: "flex", flexDirection: "column" }}>
       <div
         className="text-xl"
         style={{ display: "flex", alignItems: "center", justifyContent: "center" }}
@@ -208,9 +397,13 @@ export function ReactPanel() {
           Find React Renders
         </button>
       </div>
-      <div>
+      <div style={{ flexGrow: 1, height: "100%" }}>
         <h3 className="text-lg">Renders In Range</h3>
-        <ul>{renderedRenderEntries}</ul>
+        <div
+          style={{ overflowY: "auto", display: "flex", flexDirection: "column", maxHeight: 725 }}
+        >
+          {renderedRenderEntries}
+        </div>
       </div>
     </div>
   );

--- a/src/ui/components/ReactPanel.tsx
+++ b/src/ui/components/ReactPanel.tsx
@@ -1,0 +1,14 @@
+import AccessibleImage from "devtools/client/debugger/src/components/shared/AccessibleImage";
+
+export function ReactPanel() {
+  return (
+    <div>
+      <div
+        className="text-xl"
+        style={{ display: "flex", alignItems: "center", justifyContent: "center" }}
+      >
+        React Renders <AccessibleImage className="annotation-logo react" />
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -24,6 +24,7 @@ import useAuth0 from "ui/utils/useAuth0";
 import CommentCardsList from "./Comments/CommentCardsList";
 import ReplayInfo from "./Events/ReplayInfo";
 import ProtocolViewer from "./ProtocolViewer";
+import { ReactPanel } from "./ReactPanel";
 import StatusDropdown from "./shared/StatusDropdown";
 import { TestSuitePanel } from "./TestSuitePanel";
 import styles from "src/ui/components/SidePanel.module.css";
@@ -148,6 +149,7 @@ export default function SidePanel() {
         {selectedPrimaryPanel === "cypress" && <TestSuitePanel />}
         {selectedPrimaryPanel === "protocol" && <ProtocolViewer />}
         {selectedPrimaryPanel === "search" && <SearchFilesReduxAdapter />}
+        {selectedPrimaryPanel === "react" && <ReactPanel />}
       </div>
     </div>
   );

--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import PrimaryPanes from "devtools/client/debugger/src/components/PrimaryPanes";
 import SecondaryPanes from "devtools/client/debugger/src/components/SecondaryPanes";
 import Accordion from "devtools/client/debugger/src/components/shared/Accordion";
+import LazyOffscreen from "replay-next/components/LazyOffscreen";
 import { setSelectedPrimaryPanel } from "ui/actions/layout";
 import { setViewMode } from "ui/actions/layout";
 import Events from "ui/components/Events";
@@ -149,7 +150,9 @@ export default function SidePanel() {
         {selectedPrimaryPanel === "cypress" && <TestSuitePanel />}
         {selectedPrimaryPanel === "protocol" && <ProtocolViewer />}
         {selectedPrimaryPanel === "search" && <SearchFilesReduxAdapter />}
-        {selectedPrimaryPanel === "react" && <ReactPanel />}
+        <LazyOffscreen mode={selectedPrimaryPanel === "react" ? "visible" : "hidden"}>
+          <ReactPanel />
+        </LazyOffscreen>
       </div>
     </div>
   );

--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -145,6 +145,7 @@ export default function Toolbar() {
   const { recording } = useGetRecording(recordingId);
   const { comments, loading } = hooks.useGetComments(recordingId);
   const { value: logProtocol } = useFeature("logProtocol");
+  const { value: showReactPanel } = useFeature("reactPanel");
   const [sidePanelCollapsed, setSidePanelCollapsed] = useLocalStorage(sidePanelStorageKey, false);
 
   useEffect(() => {
@@ -219,7 +220,9 @@ export default function Toolbar() {
               showBadge={hasFrames}
               onClick={handleButtonClick}
             />
-            <ToolbarButton icon="react" name="react" label="React" onClick={handleButtonClick} />
+            {showReactPanel && (
+              <ToolbarButton icon="react" name="react" label="React" onClick={handleButtonClick} />
+            )}
           </>
         ) : null}
         {logProtocol && viewMode === "dev" ? (

--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -2,6 +2,7 @@ import classnames from "classnames";
 import classNames from "classnames";
 import React, { useContext, useEffect, useState } from "react";
 
+import AccessibleImage from "devtools/client/debugger/src/components/shared/AccessibleImage";
 import { getPauseId } from "devtools/client/debugger/src/selectors";
 import useLocalStorage from "replay-next/src/hooks/useLocalStorage";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
@@ -45,6 +46,15 @@ function CypressIcon() {
   );
 }
 
+function ReactIcon() {
+  return (
+    <div style={{ display: "flex", justifyContent: "center", alignItems: "center" }}>
+      {" "}
+      <AccessibleImage className="annotation-logo react" />
+    </div>
+  );
+}
+
 function ToolbarButtonTab({ active }: { active: boolean }) {
   return (
     <div
@@ -70,12 +80,27 @@ function ToolbarButton({
 }) {
   const selectedPrimaryPanel = useAppSelector(selectors.getSelectedPrimaryPanel);
 
+  let iconContents: string | JSX.Element = icon;
+
+  switch (icon) {
+    case "cypress": {
+      iconContents = <CypressIcon />;
+      break;
+    }
+    case "react": {
+      iconContents = <ReactIcon />;
+      break;
+    }
+    default:
+      break;
+  }
+
   const imageIcon = (
     <MaterialIcon
       className={classNames("toolbar-panel-icon text-themeToolbarPanelIconColor", name)}
       iconSize="2xl"
     >
-      {icon === "cypress" ? <CypressIcon /> : icon}
+      {iconContents}
     </MaterialIcon>
   );
   return (
@@ -194,6 +219,7 @@ export default function Toolbar() {
               showBadge={hasFrames}
               onClick={handleButtonClick}
             />
+            <ToolbarButton icon="react" name="react" label="React" onClick={handleButtonClick} />
           </>
         ) : null}
         {logProtocol && viewMode === "dev" ? (

--- a/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
+++ b/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
@@ -75,6 +75,11 @@ const EXPERIMENTAL_SETTINGS: ExperimentalSetting[] = [
       "Disable writing to and reading from the backend database when storing or retrieving recording assets",
     key: "disableRecordingAssetsInDatabase",
   },
+  {
+    label: "Enable React Panel",
+    description: "Enable experimental React render details panel",
+    key: "reactPanel",
+  },
 ];
 
 const RISKY_EXPERIMENTAL_SETTINGS: ExperimentalSetting[] = [];
@@ -129,6 +134,7 @@ export default function ExperimentalSettings({}) {
 
   const { value: enableRoutines, update: updateEnableRoutines } = useFeature("enableRoutines");
   const { value: rerunRoutines, update: updatererunRoutines } = useFeature("rerunRoutines");
+  const { value: reactPanel, update: updateReactPanel } = useFeature("reactPanel");
 
   const {
     value: disableRecordingAssetsInDatabase,
@@ -158,6 +164,8 @@ export default function ExperimentalSettings({}) {
       updatererunRoutines(!rerunRoutines);
     } else if (key === "disableRecordingAssetsInDatabase") {
       updateDisableRecordingAssetsInDatabase(!disableRecordingAssetsInDatabase);
+    } else if (key === "reactPanel") {
+      updateReactPanel(!reactPanel);
     }
   };
 
@@ -173,6 +181,7 @@ export default function ExperimentalSettings({}) {
     rerunRoutines,
     profileWorkerThreads,
     disableRecordingAssetsInDatabase,
+    reactPanel,
   };
 
   const settings = { ...userSettings, ...localSettings };

--- a/src/ui/reducers/sources.ts
+++ b/src/ui/reducers/sources.ts
@@ -38,7 +38,7 @@ export interface MiniSource {
   url?: string;
 }
 
-const sourceDetailsAdapter = createEntityAdapter<SourceDetails>();
+export const sourceDetailsAdapter = createEntityAdapter<SourceDetails>();
 
 export const {
   selectAll: getAllSourceDetails,

--- a/src/ui/state/layout.ts
+++ b/src/ui/state/layout.ts
@@ -17,6 +17,7 @@ export type PrimaryPanelName =
   | "debugger"
   | "protocol"
   | "search"
+  | "react"
   | ViewerPrimaryPanelName;
 export type SecondaryPanelName =
   | "console"

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -39,6 +39,7 @@ pref("devtools.features.profileWorkerThreads", false);
 pref("devtools.features.enableRoutines", false);
 pref("devtools.features.rerunRoutines", false);
 pref("devtools.features.protocolTimeline", false);
+pref("devtools.features.reactPanel", false);
 pref("devtools.features.repaintEvaluations", false);
 pref("devtools.features.resolveRecording", false);
 pref("devtools.features.chromiumNetMonitor", true);
@@ -79,6 +80,7 @@ export const features = new PrefsHelper("devtools.features", {
   originalClassNames: ["Bool", "originalClassNames"],
   profileWorkerThreads: ["Bool", "profileWorkerThreads"],
   protocolTimeline: ["Bool", "protocolTimeline"],
+  reactPanel: ["Bool", "reactPanel"],
   repaintEvaluations: ["Bool", "repaintEvaluations"],
   resolveRecording: ["Bool", "resolveRecording"],
   rerunRoutines: ["Bool", "rerunRoutines"],


### PR DESCRIPTION
This PR:

- Adds a new experimental "React Renders" panel to the debugger sidebar, which shows a list of all userland lines that called a React `setState` (or even a Redux `dispatch`, which ends up queueing a re-render).  The implementation:
  - Specifically looks for `react-dom.development.js`
  - Specifically looks for the React-internal function `scheduleUpdateOnFiber`, which is a central point that all queued React updates funnel through
  - Finds all times that `scheduleUpdate` got hit
  - For every hit, it gets the stack trace, filters out anything in `node_modules`, and finds the oldest stack frame in what is presumably user code, which _should_ be the code that triggered the state update and queued the render
  - Also identifies all times that React finished committing a render
- Shows list items for each `setState` call with the filename and function, as well as list items for each committed render

![image](https://user-images.githubusercontent.com/1128784/224200130-d366cd9c-d94f-4c13-b30c-7a97cf9bc264.png)

This is still very much a POC, and I've _only_ tested it with `react-dom.development` in React 18.2.

But the principle seems pretty solid, and it's worked perfectly in the two recordings (a Redux CSB and a Replay UI recording) I've tested it on.