### PR TITLE
Source search: only select first match after query changes (FE-1376)

### DIFF
--- a/packages/replay-next/components/sources/hooks/useSearch.ts
+++ b/packages/replay-next/components/sources/hooks/useSearch.ts
@@ -285,7 +285,7 @@ export default function useSearch<Item, Result, QueryData = never>(
           index = results.indexOf(prevItem);
         }
 
-        if (index < 0) {
+        if (index < 0 && queryChanged) {
           index = findInitialIndex(results);
         }
       }


### PR DESCRIPTION
@bvaughn This is the second fix/workaround I mentioned in yesterday's standup.
It does fix the test but you had some reservations whether this fix is actually correct in all situations.