### PR TITLE
Fixes #8922 by making it more specific

### DIFF
--- a/src/devtools/client/shared/components/Tabs.css
+++ b/src/devtools/client/shared/components/Tabs.css
@@ -5,10 +5,13 @@
 /* Tabs General Styles */
 
 .tabs {
-  height: 100%;
   background: var(--theme-sidebar-background);
   display: flex;
   flex-direction: column;
+}
+
+#inspector-sidebar .tabs {
+  height: 100%;
 }
 
 /* Hides the tab strip in the TabBar */


### PR DESCRIPTION
When tabs can be height 100% it can fill a lot more available space

<img width="448" alt="Screenshot 2023-03-19 at 10 03 02 AM" src="https://user-images.githubusercontent.com/254562/226193279-9fee2596-7ae1-4818-8301-34e117b939bf.png">
