### PR TITLE
Only show "Jump" button if there's a valid start time

### DIFF
--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -234,7 +234,7 @@ export function TestStepItem({
   // We only care about click events and keyboard events. Keyboard events appear to be a "type" command,
   // as in "type this text into the input".
   let shouldShowJumpToCode = false;
-  if ("category" in step) {
+  if ("category" in step && step.annotations.start) {
     shouldShowJumpToCode =
       "category" in step &&
       step.category === "command" &&


### PR DESCRIPTION
I'd copy-pasted a TS `step.annotations.start!.point` assertion in #9002 , but I'm seeing some Sentry errors indicating that's a bad assumption. Adding an existence check to handle that.