### PR TITLE
Custom Playwright formatter for local test runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     "@types/react-window": "^1.8.5",
     "@types/styled-components": "^5.1.25",
     "@types/uuid": "^7.0.3",
+    "@types/window-size": "^1.1.1",
     "@typescript-eslint/parser": "^5.38.1",
     "apollo": "^2.33.10",
     "autoprefixer": "^10.4.4",

--- a/packages/replay-next/playwright/custom-reporter.ts
+++ b/packages/replay-next/playwright/custom-reporter.ts
@@ -1,0 +1,261 @@
+import {
+  FullConfig,
+  FullResult,
+  Reporter,
+  Suite,
+  TestCase,
+  TestResult,
+  TestStatus,
+} from "@playwright/test/reporter";
+
+import windowSize from "window-size";
+
+const FORMAT_BOLD = "\x1b[1m";
+const FORMAT_COLOR_RED = "\x1b[31m";
+const FORMAT_COLOR_GREEN = "\x1b[32m";
+const FORMAT_DIM = "\x1b[2m";
+const FORMAT_RESET = "\x1b[0m";
+
+const CHARACTER_PENDING = "•";
+const CHARACTER_FAILED = "✗";
+const CHARACTER_PASSED = "✓";
+
+type TestCaseMetadata = {
+  finalStatus: TestStatus | null;
+  testCase: TestCase;
+  testRuns: Array<{
+    logs: string[];
+    status: TestStatus | null;
+  }>;
+};
+
+export default class CustomerReporter implements Reporter {
+  private completed: boolean = false;
+  private logs: string[] = [];
+  private testCaseMetadataMap = new Map<TestCase, TestCaseMetadata>();
+
+  onBegin(config: FullConfig, suite: Suite) {
+    // No-op
+  }
+
+  onEnd(result: FullResult) {
+    this.completed = true;
+
+    this.printSummary();
+  }
+
+  onTestBegin(testCase: TestCase, testResult: TestResult) {
+    let testCaseMetadata = this.testCaseMetadataMap.get(testCase);
+    if (testCaseMetadata == null) {
+      testCaseMetadata = {
+        finalStatus: null,
+        testCase,
+        testRuns: [],
+      };
+
+      this.testCaseMetadataMap.set(testCase, testCaseMetadata);
+    }
+
+    testCaseMetadata.testRuns.push({
+      logs: [],
+      status: null,
+    });
+
+    this.logs.push(`${FORMAT_BOLD}${testCase.title}${FORMAT_RESET}`);
+
+    this.printSummary();
+  }
+
+  onTestEnd(testCase: TestCase, testResult: TestResult) {
+    const testCaseMetadata = this.testCaseMetadataMap.get(testCase);
+    if (testCaseMetadata) {
+      const { testRuns } = testCaseMetadata;
+
+      const currentTestRun = testRuns[testRuns.length - 1];
+      currentTestRun.status = testResult.status;
+
+      if (testResult.status === "passed" || testRuns.length > testCase.retries) {
+        testCaseMetadata.finalStatus = testResult.status;
+      }
+    }
+  }
+
+  // TODO Track stdErr separately from stdOut
+  onStdErr(chunk: Buffer | string, testCase: TestCase, testResult: TestResult) {
+    const string = typeof chunk === "string" ? chunk : chunk.toString();
+
+    const testCaseMetadata = this.testCaseMetadataMap.get(testCase);
+    if (testCaseMetadata) {
+      const { testRuns } = testCaseMetadata;
+
+      const currentTestRun = testRuns[testRuns.length - 1];
+      currentTestRun.logs.push(string.trim());
+    }
+
+    this.logs.push(`   ${string.trim()}`);
+
+    this.printSummary();
+  }
+
+  onStdOut(chunk: Buffer | string, testCase: TestCase, testResult: TestResult) {
+    const string = typeof chunk === "string" ? chunk : chunk.toString();
+
+    const testCaseMetadata = this.testCaseMetadataMap.get(testCase);
+    if (testCaseMetadata) {
+      const { testRuns } = testCaseMetadata;
+
+      const currentTestRun = testRuns[testRuns.length - 1];
+      currentTestRun.logs.push(string.trim());
+    }
+
+    this.logs.push(`   ${string.trim()}`);
+
+    this.printSummary();
+  }
+
+  private printSummary() {
+    const logLines: string[] = [];
+
+    let numPending = 0;
+    let numFailed = 0;
+    let numPassed = 0;
+
+    for (let testCaseMetadata of this.testCaseMetadataMap.values()) {
+      switch (testCaseMetadata.finalStatus) {
+        case "failed":
+          numFailed++;
+          break;
+        case "passed":
+          numPassed++;
+          break;
+        default:
+          numPending++;
+          break;
+      }
+    }
+
+    const summaries = [];
+    summaries.push(`${FORMAT_DIM}${CHARACTER_PENDING}${FORMAT_RESET} ${numPending}`);
+    summaries.push(`${FORMAT_COLOR_RED}${CHARACTER_FAILED}${FORMAT_RESET} ${numFailed}`);
+    summaries.push(`${FORMAT_COLOR_GREEN}${CHARACTER_PASSED}${FORMAT_RESET} ${numPassed}`);
+
+    logLines.push(`Tests running  ${summaries.join("  ")}`);
+    logLines.push("");
+
+    const values = this.testCaseMetadataMap.values();
+
+    const maxTestNumber = this.testCaseMetadataMap.size;
+    const maxTestNumberChars = `${maxTestNumber}`.length;
+
+    const formatTestIndex = (index: number) => {
+      const testNumber = index + 1;
+      const testNumberChars = `${testNumber}`.length;
+      const delta = maxTestNumberChars - testNumberChars;
+
+      return `${" ".repeat(delta)}${testNumber}`;
+    };
+
+    Array.from(values).forEach(({ finalStatus, testCase, testRuns }, mapIndex) => {
+      const { title } = testCase;
+
+      let prefix;
+      let prefixFormat = "";
+      let titleFormat = FORMAT_BOLD;
+      switch (finalStatus) {
+        case "failed":
+          prefix = CHARACTER_FAILED;
+          prefixFormat = FORMAT_COLOR_RED;
+          titleFormat += FORMAT_COLOR_RED;
+          break;
+        case "passed":
+          prefix = CHARACTER_PASSED;
+          prefixFormat = FORMAT_COLOR_GREEN;
+          break;
+        default:
+          prefix = CHARACTER_PENDING;
+          prefixFormat = FORMAT_DIM;
+          break;
+      }
+
+      let suffix = "";
+      if (finalStatus !== null) {
+        if (testRuns.length > 1) {
+          suffix = ` ${FORMAT_DIM}(${testRuns.length - 1} retries)${FORMAT_RESET}`;
+        }
+      }
+
+      logLines.push(
+        `${FORMAT_DIM}${formatTestIndex(
+          mapIndex
+        )}${FORMAT_RESET} ${prefixFormat}${prefix}${FORMAT_RESET} ${titleFormat}${title}${FORMAT_RESET}${suffix}`
+      );
+
+      const minIndent = " ".repeat(maxTestNumberChars + 3);
+
+      if (this.completed || finalStatus === null) {
+        testRuns.forEach((testRun, index) => {
+          if (index > 0) {
+            let label;
+            let labelFormat = "";
+            switch (testRun.status) {
+              case "failed":
+                label = "Failed";
+                labelFormat = FORMAT_COLOR_RED;
+                break;
+              case "passed":
+                label = "Passed";
+                labelFormat = FORMAT_COLOR_GREEN;
+                break;
+              default:
+                label = "Running";
+                break;
+            }
+
+            if (testRuns.length > 1) {
+              logLines.push(
+                `${minIndent}${labelFormat}${label}${FORMAT_RESET} ${FORMAT_DIM}(retry ${index})${FORMAT_RESET}`
+              );
+            }
+          }
+
+          testRun.logs.forEach(log => {
+            logLines.push(`${minIndent}  ${log}`);
+          });
+        });
+      }
+    });
+
+    clear();
+    print(logLines.filter(line => line.trim() !== "").join("\n") + "\n", !this.completed);
+  }
+}
+
+const out = process.stdout;
+const printedLines: string[] = [];
+
+function print(text: string, trimToFit: boolean) {
+  const { width: columns } = windowSize.get();
+
+  let newLines = text.split("\n");
+
+  if (trimToFit) {
+    newLines = newLines.map(line => {
+      if (line.length > columns) {
+        return line.slice(0, columns) + "…" + FORMAT_RESET;
+      } else {
+        return line;
+      }
+    });
+  }
+
+  printedLines.push(...newLines);
+
+  out.write(newLines.join("\n"));
+}
+
+function clear(): void {
+  out.moveCursor(0, 0 - printedLines.length);
+  out.clearScreenDown();
+
+  printedLines.splice(0);
+}

