### PR TITLE
Adjust the shimmer effect in our source viewer

### DIFF
--- a/packages/replay-next/components/sources/SourceLineLoadingPlaceholder.module.css
+++ b/packages/replay-next/components/sources/SourceLineLoadingPlaceholder.module.css
@@ -1,11 +1,11 @@
 .Shimmer {
   display: inline-block;
-  height: 1rem;
-  background-color: var(--background-color-contrast-3);
+  height: 0.5rem;
+  background-color: var(--chrome);
   border-radius: 0.25rem;
 
   animation-name: shimmer;
-  animation-duration: 1s;
+  animation-duration: 2s;
   animation-iteration-count: infinite;
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9154902/226501726-3aa8b4ea-3c5a-4e31-a0e9-17076de2ea72.png)

These ended up as blobs when we moved to rems. Adjusting back to a normal size and altering the color.

Note that these animate so they're even more clear on prod.