### PR TITLE
Code auto-complete de-duplicates suggestsions by name

### DIFF
--- a/packages/replay-next/components/lexical/plugins/code-completion/findMatchingScopesAndProperties.test.ts
+++ b/packages/replay-next/components/lexical/plugins/code-completion/findMatchingScopesAndProperties.test.ts
@@ -133,4 +133,13 @@ describe("findMatches", () => {
       "fooBarBaz",
     ]);
   });
+
+  // FE-1169
+  it("should de-duplicate matches", () => {
+    const properties = createPropertiesFromNames("foo:0", "foo:1", "fooBar:1");
+    const scopes = createScopesFromNames();
+
+    expect(findMatches("array", null, scopes, properties)).toEqual(["foo", "fooBar"]);
+    expect(findMatches("array", "foo", scopes, properties)).toEqual(["foo", "fooBar"]);
+  });
 });

--- a/packages/replay-next/components/lexical/plugins/code-completion/findMatchingScopesAndProperties.ts
+++ b/packages/replay-next/components/lexical/plugins/code-completion/findMatchingScopesAndProperties.ts
@@ -46,7 +46,8 @@ export default function findMatchingScopesAndProperties(
     names = names.filter(name => name.match(IdentifierRegex));
   }
 
-  return names;
+  // De-duplicate matches with the same name but different distance weights.
+  return names === null ? names : Array.from(new Set(names));
 }
 
 function flatten(properties: WeightedProperty[] | null): string[] {


### PR DESCRIPTION
See recording [40ea33b5-7e88-4910-bcaf-ff85989ee3c1](https://app.replay.io/recording/two-tolocalestrings--40ea33b5-7e88-4910-bcaf-ff85989ee3c1) for an edge case example of a match with the same name but different _distance_ weights.