### PR TITLE
Make the loading screen less flickery

### DIFF
--- a/src/ui/components/Account/index.tsx
+++ b/src/ui/components/Account/index.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from "next/router";
 import React, { useEffect } from "react";
 
+import { LibrarySpinner } from "ui/components/Library/LibrarySpinner";
 import { setLoadingFinished } from "ui/reducers/app";
 import { useAppDispatch } from "ui/setup/hooks";
 import useAuth0 from "ui/utils/useAuth0";
@@ -31,5 +32,9 @@ export default function Account() {
     return <Login returnToPath={window.location.pathname + window.location.search} />;
   }
 
-  return <LoadingScreen fallbackMessage="Loading account details..." />;
+  return (
+    <div className="flex h-screen w-full items-center justify-center">
+      <LibrarySpinner />
+    </div>
+  );
 }

--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -4,6 +4,7 @@ import { ConnectedProps, connect } from "react-redux";
 import QuickOpenModal from "devtools/client/debugger/src/components/QuickOpenModal";
 import { getQuickOpenEnabled } from "devtools/client/debugger/src/selectors";
 import { actions } from "ui/actions";
+import { LibrarySpinner } from "ui/components/Library/LibrarySpinner";
 import hooks from "ui/hooks";
 import { Nag, useGetUserInfo } from "ui/hooks/users";
 import { getLoadingFinished, getModal, getTheme } from "ui/reducers/app";
@@ -151,7 +152,11 @@ function App({ children, hideModal, modal, quickOpenEnabled }: AppProps) {
   }, [theme]);
 
   if (auth.isLoading || userInfo.loading) {
-    return <LoadingScreen fallbackMessage="Authenticating..." />;
+    return (
+      <div className="flex h-screen w-full items-center justify-center">
+        <LibrarySpinner />
+      </div>
+    );
   }
 
   if (

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -223,7 +223,7 @@ function _DevTools({
   }, [recording]);
 
   if (!loadingFinished) {
-    return <LoadingScreen fallbackMessage="Starting your session..." />;
+    return <LoadingScreen fallbackMessage="Loading..." />;
   }
 
   return (

--- a/src/ui/components/Library/Library.tsx
+++ b/src/ui/components/Library/Library.tsx
@@ -2,6 +2,7 @@ import { useRouter } from "next/router";
 import { useEffect } from "react";
 
 import { ExperimentalUserSettings } from "shared/graphql/types";
+import { LibrarySpinner } from "ui/components/Library/LibrarySpinner";
 import { useGetTeamRouteParams, useRedirectToTeam } from "ui/components/Library/Team/utils";
 import hooks from "ui/hooks";
 import { useUpdateDefaultWorkspace } from "ui/hooks/settings";
@@ -56,7 +57,11 @@ export default function LibraryLoader() {
   const { loading: userInfoLoading, ...userInfo } = hooks.useGetUserInfo();
 
   if (userSettingsLoading || userInfoLoading) {
-    return <LoadingScreen fallbackMessage="Reloading team details..." />;
+    return (
+      <div className="flex h-screen w-full items-center justify-center">
+        <LibrarySpinner />
+      </div>
+    );
   }
 
   return <Library userSettings={userSettings} userInfo={userInfo} />;
@@ -87,7 +92,11 @@ function Library({
   }, [teamId, isValidTeamId, redirectToTeam]);
 
   if (!teamId) {
-    return <LoadingScreen fallbackMessage="Loading team information..." />;
+    return (
+      <div className="flex h-screen w-full items-center justify-center">
+        <LibrarySpinner />
+      </div>
+    );
   }
 
   return (

--- a/src/ui/components/shared/LoadingTips.tsx
+++ b/src/ui/components/shared/LoadingTips.tsx
@@ -48,13 +48,13 @@ export const LoadingTips: FC = () => {
   const currentTipIdx = Math.floor(seed * TIPS.length);
   const { title, description, icon: Icon } = TIPS[currentTipIdx];
   return (
-    <div className="h-32 w-96 space-y-8">
+    <div className="h-16 w-96 space-y-2">
       <div className="flex max-w-lg items-center space-x-4 rounded-lg bg-loadingBoxes px-8 py-4 align-middle text-bodyColor shadow-sm">
         <div className="h-16 w-16">
           <Icon />
         </div>
         <div className="flex flex-col space-y-2">
-          <div className="text-sm font-bold">{title}</div>
+          <div className="text-xs font-bold">{title}</div>
           <div className="text-xs">{description}</div>
         </div>
       </div>

--- a/src/ui/components/shared/Spinner.tsx
+++ b/src/ui/components/shared/Spinner.tsx
@@ -4,7 +4,7 @@ export default function Spinner({ className }: { className?: string }) {
   return (
     <svg className={className} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
       <circle
-        className="opacity-25"
+        className="opacity-20"
         cx="12"
         cy="12"
         r="10"
@@ -12,8 +12,8 @@ export default function Spinner({ className }: { className?: string }) {
         strokeWidth="4"
       ></circle>
       <path
-        className="opacity-75"
-        fill="currentColor"
+        className="opacity-85"
+        fill="#01ACFD"
         d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
       ></path>
     </svg>


### PR DESCRIPTION
[[Original PR is here](https://github.com/replayio/devtools/pull/8901), but I moved it to this one to address a merge conflict]

When we go to the library, the loading screen is called several times, and oftentimes each load is only for a split second. This leads to a very flickery and heavy experience.

Old on the left, new on the right:
![Better library load-v1](https://user-images.githubusercontent.com/9154902/223962553-ed16cb89-a6c4-44c9-baa9-2789d4b7a921.gif)

Here are the four small changes to loading messaging to get this effect:

* We used to say "Reloading team details" but it's not necessary.
* Same with "Loading account details"
* We changed the default from "Starting your session..." to the more user-friendly + standard "Loading..."
* We changed "Loading timeline..." to "Loading..." because that distinction isn't important enough for a flicker

* And: a small change to make the tips text a bit smaller.

--

Of note, we still have our standard messaging on devtools. That's where different states (and stalls) are much more relevant to show the user, and aren't as flickery.