### PR TITLE
added href link for recording URL in Library

### DIFF
--- a/src/ui/components/Library/Team/View/Recordings/RecordingListItem/RecordingListItem.tsx
+++ b/src/ui/components/Library/Team/View/Recordings/RecordingListItem/RecordingListItem.tsx
@@ -186,7 +186,9 @@ function RecordingRow({
                   <span>{getRelativeDate(recording.date)}</span>
                 </div>
                 <div className="overflow-hidden overflow-ellipsis whitespace-pre font-light text-gray-400">
-                  {getDisplayedUrl(recording.url)}
+                  <a href={recording.url} target="_blank" rel="noopener noreferrer">
+                    {getDisplayedUrl(recording.url)}
+                  </a>
                 </div>
                 {recording.metadata?.test?.file ? (
                   <div className="overflow-hidden overflow-ellipsis whitespace-pre font-light text-gray-400">


### PR DESCRIPTION
A draft Pull request for the issue #8919 and added a href link so that the url can be visited to see the current state or to record a new replay for comparison
the replay for  the new changes is:
in the replay it got redirected in a new tab but was not shown in replay 
https://app.replay.io/recording/overboard--3a2065a9-46f5-48e2-8910-ad7a0c739f1d