### PR TITLE
Fix e2e test flakiness

### DIFF
--- a/packages/e2e-tests/helpers/elements-panel.ts
+++ b/packages/e2e-tests/helpers/elements-panel.ts
@@ -203,13 +203,39 @@ export async function openAppliedRulesTab(page: Page) {
 }
 
 export async function openComputedPropertiesTab(page: Page): Promise<void> {
-  const locator = page.locator("#computedview-tab");
-  await locator.waitFor();
-  await locator.click();
+  await openSelectedElementTab(page, "computedview-tab");
 }
 
 export async function openElementsPanel(page: Page): Promise<void> {
   await page.locator('[data-test-id="PanelButton-inspector"]').click();
+}
+
+async function openSelectedElementTab(page: Page, tabId: string): Promise<void> {
+  await debugPrint(page, `Opening "${tabId} tab in Elements panel`, "openSelectedElementTab");
+
+  let tabLocator = page.locator(`#${tabId}`);
+
+  // When there are too many tabs to render visibly,
+  // some are hidden within a dropdown menu.
+  const dropDownLocator = page.locator(
+    '[data-test-id="InspectorTabs"] [data-test-name="ResponsiveTabsDropDownButton"]'
+  );
+  if (await dropDownLocator.isVisible()) {
+    await dropDownLocator.click();
+
+    // Note we need to scope this query because tab ids are not unique :(
+    const possibleTabLocator = page.locator(
+      `[data-test-name="ResponsiveTabsDropDownItem"] #${tabId}`
+    );
+    if (await possibleTabLocator.isVisible()) {
+      // If the specific tab we're looking for is in this dropdown,
+      // click it instead of the (hidden) tab in the main toolbar.
+      tabLocator = possibleTabLocator;
+    }
+  }
+
+  await tabLocator.isVisible();
+  await tabLocator.click({ force: true });
 }
 
 export async function searchElementsPanel(page: Page, searchText: string): Promise<void> {

--- a/src/devtools/client/inspector/components/App.tsx
+++ b/src/devtools/client/inspector/components/App.tsx
@@ -69,7 +69,10 @@ export default function InspectorApp() {
                           borderBottom: "1px solid var(--theme-splitter-color)",
                         }}
                       >
-                        <ResponsiveTabs activeIdx={availableTabs.indexOf(activeTab)}>
+                        <ResponsiveTabs
+                          activeIdx={availableTabs.indexOf(activeTab)}
+                          dataTestId="InspectorTabs"
+                        >
                           {availableTabs.map(panelId => {
                             const isPanelSelected = activeTab === panelId;
                             return (

--- a/src/devtools/client/shared/components/ResponsiveTabs.tsx
+++ b/src/devtools/client/shared/components/ResponsiveTabs.tsx
@@ -33,6 +33,7 @@ export function Tab({ id, text, active, onClick }: TabProps) {
 
 type ResponsiveTabsProps = {
   className?: string;
+  dataTestId?: string;
   dropdownButton?: ReactNode;
   dropdownClassName?: string;
   dropdownStyle?: CSSProperties;
@@ -42,6 +43,7 @@ type ResponsiveTabsProps = {
 
 export const ResponsiveTabs = ({
   className = "",
+  dataTestId,
   dropdownButton,
   dropdownClassName,
   dropdownStyle,
@@ -143,7 +145,7 @@ export const ResponsiveTabs = ({
   const hasDropdown = visibleItemsCount < tabs.length;
 
   return (
-    <div className="relative max-w-full">
+    <div className="relative max-w-full" data-test-id={dataTestId}>
       <div className={cx("flex overflow-hidden", className)} ref={containerRef}>
         {orderedTabs.map((tab, idx) => (
           <span
@@ -165,7 +167,10 @@ export const ResponsiveTabs = ({
           className={cx("absolute right-0 top-0 flex h-full items-center", dropdownClassName)}
         >
           {dropdownButton ?? (
-            <span className="flex h-full cursor-pointer select-none items-center px-1 hover:bg-[color:var(--tab-bgcolor)]">
+            <span
+              className="flex h-full cursor-pointer select-none items-center px-1 hover:bg-[color:var(--tab-bgcolor)]"
+              data-test-name="ResponsiveTabsDropDownButton"
+            >
               ···
             </span>
           )}
@@ -175,7 +180,9 @@ export const ResponsiveTabs = ({
               style={dropdownStyle}
             >
               {orderedTabs.slice(visibleItemsCount).map(tab => (
-                <div key={tab.key}>{tab}</div>
+                <div key={tab.key} data-test-name="ResponsiveTabsDropDownItem">
+                  {tab}
+                </div>
               ))}
             </div>
           )}


### PR DESCRIPTION
Noticed a test that fails on #8909 (and _sometimes_ on `main`) that was failing due to an issue in the design of the `ResponsiveTabs` component. This PR updates the e2e test helper to be more robust until we refactor that component.