### PR TITLE
Comments: Show current time bar

### DIFF
--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -106,8 +106,9 @@
   --z-index-8: 80;
   --z-index-9: 90;
   --z-index-10: 100;
+  --z-index-1--timeline-current-indicator: var(--z-index-1);
   --z-index-1--timeline-comment: var(--z-index-1);
-  --z-index-1--paused-comment: var(--z-index-1);
+  --z-index-1--paused-comment: var(--z-index-2);
   --z-index-1--paused-message: var(--z-index-1);
   --z-index-1--comment-container: var(--z-index-1);
   --z-index-1--tooltip: var(--z-index-1);

--- a/src/ui/components/Comments/CommentCard.module.css
+++ b/src/ui/components/Comments/CommentCard.module.css
@@ -17,12 +17,26 @@
 }
 
 .PausedOverlay {
+  background-color: var(--secondary-accent);
   position: absolute;
+}
+.PausedOverlay[data-position="after"] {
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+}
+.PausedOverlay[data-position="at"] {
   top: 0;
   bottom: 0;
   left: 0;
   width: 2px;
-  background-color: var(--secondary-accent);
+}
+.PausedOverlay[data-position="before"] {
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
 }
 
 .CommentCard :global(code) {

--- a/src/ui/components/Comments/CommentCard.module.css
+++ b/src/ui/components/Comments/CommentCard.module.css
@@ -26,17 +26,17 @@
   right: 0;
   height: 2px;
 }
