### PR TITLE
Refactored Analysis cache to use createCahe for results

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "reselect": "^4.1.5",
     "shared": "workspace:*",
     "slugify": "^1.6.5",
-    "suspense": "^0.0.29"
+    "suspense": "^0.0.30"
   },
   "devDependencies": {
     "@babel/core": "^7.17.8",

--- a/packages/replay-next/components/console/filters/FilterToggles.tsx
+++ b/packages/replay-next/components/console/filters/FilterToggles.tsx
@@ -182,7 +182,11 @@ function ExceptionsBadgeSuspends() {
   }
 
   try {
-    exceptionsCache.pointsCache.read(focusRange.begin.point, focusRange.end.point, replayClient);
+    exceptionsCache.pointsIntervalCache.read(
+      focusRange.begin.point,
+      focusRange.end.point,
+      replayClient
+    );
   } catch (errorOrPromise) {
     if (isPromiseLike(errorOrPromise)) {
       throw errorOrPromise;

--- a/packages/replay-next/components/console/renderers/EventLogRenderer.tsx
+++ b/packages/replay-next/components/console/renderers/EventLogRenderer.tsx
@@ -94,7 +94,7 @@ function EventLogRenderer({
 function AnalyzedContent({ eventLog }: { eventLog: EventLog }) {
   const { showTimestamps } = useContext(ConsoleFiltersContext);
 
-  const { pauseId, values } = eventsCache.getResultSuspense(eventLog.point, eventLog.eventType);
+  const { pauseId, values } = eventsCache.resultsCache.read(eventLog.point, eventLog.eventType);
 
   const content =
     values.length > 0

--- a/packages/replay-next/components/console/renderers/UncaughtExceptionRenderer.tsx
+++ b/packages/replay-next/components/console/renderers/UncaughtExceptionRenderer.tsx
@@ -96,7 +96,7 @@ function UncaughtExceptionRenderer({
 }
 
 function AnalyzedContent({ uncaughtException }: { uncaughtException: UncaughtException }) {
-  const uncaughtExceptionResult = exceptionsCache.getResultSuspense(uncaughtException.point);
+  const uncaughtExceptionResult = exceptionsCache.resultsCache.read(uncaughtException.point);
 
   const frames = uncaughtExceptionResult.data.frames || EMPTY_ARRAY;
   const showExpandable = frames.length > 0;

--- a/packages/replay-next/package.json
+++ b/packages/replay-next/package.json
@@ -25,7 +25,7 @@
     "react-dom": "0.0.0-experimental-e7d0053e6-20220325",
     "react-virtualized-auto-sizer": "^1.0.7",
     "shared": "workspace:*",
-    "suspense": "^0.0.29",
+    "suspense": "^0.0.30",
     "uuid": "^7.0.3"
   },
   "devDependencies": {

--- a/packages/replay-next/src/suspense/EventsCache.ts
+++ b/packages/replay-next/src/suspense/EventsCache.ts
@@ -130,5 +130,5 @@ function transformPoint(point: PointDescription, eventType: EventHandlerType): E
 }
 
 export const getInfallibleEventPointsSuspense = createInfallibleSuspenseCache(
-  eventsCache.pointsCache.read
+  eventsCache.pointsIntervalCache.read
 );

--- a/packages/replay-next/src/suspense/ExceptionsCache.ts
+++ b/packages/replay-next/src/suspense/ExceptionsCache.ts
@@ -70,5 +70,5 @@ function transformPoint(pointDescription: PointDescription): UncaughtException {
 }
 
 export const getInfallibleExceptionPointsSuspense = createInfallibleSuspenseCache(
-  exceptionsCache.pointsCache.read
+  exceptionsCache.pointsIntervalCache.read
 );

--- a/packages/replay-next/src/suspense/LogPointAnalysisCache.ts
+++ b/packages/replay-next/src/suspense/LogPointAnalysisCache.ts
@@ -71,7 +71,7 @@ export function getLogPointAnalysisResultSuspense(
     // because it uses points from the HitPointsCache instead (which is more efficient
     // as it shares the points with other parts of the UI), so we call it here to ensure
     // that the analysis is run for the given range
-    logPointAnalysisCache.pointsCache.readAsync(
+    logPointAnalysisCache.pointsIntervalCache.readAsync(
       range.begin,
       range.end,
       client,
@@ -79,7 +79,7 @@ export function getLogPointAnalysisResultSuspense(
       code,
       condition
     );
-    const remoteResult = logPointAnalysisCache.getResultSuspense(
+    const remoteResult = logPointAnalysisCache.resultsCache.read(
       point.point,
       location,
       code,

--- a/yarn.lock
+++ b/yarn.lock
@@ -20923,7 +20923,7 @@ __metadata:
     style-loader: ^3.3.1
     stylelint: ^14.16.0
     stylelint-config-prettier: ^9.0.4
-    suspense: ^0.0.29
+    suspense: ^0.0.30
     tailwindcss: ^3.2.4
     ts-node: ^10.7.0
     tsconfig-paths: ^3.14.1
@@ -21278,7 +21278,7 @@ __metadata:
     react-dom: 0.0.0-experimental-e7d0053e6-20220325
     react-virtualized-auto-sizer: ^1.0.7
     shared: "workspace:*"
-    suspense: ^0.0.29
+    suspense: ^0.0.30
     typescript: ^4.6.3
     uuid: ^7.0.3
   languageName: unknown
@@ -23103,16 +23103,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"suspense@npm:^0.0.29":
-  version: 0.0.29
-  resolution: "suspense@npm:0.0.29"
+"suspense@npm:^0.0.30":
+  version: 0.0.30
+  resolution: "suspense@npm:0.0.30"
   dependencies:
     interval-utilities: ^0.0.1
     point-utilities: ^0.0.2
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 2e7f1b1c7455acf898b74f345c57838463279ce7234ef5b4500fe61704c6fe074559424ab61c0536d87e71998f98851eefd35666031adc7b7dd6a08256f9a894
+  checksum: f0d0bf995a49df8795b638ca67140d5d6a623abc8d364a71a534478cf8de10469171e53f9858177edcccac5aba2943e00828a69b0871806bfdd2102c49313d10
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Continuation of #8960

- [x] Replace faux cache with `createCache` for analysis results
- [ ] ~~Replace individual timeout with per-batch timeout (controlled somehow by the interval cache?)~~

After thinking about this a bit, I don't think there's a _great_ way to implement the batch timeout (that wouldn't be very complicated). Since there was no timeout before this PR, I think the internal cache swap is probably a net benefit.