### PR TITLE
Don't show edit/delete menu for comments you don't own

### DIFF
--- a/src/ui/components/Comments/CommentCard.tsx
+++ b/src/ui/components/Comments/CommentCard.tsx
@@ -18,7 +18,6 @@ import CommentPreview from "./CommentPreview";
 import CommentReplyButton from "./CommentReplyButton";
 import EditableRemark from "./EditableRemark";
 import ReplyCard from "./ReplyCard";
-import SourceCodePreview from "./TranscriptComments/SourceCodePreview";
 import styles from "./CommentCard.module.css";
 
 export default function CommentCard({ comment }: { comment: Comment }) {
@@ -32,6 +31,7 @@ export default function CommentCard({ comment }: { comment: Comment }) {
 
   const onClick = (event: MouseEvent) => {
     event.stopPropagation();
+
     const openSource = viewMode === "dev";
     dispatch(seekToComment(comment, comment.sourceLocation, openSource));
 

--- a/src/ui/components/Comments/EditableRemark.tsx
+++ b/src/ui/components/Comments/EditableRemark.tsx
@@ -94,6 +94,7 @@ export default function EditableRemark({
 
   const onContextMenuClick: MouseEventHandler = event => {
     event.stopPropagation();
+
     onContextMenu(event);
   };
 

--- a/src/ui/components/Comments/useCommentContextMenu.tsx
+++ b/src/ui/components/Comments/useCommentContextMenu.tsx
@@ -1,9 +1,11 @@
 import { SerializedEditorState } from "lexical";
+import { ReactNode, useContext } from "react";
 
 import ContextMenuDivider from "replay-next/components/context-menu/ContextMenuDivider";
 import ContextMenuItem from "replay-next/components/context-menu/ContextMenuItem";
 import useContextMenu from "replay-next/components/context-menu/useContextMenu";
 import Icon from "replay-next/components/Icon";
+import { SessionContext } from "replay-next/src/contexts/SessionContext";
 import { setFocusRegionBeginTime, setFocusRegionEndTime } from "ui/actions/timeline";
 import { useAppDispatch } from "ui/setup/hooks";
 import type { Remark } from "ui/state/comments";
@@ -25,6 +27,9 @@ export default function useCommentContextMenu({
   type: "comment" | "reply";
 }) {
   const dispatch = useAppDispatch();
+  const { currentUserInfo } = useContext(SessionContext);
+
+  const isCurrentUserAuthor = currentUserInfo?.id === remark.user?.id;
 
   const { confirmDestructive } = useConfirm();
 
@@ -61,30 +66,47 @@ export default function useCommentContextMenu({
     dispatch(setFocusRegionBeginTime(remark.time!, true));
   };
 
-  const { contextMenu, onContextMenu } = useContextMenu(
-    <>
-      <ContextMenuItem onClick={editRemark}>Edit comment</ContextMenuItem>
-      <ContextMenuItem onClick={confirmDelete}>
+  const contextMenuItems: ReactNode[] = [];
+  if (isCurrentUserAuthor) {
+    contextMenuItems.push(
+      <ContextMenuItem key="edit" onClick={editRemark}>
+        Edit comment
+      </ContextMenuItem>
+    );
+    contextMenuItems.push(
+      <ContextMenuItem key="delete" onClick={confirmDelete}>
         {type === "comment" ? "Delete comment and replies" : "Delete comment"}
       </ContextMenuItem>
-      {!remark.isPublished && (
-        <ContextMenuItem onClick={publishRemark}>Publish comment</ContextMenuItem>
-      )}
-      <ContextMenuDivider />
-      <ContextMenuItem onClick={setFocusStart}>
-        <>
-          <Icon type="set-focus-start" />
-          Set focus start
-        </>
+    );
+  }
+  if (!remark.isPublished) {
+    contextMenuItems.push(
+      <ContextMenuItem key="publish" onClick={publishRemark}>
+        Publish comment
       </ContextMenuItem>
-      <ContextMenuItem onClick={setFocusEnd}>
-        <>
-          <Icon type="set-focus-end" />
-          Set focus end
-        </>
-      </ContextMenuItem>
-    </>
+    );
+  }
+  if (contextMenuItems.length > 0) {
+    contextMenuItems.push(<ContextMenuDivider key="divider" />);
+  }
+
+  contextMenuItems.push(
+    <ContextMenuItem key="focusStart" onClick={setFocusStart}>
+      <>
+        <Icon type="set-focus-start" />
+        Set focus start
+      </>
+    </ContextMenuItem>
   );
 
-  return { contextMenu, onContextMenu };
+  contextMenuItems.push(
+    <ContextMenuItem key="focusEnd" onClick={setFocusEnd}>
+      <>
+        <Icon type="set-focus-end" />
+        Set focus end
+      </>
+    </ContextMenuItem>
+  );
+
+  return useContextMenu(contextMenuItems);
 }


### PR DESCRIPTION
We didn't _actually_ let you edit or delete the comments– but the menu items were confusing.

### After

My comment:
<img width="486" alt="Screen Shot 2023-03-20 at 5 09 03 PM" src="https://user-images.githubusercontent.com/29597/226471792-8313918e-87bb-4c94-b33e-8b56dcf2ee3b.png">

Someone else's comment:
<img width="452" alt="Screen Shot 2023-03-20 at 5 08 59 PM" src="https://user-images.githubusercontent.com/29597/226471788-aff166aa-2e63-4549-aa46-164f3ace253b.png">
