### PR TITLE
Resolved Input disabled message

### DIFF
--- a/packages/replay-next/components/console/ConsoleInput.tsx
+++ b/packages/replay-next/components/console/ConsoleInput.tsx
@@ -36,11 +36,13 @@ export default function ConsoleInput({ inputRef }: { inputRef?: RefObject<Impera
     return (
       <div className={styles.FallbackState}>
         <Icon className={styles.Icon} type="terminal-prompt" />
+        <span>
         Input disabled because you're paused at a point outside{" "}
         <span className="cursor-pointer underline" onClick={enterFocusMode}>
           your debugging window
         </span>
         .
+        </span>
       </div>
     );
   }

--- a/packages/replay-next/components/console/ConsoleInput.tsx
+++ b/packages/replay-next/components/console/ConsoleInput.tsx
@@ -37,11 +37,11 @@ export default function ConsoleInput({ inputRef }: { inputRef?: RefObject<Impera
       <div className={styles.FallbackState}>
         <Icon className={styles.Icon} type="terminal-prompt" />
         <span>
-        Input disabled because you're paused at a point outside{" "}
-        <span className="cursor-pointer underline" onClick={enterFocusMode}>
-          your debugging window
-        </span>
-        .
+          Input disabled because you're paused at a point outside{" "}
+          <span className="cursor-pointer underline" onClick={enterFocusMode}>
+            your debugging window
+          </span>
+          .
         </span>
       </div>
     );


### PR DESCRIPTION
This issue is related to the issue https://github.com/replayio/devtools/issues/8945 and is resolved by placing the content in a container so that they are treated as a single entity and now the overflow for the whole text is treated as a whole rather than breaking it into two parts.
the replay for the changes is:
https://app.replay.io/recording/facebook-log-in-or-sign-up--cd4093f4-ea65-4146-b0d3-a01240f0bcd0