### PR TITLE
Fixed visual regression in Console input

### DIFF
--- a/packages/replay-next/components/console/ConsoleInput.module.css
+++ b/packages/replay-next/components/console/ConsoleInput.module.css
@@ -48,7 +48,7 @@
   display: flex;
   align-items: center;
   gap: 1ch;
-  padding: 0 0.25rem;
+  padding: 0.25rem;
   min-height: 1.75rem;
 
   background-color: var(--background-color-error);

--- a/packages/replay-next/components/console/ConsoleInput.tsx
+++ b/packages/replay-next/components/console/ConsoleInput.tsx
@@ -36,11 +36,13 @@ export default function ConsoleInput({ inputRef }: { inputRef?: RefObject<Impera
     return (
       <div className={styles.FallbackState}>
         <Icon className={styles.Icon} type="terminal-prompt" />
-        Input disabled because you're paused at a point outside{" "}
-        <span className="cursor-pointer underline" onClick={enterFocusMode}>
-          your debugging window
-        </span>
-        .
+        <div>
+          Input disabled because you're paused at a point outside{" "}
+          <span className="cursor-pointer underline" onClick={enterFocusMode}>
+            your debugging window
+          </span>
+          .
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
Say this while working on FE-1257:
<img width="595" alt="Screen Shot 2023-03-16 at 10 36 11 AM" src="https://user-images.githubusercontent.com/29597/225653566-e34952e9-eb13-4b86-a325-91865fe2819d.png">
