### PR TITLE
Testsuites panel polish

### DIFF
--- a/src/devtools/client/debugger/src/components/TestInfo/NetworkEvent.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/NetworkEvent.tsx
@@ -56,7 +56,7 @@ export function NetworkEvent({ request }: { request: RequestSummary }) {
         title={pathname}
       >
         <span
-          className={classNames("mr-2 h-3 w-3 rounded-full", {
+          className={classNames("mr-1 h-3 w-3 rounded-full", {
             "bg-testsuitesErrorBgcolor": error,
             "bg-testsuitesSuccessColor": !!status && status < 400,
           })}

--- a/src/devtools/client/debugger/src/components/TestInfo/ProgressBar.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/ProgressBar.tsx
@@ -9,7 +9,7 @@ export function ProgressBar({ progress, error }: { progress: number; error: bool
       strokeWidth={20}
       styles={buildStyles({
         pathColor: error ? "rgb(239 68 68)" : `var(--focus-mode-loaded-indexed-color)`,
-        trailColor: `var(--circular-progress-bar-trail-color)`,
+        trailColor: `transparent`,
       })}
       value={progress}
     />

--- a/src/devtools/client/debugger/src/components/TestInfo/TestInfo.module.css
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestInfo.module.css
@@ -10,6 +10,10 @@
   border-left: 2px solid var(--testsuites-error-border-color);
 }
 
+.TestsuitesActiveBgcolor {
+  background-color: var(--testsuites-active-bgcolor);
+}
+
 .step {
   border-radius: 4px;
   margin-right: 5px;

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -193,39 +193,43 @@ export function TestStepItem({
   const error = !!(step.error || info.getStepAsserts(step).some(s => !!s.error));
 
   return (
-    <TestStepRow
-      active={state === "paused"}
-      pending={state === "pending"}
-      error={error}
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
-      ref={ref}
-      data-test-id="TestSuites-TestCase-TestStepRow"
-      index={index + 1}
-      progress={displayedProgress}
-    >
-      <button
-        onClick={onClick}
-        onKeyUp={preventClickFromSpaceBar}
-        className="flex w-0 flex-grow items-start space-x-2 text-start"
-        title={`Step ${index + 1}: ${step.name} ${argString || ""}`}
+    <div className="flex-grow-1 flex w-full items-center justify-between">
+      <TestStepRow
+        active={state === "paused"}
+        pending={state === "pending"}
+        error={error}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+        ref={ref}
+        data-test-id="TestSuites-TestCase-TestStepRow"
+        index={index + 1}
+        progress={displayedProgress}
       >
-        <div className={`flex-grow break-all font-medium ${state === "paused" ? "font-bold" : ""}`}>
-          {step.parentId ? "- " : ""}{" "}
-          <span className={`${styles.step} ${styles[step.name]}`}>{step.name}</span>
-          <span className="opacity-70">{argString}</span>
-        </div>
-      </button>
-      <React.Suspense>
-        <MatchingElementBadge selected={isSelected} step={step} />
-      </React.Suspense>
-      {step.alias ? (
-        <span className={classNames("alias")} title={`'${argString}' aliased as '${step.alias}'`}>
-          {step.alias}
-        </span>
-      ) : null}
-      <Actions step={step} selected={isSelected} />
-    </TestStepRow>
+        <button
+          onClick={onClick}
+          onKeyUp={preventClickFromSpaceBar}
+          className="flex w-0 flex-grow items-start space-x-2 text-start"
+          title={`Step ${index + 1}: ${step.name} ${argString || ""}`}
+        >
+          <div
+            className={`flex-grow break-all font-medium ${state === "paused" ? "font-bold" : ""}`}
+          >
+            {step.parentId ? <span className="opacity-0">|</span> : ""}{" "}
+            <span className={`${styles.step} ${styles[step.name]}`}>{step.name}</span>
+            <span className="opacity-70">{argString}</span>
+          </div>
+        </button>
+        <React.Suspense>
+          <MatchingElementBadge selected={isSelected} step={step} />
+        </React.Suspense>
+        {step.alias ? (
+          <span className={classNames("alias")} title={`'${argString}' aliased as '${step.alias}'`}>
+            {step.alias}
+          </span>
+        ) : null}
+      </TestStepRow>
+      <Actions step={step} hovered={isSelected} selected={isSelected} />
+    </div>
   );
 }
 
@@ -250,7 +254,15 @@ function MatchingElementBadge({ step, selected }: { step: AnnotatedTestStep; sel
   return <span className={classNames("ElementBadge")}>{count}</span>;
 }
 
-function Actions({ step, selected }: { step: AnnotatedTestStep; selected: boolean }) {
+function Actions({
+  step,
+  hovered,
+  selected,
+}: {
+  step: AnnotatedTestStep;
+  hovered: boolean;
+  selected: boolean;
+}) {
   const { test } = useContext(TestCaseContext);
   const { show } = useContext(TestInfoContextMenuContext);
   const stepActions = useTestStepActions(step);

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -212,11 +212,15 @@ export function TestStepItem({
           title={`Step ${index + 1}: ${step.name} ${argString || ""}`}
         >
           <div
-            className={`flex-grow break-all font-medium ${state === "paused" ? "font-bold" : ""}`}
+            className={`flex flex-grow break-all font-medium ${
+              state === "paused" ? "font-bold" : ""
+            }`}
           >
-            {step.parentId ? <span className="opacity-0">|</span> : ""}{" "}
-            <span className={`${styles.step} ${styles[step.name]}`}>{step.name}</span>
-            <span className="opacity-70">{argString}</span>
+            <div>{step.parentId ? <div className="w-4 opacity-0">|</div> : ""} </div>
+            <div>
+              <span className={`${styles.step} ${styles[step.name]}`}>{step.name}</span>
+              <span className="opacity-70">{argString}</span>
+            </div>
           </div>
         </button>
         <React.Suspense>

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepRow.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepRow.tsx
@@ -41,7 +41,7 @@ export function TestStepRowBase({
           [styles.TestsuitesErrorColor]: error,
           "bg-testsuitesErrorBgcolor hover:bg-testsuitesErrorBgcolorHover": error && pending,
           "bg-testsuitesErrorBgcolorHover": error && active,
-          "bg-testsuitesActiveBgcolor": active && !error,
+          [styles.TestsuitesActiveBgcolor]: active && !error,
           "bg-testsuitesStepsBgcolor hover:bg-testsuitesStepsBgcolorHover": pending && !error,
           "hover:bg-testsuitesStepsBgcolorHover": !pending && !active && !error,
         }
@@ -50,7 +50,7 @@ export function TestStepRowBase({
       <div title={progress == null ? "" : String(progress)} className="flex h-4 w-4 items-center">
         {progress == null ? null : <ProgressBar progress={progress} error={!!error} />}
       </div>
-      <div className="w-6 text-center opacity-70">{index}</div>
+      <div className="w-5 text-center opacity-70">{index}</div>
       {children}
     </div>
   );

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepRow.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepRow.tsx
@@ -29,7 +29,7 @@ export function TestStepRowBase({
       ref={clientRef}
       className={classnames(
         className,
-        "group/step relative flex items-start gap-1 border-b border-l-2 border-testStepBorder py-2 pl-3 pr-1 font-mono",
+        "group/step relative flex w-full items-start gap-1 border-b border-l-2 border-transparent py-2 pl-3 pr-1 font-mono",
         {
           // border
           [styles.BorderPending]: pending,


### PR DESCRIPTION
* Removed divider lines
* Aligned the margins
* Improved wrap (see the alignment around the green assert)
* Overflow menu outside the row, preparing for "jump to code"
* Fixed how the circular loader looks when on a selected row

Here's a good down payment. And then when we get "jump to code" it'll be ready to go!

(We also have the concept of turning the circular progress into a vertical line, but that's a bit complicated and will be in follow-on)

![image](https://user-images.githubusercontent.com/9154902/225800268-b0f1fec9-9e81-48d0-8bdc-46bbf979cb17.png)


Addresses [DES-423](https://linear.app/replay/issue/DES-423/cypress-panel-improvements)