### PR TITLE
Use requestFocusRange and getFocusWindow APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@lexical/react": "^0.6.5",
     "@reduxjs/toolkit": "^1.8.4",
     "@replayio/overboard": "^0.4.1",
-    "@replayio/protocol": "0.40.0",
+    "@replayio/protocol": "^0.41.0",
     "@sentry/react": "^7.9.0",
     "@sentry/tracing": "^7.9.0",
     "@stripe/react-stripe-js": "^1.7.0",

--- a/packages/markerikson-stack-client-prototype/package.json
+++ b/packages/markerikson-stack-client-prototype/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@codemirror/lang-javascript": "^6.0.2",
-    "@replayio/protocol": "^0.32.2",
+    "@replayio/protocol": "^0.41.0",
     "@uiw/react-codemirror": "^4.11.4",
     "lodash": "^4.17.21",
     "next": "^12.1.6",

--- a/packages/protocol/thread/thread.ts
+++ b/packages/protocol/thread/thread.ts
@@ -26,7 +26,6 @@ import {
   SourceKind,
   SourceLocation,
   TimeStamp,
-  TimeStampedPointRange,
   Value,
   findAnnotationsResult,
   requestBodyData,
@@ -146,8 +145,6 @@ class _ThreadFront {
   // Waiter which resolves with the target used to create the recording.
   recordingCapabilitiesWaiter = defer<RecordingCapabilities>();
   recordingTargetWaiter = defer<RecordingTarget>();
-
-  initialFocusRegionWaiter = defer<TimeStampedPointRange>();
 
   // Waiter which resolves when all sources have been loaded.
   private allSourcesWaiter = defer<void>();
@@ -298,7 +295,6 @@ class _ThreadFront {
             loadedRegions.loading.length === 1,
             "there should be exactly one initially loaded region"
           );
-          this.initialFocusRegionWaiter.resolve(loadedRegions.loading[0]);
         }
         this._loadedRegionsListeners.forEach(callback => callback(loadedRegions));
       });

--- a/packages/replay-next/package.json
+++ b/packages/replay-next/package.json
@@ -11,7 +11,7 @@
     "@codemirror/state_replay_next": "npm:@codemirror/state@6.1.2",
     "@lezer/common_replay_next": "npm:@lezer/common@1.0.1",
     "@lezer/highlight_replay_next": "npm:@lezer/highlight@1.1.1",
-    "@replayio/protocol": "^0.32.3",
+    "@replayio/protocol": "^0.41.0",
     "date-fns": "^2.28.0",
     "design": "workspace:*",
     "escape-html": "^1.0.3",

