### PR TITLE
Scrollbar size is Fixed inside Replay browser and Firefox in windows

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -12,6 +12,8 @@ body {
 
 * {
   box-sizing: border-box;
+  scrollbar-width: thin;
+  scrollbar-color: transparent;
 }
 
 .showRedactions[data-private="true"] {


### PR DESCRIPTION
closes: #8905 
currently ::-webkit-scrollbar is not supported by firefox. Currently, styling scrollbars for Firefox is available with scrollbar-width and scrollbar-color properties.
Replay:-
https://app.replay.io/recording/scrollbar-size-is-fixed--cd001945-9e6d-47b8-87d9-8819df900c96