### PR TITLE
Re-enable React Timeline panel and rework to cache + stream results

### DIFF
--- a/src/ui/components/Events/Events.tsx
+++ b/src/ui/components/Events/Events.tsx
@@ -11,7 +11,7 @@ import { trackEvent } from "ui/utils/telemetry";
 
 import Event from "./Event";
 
-function CurrentTimeLine({ isActive }: { isActive: boolean }) {
+export function CurrentTimeLine({ isActive }: { isActive: boolean }) {
   return (
     <div
       className={classNames("m-0", isActive ? "bg-secondaryAccent" : "bg-transparent")}

--- a/src/ui/components/ReactPanel.tsx
+++ b/src/ui/components/ReactPanel.tsx
@@ -1,8 +1,21 @@
-import { TimeStampedPoint, TimeStampedPointRange } from "@replayio/protocol";
+import { createSelector } from "@reduxjs/toolkit";
+import {
+  ExecutionPoint,
+  Location,
+  TimeStampedPoint,
+  TimeStampedPointRange,
+} from "@replayio/protocol";
 import classnames from "classnames";
 import { ReactNode, useContext, useEffect, useState } from "react";
+import {
+  Cache,
+  StreamingCache,
+  createCache,
+  createStreamingCache,
+  useStreamingValue,
+} from "suspense";
 
-import { selectFrame as selectFrameAction } from "devtools/client/debugger/src/actions/pause/selectFrame";
+import { selectLocation } from "devtools/client/debugger/src/actions/sources/select";
 import AccessibleImage from "devtools/client/debugger/src/components/shared/AccessibleImage";
 import {
   PauseFrame,
@@ -17,19 +30,24 @@ import Icon from "replay-next/components/Icon";
 import IndeterminateLoader from "replay-next/components/IndeterminateLoader";
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
 import { breakpointPositionsCache } from "replay-next/src/suspense/BreakpointPositionsCache";
+import { frameStepsCache } from "replay-next/src/suspense/FrameStepsCache";
 import { getHitPointsForLocationAsync } from "replay-next/src/suspense/HitPointsCache";
 import { pauseIdCache } from "replay-next/src/suspense/PauseCache";
 import { sourceOutlineCache } from "replay-next/src/suspense/SourceOutlineCache";
 import { streamingSourceContentsCache } from "replay-next/src/suspense/SourcesCache";
 import { isExecutionPointsGreaterThan } from "replay-next/src/utils/time";
+import { ReplayClientContext } from "shared/client/ReplayClientContext";
+import { ReplayClientInterface } from "shared/client/types";
 import { UIThunkAction } from "ui/actions";
 import { IGNORABLE_PARTIAL_SOURCE_URLS } from "ui/actions/event-listeners";
 import { seek } from "ui/actions/timeline";
 import {
-  getAllSourceDetails,
+  SourceDetails,
+  SourcesState,
   getSourceIdsByUrl,
   getSourceToDisplayForUrl,
 } from "ui/reducers/sources";
+import { getPreferredLocation } from "ui/reducers/sources";
 import { getCurrentTime } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { getPauseFramesAsync } from "ui/suspense/frameCache";
@@ -44,57 +62,133 @@ const MORE_IGNORABLE_PARTIAL_URLS = IGNORABLE_PARTIAL_SOURCE_URLS.concat(
 );
 
 interface ReactQueuedRenderDetails extends TimeStampedPoint {
-  // frames: Frame[];
-  // formattedFrames: FormattedFrame[];
-  // filteredFrames: FormattedFrame[];
   pauseFrames: PauseFrame[];
   filteredPauseFrames: PauseFrame[];
-  userPauseFrame?: PauseFrame;
-  userPauseFrameTime?: TimeStampedPoint;
+  userPauseFrame: PauseFrame;
 }
 
-interface RenderAnalysisResults {
-  queuedRenders: ReactQueuedRenderDetails[];
-  committedRenders: TimeStampedPoint[];
-  error?: string;
+interface PointWithLocation {
+  location: Location;
+  point?: TimeStampedPoint;
 }
 
-declare let input: AnalysisInput;
+export const reactRenderQueuedJumpLocationCache: Cache<
+  [
+    replayClient: ReplayClientInterface,
+    earliestAppCodeFrame: PauseFrame,
+    sourcesState: SourcesState
+  ],
+  PointWithLocation | undefined
+> = createCache({
+  debugLabel: "NextInteractionEvent",
+  getKey: ([replayClient, earliestAppCodeFrame, sourcesState]) => earliestAppCodeFrame.pauseId,
+  load: async ([replayClient, earliestAppCodeFrame, sourcesState]) => {
+    let userPauseFrameTime: TimeStampedPoint | undefined = undefined;
 
-export function hitMapper() {
-  return [
-    {
-      key: input.point,
-      value: input,
-    },
-  ];
-}
+    if (!earliestAppCodeFrame) {
+      return;
+    }
 
-function findQueuedRendersForRange(
-  range: TimeStampedPointRange
-): UIThunkAction<Promise<RenderAnalysisResults | void>> {
-  return async (dispatch, getState, { replayClient }) => {
+    // This should already be a "preferred" location thanks to it being a `PauseFrame`
+    const { location } = earliestAppCodeFrame;
+
+    const initialPreferredLocation = getPreferredLocation(sourcesState, [location]);
+
+    let { line, sourceId, column } = initialPreferredLocation;
+
+    const [breakablePositions, breakablePositionsByLine] = await breakpointPositionsCache.readAsync(
+      replayClient,
+      sourceId
+    );
+    const breakablePositionsForLine = breakablePositionsByLine.get(line);
+
     try {
-      if (!range?.begin) {
-        return;
+      // TODO Need a _much_ better way of identifying the exact point of the earlier frame!
+      // This also doesn't seem to consistently work with the _first_ render.
+      // const arbitraryStartPoint = hitPoint.time - 50;
+      // const pointNearTime = await replayClient.getPointNearTime(arbitraryStartPoint);
+      // const functionHits: AnalysisInput[] = await replayClient.runAnalysis<AnalysisInput>({
+      //   effectful: false,
+      //   mapper: getFunctionBody(hitMapper),
+      //   location,
+      //   range: {
+      //     begin: pointNearTime.point,
+      //     end: hitPoint.point,
+      //   },
+      // });
+      // [userPauseFrameTime] = functionHits.slice(-1);
+
+      // We know the pause + point _inside_ of React.
+      // We now need to find the right execution point within that earlier frame.
+
+      // TODO [BAC-2915] Frame step locations and times don't consistently line up right!
+      if (breakablePositionsForLine) {
+        column = breakablePositionsForLine.columns[0];
       }
 
-      const sourcesByUrl = getSourceIdsByUrl(getState());
-      const allSources = getAllSourceDetails(getState());
-      const sourcesState = getState().sources;
-      const reactDomUrl = Object.keys(sourcesByUrl).find(key => {
-        return key.includes("react-dom.");
+      const searchLocation: Location = { sourceId, line, column };
+
+      const frameSteps = await frameStepsCache.readAsync(
+        replayClient,
+        earliestAppCodeFrame.pauseId,
+        earliestAppCodeFrame.protocolId
+      );
+
+      const pointsWithLocations =
+        frameSteps?.flatMap(step => {
+          return step.frame
+            ?.map(l => {
+              return {
+                location: l,
+                point: step,
+              };
+            })
+            .filter(Boolean) as PointWithLocation[];
+        }) ?? [];
+
+      // One of these locations should match up
+      const matchingFrameStep: PointWithLocation | undefined = pointsWithLocations.find(step => {
+        // Intentionally ignore columns for now - this seems to produce better results
+        // that line up with the hit points in a print statement
+        return (
+          step.location.sourceId === searchLocation.sourceId &&
+          step.location.line === searchLocation.line
+        );
       });
 
-      if (!reactDomUrl) {
-        return;
+      if (matchingFrameStep) {
+        userPauseFrameTime = matchingFrameStep.point;
       }
 
-      const reactDomSource = getSourceToDisplayForUrl(getState(), reactDomUrl);
-      if (!reactDomSource || !reactDomSource.url) {
-        return;
-      }
+      return {
+        location: searchLocation,
+        point: userPauseFrameTime,
+      };
 
+      // TODO Use scope mapping ala `event-listeners.ts` to get better function names
+    } catch (err) {
+      console.error(err);
+    }
+  },
+});
+
+const queuedRendersStreamingCache: StreamingCache<
+  [
+    replayClient: ReplayClientInterface,
+    range: TimeStampedPointRange | null,
+    reactDomSource: SourceDetails | undefined,
+    sourcesState: SourcesState
+  ],
+  ReactQueuedRenderDetails[] | undefined
+> = createStreamingCache({
+  getKey: (replayClient, range, reactDomSource, sourcesState) =>
+    `${range?.begin.point}:${range?.end.point}`,
+  load: async ({ update, resolve, reject }, replayClient, range, reactDomSource, sourcesState) => {
+    if (!reactDomSource || !range) {
+      resolve();
+      return;
+    }
+    try {
       const [symbols, breakablePositionsResult] = await Promise.all([
         sourceOutlineCache.readAsync(replayClient, reactDomSource.id),
         breakpointPositionsCache.readAsync(replayClient, reactDomSource.id),
@@ -126,8 +220,12 @@ function findQueuedRendersForRange(
         // By doing line-by-line string comparisons looking for these specific bits of code,
         // we can consistently find the specific minified functions that we care about,
         // across multiple React production builds, without needing to track minified function names.
+        // TODO Rethink this one React has sourcemaps
 
-        const streaming = await streamingSourceContentsCache.read(replayClient, reactDomSource!.id);
+        const streaming = await streamingSourceContentsCache.readAsync(
+          replayClient,
+          reactDomSource!.id
+        );
         await streaming.resolver;
         const reactDomSourceLines = streaming.contents!.split("\n");
 
@@ -203,71 +301,71 @@ function findQueuedRendersForRange(
 
       // TODO Arbitrary max of 200 points here. We need to figure out a better strategy.
       const scheduleUpdateHitPointsToCheck = scheduleUpdateHitPoints.slice(0, 200);
-      const queuedRendersPromise = Promise.all(
-        scheduleUpdateHitPointsToCheck.map(async (hitPoint): Promise<ReactQueuedRenderDetails> => {
-          const pauseId = await pauseIdCache.readAsync(replayClient, hitPoint.point, hitPoint.time);
 
-          const pauseFrames =
-            (await getPauseFramesAsync(replayClient, pauseId, sourcesState)) ?? [];
-          const filteredPauseFrames = pauseFrames.filter(frame => {
-            const { source } = frame;
-            if (!source) {
-              return false;
-            }
-            return !MORE_IGNORABLE_PARTIAL_URLS.some(partialUrl =>
-              source.url?.includes(partialUrl)
-            );
-          });
+      let currentResults: ReactQueuedRenderDetails[] = [];
 
-          let userPauseFrame: PauseFrame | undefined = filteredPauseFrames.slice(-1)[0];
+      for (let [index, hitPoint] of scheduleUpdateHitPointsToCheck.entries()) {
+        // We know a time that React's internal "schedule a render" logic ran. Start with that time.
+        const pauseId = await pauseIdCache.readAsync(replayClient, hitPoint.point, hitPoint.time);
 
-          let userPauseFrameTime: TimeStampedPoint | undefined = undefined;
-
-          if (userPauseFrame) {
-            try {
-              // TODO Need a _much_ better way of identifying the exact point of the earlier frame!
-              // This also doesn't seem to consistently work with the _first_ render.
-              const arbitraryStartPoint = hitPoint.time - 50;
-              const pointNearTime = await replayClient.getPointNearTime(arbitraryStartPoint);
-              const { location } = userPauseFrame;
-              const functionHits = await replayClient.runAnalysis<AnalysisInput>({
-                effectful: false,
-                mapper: getFunctionBody(hitMapper),
-                location,
-                range: {
-                  begin: pointNearTime.point,
-                  end: hitPoint.point,
-                },
-              });
-              [userPauseFrameTime] = functionHits.slice(-1);
-
-              // TODO Use scope mapping ala `event-listeners.ts` to get better function names
-            } catch (err) {
-              userPauseFrame = undefined;
-            }
+        // Get the stack frames for that call.
+        const pauseFrames = (await getPauseFramesAsync(replayClient, pauseId, sourcesState)) ?? [];
+        const filteredPauseFrames = pauseFrames.filter(frame => {
+          const { source } = frame;
+          if (!source) {
+            return false;
           }
+          // Filter out everything in `node_modules`, so we have just app code left
+          // TODO There may be times when we care about renders queued by lib code
+          // TODO See about just filtering out React instead?
+          return !MORE_IGNORABLE_PARTIAL_URLS.some(partialUrl => source.url?.includes(partialUrl));
+        });
 
-          return {
-            ...hitPoint,
-            pauseFrames,
-            filteredPauseFrames,
-            userPauseFrame,
-            userPauseFrameTime,
-          };
-        })
-      );
+        // We want the oldest app stack frame, which should be what called `setState()`
+        let earliestAppCodeFrame: PauseFrame | undefined = filteredPauseFrames.slice(-1)[0];
 
-      const committedRenders = onCommitFiberHitPoints.slice(0, 200);
+        const result: ReactQueuedRenderDetails = {
+          ...hitPoint,
+          pauseFrames,
+          filteredPauseFrames,
+          userPauseFrame: earliestAppCodeFrame,
+        };
 
-      const [queuedRenders] = await Promise.all([queuedRendersPromise]);
+        currentResults = currentResults.concat(result);
 
-      return {
-        queuedRenders,
-        committedRenders,
-      };
+        update(currentResults);
+      }
+
+      resolve();
     } catch (err) {
       console.error("Error getting React render data: ", err);
-      return { error: "failed to fetch events...", queuedRenders: [], committedRenders: [] };
+      reject(err);
+    }
+  },
+});
+
+function jumpToTimeAndLocationForQueuedRender(
+  earliestAppCodeFrame: PauseFrame,
+  hitPoint: TimeStampedPoint,
+  jumpBehavior: "timeOnly" | "timeAndLocation",
+  onSeek: (point: ExecutionPoint, time: number) => void
+): UIThunkAction {
+  return async (dispatch, getState, { replayClient }) => {
+    const sourcesState = getState().sources;
+    const jumpLocation = await reactRenderQueuedJumpLocationCache.readAsync(
+      replayClient,
+      earliestAppCodeFrame,
+      sourcesState
+    );
+    if (jumpLocation) {
+      if (jumpLocation.point) {
+        onSeek(jumpLocation.point.point, jumpLocation.point.time);
+      }
+
+      if (jumpBehavior === "timeAndLocation") {
+        const cx = getThreadContext(getState());
+        dispatch(selectLocation(cx, jumpLocation.location));
+      }
     }
   };
 }
@@ -288,37 +386,35 @@ function ReactQueuedRenderListItem({
   renderDetails: ReactQueuedRenderDetails;
 }) {
   const dispatch = useAppDispatch();
-  const { point, time } = renderDetails;
+  const { userPauseFrame, point, time } = renderDetails;
   const isPaused = time === currentTime && executionPoint === point;
   const [isHovered, setIsHovered] = useState(false);
   const cx = useAppSelector(getThreadContext);
 
   const [jumpToCodeStatus] = useState<JumpToCodeStatus>("not_checked");
 
-  const { userPauseFrame, userPauseFrameTime } = renderDetails;
-
   if (!userPauseFrame) {
     return null;
   }
+
+  const hitPoint: TimeStampedPoint = { point, time };
 
   const onMouseEnter = () => {};
 
   const onMouseLeave = () => {};
 
-  const onClickSeek = () => {
-    if (userPauseFrameTime) {
-      onSeek(userPauseFrameTime.point, userPauseFrameTime.time);
-    }
+  const onClickSeek = (e: React.MouseEvent) => {
+    e.stopPropagation();
+
+    dispatch(jumpToTimeAndLocationForQueuedRender(userPauseFrame, hitPoint, "timeOnly", onSeek));
   };
 
   const onClickJumpToCode = async (e: React.MouseEvent) => {
     e.stopPropagation();
 
-    // Seek to the sidebar event timestamp right away.
-    // That way we're at least _close_ to the right time
-    onClickSeek();
-
-    dispatch(selectFrameAction(cx, userPauseFrame!));
+    dispatch(
+      jumpToTimeAndLocationForQueuedRender(userPauseFrame, hitPoint, "timeAndLocation", onSeek)
+    );
   };
 
   const timeLabel =
@@ -393,56 +489,82 @@ function ReactQueuedRenderListItem({
   );
 }
 
+const getReactDomSourceUrl = createSelector(getSourceIdsByUrl, sourcesByUrl => {
+  const reactDomUrl = Object.keys(sourcesByUrl).find(key => {
+    return key.includes("react-dom.");
+  });
+  return reactDomUrl;
+});
+
 export function ReactPanel() {
   const dispatch = useAppDispatch();
   const currentTime = useAppSelector(getCurrentTime);
   const executionPoint = useAppSelector(getExecutionPoint);
+  const replayClient = useContext(ReplayClientContext);
   const { rangeForDisplay: focusRange } = useContext(FocusContext);
-  const [renderDetails, setRenderDetails] = useState<RenderAnalysisResults | null>(null);
 
-  useEffect(() => {
-    setRenderDetails(null);
-    (async () => {
-      const renderAnalysisResults =
-        (await dispatch(findQueuedRendersForRange(focusRange!))) ?? null;
-      setRenderDetails(renderAnalysisResults);
-    })();
-  }, [focusRange, dispatch]);
+  const reactDomSourceUrl = useAppSelector(getReactDomSourceUrl);
+  const sourcesState = useAppSelector(state => state.sources);
+  const reactDomSource = useAppSelector(state => {
+    if (!reactDomSourceUrl) {
+      return undefined;
+    }
+
+    const reactDomSource = getSourceToDisplayForUrl(state, reactDomSourceUrl);
+    if (!reactDomSource || !reactDomSource.url) {
+      return;
+    }
+
+    return reactDomSource;
+  });
+
+  const streamingValue = queuedRendersStreamingCache.stream(
+    replayClient,
+    focusRange,
+    reactDomSource,
+    sourcesState
+  );
+  const streamingRes = useStreamingValue(streamingValue);
+  const { data, progress, value: streamingRenderData } = streamingRes;
+
+  if (!focusRange?.begin) {
+    return <div>No focus range</div>;
+  } else if (!reactDomSource) {
+    if (sourcesState.allSourcesReceived) {
+      return <div>ReactDOM not found</div>;
+    } else {
+      return <div>Loading sources...</div>;
+    }
+  }
 
   const onSeek = (point: string, time: number) => {
     // trackEvent("events_timeline.select");
     dispatch(seek(point, time, false));
   };
 
-  if (!renderDetails) {
-    return (
-      <div style={{ height: "100%", display: "flex", flexDirection: "column", overflowY: "auto" }}>
-        <IndeterminateLoader />
-      </div>
-    );
-  }
+  const queuedRenders = streamingRenderData?.filter(entry => entry.userPauseFrame) ?? [];
 
-  if (renderDetails.error) {
-    return (
-      <div style={{ height: "100%", display: "flex", flexDirection: "column", overflowY: "auto" }}>
-        <div className="flex h-full items-center justify-center text-gray-400">
-          <span>{renderDetails.error}</span>
-        </div>
-      </div>
-    );
-  }
+  // TODO Add the red "curent time" line from `Events.tsx`
 
-  const queuedRenders = renderDetails?.queuedRenders.filter(entry => entry.userPauseFrame) ?? [];
   return (
     <div style={{ height: "100%", display: "flex", flexDirection: "column", overflowY: "auto" }}>
-      {queuedRenders.map(entry => (
-        <ReactQueuedRenderListItem
-          currentTime={currentTime}
-          executionPoint={executionPoint!}
-          renderDetails={entry}
-          onSeek={onSeek}
-          key={entry.point}
-        />
+      {streamingRes.status === "pending" && (
+        <div style={{ flexShrink: 1 }}>
+          <IndeterminateLoader />
+        </div>
+      )}
+      {queuedRenders.map((entry, i) => (
+        <div key={entry.point}>
+          <div className="px-1.5">
+            <ReactQueuedRenderListItem
+              currentTime={currentTime}
+              executionPoint={executionPoint!}
+              renderDetails={entry}
+              onSeek={onSeek}
+              key={entry.point}
+            />
+          </div>
+        </div>
       ))}
     </div>
   );

--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import PrimaryPanes from "devtools/client/debugger/src/components/PrimaryPanes";
 import SecondaryPanes from "devtools/client/debugger/src/components/SecondaryPanes";
 import Accordion from "devtools/client/debugger/src/components/shared/Accordion";
+import LazyOffscreen from "replay-next/components/LazyOffscreen";
 import { setSelectedPrimaryPanel } from "ui/actions/layout";
 import { setViewMode } from "ui/actions/layout";
 import Events from "ui/components/Events";
@@ -25,6 +26,7 @@ import useAuth0 from "ui/utils/useAuth0";
 import CommentCardsList from "./Comments/CommentCardsList";
 import ReplayInfo from "./Events/ReplayInfo";
 import ProtocolViewer from "./ProtocolViewer";
+import { ReactPanel } from "./ReactPanel";
 import StatusDropdown from "./shared/StatusDropdown";
 import { TestSuitePanel } from "./TestSuitePanel";
 import Tour from "./Tour/Tour";
@@ -140,6 +142,9 @@ export default function SidePanel() {
         {selectedPrimaryPanel === "cypress" && <TestSuitePanel />}
         {selectedPrimaryPanel === "protocol" && <ProtocolViewer />}
         {selectedPrimaryPanel === "search" && <SearchFilesReduxAdapter />}
+        <LazyOffscreen mode={selectedPrimaryPanel === "react" ? "visible" : "hidden"}>
+          <ReactPanel />
+        </LazyOffscreen>
       </div>
     </div>
   );


### PR DESCRIPTION
This PR:

- Re-enables showing the React Timeline panel, which had been inadvertently removed in the Replay Tour work
- Heavily rewrites the panel processing logic:
  - The primary searching for hits _inside_ React are now fetched in a streaming cache, so they will pop in over time.  (This is slow, but at least it shows _something_ happening instead of waiting for all up-to-200 hits to come back.)
      - I was seeing `createPause` times get _extremely_ slow when I tried to create large numbers of pauses simultaneously, which I've seen while doing routines work too.
  - Moves the _exact_ calculation of the final file location and potential timestamp to be done when you click "Jump to Code", just to cut down on the amount of processing down during the initial search
  - Switches from using analysis to using `getFrameSteps` to identify the right time.  This does work, but with caveats:
      - I ran into issues where the column of the original frame did not match the columns in the frame steps, such as an `onClick={() => dispatch(increment())}` having the frame point to the `dispatch` (column 33), but the frame _steps_ pointing to the `onClick=` (column 25).
      - The [recording I was testing against](https://app.replay.io/recording/breakpoints-03-test-stepping-forward-through-breakpoints-when-rewound-before-the-first-one--07c4ac6d-ac19-4cd8-a3b7-fadda36b3e39) seems to have a bunch of cases where execution clearly _should_ have hit a certain line, and the _frame_ says it hit that line, but I'm not getting back any breakable positions or hit counts for that line.
      - Given that, I half-gave-up, and am jumping to the location even if there's no exact frame step / execution point time to seek to

In general, this still needs a lot of further work to figure out why these load relatively slowly, why there's frame step / frame mismatches, etc.

But I think it's generally finding the right location and opening it consistently.
