### PR TITLE
Polishing testsuites

### DIFF
--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -282,13 +282,15 @@ export function TestStepItem({
         ) : null}
       </TestStepRow>
       <Actions step={step} hovered={isSelected} selected={isSelected} />
-      {shouldShowJumpToCode ? (
-        <JumpToCodeButton
-          onClick={onJumpToClickEvent}
-          status={jumpToCodeStatus}
-          currentExecutionPoint={executionPoint}
-          targetExecutionPoint={step.annotations.start!.point}
-        />
+      {shouldShowJumpToCode && isSelected ? (
+        <div className="absolute right-9">
+          <JumpToCodeButton
+            onClick={onJumpToClickEvent}
+            status={jumpToCodeStatus}
+            currentExecutionPoint={executionPoint}
+            targetExecutionPoint={step.annotations.start!.point}
+          />
+        </div>
       ) : null}
     </div>
   );

--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepRow.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepRow.tsx
@@ -1,7 +1,6 @@
 import classnames from "classnames";
 import React, { forwardRef } from "react";
 
-import { ProgressBar } from "./ProgressBar";
 import styles from "./TestInfo.module.css";
 
 interface TestStepRowProps {
@@ -47,9 +46,6 @@ export function TestStepRowBase({
         }
       )}
     >
-      <div title={progress == null ? "" : String(progress)} className="flex h-4 w-4 items-center">
-        {progress == null ? null : <ProgressBar progress={progress} error={!!error} />}
-      </div>
       <div className="w-5 text-center opacity-70">{index}</div>
       {children}
     </div>


### PR DESCRIPTION
* Removed the circular progress loader
* The button only appears when a row is selected
* Absolute positioning so it doesn't push against other text

![image](https://user-images.githubusercontent.com/9154902/228395912-3ede367c-4a95-4b08-999a-696f8a5c2a1b.png)
