### PR TITLE
Rewrote StreamingSourceCache to use createStreamingCache

### DIFF
--- a/packages/replay-next/components/comments/CommentPreview.tsx
+++ b/packages/replay-next/components/comments/CommentPreview.tsx
@@ -34,7 +34,7 @@ export default function CommentPreview({
         columnIndex={typeData.columnIndex}
         lineNumber={typeData.lineNumber}
         parsedTokens={typeData.parsedTokens}
-        rawText={typeData.rawText}
+        rawText={typeData.plainText}
         sourceId={typeData.sourceId}
         sourceUrl={typeData.sourceUrl}
       />

--- a/packages/replay-next/components/sources/SourceList.tsx
+++ b/packages/replay-next/components/sources/SourceList.tsx
@@ -11,7 +11,11 @@ import {
   useSyncExternalStore,
 } from "react";
 import { VariableSizeList as List, ListOnItemsRenderedProps } from "react-window";
-import { useImperativeCacheValue, useImperativeIntervalCacheValues } from "suspense";
+import {
+  useImperativeCacheValue,
+  useImperativeIntervalCacheValues,
+  useStreamingValue,
+} from "suspense";
 
 import { findPointForLocation } from "replay-next/components/sources/utils/points";
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
@@ -26,7 +30,7 @@ import {
   getCachedMinMaxSourceHitCounts,
   sourceHitCountsCache,
 } from "replay-next/src/suspense/SourceHitCountsCache";
-import { StreamingSourceContents } from "replay-next/src/suspense/SourcesCache";
+import { StreamingSourceContentsValue } from "replay-next/src/suspense/SourcesCache";
 import { StreamingParser } from "replay-next/src/suspense/SyntaxParsingCache";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { POINT_BEHAVIOR_DISABLED, POINT_BEHAVIOR_ENABLED } from "shared/client/types";
@@ -45,14 +49,12 @@ export default function SourceList({
   showColumnBreakpoints,
   source,
   streamingParser,
-  streamingSourceContents,
   width,
 }: {
   height: number;
   showColumnBreakpoints: boolean;
   source: ProtocolSource;
   streamingParser: StreamingParser;
-  streamingSourceContents: StreamingSourceContents;
   width: number;
 }) {
   const { sourceId } = source;
@@ -83,11 +85,8 @@ export default function SourceList({
   const { lineHeight, pointPanelHeight, pointPanelWithConditionalHeight } =
     useFontBasedListMeasurements(listRef);
 
-  const lineCount = useSyncExternalStore(
-    streamingSourceContents.subscribe,
-    () => streamingSourceContents.lineCount,
-    () => streamingSourceContents.lineCount
-  );
+  const { data } = useStreamingValue(streamingParser);
+  const lineCount = data?.lineCount ?? 0;
 
   // Both hit counts and breakable positions are key info,
   // but neither should actually _block_ us from showing source text.

--- a/packages/replay-next/components/sources/SourceListRow.tsx
+++ b/packages/replay-next/components/sources/SourceListRow.tsx
@@ -9,9 +9,9 @@ import {
   useContext,
   useMemo,
   useState,
-  useSyncExternalStore,
 } from "react";
 import { areEqual } from "react-window";
+import { useStreamingValue } from "suspense";
 
 import useGetDefaultLogPointContent from "replay-next/components/sources/hooks/useGetDefaultLogPointContent";
 import SearchResultHighlight from "replay-next/components/sources/SearchResultHighlight";
@@ -106,17 +106,11 @@ const SourceListRow = memo(
 
     const { sourceId } = source;
 
-    let tokens: ParsedToken[] | null = useSyncExternalStore(
-      streamingParser.subscribe,
-      () => streamingParser.value?.[index] ?? null,
-      () => streamingParser.value?.[index] ?? null
-    );
+    const { data: streamingData, value: streamingValue } = useStreamingValue(streamingParser);
 
-    const plainText = useSyncExternalStore(
-      streamingParser.subscribe,
-      () => streamingParser.data?.text[index] ?? null,
-      () => streamingParser.data?.text[index] ?? null
-    );
+    const plainText = streamingData?.plainText[index] ?? null;
+
+    let tokens: ParsedToken[] | null = streamingValue?.[index] ?? null;
 
     let testStateContents = "loading";
     if (tokens !== null) {

--- a/packages/replay-next/components/sources/SourceSearchContext.tsx
+++ b/packages/replay-next/components/sources/SourceSearchContext.tsx
@@ -35,8 +35,9 @@ export function SourceSearchContextRoot({ children }: { children: ReactNode }) {
   useEffect(() => {
     async function updateSourceContents(focusedSourceId: string | null, setScope: SetScope) {
       if (focusedSourceId) {
-        const { resolver } = await streamingSourceContentsCache.read(client, focusedSourceId);
-        const { contents: code } = await resolver;
+        const streaming = streamingSourceContentsCache.stream(client, focusedSourceId);
+        await streaming.resolver;
+        const code = streaming.value;
         setScope(focusedSourceId, code || "");
       } else {
         setScope(null, "");

--- a/packages/replay-next/components/sources/StreamingSourceLoadingProgressHeader.tsx
+++ b/packages/replay-next/components/sources/StreamingSourceLoadingProgressHeader.tsx
@@ -1,25 +1,19 @@
-import { useSyncExternalStore } from "react";
+import { useStreamingValue } from "suspense";
 
+import { StreamingSourceContentsValue } from "replay-next/src/suspense/SourcesCache";
 import { StreamingParser } from "replay-next/src/suspense/SyntaxParsingCache";
 
 import styles from "./StreamingSourceLoadingProgressHeader.module.css";
 
 export default function StreamingSourceLoadingProgressHeader({
   streamingParser,
+  streamingSourceContents,
 }: {
   streamingParser: StreamingParser;
+  streamingSourceContents: StreamingSourceContentsValue;
 }) {
-  const rawTextPercentage = useSyncExternalStore(
-    streamingParser.subscribe,
-    () => streamingParser.data?.progress ?? 0,
-    () => streamingParser.data?.progress ?? 0
-  );
-
-  const parsedTokensPercentage = useSyncExternalStore(
-    streamingParser.subscribe,
-    () => streamingParser.progress ?? 0,
-    () => streamingParser.progress ?? 0
-  );
+  const { progress: rawTextPercentage = 0 } = useStreamingValue(streamingSourceContents);
+  const { progress: parsedTokensPercentage = 0 } = useStreamingValue(streamingParser);
 
   const loadedProgressBarWidth = Math.round(rawTextPercentage * 100);
   const parsedTokensPercentageBarWidth = Math.round(parsedTokensPercentage * 100);

--- a/packages/replay-next/components/sources/utils/comments.ts
+++ b/packages/replay-next/components/sources/utils/comments.ts
@@ -1,10 +1,7 @@
 import { SourceId } from "@replayio/protocol";
 
 import { assert } from "protocol/utils";
-import {
-  getSourceAsync,
-  streamingSourceContentsCache,
-} from "replay-next/src/suspense/SourcesCache";
+import { getSourceAsync } from "replay-next/src/suspense/SourcesCache";
 import { streamingSyntaxParsingCache } from "replay-next/src/suspense/SyntaxParsingCache";
 import { getBase64Png } from "replay-next/src/utils/canvas";
 import { getSourceFileName } from "replay-next/src/utils/source";
@@ -42,7 +39,7 @@ export interface SourceCodeCommentTypeData {
   columnIndex: number;
   lineNumber: number;
   parsedTokens: ParsedToken[] | null;
-  rawText: string | null;
+  plainText: string | null;
   sourceId: SourceId;
   sourceUrl: string | null;
 }
@@ -81,23 +78,22 @@ export async function createTypeDataForSourceCodeComment(
   maxTextLength = 100
 ): Promise<SourceCodeCommentTypeData> {
   let parsedTokens: ParsedToken[] | null = null;
-  let rawText: string | null = null;
+  let plainText: string | null = null;
 
   const source = await getSourceAsync(replayClient, sourceId);
   const sourceUrl = source?.url ?? null;
   const fileName = source ? getSourceFileName(source) : null;
 
   // Secondary label is used to store the syntax-highlighted markup for the line
-  const streamingSource = streamingSourceContentsCache.read(replayClient, sourceId);
-  const parsedSource = await streamingSyntaxParsingCache.stream(streamingSource, fileName);
+  const parsedSource = await streamingSyntaxParsingCache.stream(replayClient, sourceId, fileName);
   if (parsedSource != null) {
-    if ((parsedSource.data?.text.length ?? 0) < lineNumber) {
+    if ((parsedSource.data?.plainText.length ?? 0) < lineNumber) {
       // If the streaming source hasn't finished loading yet, wait for it to load;
       // Note that it's important to check raw lines as parsed lines may be clipped
       // if the source is larger than the parser has been configured to handle.
       await new Promise<void>(resolve => {
         parsedSource.subscribe(() => {
-          if ((parsedSource.data?.text.length ?? 0) >= lineNumber) {
+          if ((parsedSource.data?.plainText.length ?? 0) >= lineNumber) {
             resolve();
           }
         });
@@ -106,14 +102,14 @@ export async function createTypeDataForSourceCodeComment(
 
     assert(parsedSource.data && parsedSource.value);
 
-    rawText = parsedSource.data.text[lineNumber - 1];
-    if (rawText.length <= maxTextLength) {
+    plainText = parsedSource.data.plainText[lineNumber - 1];
+    if (plainText.length <= maxTextLength) {
       // If the raw text is longer than the max length, we can't safely use the parsed tokens.
       if (parsedSource.value.length >= lineNumber) {
         parsedTokens = parsedSource.value[lineNumber - 1];
       }
     } else {
-      rawText = rawText.substring(0, maxTextLength);
+      plainText = plainText.substring(0, maxTextLength);
     }
   }
 
@@ -121,7 +117,7 @@ export async function createTypeDataForSourceCodeComment(
     columnIndex,
     lineNumber,
     parsedTokens,
-    rawText,
+    plainText,
     sourceId,
     sourceUrl,
   };

--- a/packages/replay-next/playwright/tests/utils/source.ts
+++ b/packages/replay-next/playwright/tests/utils/source.ts
@@ -276,24 +276,6 @@ function getNextHitPointButton(page: Page, lineNumber: number): Locator {
   return pointPanelLocator.locator(`[data-test-name="NextHitPointButton"]`);
 }
 
-async function getNumLines(page: Page, sourceId: string): Promise<number> {
-  const sourceLocator = getSourceLocator(page, sourceId);
-  await expect(sourceLocator).toBeVisible();
-
-  let numLines: number | undefined;
-
-  await waitFor(async () => {
-    const attribute = await sourceLocator.getAttribute("data-test-num-lines");
-
-    numLines = parseInt(attribute!, 10);
-    if (isNaN(numLines)) {
-      throw Error(`Waiting for source ${sourceId} to have a num-lines attribute`);
-    }
-  });
-
-  return numLines!;
-}
-
 function getPreviousHitPointButton(page: Page, lineNumber: number): Locator {
   const pointPanelLocator = getPointPanelLocator(page, lineNumber);
   return pointPanelLocator.locator(`[data-test-name="PreviousHitPointButton"]`);
@@ -1016,16 +998,10 @@ export async function waitForSourceContentsToStream(page: Page, sourceId: string
   const sourceLocator = getSourceLocator(page, sourceId);
   await expect(sourceLocator).toBeVisible();
 
-  const numLines = await getNumLines(page, sourceId);
-  await goToLine(page, sourceId, numLines);
-
-  const lastLine = page.locator('[data-test-name="SourceLine"]').last();
-  await lastLine.isVisible();
-
   await waitFor(async () => {
-    const contentsState = await lastLine.getAttribute("data-test-contents-state");
-    if (contentsState !== "parsed") {
-      throw Error(`Waiting for line ${numLines} to be parsed but is "${contentsState}"`);
+    const status = await sourceLocator.getAttribute("data-test-source-status");
+    if (status !== "resolved") {
+      throw Error(`Waiting for source to be "resolved" but is "${status}"`);
     }
   });
 }

--- a/src/devtools/client/debugger/src/actions/ui.ts
+++ b/src/devtools/client/debugger/src/actions/ui.ts
@@ -98,9 +98,9 @@ export function flashLineRange(location: HighlightedRange): UIThunkAction {
 
 export function copyToClipboard(source: SourceDetails): UIThunkAction {
   return (dispatch, getState, { replayClient }) => {
-    const streaming = streamingSourceContentsCache.getValueIfCached(replayClient, source.id);
+    const streaming = streamingSourceContentsCache.stream(replayClient, source.id);
     if (streaming?.complete) {
-      copyTextToClipboard(streaming.contents!);
+      copyTextToClipboard(streaming.value!);
     }
   };
 }

--- a/src/devtools/client/debugger/src/components/QuickOpenModal.tsx
+++ b/src/devtools/client/debugger/src/components/QuickOpenModal.tsx
@@ -314,10 +314,7 @@ class QuickOpenModal extends Component<QuickOpenModalProps, QOMState> {
 
     let selectedContentLoaded = false;
     if (selectedSource) {
-      const streaming = streamingSourceContentsCache.getValueIfCached(
-        null as any,
-        selectedSource.id
-      );
+      const streaming = streamingSourceContentsCache.stream(replayClient, selectedSource.id);
       selectedContentLoaded = streaming?.complete === true;
     }
     const noSource = !selectedSource || !selectedContentLoaded;

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointOptions.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointOptions.tsx
@@ -3,7 +3,6 @@ import { useStreamingValue } from "suspense";
 
 import Loader from "replay-next/components/Loader";
 import SyntaxHighlightedLine from "replay-next/components/sources/SyntaxHighlightedLine";
-import { streamingSourceContentsCache } from "replay-next/src/suspense/SourcesCache";
 import { streamingSyntaxParsingCache } from "replay-next/src/suspense/SyntaxParsingCache";
 import { ParsedToken } from "replay-next/src/utils/syntax-parser";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
@@ -20,22 +19,19 @@ function BreakpointLineContents({ breakpoint }: BreakpointProps) {
   const replayClient = useContext(ReplayClientContext);
   const { sourceId } = breakpoint.location;
 
-  // TODO use useStreamingValue() for this
-  // once streamingSourceContentsCache has been migrated to "suspense"
-  const streamingSourceContents = streamingSourceContentsCache.read(replayClient, sourceId);
-  const parsedStream = streamingSyntaxParsingCache.stream(streamingSourceContents, null);
+  const parsedStream = streamingSyntaxParsingCache.stream(replayClient, sourceId, null);
   const { data, value } = useStreamingValue(parsedStream);
 
   const parsedTokensByLine = value;
-  const rawTextByLine = data?.text;
+  const plainTextByLine = data!.plainText;
 
   const { snippet, tokens } = useMemo((): { snippet: string; tokens: ParsedToken[] } => {
     const { column, line } = breakpoint.location;
     let snippet = "";
     let tokens: ParsedToken[] = [];
 
-    if (rawTextByLine && rawTextByLine[line - 1]) {
-      const lineText = rawTextByLine[line - 1];
+    if (plainTextByLine && plainTextByLine[line - 1]) {
+      const lineText = plainTextByLine[line - 1];
       snippet = lineText.slice(column, column! + 100).trim();
     }
 
@@ -47,7 +43,7 @@ function BreakpointLineContents({ breakpoint }: BreakpointProps) {
     }
 
     return { snippet, tokens };
-  }, [rawTextByLine, parsedTokensByLine, breakpoint]);
+  }, [plainTextByLine, parsedTokensByLine, breakpoint]);
 
   if (!snippet || !tokens) {
     return null;

--- a/src/ui/components/Comments/TranscriptComments/SourceCodePreview.tsx
+++ b/src/ui/components/Comments/TranscriptComments/SourceCodePreview.tsx
@@ -33,7 +33,7 @@ export default function SourceCodePreview({ comment }: { comment: Comment }) {
         columnIndex={typeData.columnIndex}
         lineNumber={typeData.lineNumber}
         parsedTokens={typeData.parsedTokens}
-        rawText={typeData.rawText}
+        rawText={typeData.plainText}
         sourceId={typeData.sourceId}
         sourceUrl={typeData.sourceUrl}
       />
@@ -101,7 +101,7 @@ function LegacySourceCodePreview({
         columnIndex={typeData.columnIndex}
         lineNumber={typeData.lineNumber}
         parsedTokens={typeData.parsedTokens}
-        rawText={typeData.rawText}
+        rawText={typeData.plainText}
         sourceId={typeData.sourceId}
         sourceUrl={typeData.sourceUrl}
       />

--- a/src/ui/components/ReactPanel.tsx
+++ b/src/ui/components/ReactPanel.tsx
@@ -6,7 +6,7 @@ import {
   TimeStampedPointRange,
 } from "@replayio/protocol";
 import classnames from "classnames";
-import { ReactNode, useContext, useEffect, useState } from "react";
+import { ReactNode, useContext, useState } from "react";
 import {
   Cache,
   StreamingCache,
@@ -25,7 +25,6 @@ import {
 import type { AstPosition } from "devtools/client/debugger/src/selectors";
 import { findClosestofSymbol } from "devtools/client/debugger/src/utils/ast";
 import { simplifyDisplayName } from "devtools/client/debugger/src/utils/pause/frames/displayName";
-import { AnalysisInput, getFunctionBody } from "protocol/evaluation-utils";
 import Icon from "replay-next/components/Icon";
 import IndeterminateLoader from "replay-next/components/IndeterminateLoader";
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
@@ -222,12 +221,10 @@ const queuedRendersStreamingCache: StreamingCache<
         // across multiple React production builds, without needing to track minified function names.
         // TODO Rethink this one React has sourcemaps
 
-        const streaming = await streamingSourceContentsCache.readAsync(
-          replayClient,
-          reactDomSource!.id
-        );
+        const streaming = streamingSourceContentsCache.stream(replayClient, reactDomSource!.id);
         await streaming.resolver;
-        const reactDomSourceLines = streaming.contents!.split("\n");
+
+        const reactDomSourceLines = streaming.value!.split("\n");
 
         // A build-extracted React error code
         const MAGIC_SCHEDULE_UPDATE_CONTENTS = "(185)";


### PR DESCRIPTION
Resolves FE-1355

- [x] Rewrite source (contents) cache to use `createStreamingCache`
- [x] Update syntax parsing cache to use new source contents cache
- [x] Cleaned up a few outstanding "TODO" comments in our e2e test helpers now that this migration has been finished