--- a/packages/replay-next/src/utils/testing.tsx
+++ b/packages/replay-next/src/utils/testing.tsx
@@ -196,6 +196,7 @@ export function createMockReplayClient() {
     getCorrespondingLocations: jest.fn().mockImplementation(() => []),
     getEventCountForTypes: jest.fn().mockImplementation(async () => {}),
     getEventCountForType: jest.fn().mockImplementation(async () => 0),
+    getFocusWindow: jest.fn().mockImplementation(async () => ({})),
     getFrameSteps: jest.fn().mockImplementation(async () => []),
     getHitPointsForLocation: jest.fn().mockImplementation(async () => []),
     getMappedLocation: jest.fn().mockImplementation(async () => []),

--- a/packages/shared/client/ReplayClient.ts
+++ b/packages/shared/client/ReplayClient.ts
@@ -380,6 +380,12 @@ export class ReplayClient implements ReplayClientInterface {
     return Object.fromEntries(counts.map(({ type, count }) => [type, count]));
   }
 
+  async getFocusWindow(): Promise<TimeStampedPointRange> {
+    const sessionId = this.getSessionIdThrows();
+    const { window } = await client.Session.getFocusWindow({}, sessionId);
+    return window;
+  }
+
   async getFrameSteps(pauseId: PauseId, frameId: FrameId): Promise<PointDescription[]> {
     const sessionId = this.getSessionIdThrows();
     const { steps } = await client.Pause.getFrameSteps({ frameId }, sessionId, pauseId);

--- a/packages/shared/client/ReplayClient.ts
+++ b/packages/shared/client/ReplayClient.ts
@@ -611,11 +611,11 @@ export class ReplayClient implements ReplayClientInterface {
     return mappedLocation;
   }
 
-  async requestFocusRange(range: TimeRange): Promise<requestFocusRangeResult> {
+  async requestFocusRange(range: TimeRange): Promise<TimeStampedPointRange> {
     const sessionId = this.getSessionIdThrows();
-    const result = await client.Session.requestFocusRange({ range }, sessionId);
+    const { window } = await client.Session.requestFocusRange({ range }, sessionId);
 
-    return result;
+    return window;
   }
 
   isOriginalSource(sourceId: SourceId): boolean {

--- a/packages/shared/client/types.ts
+++ b/packages/shared/client/types.ts
@@ -170,6 +170,7 @@ export interface ReplayClientInterface {
     eventTypes: EventHandlerType[],
     focusRange: PointRange | null
   ): Promise<Record<string, number>>;
+  getFocusWindow(): Promise<TimeStampedPointRange>;
   getFrameSteps(pauseId: PauseId, frameId: FrameId): Promise<PointDescription[]>;
   getMappedLocation(location: Location): Promise<MappedLocation>;
   getObjectWithPreview(

--- a/packages/shared/client/types.ts
+++ b/packages/shared/client/types.ts
@@ -199,7 +199,7 @@ export interface ReplayClientInterface {
   initialize(recordingId: string, accessToken: string | null): Promise<SessionId>;
   isOriginalSource(sourceId: SourceId): boolean;
   isPrettyPrintedSource(sourceId: SourceId): boolean;
-  requestFocusRange(range: TimeRange): Promise<requestFocusRangeResult>;
+  requestFocusRange(range: TimeRange): Promise<TimeStampedPointRange>;
   removeEventListener(type: ReplayClientEvents, handler: Function): void;
   repaintGraphics(pauseId: PauseId): Promise<repaintGraphicsResult>;
   runAnalysis<Result>(analysisParams: RunAnalysisParams): Promise<Result[]>;

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -338,8 +338,8 @@ export function createSocket(
       dispatch(actions.setLoadingFinished(true));
 
       if (!focusRegion) {
-        const initialFocusRegion = await ThreadFront.initialFocusRegionWaiter.promise;
-        dispatch(setFocusRegion(initialFocusRegion));
+        const focusWindow = await replayClient.getFocusWindow();
+        dispatch(setFocusRegion(focusWindow));
       }
     } catch (e: any) {
       const currentError = getUnexpectedError(getState());

--- a/yarn.lock
+++ b/yarn.lock
@@ -4144,24 +4144,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@replayio/protocol@npm:0.40.0":
-  version: 0.40.0
-  resolution: "@replayio/protocol@npm:0.40.0"
-  checksum: 30b5f73d42913e57b22e13b7d6fc1e0e2e977b6c554aa5dada1a09426ca2b195e1978c682395f7e4068203c5dedf8397da9c6b0e10c67ffb8a9148a5e2aa5c5c
-  languageName: node
-  linkType: hard
-
-"@replayio/protocol@npm:^0.32.2":
-  version: 0.32.2
-  resolution: "@replayio/protocol@npm:0.32.2"
-  checksum: 26c76597dad8dd01498ef3ab2e7fd01a7031a63acf1dd405e821143a60c4e288d14bcb4a56c3858fef8ea2d29de3e52a57fea2287571a91595ab0e79f221fe88
-  languageName: node
-  linkType: hard
-
-"@replayio/protocol@npm:^0.32.3":
-  version: 0.32.3
-  resolution: "@replayio/protocol@npm:0.32.3"
-  checksum: f8d6469ba734f654ce2c1a34552ccc24082f252b5b688848393b06821ac0cb8bd512802686c08321a05993906f7f77d77a15e09fb5750652f471de02fce9b90a
+"@replayio/protocol@npm:^0.41.0":
+  version: 0.41.0
+  resolution: "@replayio/protocol@npm:0.41.0"
+  checksum: ae67ac38e5eccedaf5c55f41b2bca1a5d5657e93fd335e7249a44771dd1bc8902d1a79e873082ed3ad26f10c1d2ddd9340aec86a6d4f640f5002a8b693c2727e
   languageName: node
   linkType: hard
 
@@ -17153,7 +17139,7 @@ __metadata:
   resolution: "markerikson-stack-client-prototype-227d06@workspace:packages/markerikson-stack-client-prototype"
   dependencies:
     "@codemirror/lang-javascript": ^6.0.2
-    "@replayio/protocol": ^0.32.2
+    "@replayio/protocol": ^0.41.0
     "@testing-library/jest-dom": ^5.16.3
     "@testing-library/react": ^13.2.0
     "@uiw/react-codemirror": ^4.11.4
@@ -20779,7 +20765,7 @@ __metadata:
     "@recordreplay/sourcemap-upload-cli": ^0.1.1
     "@reduxjs/toolkit": ^1.8.4
     "@replayio/overboard": ^0.4.1
-    "@replayio/protocol": 0.40.0
+    "@replayio/protocol": ^0.41.0
     "@replayio/replay": ^0.12.4
     "@sentry/react": ^7.9.0
     "@sentry/tracing": ^7.9.0
@@ -21257,7 +21243,7 @@ __metadata:
     "@lezer/common_replay_next": "npm:@lezer/common@1.0.1"
     "@lezer/highlight_replay_next": "npm:@lezer/highlight@1.1.1"
     "@playwright/test": ^1.23.1
-    "@replayio/protocol": ^0.32.3
+    "@replayio/protocol": ^0.41.0
     "@testing-library/jest-dom": ^5.16.3
     "@testing-library/react": ^13.2.0
     "@types/uuid": ^7.0.3


### PR DESCRIPTION
### Verification:
* Before: [db03084b-6ac5-47f4-9224-e295615efd73](https://app.replay.io/recording/troublesome-azure-test--db03084b-6ac5-47f4-9224-e295615efd73)
* After: [c20072fa-125f-477d-9a8a-b90553c46504](https://app.replay.io/recording/troublesome-azure-test-after--c20072fa-125f-477d-9a8a-b90553c46504)

### API integration
- [x] Update @replayio/protocol package to 0.41.0
- [x] Add `getFocusWindow` to `ReplayClientInterface`
- [x] Update `requestFocusRange` to return new applied window result

### Redux actions
- [x] Sync focus window with backend at start of session using `getFocusWindow`
- [x] Sync actual focus window with backend after requested changes

### Tests
- [x] Update protocol fixture data (if needed)
- [x] ~~Add new e2e test with long recording~~ I'm going to hold off on this until BAC-2964 lands and we can do the better version of the UX.