### PR TITLE
Fix Network panel CSS filter

### DIFF
--- a/src/ui/components/NetworkMonitor/utils.ts
+++ b/src/ui/components/NetworkMonitor/utils.ts
@@ -157,6 +157,7 @@ export const partialRequestsToCompleteSummaries = (
       const response = r.events.response;
       const requestDone = r.events["request-done"];
       const documentType = response ? getDocumentType(response.event.responseHeaders) : undefined;
+
       return {
         cause: request.event.requestCause,
         documentType,
@@ -179,7 +180,7 @@ export const partialRequestsToCompleteSummaries = (
         start: request.time,
         status: response?.event.responseStatus,
         triggerPoint: r.triggerPoint,
-        type: REQUEST_TYPES[request.event.requestCause || ""] || CanonicalRequestType.OTHER,
+        type: REQUEST_TYPES[request.event.requestCause || ""] ?? CanonicalRequestType.OTHER,
         url: request.event.requestUrl,
       };
     })


### PR DESCRIPTION
We should have been using a nullish check rather than a falsy check. The CSS filter was the first item in the array, and 0 was failing the falsy check.