### PR TITLE
Implement initial Cypress "Jump to Code" button for click/type steps

### DIFF
--- a/packages/shared/graphql/types.ts
+++ b/packages/shared/graphql/types.ts
@@ -302,6 +302,7 @@ export type AnnotatedTestStep = TestStep & {
   absoluteEndTime: number;
   index: number;
   annotations: Annotations;
+  category?: string;
 };
 
 type Annotations = {

--- a/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
@@ -275,7 +275,7 @@ function TestSection({
       ) : null}
       {events.map(({ event: s, type, time }, i) =>
         type === "step" ? (
-          <>
+          <React.Fragment key={s.id}>
             <TestStepItem
               step={s}
               key={s.id}
@@ -289,7 +289,7 @@ function TestSection({
               autoSelect={s.id === autoSelectId}
             />
             {s.error ? <TestError error={s.error!} /> : null}
-          </>
+          </React.Fragment>
         ) : type === "network" ? (
           <NetworkEvent key={s.id} request={s} />
         ) : (

--- a/src/devtools/client/debugger/src/components/shared/ResultList.tsx
+++ b/src/devtools/client/debugger/src/components/shared/ResultList.tsx
@@ -42,7 +42,6 @@ export default class ResultList extends Component<ResultListProps> {
     const { selectItem, selected } = this.props;
     const props: React.ComponentPropsWithRef<"li"> = {
       onClick: (event: any) => selectItem(event, item),
-      key: `${item.id}${item.value}${index}`,
       ref: element => {
         // Keep a lookup table of items by index for scrolling
         if (element) {
@@ -61,7 +60,7 @@ export default class ResultList extends Component<ResultListProps> {
     };
 
     return (
-      <li {...props}>
+      <li key={`${item.id}${item.value}${index}`} {...props}>
         {item.icon && (
           <div className="icon">
             <AccessibleImage className={item.icon} />

--- a/src/ui/actions/event-listeners.ts
+++ b/src/ui/actions/event-listeners.ts
@@ -279,6 +279,8 @@ export const IGNORABLE_PARTIAL_SOURCE_URLS = [
   "webpack:///src/sandbox/",
   "webpack:///sandpack-core/",
   "webpack:////home/circleci/codesandbox-client",
+  // or Cypress
+  "__cypress/runner/",
 ];
 
 export function shouldIgnoreEventFromSource(sourceDetails?: SourceDetails) {

--- a/src/ui/actions/event-listeners.ts
+++ b/src/ui/actions/event-listeners.ts
@@ -7,7 +7,7 @@ import { Cache, createCache } from "suspense";
 import type { ThreadFront as TF } from "protocol/thread";
 import { topFrameCache } from "replay-next/src/suspense/FrameCache";
 import { objectCache } from "replay-next/src/suspense/ObjectPreviews";
-import { cachePauseData } from "replay-next/src/suspense/PauseCache";
+import { cachePauseData, updateMappedLocation } from "replay-next/src/suspense/PauseCache";
 import { scopeMapCache } from "replay-next/src/suspense/ScopeMapCache";
 import { ReplayClientInterface } from "shared/client/types";
 import {
@@ -88,6 +88,8 @@ export const formatEventListener = async (
   framework?: string
 ) => {
   const { functionLocation, functionName = "", functionParameterNames = [] } = fnPreview;
+
+  updateMappedLocation(replayClient, functionLocation);
 
   let location: Location | undefined = undefined;
   let locationUrl: string | undefined = undefined;

--- a/src/ui/components/Events/Event.tsx
+++ b/src/ui/components/Events/Event.tsx
@@ -5,7 +5,6 @@ import {
   MouseEvent as ReplayMouseEvent,
   SameLineSourceLocations,
 } from "@replayio/protocol";
-import classNames from "classnames";
 import classnames from "classnames";
 import React, { ReactNode, useState } from "react";
 import { Cache, createCache } from "suspense";
@@ -15,18 +14,17 @@ import { getThreadContext } from "devtools/client/debugger/src/reducers/pause";
 import { getFunctionBody } from "protocol/evaluation-utils";
 import type { ThreadFront as TF } from "protocol/thread";
 import { RecordingTarget } from "protocol/thread/thread";
-import Icon from "replay-next/components/Icon";
 import { breakpointPositionsCache } from "replay-next/src/suspense/BreakpointPositionsCache";
 import { EventLog, eventsMapper } from "replay-next/src/suspense/EventsCache";
 import { getHitPointsForLocationAsync } from "replay-next/src/suspense/HitPointsCache";
 import { pauseIdCache } from "replay-next/src/suspense/PauseCache";
-import { isExecutionPointsGreaterThan } from "replay-next/src/utils/time";
 import { compareExecutionPoints } from "replay-next/src/utils/time";
 import { ReplayClientInterface } from "shared/client/types";
 import type { UIThunkAction } from "ui/actions";
 import { SEARCHABLE_EVENT_TYPES, eventListenerLocationCache } from "ui/actions/event-listeners";
 import { setViewMode } from "ui/actions/layout";
 import useEventContextMenu from "ui/components/Events/useEventContextMenu";
+import { JumpToCodeButton, JumpToCodeStatus } from "ui/components/shared/JumpToCodeButton";
 import { getLoadedRegions } from "ui/reducers/app";
 import { getViewMode } from "ui/reducers/layout";
 import { setMarkTimeStampPoint } from "ui/reducers/timeline";
@@ -112,14 +110,6 @@ export const getEventLabel = (event: ReplayEvent) => {
   }
 
   return label;
-};
-
-export type JumpToCodeFailureReason = "not_loaded" | "no_hits";
-export type JumpToCodeStatus = JumpToCodeFailureReason | "not_checked" | "loading" | "found";
-
-export const errorMessages: Record<JumpToCodeFailureReason, string> = {
-  not_loaded: "Not loaded",
-  no_hits: "No results",
 };
 
 /*
@@ -279,7 +269,6 @@ export default React.memo(function Event({
   const dispatch = useAppDispatch();
   const { kind, point, time } = event;
   const isPaused = time === currentTime && executionPoint === point;
-  const [isHovered, setIsHovered] = useState(false);
   const label = getEventLabel(event);
   const { icon } = getReplayEvent(kind);
   const [jumpToCodeStatus, setJumpToCodeStatus] = useState<JumpToCodeStatus>("not_checked");
@@ -290,9 +279,7 @@ export default React.memo(function Event({
     onSeek(point, time);
   };
 
-  const onClickJumpToCode = async (e: React.MouseEvent) => {
-    e.stopPropagation();
-
+  const onClickJumpToCode = async () => {
     // Seek to the sidebar event timestamp right away.
     // That way we're at least _close_ to the right time
     onSeek(point, time);
@@ -314,40 +301,6 @@ export default React.memo(function Event({
 
   const { contextMenu, onContextMenu } = useEventContextMenu(event);
 
-  const timeLabel =
-    executionPoint === null || isExecutionPointsGreaterThan(event.point, executionPoint)
-      ? "fast-forward"
-      : "rewind";
-
-  const jumpToCodeButtonAvailable =
-    jumpToCodeStatus === "not_checked" || jumpToCodeStatus === "found";
-
-  const jumpToCodeButtonClassname = classnames(
-    "transition-width flex items-center justify-center rounded-full  duration-100 ease-out h-6",
-    {
-      "bg-primaryAccent": jumpToCodeButtonAvailable,
-      "bg-gray-400 cursor-default": !jumpToCodeButtonAvailable,
-      "px-2 shadow-sm": isHovered,
-      "w-6": !isHovered,
-    }
-  );
-
-  const onJumpButtonMouseEnter = (e: React.MouseEvent) => {
-    setIsHovered(true);
-  };
-
-  const onJumpButtonMouseLeave = (e: React.MouseEvent) => {
-    setIsHovered(false);
-  };
-
-  let jumpButtonText = "Jump to code";
-
-  if (jumpToCodeStatus in errorMessages) {
-    jumpButtonText = errorMessages[jumpToCodeStatus as JumpToCodeFailureReason];
-  } else if (jumpToCodeStatus === "loading") {
-    jumpButtonText = "Loading...";
-  }
-
   const onMouseEnter = () => {
     dispatch(
       setMarkTimeStampPoint({
@@ -364,7 +317,7 @@ export default React.memo(function Event({
   return (
     <>
       <div
-        className={classNames(styles.eventRow, "group block w-full", {
+        className={classnames(styles.eventRow, "group block w-full", {
           "text-lightGrey": currentTime < time,
           "font-semibold text-primaryAccent": isPaused,
         })}
@@ -380,17 +333,12 @@ export default React.memo(function Event({
         </div>
         <div className="flex space-x-2 opacity-0 group-hover:opacity-100">
           {event.kind === "mousedown" || event.kind === "keypress" ? (
-            <div
-              onClick={jumpToCodeButtonAvailable ? onClickJumpToCode : undefined}
-              onMouseEnter={onJumpButtonMouseEnter}
-              onMouseLeave={onJumpButtonMouseLeave}
-              className={jumpToCodeButtonClassname}
-            >
-              <div className="flex items-center space-x-1">
-                {isHovered && <span className="truncate text-white ">{jumpButtonText}</span>}
-                <Icon type={timeLabel} className="w-3.5 text-white" />
-              </div>
-            </div>
+            <JumpToCodeButton
+              onClick={onClickJumpToCode}
+              status={jumpToCodeStatus}
+              currentExecutionPoint={executionPoint}
+              targetExecutionPoint={event.point}
+            />
           ) : null}
         </div>
       </div>

--- a/src/ui/components/shared/JumpToCodeButton.tsx
+++ b/src/ui/components/shared/JumpToCodeButton.tsx
@@ -1,0 +1,87 @@
+import { ExecutionPoint } from "@replayio/protocol";
+import classnames from "classnames";
+import React, { useState } from "react";
+
+import Icon from "replay-next/components/Icon";
+import { isExecutionPointsGreaterThan } from "replay-next/src/utils/time";
+
+export type JumpToCodeFailureReason = "not_loaded" | "no_hits";
+export type JumpToCodeStatus = JumpToCodeFailureReason | "not_checked" | "loading" | "found";
+
+export const errorMessages: Record<JumpToCodeFailureReason, string> = {
+  not_loaded: "Not loaded",
+  no_hits: "No results",
+};
+
+interface JumpToCodeButtonProps {
+  status: JumpToCodeStatus;
+  onClick: () => void;
+  currentExecutionPoint: ExecutionPoint | null;
+  targetExecutionPoint: ExecutionPoint;
+}
+
+export function JumpToCodeButton({
+  status,
+  onClick,
+  currentExecutionPoint,
+  targetExecutionPoint,
+}: JumpToCodeButtonProps) {
+  const [isHovered, setIsHovered] = useState(false);
+
+  const jumpToCodeButtonAvailable = status === "not_checked" || status === "found";
+
+  const jumpToCodeButtonClassname = classnames(
+    "transition-width flex items-center justify-center rounded-full  duration-100 ease-out h-6",
+    {
+      "bg-primaryAccent cursor-pointer cursor-default": jumpToCodeButtonAvailable,
+      "bg-gray-400 ": !jumpToCodeButtonAvailable,
+      "px-2 shadow-sm": isHovered,
+      "w-6": !isHovered,
+    }
+  );
+
+  const onJumpButtonMouseEnter = (e: React.MouseEvent) => {
+    setIsHovered(true);
+  };
+
+  const onJumpButtonMouseLeave = (e: React.MouseEvent) => {
+    setIsHovered(false);
+  };
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+
+    if (jumpToCodeButtonAvailable) {
+      onClick();
+    }
+  };
+
+  const timeLabel =
+    currentExecutionPoint === null ||
+    isExecutionPointsGreaterThan(targetExecutionPoint, currentExecutionPoint)
+      ? "fast-forward"
+      : "rewind";
+
+  let jumpButtonText = "Jump to code";
+
+  if (status in errorMessages) {
+    jumpButtonText = errorMessages[status as JumpToCodeFailureReason];
+  } else if (status === "loading") {
+    jumpButtonText = "Loading...";
+  }
+
+  return (
+    <div
+      onClick={handleClick}
+      onMouseEnter={onJumpButtonMouseEnter}
+      onMouseLeave={onJumpButtonMouseLeave}
+      className={jumpToCodeButtonClassname}
+    >
+      <div className="flex items-center space-x-1">
+        {isHovered && <span className="truncate text-white ">{jumpButtonText}</span>}
+        <Icon type={timeLabel} className="w-3.5 text-white" />
+      </div>
+    </div>
+  );
+}

--- a/src/ui/reducers/sources.ts
+++ b/src/ui/reducers/sources.ts
@@ -277,10 +277,19 @@ export function getPreferredLocation(sources: SourcesState, locations: MappedLoc
   );
   const preferredLocation = locations.find(l => l.sourceId == sourceId);
   assert(preferredLocation, "no preferred location found");
+
+  const correspondingSources = getCorrespondingSourceIdsFromSourcesState(
+    sources,
+    preferredLocation.sourceId
+  );
+  const assertion = preferredLocation.sourceId === correspondingSources[0];
+
   assert(
-    preferredLocation.sourceId ===
-      getCorrespondingSourceIdsFromSourcesState(sources, preferredLocation.sourceId)[0],
-    "location.sourceId should be updated to the first corresponding sourceId"
+    assertion,
+    `location.sourceId should be updated to the first corresponding sourceId: ${JSON.stringify({
+      preferredLocation,
+      correspondingSources,
+    })}`
   );
   return preferredLocation;
 }


### PR DESCRIPTION
This PR:

- Fixes two leftover React key warnings I ran across
- Extracts a reusable `<JumpToCodeButton>` component
- Fixes an issue where function preview locations sometimes hadn't been updated with proper mapped locations
- Adds the actual "Jump" button to Cypress "click/type" test step rows

General appearance:

- No hover: 
  ![image](https://user-images.githubusercontent.com/1128784/228331349-10a8a9a7-5049-4109-a79d-b3752abe1729.png)

- Button hovered:  
  ![image](https://user-images.githubusercontent.com/1128784/228331420-9022cfc0-f354-4bce-a430-86115e0e8d80.png)

The non-hovered state does appear a bit squished horizontally compared to the "Events" panel atm, but I'm going to skip that for now.

The "find location" logic seems to work decently for clicks.  The one example I have of a Cypress+FF recording with a `"type"` command (keyboard text) doesn't seem to be working right because the recording only shows `keydown` events captured, not `keypress`, even though Cypress is trying to fire all standard keyboard events in sequence.  That feels like a runtime bug of some kind.  Unfortunately I don't yet have other Cypress+FF recordings to compare against right now.

So, my vote is to go ahead and merge this in, let Jon tweak the design of the button, and then focus on getting the Chromium Events PR in so that we can start testing those pieces together.