### PR TITLE
Relax getPausePointParams() to decouple point+time from focus region

### DIFF
--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -236,7 +236,7 @@ export function createSocket(
         }
       }
 
-      const focusRegion = getPausePointParams()?.focusRegion;
+      const focusRegion = getPausePointParams().focusRegion;
       const focusRange = focusRegion
         ? {
             begin: focusRegion.begin.time,

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -121,9 +121,10 @@ export function jumpToInitialPausePoint(): UIThunkAction<Promise<void>> {
     }
 
     const initialPausePoint = await getInitialPausePoint(ThreadFront.recordingId!);
-
-    if (initialPausePoint) {
+    if (initialPausePoint?.point) {
       point = initialPausePoint.point;
+    }
+    if (initialPausePoint?.time) {
       time = initialPausePoint.time;
     }
     ThreadFront.timeWarp(point, time, false);
@@ -132,7 +133,7 @@ export function jumpToInitialPausePoint(): UIThunkAction<Promise<void>> {
 
 export async function getInitialPausePoint(recordingId: string) {
   const pausePointParams = getPausePointParams();
-  if (pausePointParams) {
+  if (pausePointParams.point !== null) {
     return pausePointParams;
   }
 

--- a/src/ui/reducers/timeline.ts
+++ b/src/ui/reducers/timeline.ts
@@ -12,7 +12,7 @@ function initialTimelineState(): TimelineState {
   return {
     allPaintsReceived: false,
     currentTime: 0,
-    focusRegion: getPausePointParams()?.focusRegion || null,
+    focusRegion: getPausePointParams().focusRegion,
     focusRegionBackup: null,
     displayedFocusRegion: null,
     hoverTime: null,

--- a/src/ui/utils/environment.ts
+++ b/src/ui/utils/environment.ts
@@ -1,5 +1,5 @@
 import { MockedResponse } from "@apollo/client/testing";
-import { TimeStampedPointRange } from "@replayio/protocol";
+import { ExecutionPoint, TimeStampedPointRange } from "@replayio/protocol";
 
 import { injectCustomSocketSendMessageForTesting } from "protocol/socket";
 
@@ -104,22 +104,32 @@ export function getFocusRegion() {
   return focusRegionParam ? (decodeBase64FromURL(focusRegionParam) as TimeStampedPointRange) : null;
 }
 
-export function getPausePointParams() {
+export function getPausePointParams(): {
+  focusRegion: TimeStampedPointRange | null;
+  point: ExecutionPoint | null;
+  time: number | null;
+} {
   const url = getURL();
 
   const pointParam = url.searchParams.get("point");
-  const point = `${pointParam}`;
+  const point = pointParam ? `${pointParam}` : null;
 
+  let time: number | null = null;
   const timeParam = url.searchParams.get("time");
-  const time = timeParam ? +timeParam : 0;
+  if (timeParam) {
+    const maybeTime = +timeParam;
+    if (!isNaN(maybeTime)) {
+      time = maybeTime;
+    }
+  }
 
   const focusRegion = getFocusRegion();
 
-  if (pointParam && timeParam) {
-    return { point, time, focusRegion };
+  if (time != null && point != null) {
+    return { focusRegion, point, time };
+  } else {
+    return { focusRegion, point: null, time: null };
   }
-
-  return null;
 }
 
 export function getParams() {


### PR DESCRIPTION
While looking into an issue reported by @Domiii, I noticed something unexpected in the `getPausePointParams()` method– the `time` and `point` parameters from the URL were ignored unless there was also a `focusRegion` parameter. (See my comments on [58ea8126-70f7-4fb1-8219-d9de1214343e](https://app.replay.io/recording/replay-of-what-domi-reported--58ea8126-70f7-4fb1-8219-d9de1214343e).)

This PR relaxes that coupling. Unfortunately I was not able to also relax the coupling between `point` and `time` parameters. In theory, we should only need a `point` (since it also encodes the time) – but I am not aware of any way to map or convert an execution point to a time value on the client (or using the Protocol API). Please let me know if I'm overlooking something!