### PR TITLE
Fix focus mode race conditions

### DIFF
--- a/packages/shared/utils/function.test.ts
+++ b/packages/shared/utils/function.test.ts
@@ -1,0 +1,318 @@
+import { Deferred, Status, createDeferred } from "suspense";
+
+import { DebouncedOrThrottledFunction, debounce, throttle } from "./function";
+
+describe("function", () => {
+  describe("debounce", () => {
+    let asyncFunc: jest.Mock;
+    let debouncedAsyncFunc: DebouncedOrThrottledFunction<any>;
+    let debouncedFunc: DebouncedOrThrottledFunction<any>;
+    let func: jest.Mock;
+    let mostRecentDeferred: Deferred<any> | undefined;
+
+    beforeEach(() => {
+      mostRecentDeferred = undefined;
+
+      asyncFunc = jest.fn(async () => {
+        mostRecentDeferred = createDeferred();
+        await mostRecentDeferred.promise;
+      });
+      func = jest.fn();
+
+      debouncedAsyncFunc = debounce(asyncFunc, 100);
+      debouncedFunc = debounce(func, 100);
+
+      jest.useFakeTimers();
+    });
+
+    it("should call the inner function after the specified delay", () => {
+      debouncedFunc(123, "abc");
+      jest.advanceTimersByTime(99);
+      expect(func).not.toBeCalled();
+
+      jest.advanceTimersByTime(1);
+      expect(func).toBeCalledTimes(1);
+      expect(func).toBeCalledWith(123, "abc");
+    });
+
+    it("should replace previous pending call with new call", () => {
+      debouncedFunc("a");
+      jest.advanceTimersByTime(50);
+      expect(func).not.toBeCalled();
+
+      // This should replace the previous call AND reset the timer
+      debouncedFunc("b");
+      jest.advanceTimersByTime(75);
+      expect(func).not.toBeCalled();
+
+      jest.advanceTimersByTime(25);
+      expect(func).toBeCalledTimes(1);
+      expect(func).toBeCalledWith("b");
+    });
+
+    it("should await the eventual callback", async () => {
+      debouncedAsyncFunc("a");
+
+      let resolvedCount = 0;
+      let promises: Promise<any>[] = [
+        debouncedAsyncFunc("b").then(() => {
+          resolvedCount++;
+        }),
+        debouncedAsyncFunc("c").then(() => {
+          resolvedCount++;
+        }),
+        debouncedAsyncFunc("d").then(() => {
+          resolvedCount++;
+        }),
+      ];
+
+      jest.advanceTimersByTime(100);
+
+      await Promise.resolve();
+      expect(resolvedCount).toBe(0);
+
+      mostRecentDeferred!.resolve();
+
+      await Promise.all(promises);
+      await expect(resolvedCount).toBe(3);
+    });
+
+    describe("cancel", () => {
+      it("should cancel a pending callback", () => {
+        debouncedFunc("a");
+        debouncedFunc.cancel();
+        jest.advanceTimersByTime(200);
+        expect(func).not.toBeCalled();
+      });
+
+      it("should do nothing if no pending callback", () => {
+        debouncedFunc.cancel();
+      });
+    });
+
+    describe("hasPending", () => {
+      it("should return true if there is a pending callback", () => {
+        debouncedFunc("a");
+        expect(func).not.toBeCalled();
+        expect(debouncedFunc.hasPending()).toBe(true);
+
+        jest.advanceTimersByTime(100);
+        expect(func).toBeCalledTimes(1);
+        expect(debouncedFunc.hasPending()).toBe(false);
+      });
+
+      it("should return false if there is no pending callback", () => {
+        expect(debouncedFunc.hasPending()).toBe(false);
+      });
+    });
+
+    describe("flush", () => {
+      it("should flush a pending callback", () => {
+        debouncedFunc(123, "abc");
+        expect(func).not.toBeCalled();
+
+        debouncedFunc.flush();
+        expect(func).toBeCalledTimes(1);
+        expect(func).toBeCalledWith(123, "abc");
+
+        expect(debouncedFunc.hasPending()).toBe(false);
+        debouncedFunc.flush();
+        expect(func).toBeCalledTimes(1);
+      });
+
+      it("should do nothing if no pending callback", () => {
+        debouncedFunc.flush();
+      });
+
+      it("should await the pending callback", async () => {
+        debouncedAsyncFunc("a");
+        expect(debouncedAsyncFunc.hasPending()).toBe(true);
+
+        let resolved = false;
+        const promise = debouncedAsyncFunc.flush().then(() => {
+          resolved = true;
+        });
+
+        await Promise.resolve();
+        expect(resolved).toBe(false);
+
+        mostRecentDeferred!.resolve();
+        await promise;
+        expect(resolved).toBe(true);
+      });
+    });
+  });
+
+  describe("throttle", () => {
+    let asyncFunc: jest.Mock;
+    let throttledAsyncFunc: DebouncedOrThrottledFunction<any>;
+    let throttledFunc: DebouncedOrThrottledFunction<any>;
+    let func: jest.Mock;
+    let mostRecentDeferred: Deferred<any> | undefined;
+
+    beforeEach(() => {
+      mostRecentDeferred = undefined;
+
+      asyncFunc = jest.fn(async () => {
+        mostRecentDeferred = createDeferred();
+        await mostRecentDeferred.promise;
+      });
+      func = jest.fn();
+
+      throttledAsyncFunc = throttle(asyncFunc, 100);
+      throttledFunc = throttle(func, 100);
+
+      jest.useFakeTimers();
+    });
+
+    it("should call the inner function after the specified delay", () => {
+      throttledFunc(123, "abc");
+      expect(func).toBeCalledTimes(1);
+      expect(func).toBeCalledWith(123, "abc");
+
+      throttledFunc(456, "def");
+      jest.advanceTimersByTime(99);
+      expect(func).toBeCalledTimes(1);
+
+      jest.advanceTimersByTime(1);
+      expect(func).toBeCalledTimes(2);
+      expect(func).toBeCalledWith(456, "def");
+    });
+
+    it("should replace previous pending call with new call", () => {
+      throttledFunc("a");
+      expect(func).toBeCalledTimes(1);
+      expect(func).toBeCalledWith("a");
+
+      throttledFunc("b");
+      jest.advanceTimersByTime(75);
+      expect(func).toBeCalledTimes(1);
+
+      // This should replace the previous call BUT not reset the timer
+      throttledFunc("c");
+      jest.advanceTimersByTime(24);
+      expect(func).toBeCalledTimes(1);
+
+      jest.advanceTimersByTime(1);
+      expect(func).toBeCalledTimes(2);
+      expect(func).toBeCalledWith("c");
+    });
+
+    it("should await a non-throttled callback", async () => {
+      let resolved = false;
+      const promise = throttledAsyncFunc("a").then(() => {
+        resolved = true;
+      });
+
+      await Promise.resolve();
+      expect(resolved).toBe(false);
+
+      mostRecentDeferred!.resolve();
+      await promise;
+      expect(resolved).toBe(true);
+    });
+
+    it("should await the eventual callback (if throttled)", async () => {
+      throttledAsyncFunc("a");
+
+      let resolvedCount = 0;
+      let promises: Promise<any>[] = [
+        throttledAsyncFunc("b").then(() => {
+          resolvedCount++;
+        }),
+        throttledAsyncFunc("c").then(() => {
+          resolvedCount++;
+        }),
+        throttledAsyncFunc("d").then(() => {
+          resolvedCount++;
+        }),
+      ];
+
+      await Promise.resolve();
+      expect(resolvedCount).toBe(0);
+
+      mostRecentDeferred!.resolve();
+
+      await Promise.all(promises);
+      await expect(resolvedCount).toBe(3);
+    });
+
+    describe("cancel", () => {
+      it("should cancel a pending callback", () => {
+        throttledFunc("a");
+        expect(func).toBeCalledTimes(1);
+
+        throttledFunc("b");
+        throttledFunc.cancel();
+        jest.advanceTimersByTime(200);
+        expect(func).toBeCalledTimes(1);
+      });
+
+      it("should do nothing if no pending callback", () => {
+        throttledFunc.cancel();
+      });
+    });
+
+    describe("hasPending", () => {
+      it("should return true if there is a pending callback", () => {
+        throttledFunc("a");
+        expect(func).toBeCalledTimes(1);
+        expect(throttledFunc.hasPending()).toBe(false);
+
+        throttledFunc("b");
+        expect(throttledFunc.hasPending()).toBe(true);
+
+        jest.advanceTimersByTime(100);
+        expect(func).toBeCalledTimes(2);
+        expect(throttledFunc.hasPending()).toBe(false);
+      });
+
+      it("should return false if there is no pending callback", () => {
+        expect(throttledFunc.hasPending()).toBe(false);
+      });
+    });
+
+    describe("flush", () => {
+      it("should flush a pending callback", () => {
+        throttledFunc(123, "abc");
+        expect(func).toBeCalledTimes(1);
+        expect(func).toBeCalledWith(123, "abc");
+
+        throttledFunc(456, "def");
+        expect(func).toBeCalledTimes(1);
+
+        throttledFunc.flush();
+        expect(func).toBeCalledTimes(2);
+        expect(func).toBeCalledWith(456, "def");
+
+        expect(throttledFunc.hasPending()).toBe(false);
+        throttledFunc.flush();
+        expect(func).toBeCalledTimes(2);
+      });
+
+      it("should do nothing if no pending callback", () => {
+        throttledFunc.flush();
+      });
+
+      it("should await the pending callback", async () => {
+        throttledAsyncFunc("a");
+        expect(throttledAsyncFunc.hasPending()).toBe(false);
+
+        throttledAsyncFunc("b");
+        expect(throttledAsyncFunc.hasPending()).toBe(true);
+
+        let resolved = false;
+        const promise = throttledAsyncFunc.flush().then(() => {
+          resolved = true;
+        });
+
+        await Promise.resolve();
+        expect(resolved).toBe(false);
+
+        mostRecentDeferred!.resolve();
+        await promise;
+        expect(resolved).toBe(true);
+      });
+    });
+  });
+});