-.PausedOverlay[data-position="at"] {
-  top: 0;
-  bottom: 0;
-  left: 0;
-  width: 2px;
-}
 .PausedOverlay[data-position="before"] {
   top: 0;
   left: 0;
   right: 0;
   height: 2px;
+}
+.PausedOverlay[data-position="current"] {
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 2px;
 }
 
 .CommentCard :global(code) {

--- a/src/ui/components/Comments/CommentCard.tsx
+++ b/src/ui/components/Comments/CommentCard.tsx
@@ -22,7 +22,7 @@ import EditableRemark from "./EditableRemark";
 import ReplyCard from "./ReplyCard";
 import styles from "./CommentCard.module.css";
 
-export type PauseOverlayPosition = "after" | "at" | "before";
+export type PauseOverlayPosition = "after" | "before" | "current";
 
 function CommentCard({
   comment,

--- a/src/ui/components/Comments/CommentCard.tsx
+++ b/src/ui/components/Comments/CommentCard.tsx
@@ -1,8 +1,7 @@
 import classNames from "classnames";
-import { MouseEvent, useContext } from "react";
+import { MouseEvent, memo, useContext } from "react";
 
 import { selectLocation } from "devtools/client/debugger/src/actions/sources";
-import { getExecutionPoint } from "devtools/client/debugger/src/selectors";
 import { getThreadContext } from "devtools/client/debugger/src/selectors";
 import { isSourceCodeCommentTypeData } from "replay-next/components/sources/utils/comments";
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
@@ -12,7 +11,6 @@ import { seekToComment } from "ui/actions/comments";
 import { setViewMode } from "ui/actions/layout";
 import useUserCommentPreferences from "ui/components/Comments/useUserCommentPreferences";
 import { getViewMode } from "ui/reducers/layout";
-import { getCurrentTime } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { Comment } from "ui/state/comments";
 import { isCommentContentEmpty } from "ui/utils/comments";
@@ -24,14 +22,19 @@ import EditableRemark from "./EditableRemark";
 import ReplyCard from "./ReplyCard";
 import styles from "./CommentCard.module.css";
 
-export default function CommentCard({ comment }: { comment: Comment }) {
+export type PauseOverlayPosition = "after" | "at" | "before";
+
+function CommentCard({
+  comment,
+  pauseOverlayPosition,
+}: {
+  comment: Comment;
+  pauseOverlayPosition: PauseOverlayPosition | null;
+}) {
   const { rangeForDisplay: focusRange } = useContext(FocusContext);
   const { currentUserInfo } = useContext(SessionContext);
 
-  const currentTime = useAppSelector(getCurrentTime);
-  const executionPoint = useAppSelector(getExecutionPoint);
   const viewMode = useAppSelector(getViewMode);
-  const isPaused = currentTime === comment.time && executionPoint === comment.point;
 
   const context = useAppSelector(getThreadContext);
   const dispatch = useAppDispatch();
@@ -81,9 +84,13 @@ export default function CommentCard({ comment }: { comment: Comment }) {
         !comment.isPublished && styles.Unpublished,
         isFocused || styles.UnfocusedDimmed
       )}
+      data-test-name="CommentCard"
+      data-test-comment-time={comment.time}
       onClick={onClick}
     >
-      {isPaused && <div className={styles.PausedOverlay} />}
+      {pauseOverlayPosition !== null && (
+        <div className={styles.PausedOverlay} data-position={pauseOverlayPosition} />
+      )}
 
       <CommentPreview comment={comment} onClick={onPreviewClick} />
 
@@ -96,4 +103,11 @@ export default function CommentCard({ comment }: { comment: Comment }) {
       {showReplyButton && <CommentReplyButton comment={comment} />}
     </div>
   );
+}
+
+const MemoizedCommentCard = memo(CommentCard);
+export default MemoizedCommentCard;
+
+export function getCommentTimeFromElement(element: Element) {
+  return parseInt(element.getAttribute("data-test-comment-time") ?? "", 10);
 }

--- a/src/ui/components/Comments/CommentCardsList.tsx
+++ b/src/ui/components/Comments/CommentCardsList.tsx
@@ -75,7 +75,7 @@ export default function CommentCardsList() {
           if (comment.time >= showPauseOverlayAtTime) {
             hasShownPauseOverlay = true;
             if (showPauseOverlayAtTime === comment.time) {
-              pauseOverlayPosition = "at";
+              pauseOverlayPosition = "current";
             } else {
               pauseOverlayPosition = "before";
             }

--- a/src/ui/components/Comments/index.tsx
+++ b/src/ui/components/Comments/index.tsx
@@ -1,5 +1,5 @@
 import sortBy from "lodash/sortBy";
-import React, { useMemo } from "react";
+import React, { ReactNode, useMemo } from "react";
 import { ConnectedProps, connect } from "react-redux";
 
 import { useGetComments } from "ui/hooks/comments/comments";
@@ -23,7 +23,7 @@ function Comments({ hoveredItem }: PropsFromRedux) {
   }
 
   return (
-    <div className="comments-container">
+    <>
       {sortedComments.map((comment, index) => {
         const isPrimaryHighlighted = hoveredItem?.point === comment.point;
         return (
@@ -35,7 +35,7 @@ function Comments({ hoveredItem }: PropsFromRedux) {
           />
         );
       })}
-    </div>
+    </>
   );
 }
 

--- a/src/ui/components/Timeline/Timeline.css
+++ b/src/ui/components/Timeline/Timeline.css
@@ -224,6 +224,7 @@
   top: 50%;
   transform: translate(-50%, -50%);
   cursor: grab;
+  z-index: var(--z-index-1--timeline-current-indicator);
 }
 
 .timeline .progress-line-paused-edit-mode-active {

--- a/src/ui/components/Timeline/Timeline.tsx
+++ b/src/ui/components/Timeline/Timeline.tsx
@@ -147,11 +147,13 @@ export default function Timeline() {
             <div className="progress-bar" ref={progressBarRef}>
               <ProgressBars />
               <PreviewMarkers />
-              <Comments />
+              <div className="comments-container">
+                <Comments />
+                <CurrentTimeIndicator editMode={editMode} />
+              </div>
               <NonLoadingRegions />
               <UnfocusedRegion />
               {showLoadingProgress && <LoadingProgressBars />}
-              <CurrentTimeIndicator editMode={editMode} />
               <Focuser
                 editMode={editMode}
                 setEditMode={setEditMode}


### PR DESCRIPTION
### [Loom overview](https://www.loom.com/share/87b4cd85a5734145a92718aaeb39c64b)

- [x] Always Timeline current time indicator _above_ comment markers.
  - [x] The one exception is when we're paused _at a comment_ (in which case we just show the red comment marker).
- [x] Show a current time indicator above/below the nearest comment.

<img width="947" alt="Screen Shot 2023-03-31 at 6 44 58 PM" src="https://user-images.githubusercontent.com/29597/229245632-cb4dd2e4-d588-4761-aec1-338689ea09a2.png">

cc @jonbell-lot23 