### PR TITLE
Reuse The function to convert milliseconds into timestamp string

### DIFF
--- a/packages/shared/utils/time.test.ts
+++ b/packages/shared/utils/time.test.ts
@@ -1,6 +1,6 @@
 import { ExecutionPoint, TimeStampedPointRange } from "@replayio/protocol";
 
-import { isRangeInRegions } from "./time";
+import { getFormattedTime, isRangeInRegions } from "./time";
 
 describe("time util", () => {
   describe("isRangeInRegions", () => {
@@ -80,5 +80,30 @@ describe("time util", () => {
         isRangeInRegions(createRange("5", 2, "10", 15), quadruplesToRanges("0", 0, "10", 10))
       ).toBe(false);
     });
+  });
+});
+
+describe("getFormattedTime", () => {
+  it("should properly format time with milliseconds", () => {
+    expect(getFormattedTime(0, true)).toBe("0:00.000");
+    expect(getFormattedTime(1_000, true)).toBe("0:01.000");
+    expect(getFormattedTime(1_234, true)).toBe("0:01.234");
+    expect(getFormattedTime(30_000, true)).toBe("0:30.000");
+    expect(getFormattedTime(60_000, true)).toBe("1:00.000");
+    expect(getFormattedTime(60_001, true)).toBe("1:00.001");
+    expect(getFormattedTime(61_000, true)).toBe("1:01.000");
+    expect(getFormattedTime(12_345, true)).toBe("0:12.345");
+    expect(getFormattedTime(120_500, true)).toBe("2:00.500");
+  });
+
+  it("should properly format time without milliseconds", () => {
+    expect(getFormattedTime(0, false)).toBe("0:00");
+    expect(getFormattedTime(1_000, false)).toBe("0:01");
+    expect(getFormattedTime(1_499, false)).toBe("0:01");
+    expect(getFormattedTime(1_500, false)).toBe("0:02");
+    expect(getFormattedTime(58_900, false)).toBe("0:59");
+    expect(getFormattedTime(59_900, false)).toBe("1:00");
+    expect(getFormattedTime(60_000, false)).toBe("1:00");
+    expect(getFormattedTime(120_500, false)).toBe("2:01");
   });
 });

--- a/packages/shared/utils/time.ts
+++ b/packages/shared/utils/time.ts
@@ -80,3 +80,29 @@ export function toPointRange(range: TimeStampedPointRange | PointRange): PointRa
     };
   }
 }
+
+// Format a time value to mm:ss
+export function getFormattedTime(time: number, showMilliseconds: boolean = false) {
+  const date = new Date(time);
+  let minutes = date.getUTCMinutes();
+  let seconds = date.getUTCSeconds();
+  const milliseconds = date.getUTCMilliseconds();
+
+  if (!showMilliseconds) {
+    if (milliseconds >= 500) {
+      seconds++;
+    }
+    if (seconds >= 60) {
+      seconds = 0;
+      minutes++;
+    }
+  }
+
+  if (showMilliseconds) {
+    return `${minutes}:${seconds.toString().padStart(2, "0")}.${milliseconds
+      .toString()
+      .padStart(3, "0")}`;
+  } else {
+    return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+  }
+}

--- a/src/ui/components/Library/Team/View/TestRuns/utils.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/utils.tsx
@@ -5,10 +5,3 @@ export function getDuration(recordings: Recording[]) {
     .flatMap(r => r.metadata?.test?.tests?.map(t => t.duration))
     .reduce<number>((acc, v) => acc + (v || 0), 0);
 }
-export const getDurationString = (duration: number) => {
-  const date = new Date(duration);
-  const minutes = date.getMinutes() + "";
-  const seconds = date.getSeconds() + "";
-
-  return `${minutes.padStart(2, "0")}:${seconds.padStart(2, "0")}`;
-};

--- a/src/ui/components/Timeline/FocusInputs.tsx
+++ b/src/ui/components/Timeline/FocusInputs.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 
+import { getFormattedTime } from "shared/utils/time";
 import { updateDisplayedFocusRegion } from "ui/actions/timeline";
 import { selectors } from "ui/reducers";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
-import { getFormattedTime, getSecondsFromFormattedTime } from "ui/utils/timeline";
+import { getSecondsFromFormattedTime } from "ui/utils/timeline";
 
 import EditableTimeInput from "./EditableTimeInput";
 import styles from "./FocusInputs.module.css";