--- a/packages/shared/utils/function.ts
+++ b/packages/shared/utils/function.ts
@@ -1,0 +1,128 @@
+import { Deferred, createDeferred, isPromiseLike } from "suspense";
+
+export interface DebouncedOrThrottledFunction<
+  Function extends (...args: any[]) => void | Promise<void>
+> {
+  (...args: Parameters<Function>): Promise<void>;
+  cancel(): void;
+  hasPending(): boolean;
+  flush(): Promise<void>;
+}
+
+// Note this implementation makes two simplifying constraints:
+// 1: A function must have a void return value;
+//    This avoids the need to return a wrapper Promise for pending values or manage invalidation of said wrapper.
+// 2: Debouncing only takes call time into account (not duration).
+//    If an async function runs longer than the debounce duration,
+//    a second invocation may start running in parallel.
+//
+// The main advantages this implementation has over lodash's debounce/throttle are:
+// 1: The ability to query if there is a pending callback.
+// 2: Calling flush() if there is no pending callback will do nothing;
+//    it will not invoke the most recent (already completed) callback.
+
+function createDebouncedOrThrottledFunction<Function extends (...args: any) => any>(
+  func: Function,
+  delay: number,
+  mode: "debounce" | "throttle"
+): DebouncedOrThrottledFunction<Function> {
+  let lastArgs: any[] | undefined;
+  let lastThis: any;
+  let lastCallTime = 0 - delay;
+  let lastInvokeTime = 0 - delay;
+  let pending: Deferred<void> | undefined;
+  let timeoutId: NodeJS.Timeout | undefined = undefined;
+
+  function cancelIfPending() {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
+
+    resetCachedValues();
+  }
+
+  async function flushIfPending(): Promise<void> {
+    if (timeoutId !== undefined) {
+      await invokeCallback();
+    }
+  }
+
+  function getTimeout(time: number): number {
+    switch (mode) {
+      case "debounce":
+        return Math.max(0, lastCallTime + delay - time);
+      case "throttle":
+        return Math.max(0, lastInvokeTime + delay - time);
+    }
+  }
+
+  function hasPending() {
+    return timeoutId !== undefined;
+  }
+
+  async function invokeCallback(): Promise<void> {
+    lastInvokeTime = performance.now();
+
+    try {
+      const result = func.apply(lastThis, lastArgs as any[]);
+      if (result != undefined && isPromiseLike(result)) {
+        await result;
+      }
+    } finally {
+      pending?.resolve();
+      pending = undefined;
+
+      resetCachedValues();
+    }
+  }
+
+  function resetCachedValues() {
+    lastArgs = undefined;
+    lastThis = undefined;
+    timeoutId = undefined;
+  }
+
+  async function debouncedOrThrottledFunction(...args: any[]): Promise<void> {
+    cancelIfPending();
+
+    const time = performance.now();
+
+    lastArgs = args;
+    // @ts-ignore
+    lastThis = this;
+    lastCallTime = time;
+
+    const timeout = getTimeout(time);
+    if (timeout === 0) {
+      await invokeCallback();
+    } else {
+      if (pending === undefined) {
+        pending = createDeferred();
+      }
+
+      timeoutId = setTimeout(flushIfPending, timeout);
+
+      await pending.promise;
+    }
+  }
+
+  debouncedOrThrottledFunction.cancel = cancelIfPending;
+  debouncedOrThrottledFunction.flush = flushIfPending;
+  debouncedOrThrottledFunction.hasPending = hasPending;
+
+  return debouncedOrThrottledFunction as DebouncedOrThrottledFunction<Function>;
+}
+
+export function debounce<Function extends (...args: any) => any>(
+  func: Function,
+  delay: number
+): DebouncedOrThrottledFunction<Function> {
+  return createDebouncedOrThrottledFunction(func, delay, "debounce");
+}
+
+export function throttle<Function extends (...args: any) => any>(
+  func: Function,
+  delay: number
+): DebouncedOrThrottledFunction<Function> {
+  return createDebouncedOrThrottledFunction(func, delay, "throttle");
+}

