### PR TITLE
Fix CI flakiness for "console_errors" e2e test

### DIFF
--- a/packages/e2e-tests/helpers/console-panel.ts
+++ b/packages/e2e-tests/helpers/console-panel.ts
@@ -50,9 +50,14 @@ export async function enableConsoleMessageType(
   page: Page,
   type: "exceptions" | "logs" | "warnings" | "errors"
 ) {
+  // Use checkbox.click() rather than checkbox.check()
+  // because the latter wil sometimes fail prematurely if the checkbox state doesn't change quickly enough
+  // Note this requires us to verify the initial state of the checkbox before clicking
   const checkbox = getConsoleMessageTypeCheckbox(page, type);
-  await delay(500);
-  await checkbox.check();
+  const isChecked = await checkbox.isChecked();
+  if (!isChecked) {
+    await checkbox.click({ timeout: 500 });
+  }
 }
 
 export async function executeTerminalExpression(


### PR DESCRIPTION
See comments on [bdf00b56-5422-41d7-994d-6f639018263d](https://app.replay.io/recording/replay-of-localhost8080--bdf00b56-5422-41d7-994d-6f639018263d). From what I can tell, Playwright is failing the test a little before our app is able to finish re-rendering (on a presumably underpowered CI box)

This is a bit concerning but I'm not sure of how to best tackle it. I am only able to repro it locally if I add an intentional `setTimeout` to simulate a slow response. In that case, I've found that replacing `checkbox.check()` with `checkbox.click()` avoids this issue. (Indeed this is what we're doing in the other e2e test helpers– the screenshot tests.)