### PR TITLE
Remove "js-tokens" dependency

### DIFF
--- a/packages/replay-next/package.json
+++ b/packages/replay-next/package.json
@@ -16,7 +16,6 @@
     "design": "workspace:*",
     "escape-html": "^1.0.3",
     "idb": "^7.1.1",
-    "js-tokens": "^8.0.0",
     "lodash": "^4.17.21",
     "next": "13.1.3-canary.4",
     "pretty-ms": "^7.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16178,13 +16178,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-tokens@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "js-tokens@npm:8.0.0"
-  checksum: 7a069cf43d93bd5f0e047f975fcc7fcdf6176378d2ebff45020ed4360e031d013f5ed55e0a26cf9694537af9bb04f06aa6c200077f26bf7cb0f59102b46d0e56
-  languageName: node
-  linkType: hard
-
 "js-yaml@npm:^3.13.1, js-yaml@npm:^3.14.1":
   version: 3.14.1
   resolution: "js-yaml@npm:3.14.1"
@@ -21253,7 +21246,6 @@ __metadata:
     idb: ^7.1.1
     jest: ^28.0.2
     jest-environment-jsdom: ^28.0.2
-    js-tokens: ^8.0.0
     lodash: ^4.17.21
     next: 13.1.3-canary.4
     node-fetch: ^2.0.0


### PR DESCRIPTION
PR #8992 updated terminal expressions to use a Lezer-based parser instead of "js-tokens" (bringing it inline with the Source viewer and log point panels).

This PR removes the last dependency on the "js-tokens" package, in `LogPointAnalysisCache`. Now all of our parsing is done by Lezer.

No user-facing changes in behavior are expected (and thankfully we have pretty good test coverage). This should save a few kB from the bundle, and more importantly, should hopefully eliminate a source of potential mismatch between how we parse strings.