### PR TITLE
Migrate additional caches to "suspense"

### DIFF
--- a/packages/replay-next/components/comments/CommentList.tsx
+++ b/packages/replay-next/components/comments/CommentList.tsx
@@ -4,7 +4,7 @@ import ErrorBoundary from "replay-next/components/ErrorBoundary";
 import Loader from "replay-next/components/Loader";
 import { GraphQLClientContext } from "replay-next/src/contexts/GraphQLClientContext";
 import { SessionContext } from "replay-next/src/contexts/SessionContext";
-import { getCommentListSuspense } from "replay-next/src/suspense/CommentsCache";
+import { commentsCache } from "replay-next/src/suspense/CommentsCache";
 
 import Comment from "./Comment";
 import styles from "./CommentList.module.css";
@@ -14,7 +14,7 @@ import styles from "./CommentList.module.css";
 export default function CommentList() {
   const graphQLClient = useContext(GraphQLClientContext);
   const { accessToken, recordingId } = useContext(SessionContext);
-  const commentList = getCommentListSuspense(recordingId, graphQLClient, accessToken);
+  const commentList = commentsCache.read(graphQLClient, accessToken, recordingId);
 
   return (
     <ErrorBoundary>

--- a/packages/replay-next/components/console/filters/EventsList.tsx
+++ b/packages/replay-next/components/console/filters/EventsList.tsx
@@ -2,7 +2,7 @@ import { ChangeEvent, Suspense, useContext, useMemo, useState, useTransition } f
 
 import Loader from "replay-next/components/Loader";
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
-import { getEventCategoryCountsSuspense } from "replay-next/src/suspense/EventsCache";
+import { eventsCache } from "replay-next/src/suspense/EventsCache";
 import type { EventCategory as EventCategoryType } from "replay-next/src/suspense/EventsCache";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
@@ -50,7 +50,7 @@ function EventsListCategories({
   const client = useContext(ReplayClientContext);
   const { range } = useContext(FocusContext);
   const pointRange = range ? { begin: range.begin.point, end: range.end.point } : null;
-  const eventCategoryCounts = getEventCategoryCountsSuspense(pointRange, client);
+  const eventCategoryCounts = eventsCache.read(client, pointRange);
 
   const [commonEventCategories, otherEventCategories] = useMemo<
     [EventCategoryType[], EventCategoryType[]]

--- a/packages/replay-next/src/suspense/CommentsCache.ts
+++ b/packages/replay-next/src/suspense/CommentsCache.ts
@@ -1,25 +1,16 @@
 import { RecordingId } from "@replayio/protocol";
+import { Cache, createCache } from "suspense";
 
-import { createGenericCache } from "replay-next/src/suspense/createGenericCache";
 import { getComments as getCommentsGraphQL } from "shared/graphql/Comments";
 import { GraphQLClientInterface } from "shared/graphql/GraphQLClient";
 import { Comment } from "shared/graphql/types";
 
-export const {
-  getValueSuspense: getCommentListSuspense,
-  getValueAsync: getCommentListAsync,
-  getValueIfCached: getCommentListIfCached,
-  addValue: setLatestIDBValue,
-} = createGenericCache<
-  [graphQLClient: GraphQLClientInterface, accessToken: string | null],
-  [recordingId: RecordingId],
+export const commentsCache: Cache<
+  [graphQLClient: GraphQLClientInterface, accessToken: string | null, recordingId: RecordingId],
   Comment[]
->(
-  "CommentsCache: getCommentsGraphQL",
-  async (
-    recordingId: RecordingId,
-    graphQLClient: GraphQLClientInterface,
-    accessToken: string | null
-  ) => await getCommentsGraphQL(graphQLClient, recordingId, accessToken),
-  (recordingId: RecordingId) => recordingId
-);
+> = createCache({
+  debugLabel: "CommentsCache",
+  getKey: ([graphQLClient, accessToken, recordingId]) => recordingId,
+  load: async ([graphQLClient, accessToken, recordingId]) =>
+    await getCommentsGraphQL(graphQLClient, recordingId, accessToken),
+});

--- a/packages/replay-next/src/suspense/EventsCache.ts
+++ b/packages/replay-next/src/suspense/EventsCache.ts
@@ -1,5 +1,6 @@
 import { PointDescription, PointRange } from "@replayio/protocol";
 import { EventHandlerType, ExecutionPoint, PauseData } from "@replayio/protocol";
+import { Cache, createCache } from "suspense";
 
 import { AnalysisInput, SendCommand, getFunctionBody } from "protocol/evaluation-utils";
 import { ReplayClientInterface } from "shared/client/types";
@@ -7,7 +8,6 @@ import { ReplayClientInterface } from "shared/client/types";
 import { STANDARD_EVENT_CATEGORIES } from "../constants";
 import { createInfallibleSuspenseCache } from "../utils/suspense";
 import { getAnalysisCache } from "./AnalysisCache";
-import { createGenericCache } from "./createGenericCache";
 
 export type Event = {
   count: number;
@@ -25,17 +25,13 @@ export type EventLog = PointDescription & {
   type: "EventLog";
 };
 
-export const {
-  getValueSuspense: getEventCategoryCountsSuspense,
-  getValueAsync: getEventCategoryCountsAsync,
-  getValueIfCached: getEventCategoryCountsIfCached,
-} = createGenericCache<
-  [client: ReplayClientInterface],
-  [range: PointRange | null],
+export const eventsCache: Cache<
+  [client: ReplayClientInterface, range: PointRange | null],
   EventCategory[]
->(
-  "getEventCategoryCounts",
-  async (range, client) => {
+> = createCache({
+  debugLabel: "EventsCache",
+  getKey: ([client, range]) => (range ? `${range.begin}:${range.end}` : ""),
+  load: async ([client, range]) => {
     const allEvents = await client.getEventCountForTypes(
       Object.values(STANDARD_EVENT_CATEGORIES)
         .map(c => c.events.map(e => e.type))
@@ -52,8 +48,7 @@ export const {
       };
     });
   },
-  range => (range ? `${range.begin}:${range.end}` : "")
-);
+});
 
 // Variables in scope in an analysis
 declare let sendCommand: SendCommand;


### PR DESCRIPTION
- [x] Comments cache (GraphQL)
- [x] Events cache (protocol)
- [x] Indexed DB and latest value caches (IndexedDB)
  * This one uses the _mutation_ hook and avoids manually syncing values between React state and indexed DB