### PR TITLE
Set `overscroll-behavior: none;` on the `SourceList`

### DIFF
--- a/packages/replay-next/components/sources/SourceList.module.css
+++ b/packages/replay-next/components/sources/SourceList.module.css
@@ -1,3 +1,7 @@
+.List {
+  overscroll-behavior: none;
+}
+
 .List > div {
   min-width: var(--longest-line-width);
 }


### PR DESCRIPTION
I went back in the browser's history accidentally on multiple occasions cause of the default behavior of the overscroll. I find this default behavior often annoying for "long-lived" scrollable containers (like this `SourceList`) so I propose to turn it off.