### PR TITLE
Focus source viewer on source switch so that CMD+F works okay

### DIFF
--- a/packages/replay-next/components/sources/Source.tsx
+++ b/packages/replay-next/components/sources/Source.tsx
@@ -29,6 +29,9 @@ export type HoveredState = {
   target: HTMLElement;
 };
 
+/**
+ * Rendered in the main app by `<NewSourceAdapter>`
+ */
 export default function Source({
   source,
   showColumnBreakpoints,

--- a/src/devtools/client/debugger/src/components/Editor/NewSourceAdapter.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/NewSourceAdapter.tsx
@@ -58,7 +58,7 @@ function NewSourceAdapter() {
 
     // TRICKY
     // Legacy code passes 1-based line numbers around,
-    // Except when a filed is opened (e.g. by clicking on the file tab) in which cases it passes 0.
+    // Except when a file is opened (e.g. by clicking on the file tab) in which cases it passes 0.
     // We ignore the 0 because it breaks scroll state preservation between tabs.
     const lineNumber = location?.line ?? 0;
     const lineIndex = lineNumber > 0 ? lineNumber - 1 : undefined;
@@ -80,6 +80,13 @@ function NewSourceAdapter() {
       dispatch(setViewport(visibleLines));
     }
   }, [dispatch, visibleLines]);
+
+  useEffect(() => {
+    if (focusedSourceId != null && containerRef.current) {
+      // Focus source viewer whenever we load or switch a source so that CMD+F for "search" works right
+      containerRef.current.focus();
+    }
+  }, [focusedSourceId]);
 
   const onKeyDown = (event: KeyboardEvent) => {
     switch (event.key.toLowerCase()) {


### PR DESCRIPTION
This PR:

- Adds a `useEffect` to the main app's `<NewSourceAdapter>` so that we auto-focus the current source viewer's container element whenever the selected source changes.  This enables `CMD+F` to work immediately

(Hopefully this is the right spot to put that check - please let me know if there's a better place!)