### PR TITLE
Pass "bias" param to Session.requestFocusRange

### DIFF
--- a/packages/shared/client/ReplayClient.ts
+++ b/packages/shared/client/ReplayClient.ts
@@ -36,7 +36,6 @@ import {
   keyboardEvents,
   navigationEvents,
   repaintGraphicsResult,
-  requestFocusRangeResult,
   searchSourceContentsMatches,
   sourceContentsChunk,
   sourceContentsInfo,


### PR DESCRIPTION
If the `currentTime` falls within the requested focus region, try to ensure it remains within the region (even if the backend clips the requested range).

I think this PR will wrap up FE-1339 but unfortunately it will not fix Test Suite issues like FE-1359.