### PR TITLE
Search input sometimes erased unexpectedly

### DIFF
--- a/packages/replay-next/components/sources/SourceSearchContext.tsx
+++ b/packages/replay-next/components/sources/SourceSearchContext.tsx
@@ -36,9 +36,12 @@ export function SourceSearchContextRoot({ children }: { children: ReactNode }) {
     async function updateSourceContents(focusedSourceId: string | null, setScope: SetScope) {
       if (focusedSourceId) {
         const streaming = streamingSourceContentsCache.stream(client, focusedSourceId);
+        if (!streaming.complete) {
+          // It may take a while to stream this code, so update the search scope beforehand.
+          setScope(focusedSourceId, "");
+        }
         await streaming.resolver;
-        const code = streaming.value;
-        setScope(focusedSourceId, code || "");
+        setScope(focusedSourceId, streaming.value!);
       } else {
         setScope(null, "");
       }

--- a/packages/replay-next/components/sources/hooks/useSearch.ts
+++ b/packages/replay-next/components/sources/hooks/useSearch.ts
@@ -271,10 +271,6 @@ export default function useSearch<Item, Result, QueryData = never>(
       dispatch({ type: "updateItems", items });
     }
 
-    if (queryChanged || queryDataChanged) {
-      dispatch({ type: "updateQuery", query: deferredQuery, queryData: deferredQueryData });
-    }
-
     const results = deferredQuery
       ? stableSearch(deferredQuery, items, deferredQueryData)
       : EMPTY_ARRAY;


### PR DESCRIPTION
Resolves FE-1322

- [x] Fix loose memoization in `useSourceSearch` that caused an effect in `SourceSearchContext` to run too many times.
- [x] Don't wait for source contents to stream in before updating search scope.
- [x] Fix issue where "default" focus id causes source search to reset after a source loads.

See comment trail on [8ff1203c-2503-4aab-bbb3-ff4cb8dbc8a2](https://app.replay.io/recording/fe-1322-search-clear-bug--8ff1203c-2503-4aab-bbb3-ff4cb8dbc8a2) for why these changes were made.

cc @Andarist 