### PR TITLE
Fix parsing bug in getExpressionForTokenElement()

### DIFF
--- a/packages/replay-next/components/sources/SourceListRow.tsx
+++ b/packages/replay-next/components/sources/SourceListRow.tsx
@@ -17,6 +17,7 @@ import useGetDefaultLogPointContent from "replay-next/components/sources/hooks/u
 import SearchResultHighlight from "replay-next/components/sources/SearchResultHighlight";
 import { SourceSearchContext } from "replay-next/components/sources/SourceSearchContext";
 import useSourceContextMenu from "replay-next/components/sources/useSourceContextMenu";
+import { getClassNames, isTokenInspectable } from "replay-next/components/sources/utils/tokens";
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
 import { PointsContext } from "replay-next/src/contexts/points/PointsContext";
 import { PointBehaviorsObject } from "replay-next/src/contexts/points/types";
@@ -479,29 +480,12 @@ SourceListRow.displayName = "SourceListRow";
 export default SourceListRow;
 
 function renderToken(token: ParsedToken, key?: any): ReactElement {
-  let inspectable = token.types
-    ? token.types.some(type => {
-        switch (type) {
-          case "definition":
-          case "local":
-          case "propertyName":
-          case "typeName":
-          case "variableName":
-          case "variableName2":
-            return true;
-        }
-        return false;
-      })
-    : false;
-
-  let className = undefined;
-  if (token.types) {
-    className = token.types.map(type => `tok-${type}`).join(" ");
-  }
+  const classNames = getClassNames(token);
+  const inspectable = isTokenInspectable(token);
 
   return (
     <span
-      className={className}
+      className={classNames.join(" ")}
       data-column-index={token.columnIndex}
       data-inspectable-token={inspectable || undefined}
       key={key}

--- a/packages/replay-next/components/sources/utils/getExpressionForTokenElement.test.ts
+++ b/packages/replay-next/components/sources/utils/getExpressionForTokenElement.test.ts
@@ -1,0 +1,119 @@
+import { assert } from "protocol/utils";
+import { getClassNames, isTokenInspectable } from "replay-next/components/sources/utils/tokens";
+import { parse } from "replay-next/src/suspense/SyntaxParsingCache";
+
+import getExpressionForTokenElement from "./getExpressionForTokenElement";
+
+// Syntax parses a string like: "foo b|ar" and evaluates the token "bar"
+function getExpressionHelper(expression: string): string | null {
+  const cursorIndex = expression.indexOf("|");
+  const code = expression.replace("|", "");
+
+  const tokens = parse(code, ".js")[0];
+
+  let targetElement: HTMLElement | null = null;
+
+  const containerElement = document.createElement("div");
+  for (let index = 0; index < tokens.length; index++) {
+    const token = tokens[index];
+
+    const inspectable = isTokenInspectable(token);
+    const classNames = getClassNames(token);
+
+    const tokenHtmlElement = document.createElement("span");
+    tokenHtmlElement.className = classNames.join(" ");
+    tokenHtmlElement.textContent = token.value;
+    tokenHtmlElement.setAttribute("data-column-index", token.columnIndex.toString());
+    if (inspectable) {
+      tokenHtmlElement.setAttribute("data-inspectable-token", "true");
+    }
+
+    if (
+      targetElement === null &&
+      cursorIndex >= token.columnIndex &&
+      cursorIndex <= token.columnIndex + token.value.length
+    ) {
+      targetElement = tokenHtmlElement;
+    }
+
+    containerElement.appendChild(tokenHtmlElement);
+  }
+
+  assert(targetElement);
+
+  return getExpressionForTokenElement(containerElement, targetElement);
+}
+
+describe("getExpressionForTokenElement", () => {
+  it("should parse simple non-inspectable values", () => {
+    expect(getExpressionHelper('"f|oo"')).toBe(null);
+    expect(getExpressionHelper("1|23")).toBe(null);
+    expect(getExpressionHelper("tr|ue")).toBe(null);
+    expect(getExpressionHelper("fals|e")).toBe(null);
+  });
+
+  it("should parse simple expressions", () => {
+    expect(getExpressionHelper('l|et foo = "bar";')).toBe(null);
+    expect(getExpressionHelper('let f|oo = "bar";')).toBe("foo");
+    expect(getExpressionHelper('let foo = "b|ar";')).toBe(null);
+  });
+
+  it("should parse inline array declaration", () => {
+    expect(getExpressionHelper("c|onst foo = [bar, baz]")).toBe(null);
+    expect(getExpressionHelper("const f|oo = [bar, baz]")).toBe("foo");
+    expect(getExpressionHelper("const foo = [b|ar, baz]")).toBe("bar");
+    expect(getExpressionHelper("const foo = [bar, b|az]")).toBe("baz");
+  });
+
+  it("should parse destructuring syntax", () => {
+    expect(getExpressionHelper("c|onst {foo, bar = 123} = baz;")).toBe(null);
+    expect(getExpressionHelper("const {f|oo, bar = 123} = baz;")).toBe("foo");
+    expect(getExpressionHelper("const {foo, b|ar = 123} = baz;")).toBe("bar");
+    expect(getExpressionHelper("const {foo, bar = 12|3} = baz;")).toBe(null);
+    expect(getExpressionHelper("const {foo, bar = 123} = b|az;")).toBe("baz");
+  });
+
+  // FE-1102
+  it("should parse function parameters", () => {
+    expect(getExpressionHelper("f|unction foo(bar, baz = 123) {}")).toBe(null);
+    expect(getExpressionHelper("function fo|o(bar, baz = 123) {}")).toBe("foo");
+    expect(getExpressionHelper("function foo(b|ar, baz = 123) {}")).toBe("bar");
+    expect(getExpressionHelper("function foo(bar, b|az = 123) {}")).toBe("baz");
+    expect(getExpressionHelper("function foo(bar, baz = 12|3) {}")).toBe(null);
+  });
+
+  it("should parse expressions containing dot notation", () => {
+    expect(getExpressionHelper("co|nst foo = bar.baz;")).toBe(null);
+    expect(getExpressionHelper("const f|oo = bar.baz;")).toBe("foo");
+    expect(getExpressionHelper("const foo = b|ar.baz;")).toBe("bar");
+    expect(getExpressionHelper("const foo = bar.b|az;")).toBe("bar.baz");
+    expect(getExpressionHelper("const foo = bar.baz.q|ux;")).toBe("bar.baz.qux");
+  });
+
+  // FE-1136
+  it("should parse expressions containing bracket notation", () => {
+    expect(getExpressionHelper("v|ar foo = bar[0];")).toBe(null);
+    expect(getExpressionHelper("var f|oo = bar[0];")).toBe("foo");
+    expect(getExpressionHelper("var foo = ba|r[0];")).toBe("bar");
+    expect(getExpressionHelper("var foo = bar[|0];")).toBe(null);
+  });
+
+  it("should parse expressions within template strings", () => {
+    expect(getExpressionHelper("`f|oo ${bar.baz.qux}`")).toBe(null);
+    expect(getExpressionHelper("`foo ${b|ar.baz.qux}`")).toBe("bar");
+    expect(getExpressionHelper("`foo ${bar.b|az.qux}`")).toBe("bar.baz");
+    expect(getExpressionHelper("`foo ${bar.baz.q|ux}`")).toBe("bar.baz.qux");
+  });
+
+  // FE-1368
+  it("should properly handle negation operator", () => {
+    expect(getExpressionHelper("i|f (!foo) {}")).toBe(null);
+    expect(getExpressionHelper("if (!fo|o) {}")).toBe("foo");
+  });
+
+  it("should parse function calls", () => {
+    expect(getExpressionHelper("const foo = b|ar() || 0")).toBe("bar");
+    expect(getExpressionHelper("const foo = b|ar(baz) || 0")).toBe("bar");
+    expect(getExpressionHelper("const foo = bar(b|az) || 0")).toBe("baz");
+  });
+});

--- a/packages/replay-next/components/sources/utils/getExpressionFromString.test.ts
+++ b/packages/replay-next/components/sources/utils/getExpressionFromString.test.ts
@@ -182,6 +182,13 @@ describe("getExpressionFromString", () => {
     expect(getExpressionHelper("const foo = bar[baz|];")).toBe("bar[baz]");
   });
 
+  // FE-1368
+  it("should properly handle negation operator", () => {
+    expect(getExpressionHelper("if (!f|oo) {")).toBe("foo");
+    expect(getExpressionHelper("if (!fo|o) {")).toBe("foo");
+    expect(getExpressionHelper("if (!foo|) {")).toBe("foo");
+  });
+
   describe("minified/mangled code", () => {
     it("keywords", () => {
       expect(getExpressionHelper('!fu|nction(){"use strict";var e={4:function(e,t,n)')).toBe(

--- a/packages/replay-next/components/sources/utils/tokens.ts
+++ b/packages/replay-next/components/sources/utils/tokens.ts
@@ -1,0 +1,28 @@
+import { ParsedToken } from "replay-next/src/utils/syntax-parser";
+
+export function getClassNames(token: ParsedToken): string[] {
+  return token.types?.map(type => `tok-${type}`) ?? [];
+}
+
+export function getTokenTypeFromClassName(className: string): string | null {
+  const classNames = className.split(" ");
+  return classNames.find(className => className.startsWith("tok-"))?.slice(4) ?? null;
+}
+
+export function isTokenInspectable(token: ParsedToken): boolean {
+  return (
+    token.types != null &&
+    token.types.some(type => {
+      switch (type) {
+        case "definition":
+        case "local":
+        case "propertyName":
+        case "typeName":
+        case "variableName":
+        case "variableName2":
+          return true;
+      }
+      return false;
+    })
+  );
+}


### PR DESCRIPTION
- [x] Fix parsing bug with `!` operator in `getExpressionForTokenElement`
  - [x] Refactor `getExpressionForTokenElement` to better handle edge cases (e.g. expressions with multiple dot notations like `foo.bar.baz`)
- [x] Add missing unit tests

See comments on Replay [026e28a5-8399-4b2f-9e6d-b013415cf549](https://app.replay.io/recording/inconsistent-hoverevaluation--026e28a5-8399-4b2f-9e6d-b013415cf549) for the original bug.

cc @Andarist 