### PR TITLE
Upgrade suspense@0.0.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "reselect": "^4.1.5",
     "shared": "workspace:*",
     "slugify": "^1.6.5",
-    "suspense": "^0.0.26"
+    "suspense": "^0.0.28"
   },
   "devDependencies": {
     "@babel/core": "^7.17.8",

--- a/packages/replay-next/package.json
+++ b/packages/replay-next/package.json
@@ -25,7 +25,7 @@
     "react-dom": "0.0.0-experimental-e7d0053e6-20220325",
     "react-virtualized-auto-sizer": "^1.0.7",
     "shared": "workspace:*",
-    "suspense": "^0.0.26",
+    "suspense": "^0.0.28",
     "uuid": "^7.0.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -20923,7 +20923,7 @@ __metadata:
     style-loader: ^3.3.1
     stylelint: ^14.16.0
     stylelint-config-prettier: ^9.0.4
-    suspense: ^0.0.26
+    suspense: ^0.0.28
     tailwindcss: ^3.2.4
     ts-node: ^10.7.0
     tsconfig-paths: ^3.14.1
@@ -21278,7 +21278,7 @@ __metadata:
     react-dom: 0.0.0-experimental-e7d0053e6-20220325
     react-virtualized-auto-sizer: ^1.0.7
     shared: "workspace:*"
-    suspense: ^0.0.26
+    suspense: ^0.0.28
     typescript: ^4.6.3
     uuid: ^7.0.3
   languageName: unknown
@@ -23103,16 +23103,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"suspense@npm:^0.0.26":
-  version: 0.0.26
-  resolution: "suspense@npm:0.0.26"
+"suspense@npm:^0.0.28":
+  version: 0.0.28
+  resolution: "suspense@npm:0.0.28"
   dependencies:
     interval-utilities: ^0.0.1
     point-utilities: ^0.0.2
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 2aa4391a0ce2d24907048d4bb4bb8d6ab4a6d650efa452285fa30d664d60dabf80276ffa880452d8e72b965b881876cd07f228d150fa4b10fbe84e2983adcf64
+  checksum: 6c9b6cd87a0fd359e6ee9e1bf53caec2ae499a739dcd7632bae2a2f3d1c64dfd41d390bcd217fbe319d7ba4ff0184b838525849feaad7d3b7ead0a7b5f633000
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds the following capabilities:
* Removed `useWeakRef` config option for `createCache` and replaced with `getCache` option in order to support LRU type caches in addition to `WeakRef` based caches. Thanks to @cevr for contributing to this release!
* Add `useImperativeIntervalCacheValue` hook for imperatively loading and subscribing to `createIntervalCache` data.
* Add `getValue` and `getValueIfCached` methods to `createIntervalCache` type.