### PR TITLE
Comments: Show/hide preview toggle

### DIFF
--- a/src/ui/components/Comments/CommentCard.tsx
+++ b/src/ui/components/Comments/CommentCard.tsx
@@ -39,7 +39,7 @@ function CommentCard({
   const context = useAppSelector(getThreadContext);
   const dispatch = useAppDispatch();
 
-  const { filter } = useUserCommentPreferences();
+  const { filter, showPreview } = useUserCommentPreferences();
 
   const onClick = (event: MouseEvent) => {
     event.stopPropagation();
@@ -92,7 +92,7 @@ function CommentCard({
         <div className={styles.PausedOverlay} data-position={pauseOverlayPosition} />
       )}
 
-      <CommentPreview comment={comment} onClick={onPreviewClick} />
+      {showPreview && <CommentPreview comment={comment} onClick={onPreviewClick} />}
 
       <EditableRemark remark={comment} type="comment" />
 

--- a/src/ui/components/Comments/CommentDropDownMenu.tsx
+++ b/src/ui/components/Comments/CommentDropDownMenu.tsx
@@ -19,7 +19,8 @@ function createClickHandler(callback: () => void): (event: MouseEvent) => void {
 }
 
 export default function CommentDropDownMenu() {
-  const { filter, setFilter, setSortBy, sortBy } = useUserCommentPreferences();
+  const { filter, showPreview, setFilter, setShowPreview, setSortBy, sortBy } =
+    useUserCommentPreferences();
 
   const { contextMenu, onContextMenu: onClick } = useContextMenu(
     <>
@@ -57,6 +58,15 @@ export default function CommentDropDownMenu() {
           type={sortBy === "created-at" ? "radio-selected" : "radio-unselected"}
         />
         Creation date
+      </ContextMenuItem>
+      <ContextMenuDivider />
+      <ContextMenuItem onClick={createClickHandler(() => setShowPreview(!showPreview))}>
+        <Icon
+          className={styles.Icon}
+          data-selected={showPreview || undefined}
+          type={showPreview ? "checked-rounded" : "unchecked-rounded"}
+        />
+        Show preview?
       </ContextMenuItem>
     </>
   );

--- a/src/ui/components/Comments/useUserCommentPreferences.ts
+++ b/src/ui/components/Comments/useUserCommentPreferences.ts
@@ -7,6 +7,10 @@ type SortBy = "created-at" | "recording-time";
 
 export default function useUserCommentPreferences() {
   const [filter, setFilter] = useLocalStorage<Filter>("Replay:CommentPreferences:Filter", null);
+  const [showPreview, setShowPreview] = useLocalStorage<boolean>(
+    "Replay:CommentPreferences:ShowPreview",
+    true
+  );
   const [sortBy, setSortBy] = useLocalStorage<SortBy>(
     "Replay:CommentPreferences:sortBy",
     "recording-time"
@@ -16,9 +20,11 @@ export default function useUserCommentPreferences() {
     () => ({
       filter,
       setFilter,
+      setShowPreview,
       setSortBy,
+      showPreview,
       sortBy,
     }),
-    [filter, setFilter, setSortBy, sortBy]
+    [filter, setFilter, setShowPreview, setSortBy, showPreview, sortBy]
   );
 }


### PR DESCRIPTION
### [Loom overview](https://www.loom.com/share/464dd3cc48ed446dbb3672d94e0e1a5b)

This came up in a discussion between Jason, Jon, and I about additional ways to reduce "clutter" in the Comments list.

### Show preview (default behavior unchanged)
<img width="562" alt="Screen Shot 2023-04-01 at 10 30 11 AM" src="https://user-images.githubusercontent.com/29597/229295351-7b8910ee-e20e-486a-889e-06d8694138b4.png">

### Hide preview
<img width="559" alt="Screen Shot 2023-04-01 at 10 30 30 AM" src="https://user-images.githubusercontent.com/29597/229295352-37c8ad33-c378-45ae-9109-52a6999cd99f.png">


cc @jonbell-lot23 @jasonLaster 