--- a/src/ui/components/Timeline/Tooltip.tsx
+++ b/src/ui/components/Timeline/Tooltip.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import { getFormattedTime } from "shared/utils/time";
 import { getNonLoadingTimeRanges } from "ui/reducers/app";
 import {
   getDisplayedFocusRegion,
@@ -9,14 +10,6 @@ import {
 } from "ui/reducers/timeline";
 import { useAppSelector } from "ui/setup/hooks";
 import { getVisiblePosition } from "ui/utils/timeline";
-
-const getTimestamp = (time?: number) => {
-  const date = new Date(time || 0);
-  const seconds = date.getSeconds().toString().padStart(2, "0");
-  const minutes = date.getMinutes();
-
-  return `${minutes}:${seconds}`;
-};
 
 export default function Tooltip({ timelineWidth }: { timelineWidth: number }) {
   const hoverTime = useAppSelector(getHoverTime);
@@ -39,7 +32,7 @@ export default function Tooltip({ timelineWidth }: { timelineWidth: number }) {
     displayedFocusRegion &&
     (displayedFocusRegion.begin > hoverTime || displayedFocusRegion.end < hoverTime);
 
-  const timestamp = getTimestamp(hoverTime);
+  const timestamp = getFormattedTime(hoverTime);
   const message =
     isHoveredOnNonLoadingRegion || isHoveredOnUnFocusedRegion
       ? `${timestamp} (Unloaded)`

--- a/src/ui/utils/timeline.test.ts
+++ b/src/ui/utils/timeline.test.ts
@@ -16,7 +16,6 @@ const focusRegion = (from: number, to: number): FocusRegion => ({
   end: point(to),
 });
 
-
 describe("getSecondsFromFormattedTime", () => {
   it("should parse standalone seconds", () => {
     expect(getSecondsFromFormattedTime("0")).toBe(0);

--- a/src/ui/utils/timeline.test.ts
+++ b/src/ui/utils/timeline.test.ts
@@ -2,7 +2,6 @@ import { FocusRegion, ZoomRegion } from "ui/state/timeline";
 
 import {
   filterToFocusRegion,
-  getFormattedTime,
   getSecondsFromFormattedTime,
   getTimeFromPosition,
   isFocusRegionSubset,
@@ -17,30 +16,6 @@ const focusRegion = (from: number, to: number): FocusRegion => ({
   end: point(to),
 });
 
-describe("getFormattedTime", () => {
-  it("should properly format time with milliseconds", () => {
-    expect(getFormattedTime(0, true)).toBe("0:00.000");
-    expect(getFormattedTime(1_000, true)).toBe("0:01.000");
-    expect(getFormattedTime(1_234, true)).toBe("0:01.234");
-    expect(getFormattedTime(30_000, true)).toBe("0:30.000");
-    expect(getFormattedTime(60_000, true)).toBe("1:00.000");
-    expect(getFormattedTime(60_001, true)).toBe("1:00.001");
-    expect(getFormattedTime(61_000, true)).toBe("1:01.000");
-    expect(getFormattedTime(12_345, true)).toBe("0:12.345");
-    expect(getFormattedTime(120_500, true)).toBe("2:00.500");
-  });
-
-  it("should properly format time without milliseconds", () => {
-    expect(getFormattedTime(0, false)).toBe("0:00");
-    expect(getFormattedTime(1_000, false)).toBe("0:01");
-    expect(getFormattedTime(1_499, false)).toBe("0:01");
-    expect(getFormattedTime(1_500, false)).toBe("0:02");
-    expect(getFormattedTime(58_900, false)).toBe("0:59");
-    expect(getFormattedTime(59_900, false)).toBe("1:00");
-    expect(getFormattedTime(60_000, false)).toBe("1:00");
-    expect(getFormattedTime(120_500, false)).toBe("2:01");
-  });
-});
 
 describe("getSecondsFromFormattedTime", () => {
   it("should parse standalone seconds", () => {

--- a/src/ui/utils/timeline.ts
+++ b/src/ui/utils/timeline.ts
@@ -120,32 +120,6 @@ export function getNewZoomRegion({
   return { begin: newBegin, end: newEnd };
 }
 
-// Format a time value to mm:ss
-export function getFormattedTime(time: number, showMilliseconds: boolean = false) {
-  const date = new Date(time);
-  let minutes = date.getUTCMinutes();
-  let seconds = date.getUTCSeconds();
-  const milliseconds = date.getUTCMilliseconds();
-
-  if (!showMilliseconds) {
-    if (milliseconds >= 500) {
-      seconds++;
-    }
-    if (seconds >= 60) {
-      seconds = 0;
-      minutes++;
-    }
-  }
-
-  if (showMilliseconds) {
-    return `${minutes}:${seconds.toString().padStart(2, "0")}.${milliseconds
-      .toString()
-      .padStart(3, "0")}`;
-  } else {
-    return `${minutes}:${seconds.toString().padStart(2, "0")}`;
-  }
-}
-
 const TIME_REGEX = /^([0-9]+)(:[0-9]{0,2}){0,1}(\.[0-9]{0,3}){0,1}$/;
 
 export function isValidTimeString(formatted: string): boolean {


### PR DESCRIPTION

This pull request is a follow up to https://github.com/replayio/devtools/pull/8897#pullrequestreview-1347005359 

### Unit Tests
all existing unit tests are passing after refactor
<img width="374" alt="image" src="https://user-images.githubusercontent.com/63918341/227006736-421c8f63-5ba3-4514-801b-eb3319e54de1.png">
***
merging this PR will also fix the issue of offset of certain minutes in few timezones
e.g. below is a screenshot when we hover over a replay in IST timezone
<img width="237" alt="image" src="https://user-images.githubusercontent.com/63918341/227011005-478b122f-6fe7-4870-9e73-f1c389e9fbad.png">
the timestamp shown in tooltip (30:12) is 30 minutes ahead of actual timestamp
it's because of fix in https://github.com/replayio/devtools/pull/8897

@bvaughn could you please review this.

