### PR TITLE
scrollbar not showing in inspector-sidebar-container fixed

### DIFF
--- a/src/devtools/client/shared/components/Tabs.css
+++ b/src/devtools/client/shared/components/Tabs.css
@@ -5,6 +5,7 @@
 /* Tabs General Styles */
 
 .tabs {
+  height: 100%;
   background: var(--theme-sidebar-background);
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Description:
Vertical scrollbar is  not appearing in inspector-sidebar-container, as mentioned in [#8820](https://github.com/replayio/devtools/issues/8820) .
Steps to Reproduce:
1. Open Replay browser
2. Change from viewer to Devtools
3. Open element on Devtools
4.Try to scroll Rules, Layout or computed list.

Expected Result:
The scrollbar should appear and work to see the complete list.

Screenshots:

Before (on Replay, although not showing in any browser):
![replay_before](https://user-images.githubusercontent.com/78597533/224512402-3e35caa4-8e5b-4745-b794-310987df665b.png)

After:
Replay | Chrome
![replay_after](https://user-images.githubusercontent.com/78597533/224512521-cd8bd4f2-f1e3-419f-9e6f-29a9371999d2.png)

Firefox | Edge

![firefox_after](https://user-images.githubusercontent.com/78597533/224512555-be61baa5-4056-4b8a-8aa7-057d6c802c5f.png)

It was just a oneline change of a class to adjust the height and avoid overflowing.


