### PR TITLE
Menu icons no longer flicker because they're preloaded

### DIFF
--- a/src/ui/components/Header/UserOptions.tsx
+++ b/src/ui/components/Header/UserOptions.tsx
@@ -41,6 +41,19 @@ function UserOptions({ setModal, noBrowserItem }: UserOptionsProps) {
     setModal("settings");
   };
 
+  const preloadIcons = () => (
+    <div style={{ display: "none" }}>
+      <Icon filename="docs" className="bg-iconColor" />
+      <Icon filename="help" className="bg-iconColor" />
+      <Icon filename="settings" className="bg-iconColor" />
+      <Icon filename="replay-logo" className="bg-iconColor" />
+    </div>
+  );
+
+  {
+    preloadIcons();
+  }
+
   return (
     <div className="user-options text-blue-400">
       <Dropdown

--- a/src/ui/components/shared/SharingModal/PrivacyDropdown.tsx
+++ b/src/ui/components/shared/SharingModal/PrivacyDropdown.tsx
@@ -157,8 +157,18 @@ export default function PrivacyDropdown({ recording }: { recording: Recording })
     );
   }
 
+  const preloadIcons = () => (
+    <div style={{ display: "none" }}>
+      <MaterialIcon>globe</MaterialIcon>
+      <MaterialIcon>group</MaterialIcon>
+      <MaterialIcon>lock</MaterialIcon>
+      <MaterialIcon>expand_more</MaterialIcon>
+    </div>
+  );
+
   return (
     <>
+      {preloadIcons()}
       <PortalDropdown
         buttonContent={<DropdownButton>{summary}</DropdownButton>}
         buttonStyle={"overflow-hidden"}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9154902/227416152-8c8d86b1-eac9-430d-b0fa-9e84dc5f3f31.png)