--- a/packages/replay-next/playwright/package.json
+++ b/packages/replay-next/playwright/package.json
@@ -4,8 +4,10 @@
   "devDependencies": {
     "@playwright/test": "^1.25.1",
     "@replayio/playwright": "^0.3.21",
+    "@types/window-size": "^1.1.1",
     "chalk": "^4",
-    "playwright": "^1.25.1"
+    "playwright": "^1.25.1",
+    "window-size": "^1.1.1"
   },
   "scripts": {
     "playwright:install": "playwright install chromium",

--- a/packages/replay-next/playwright/playwright.config.ts
+++ b/packages/replay-next/playwright/playwright.config.ts
@@ -16,7 +16,7 @@ const config: FullConfig = {
   forbidOnly: !!CI,
   globalSetup: require.resolve("./playwright.globalSetup"),
   // @ts-ignore
-  reporter: CI ? "github" : "list",
+  reporter: CI ? "github" : "./custom-reporter.ts",
   retries: RECORD_VIDEO || VISUAL_DEBUG ? 0 : 2,
   snapshotDir: "./snapshots",
   use: {

--- a/packages/replay-next/playwright/yarn.lock
+++ b/packages/replay-next/playwright/yarn.lock
@@ -95,6 +95,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/window-size@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@types/window-size@npm:1.1.1"
+  dependencies:
+    "@types/node": "*"
+  checksum: 055a6c513481b8c681e6497e7cc26212413e646dada1e4fcb07bef8e1c96d4fecc9a639d57e578f2e67830861ebf544ea8b06495772044521fa4eaa342c332a8
+  languageName: node
+  linkType: hard
+
 "aggregate-error@npm:^3.0.0":
   version: 3.1.0
   resolution: "aggregate-error@npm:3.1.0"
@@ -230,6 +239,15 @@ __metadata:
     has-property-descriptors: ^1.0.0
     object-keys: ^1.1.1
   checksum: e60aee6a19b102df4e2b1f301816804e81ab48bb91f00d0d935f269bf4b3f79c88b39e4f89eaa132890d23267335fd1140dfcd8d5ccd61031a0a2c41a54e33a6
+  languageName: node
+  linkType: hard
+
+"define-property@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "define-property@npm:1.0.0"
+  dependencies:
+    is-descriptor: ^1.0.0
+  checksum: 5fbed11dace44dd22914035ba9ae83ad06008532ca814d7936a53a09e897838acdad5b108dd0688cc8d2a7cf0681acbe00ee4136cf36743f680d10517379350a
   languageName: node
   linkType: hard
 
@@ -499,6 +517,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-accessor-descriptor@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "is-accessor-descriptor@npm:1.0.0"
+  dependencies:
+    kind-of: ^6.0.0
+  checksum: 8e475968e9b22f9849343c25854fa24492dbe8ba0dea1a818978f9f1b887339190b022c9300d08c47fe36f1b913d70ce8cbaca00369c55a56705fdb7caed37fe
+  languageName: node
+  linkType: hard
+
 "is-array-buffer@npm:^3.0.1":
   version: 3.0.1
   resolution: "is-array-buffer@npm:3.0.1"
@@ -529,10 +556,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-buffer@npm:^1.1.5":
+  version: 1.1.6
+  resolution: "is-buffer@npm:1.1.6"
+  checksum: 4a186d995d8bbf9153b4bd9ff9fd04ae75068fe695d29025d25e592d9488911eeece84eefbd8fa41b8ddcc0711058a71d4c466dcf6f1f6e1d83830052d8ca707
+  languageName: node
+  linkType: hard
+
 "is-callable@npm:^1.1.3, is-callable@npm:^1.1.4, is-callable@npm:^1.2.7":
   version: 1.2.7
   resolution: "is-callable@npm:1.2.7"
   checksum: 61fd57d03b0d984e2ed3720fb1c7a897827ea174bd44402878e059542ea8c4aeedee0ea0985998aa5cc2736b2fa6e271c08587addb5b3959ac52cf665173d1ac
+  languageName: node
+  linkType: hard
+
+"is-data-descriptor@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "is-data-descriptor@npm:1.0.0"
+  dependencies:
+    kind-of: ^6.0.0
+  checksum: e705e6816241c013b05a65dc452244ee378d1c3e3842bd140beabe6e12c0d700ef23c91803f971aa7b091fb0573c5da8963af34a2b573337d87bc3e1f53a4e6d
   languageName: node
   linkType: hard
 
@@ -542,6 +585,17 @@ __metadata:
   dependencies:
     has-tostringtag: ^1.0.0
   checksum: baa9077cdf15eb7b58c79398604ca57379b2fc4cf9aa7a9b9e295278648f628c9b201400c01c5e0f7afae56507d741185730307cbe7cad3b9f90a77e5ee342fc
+  languageName: node
+  linkType: hard
+
+"is-descriptor@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "is-descriptor@npm:1.0.2"
+  dependencies:
+    is-accessor-descriptor: ^1.0.0
+    is-data-descriptor: ^1.0.0
+    kind-of: ^6.0.2
+  checksum: 2ed623560bee035fb67b23e32ce885700bef8abe3fbf8c909907d86507b91a2c89a9d3a4d835a4d7334dd5db0237a0aeae9ca109c1e4ef1c0e7b577c0846ab5a
   languageName: node
   linkType: hard
 
@@ -558,6 +612,15 @@ __metadata:
   dependencies:
     has-tostringtag: ^1.0.0
   checksum: d1e8d01bb0a7134c74649c4e62da0c6118a0bfc6771ea3c560914d52a627873e6920dd0fd0ebc0e12ad2ff4687eac4c308f7e80320b973b2c8a2c8f97a7524f7
+  languageName: node
+  linkType: hard
+
+"is-number@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "is-number@npm:3.0.0"
+  dependencies:
+    kind-of: ^3.0.2
+  checksum: 0c62bf8e9d72c4dd203a74d8cfc751c746e75513380fef420cda8237e619a988ee43e678ddb23c87ac24d91ac0fe9f22e4ffb1301a50310c697e9d73ca3994e9
   languageName: node
   linkType: hard
 
@@ -631,6 +694,22 @@ __metadata:
   version: 1.8.6
   resolution: "jsonata@npm:1.8.6"
   checksum: 748e052aa1d848ba263918603a5e7e872c26fbd63fbb3330dd28cb9fa9aed0478730732fe03149fddcb1b1b4963f5eb359f06da6e17ef84734f2067b1841b995
+  languageName: node
+  linkType: hard
+
+"kind-of@npm:^3.0.2":
+  version: 3.2.2
+  resolution: "kind-of@npm:3.2.2"
+  dependencies:
+    is-buffer: ^1.1.5
+  checksum: e898df8ca2f31038f27d24f0b8080da7be274f986bc6ed176f37c77c454d76627619e1681f6f9d2e8d2fd7557a18ecc419a6bb54e422abcbb8da8f1a75e4b386
+  languageName: node
+  linkType: hard
+
+"kind-of@npm:^6.0.0, kind-of@npm:^6.0.2":
+  version: 6.0.3
+  resolution: "kind-of@npm:6.0.3"
+  checksum: 3ab01e7b1d440b22fe4c31f23d8d38b4d9b91d9f291df683476576493d5dfd2e03848a8b05813dd0c3f0e835bc63f433007ddeceb71f05cb25c45ae1b19c6d3b
   languageName: node
   linkType: hard
 
@@ -844,8 +923,10 @@ __metadata:
   dependencies:
     "@playwright/test": ^1.25.1
     "@replayio/playwright": ^0.3.21
+    "@types/window-size": ^1.1.1
     chalk: ^4
     playwright: ^1.25.1
+    window-size: ^1.1.1
   languageName: unknown
   linkType: soft
 
@@ -936,6 +1017,18 @@ __metadata:
     has-tostringtag: ^1.0.0
     is-typed-array: ^1.1.10
   checksum: fe0178ca44c57699ca2c0e657b64eaa8d2db2372a4e2851184f568f98c478ae3dc3fdb5f7e46c384487046b0cf9e23241423242b277e03e8ba3dabc7c84c98ef
+  languageName: node
+  linkType: hard
+
+"window-size@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "window-size@npm:1.1.1"
+  dependencies:
+    define-property: ^1.0.0
+    is-number: ^3.0.0
+  bin:
+    window-size: cli.js
+  checksum: 4ab5ea0d5f224d6859eb0747049cbebf43ed3ba9fe535a2cbd2024b1f9cfd3c9021db33a3b20ee42ef8b5c5a036ddca46271bf1fc471aef7fc4cb4a98bfb2e67
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6552,6 +6552,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/window-size@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@types/window-size@npm:1.1.1"
+  dependencies:
+    "@types/node": "*"
+  checksum: 055a6c513481b8c681e6497e7cc26212413e646dada1e4fcb07bef8e1c96d4fecc9a639d57e578f2e67830861ebf544ea8b06495772044521fa4eaa342c332a8
+  languageName: node
+  linkType: hard
+
 "@types/ws@npm:^8.0.0":
   version: 8.5.3
   resolution: "@types/ws@npm:8.5.3"
@@ -20805,6 +20814,7 @@ __metadata:
     "@types/react-window": ^1.8.5
     "@types/styled-components": ^5.1.25
     "@types/uuid": ^7.0.3
+    "@types/window-size": ^1.1.1
     "@typescript-eslint/parser": ^5.38.1
     apollo: ^2.33.10
     autoprefixer: ^10.4.4


### PR DESCRIPTION
The way logs were interleaved previous was annoying and difficult to read. While things were kind of down this afternoon I decided to write a formatter.

Here's an example run of a few random tests (with some expected failures):

https://user-images.githubusercontent.com/29597/224442133-48f3567d-fbab-4894-95c0-c653de1daf49.mp4

And here are some screenshots of the runner in progress:

<img width="962" alt="Screen Shot 2023-03-10 at 6 02 38 PM" src="https://user-images.githubusercontent.com/29597/224444176-43f9206e-218d-4e8a-8358-66e0cdff0d8e.png">

<img width="962" alt="Screen Shot 2023-03-10 at 6 02 35 PM" src="https://user-images.githubusercontent.com/29597/224444175-f96d8d67-1b22-4f6a-bf6a-4aaeec498a79.png">