--- a/src/ui/components/FocusContextReduxAdapter.tsx
+++ b/src/ui/components/FocusContextReduxAdapter.tsx
@@ -1,12 +1,4 @@
-import {
-  PropsWithChildren,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-  useTransition,
-} from "react";
+import { PropsWithChildren, useCallback, useEffect, useMemo, useState, useTransition } from "react";
 
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
 import { SessionContext } from "replay-next/src/contexts/SessionContext";

--- a/src/ui/components/Timeline/FocusInputs.tsx
+++ b/src/ui/components/Timeline/FocusInputs.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { getFormattedTime } from "shared/utils/time";
-import { updateDisplayedFocusRegion } from "ui/actions/timeline";
+import { updateFocusRegion } from "ui/actions/timeline";
 import { selectors } from "ui/reducers";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { getSecondsFromFormattedTime } from "ui/utils/timeline";
@@ -12,7 +12,7 @@ import styles from "./FocusInputs.module.css";
 export default function FocusInputs() {
   const dispatch = useAppDispatch();
   const currentTime = useAppSelector(selectors.getCurrentTime);
-  const displayedFocusRegion = useAppSelector(selectors.getDisplayedFocusRegion);
+  const focusRegion = useAppSelector(selectors.getFocusRegion);
   const showFocusModeControls = useAppSelector(selectors.getShowFocusModeControls);
   const recordingDuration = useAppSelector(selectors.getRecordingDuration);
 
@@ -22,9 +22,9 @@ export default function FocusInputs() {
   // Avoid layout shift; keep input size consistent when focus mode toggles.
   const inputSize = formattedDuration.length;
 
-  if (showFocusModeControls && displayedFocusRegion !== null) {
-    const formattedEndTime = getFormattedTime(displayedFocusRegion.end);
-    const formattedBeginTime = getFormattedTime(displayedFocusRegion.begin);
+  if (showFocusModeControls && focusRegion !== null) {
+    const formattedEndTime = getFormattedTime(focusRegion.end.time);
+    const formattedBeginTime = getFormattedTime(focusRegion.begin.time);
 
     const validateAndSaveBeginTime = async (pending: string) => {
       try {
@@ -33,10 +33,10 @@ export default function FocusInputs() {
           // If the new end time is less than the current start time, the user is probably trying to move the whole range.
           // We can simplify this operation by resetting both the start and end time to the same value.
           const newEndTime =
-            newBeginTime <= displayedFocusRegion.end ? displayedFocusRegion.end : newBeginTime;
+            newBeginTime <= focusRegion.end.time ? focusRegion.end.time : newBeginTime;
 
           await dispatch(
-            updateDisplayedFocusRegion({
+            updateFocusRegion({
               begin: newBeginTime,
               end: newEndTime,
             })
@@ -53,10 +53,10 @@ export default function FocusInputs() {
           // If the new start time is greater than the current end time, the user is probably trying to move the whole range.
           // We can simplify this operation by resetting both the start and end time to the same value.
           const newBeginTime =
-            newEndTime >= displayedFocusRegion.begin ? displayedFocusRegion.begin : newEndTime;
+            newEndTime >= focusRegion.begin.time ? focusRegion.begin.time : newEndTime;
 
           await dispatch(
-            updateDisplayedFocusRegion({
+            updateFocusRegion({
               begin: newBeginTime,
               end: newEndTime,
             })

--- a/src/ui/components/Timeline/PlaybackControls.tsx
+++ b/src/ui/components/Timeline/PlaybackControls.tsx
@@ -6,12 +6,12 @@ import { trackEvent } from "ui/utils/telemetry";
 export default function PlayPauseButton() {
   const dispatch = useAppDispatch();
   const currentTime = useAppSelector(selectors.getCurrentTime);
-  const displayedFocusRegion = useAppSelector(selectors.getDisplayedFocusRegion);
+  const focusRegion = useAppSelector(selectors.getFocusRegion);
   const playback = useAppSelector(selectors.getPlayback);
   const recordingDuration = useAppSelector(selectors.getRecordingDuration);
 
-  const isAtEnd = displayedFocusRegion
-    ? currentTime === displayedFocusRegion.end
+  const isAtEnd = focusRegion
+    ? currentTime === focusRegion.end.time
     : currentTime == recordingDuration;
 
   let onClick;

--- a/src/ui/components/Timeline/Timeline.tsx
+++ b/src/ui/components/Timeline/Timeline.tsx
@@ -1,6 +1,12 @@
 import { MouseEvent, useLayoutEffect, useRef, useState } from "react";
 
-import { seekToTime, setTimelineToTime, stopPlayback } from "ui/actions/timeline";
+import { throttle } from "shared/utils/function";
+import {
+  seekToTime,
+  setTimelineToTime,
+  stopPlayback,
+  updateFocusRegion,
+} from "ui/actions/timeline";
 import useTimelineContextMenu from "ui/components/Timeline/useTimelineContextMenu";
 import { selectors } from "ui/reducers";
 import {
@@ -9,6 +15,7 @@ import {
   setTimelineState,
 } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
+import { AppDispatch } from "ui/setup/store";
 import { getTimeFromPosition } from "ui/utils/timeline";
 
 import Comments from "../Comments";
@@ -121,7 +128,7 @@ export default function Timeline() {
 
   return (
     <>
-      <FocusModePopout />
+      <FocusModePopout updateFocusRegionThrottled={updateFocusRegionThrottled} />
       <div className="timeline">
         <div className="commands">
           <PlayPauseButton />
@@ -145,7 +152,11 @@ export default function Timeline() {
               <UnfocusedRegion />
               {showLoadingProgress && <LoadingProgressBars />}
               <CurrentTimeIndicator editMode={editMode} />
-              <Focuser editMode={editMode} setEditMode={setEditMode} />
+              <Focuser
+                editMode={editMode}
+                setEditMode={setEditMode}
+                updateFocusRegionThrottled={updateFocusRegionThrottled}
+              />
             </div>
           </div>
 
@@ -158,3 +169,7 @@ export default function Timeline() {
     </>
   );
 }
+
+const updateFocusRegionThrottled = throttle((dispatch: AppDispatch, begin: number, end: number) => {
+  return dispatch(updateFocusRegion({ begin, end }));
+}, 250);

--- a/src/ui/components/Timeline/Tooltip.tsx
+++ b/src/ui/components/Timeline/Tooltip.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { getFormattedTime } from "shared/utils/time";
 import { getNonLoadingTimeRanges } from "ui/reducers/app";
 import {
-  getDisplayedFocusRegion,
+  getFocusRegion,
   getHoverTime,
   getShowFocusModeControls,
   getZoomRegion,
@@ -16,7 +16,7 @@ export default function Tooltip({ timelineWidth }: { timelineWidth: number }) {
   const zoomRegion = useAppSelector(getZoomRegion);
   const showFocusModeControls = useAppSelector(getShowFocusModeControls);
   const nonLoadingRegion = useAppSelector(getNonLoadingTimeRanges);
-  const displayedFocusRegion = useAppSelector(getDisplayedFocusRegion);
+  const focusRegion = useAppSelector(getFocusRegion);
 
   if (!hoverTime || showFocusModeControls) {
     return null;
@@ -29,8 +29,7 @@ export default function Tooltip({ timelineWidth }: { timelineWidth: number }) {
   );
 
   const isHoveredOnUnFocusedRegion =
-    displayedFocusRegion &&
-    (displayedFocusRegion.begin > hoverTime || displayedFocusRegion.end < hoverTime);
+    focusRegion && (focusRegion.begin.time > hoverTime || focusRegion.end.time < hoverTime);
 
   const timestamp = getFormattedTime(hoverTime);
   const message =

--- a/src/ui/components/Timeline/UnfocusedRegion.tsx
+++ b/src/ui/components/Timeline/UnfocusedRegion.tsx
@@ -5,16 +5,15 @@ import { useAppSelector } from "ui/setup/hooks";
 import { getVisiblePosition } from "ui/utils/timeline";
 
 export default function UnfocusedRegion() {
-  const displayedFocusRegion = useAppSelector(selectors.getDisplayedFocusRegion);
   const focusRegion = useAppSelector(selectors.getFocusRegion);
   const zoomRegion = useAppSelector(selectors.getZoomRegion);
 
-  if (!displayedFocusRegion && !focusRegion) {
+  if (!focusRegion) {
     return null;
   }
 
-  const beginTime = displayedFocusRegion?.begin ?? focusRegion!.begin.time;
-  const endTime = displayedFocusRegion?.end ?? focusRegion!.end.time;
+  const beginTime = focusRegion!.begin.time;
+  const endTime = focusRegion!.end.time;
   const duration = zoomRegion.endTime - zoomRegion.beginTime;
 
   const start = getVisiblePosition({ time: beginTime, zoom: zoomRegion }) * 100;

--- a/src/ui/components/Timeline/useTimelineContextMenu.tsx
+++ b/src/ui/components/Timeline/useTimelineContextMenu.tsx
@@ -16,7 +16,7 @@ import {
   getUrlParams,
   seekToTime,
   syncFocusedRegion,
-  updateDisplayedFocusRegion,
+  updateFocusRegion,
 } from "ui/actions/timeline";
 import { useAppDispatch } from "ui/setup/hooks";
 import { getUrlString } from "ui/utils/environment";
@@ -62,7 +62,7 @@ export default function useTimelineContextMenu() {
     let end = focusEndTime ?? duration;
     end = Math.min(end, currentTime + MAX_FOCUS_REGION_DURATION);
 
-    await dispatch(updateDisplayedFocusRegion({ begin: currentTime, end }));
+    await dispatch(updateFocusRegion({ begin: currentTime, end }));
     dispatch(syncFocusedRegion());
   };
 
@@ -70,7 +70,7 @@ export default function useTimelineContextMenu() {
     let begin = focusBeginTime ?? 0;
     begin = Math.max(begin, currentTime - MAX_FOCUS_REGION_DURATION);
 
-    await dispatch(updateDisplayedFocusRegion({ begin, end: currentTime }));
+    await dispatch(updateFocusRegion({ begin, end: currentTime }));
     dispatch(syncFocusedRegion());
   };
 

--- a/src/ui/reducers/timeline.ts
+++ b/src/ui/reducers/timeline.ts
@@ -14,7 +14,6 @@ function initialTimelineState(): TimelineState {
     currentTime: 0,
     focusRegion: getPausePointParams().focusRegion,
     focusRegionBackup: null,
-    displayedFocusRegion: null,
     hoveredItem: null,
     markTimeStampedPoint: null,
     hoverTime: null,
@@ -63,9 +62,6 @@ const timelineSlice = createSlice({
     setFocusRegion(state, action: PayloadAction<FocusRegion | null>) {
       state.focusRegion = action.payload;
     },
-    setDisplayedFocusRegion(state, action: PayloadAction<FocusWindow | null>) {
-      state.displayedFocusRegion = action.payload;
-    },
     pointsReceived(state, action: PayloadAction<TimeStampedPoint[]>) {
       const mutablePoints = [...state.points];
       state.points = mergeSortedPointLists(
@@ -101,7 +97,6 @@ export const {
   setPlaybackFocusRegion,
   setPlaybackStalled,
   setFocusRegion,
-  setDisplayedFocusRegion,
   setTimelineState,
   pointsReceived,
   paintsReceived,
@@ -137,11 +132,10 @@ export const getBasicProcessingProgress = (state: UIState) => {
 export const getPlaybackPrecachedTime = (state: UIState) => state.timeline.playbackPrecachedTime;
 export const getPlaybackFocusRegion = (state: UIState) => state.timeline.playbackFocusRegion;
 export const getFocusRegion = (state: UIState) => state.timeline.focusRegion;
-export const getDisplayedFocusRegion = (state: UIState) => state.timeline.displayedFocusRegion;
 export const isMaximumFocusRegion = (state: UIState) => {
-  const focusRegion = state.timeline.displayedFocusRegion;
+  const focusRegion = getFocusRegion(state);
   if (focusRegion) {
-    const duration = focusRegion.end - focusRegion.begin;
+    const duration = focusRegion.end.time - focusRegion.begin.time;
     // JavaScript floating point numbers are not precise enough,
     // so in order to avoid occasional flickers from rounding errors, fuzz it a bit.
     return duration + 0.1 >= MAX_FOCUS_REGION_DURATION;

--- a/src/ui/state/timeline.ts
+++ b/src/ui/state/timeline.ts
@@ -14,7 +14,6 @@ export interface FocusRegion {
 export interface TimelineState {
   allPaintsReceived: boolean;
   currentTime: number;
-  displayedFocusRegion: FocusWindow | null;
   dragging: boolean;
   focusRegion: FocusRegion | null;
   focusRegionBackup: FocusRegion | null;


### PR DESCRIPTION
Fix the potential race case with focus region updates that @jcmorrow reported in FE-1370.

[**This Loom video**](https://www.loom.com/share/f0bed81eb64f44f39e693b19286c7beb) is a thorough explanation of what changed and why, but the tl;dr version is:
* Add new `debounce` and `throttle` utilities that support querying to see if there is a pending update _and_ only invoking a _pending_ update on flush (not just the most recent one).
* Remove the "throttle" option from Redux Timeline actions. (Throttling can be managed in imperative land for simplicity.)
* Remove the redundant "for display" focus region from Redux Timeline state. (This is stored in React state instead, since it's component-local.)
* On save, the timeline focus editor will **flush and await** any pending update before syncing to the backend.

Overall I think this is a simplification (at least of our Redux state).