### PR TITLE
Fix screenshot flakiness

### DIFF
--- a/packages/replay-next/components/sources/Source.tsx
+++ b/packages/replay-next/components/sources/Source.tsx
@@ -149,6 +149,9 @@ function SourceRenderer({
     setHoveredState(null);
   };
 
+  // TODO Once source and syntax parsing caches have been converted to "suspense" package
+  // we can replace data-test-num-lines attribute with data-test-state="loading" | "loaded" | "parsed"
+  // This will simplify e2e test logic
   return (
     <div
       className={styles.Source}

--- a/packages/replay-next/components/sources/Source.tsx
+++ b/packages/replay-next/components/sources/Source.tsx
@@ -153,8 +153,9 @@ function SourceRenderer({
     <div
       className={styles.Source}
       data-test-id={`Source-${source.sourceId}`}
-      data-test-source-id={source.sourceId}
       data-test-name="Source"
+      data-test-num-lines={streamingSourceContents.lineCount}
+      data-test-source-id={source.sourceId}
       onMouseEnter={trackMouseHover}
     >
       <div className={styles.SourceList} onMouseMove={onMouseMove} ref={sourceRef}>

--- a/packages/replay-next/components/sources/SourceListRow.tsx
+++ b/packages/replay-next/components/sources/SourceListRow.tsx
@@ -371,11 +371,19 @@ const SourceListRow = memo(
       }
     }
 
+    let testState = "loading";
+    if (tokens !== null) {
+      testState = "parsed";
+    } else if (plainText !== null) {
+      testState = "loaded";
+    }
+
     return (
       <div
         className={styles.Row}
         data-test-id={`SourceLine-${lineNumber}`}
         data-test-name="SourceLine"
+        data-test-state={testState}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
         style={{

--- a/packages/replay-next/playwright/tests/source-and-console.ts
+++ b/packages/replay-next/playwright/tests/source-and-console.ts
@@ -40,6 +40,7 @@ import {
   verifyCurrentSearchResult,
   verifyHitPointButtonsEnabled,
   verifyLogPointStep,
+  waitForSourceContentsToStream,
 } from "./utils/source";
 import testSetup from "./utils/testSetup";
 
@@ -53,6 +54,10 @@ test.beforeEach(async ({ page }) => {
 
   await page.goto(getTestUrl("source-and-console"));
   await openSourceFile(page, sourceId);
+
+  // Wait for source contents to finish streaming (loading and parsing)
+  await waitForSourceContentsToStream(page, sourceId);
+  await goToLine(page, sourceId, 1);
 });
 
 test("should not allow saving log points with invalid content", async ({ page }) => {


### PR DESCRIPTION
PR #8925 introduced a new source of flakiness for screenshot tests. This commit addresses it by explicitly waiting for source to be downloaded and parsed before taking screenshots.

I think we can _simplify_ this once the "suspense" package has been fully adopted.