### PR TITLE
Fixed Timeline/Comment marker alignment and size issues

### DIFF
--- a/src/ui/components/Comments/Comments.css
+++ b/src/ui/components/Comments/Comments.css
@@ -2,8 +2,9 @@
   position: absolute;
   pointer-events: none;
   width: 100%;
-  top: 9px; /* Arbitrary value to push the markers away from the bottom of the overlay container */
-  height: 17px; /* Corresponds with the height of the comment marker */
+  top: 50%;
+  transform: translate(0, -50%);
+  height: 15px;
   z-index: var(--z-index-1--timeline-comment);
 }
 
@@ -15,6 +16,8 @@
   width: 15px;
   height: 15px;
   position: absolute;
+  top: 50%;
+  transform: translate(0, -50%);
   outline: none;
   background-color: var(--primary-accent);
   border-radius: 8px;

--- a/src/ui/components/Timeline/Timeline.css
+++ b/src/ui/components/Timeline/Timeline.css
@@ -9,6 +9,8 @@
   padding: 10px 12px 12px 6px;
   align-items: center;
   user-select: none;
+
+  --timeline-size: 5px;
 }
 
 .theme-light .timeline,
@@ -94,8 +96,8 @@
 
 .timeline .commands > button {
   cursor: pointer;
-  padding: 4px;
-  border-radius: 4px;
+  padding: var(--timeline-size);
+  border-radius: var(--timeline-size);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -137,7 +139,7 @@
 .timeline .progress-line,
 .breakpoint-navigation-timeline .progress-line {
   width: 0%;
-  height: 4px;
+  height: var(--timeline-size);
   background-color: var(--primary-accent);
   position: absolute;
   pointer-events: none;
@@ -145,11 +147,11 @@
   margin-bottom: auto;
   top: 0;
   bottom: 0;
-  border-radius: 4px;
+  border-radius: var(--timeline-size);
 }
 
 .timeline .overlay-container:hover .progress-line {
-  height: 5px;
+  height: var(--timeline-size);
 }
 
 .timeline .progress-line.full,
@@ -170,8 +172,8 @@
 .timeline .unloaded-regions,
 .timeline .unfocused-regions-container,
 .breakpoint-navigation-timeline .unloaded-regions {
-  height: 5px;
-  border-radius: 5px;
+  height: var(--timeline-size);
+  border-radius: var(--timeline-size);
   position: absolute;
   margin-top: auto;
   margin-bottom: auto;
@@ -212,7 +214,7 @@
 
 .timeline .zoomboundary {
   padding-top: 7px;
-  padding-right: 4px;
+  padding-right: 0.25rem;
 }
 
 .timeline .progress-line-paused-edit-mode-active,


### PR DESCRIPTION
There were some `4px` vs `5px` and `17px` vs `15px` mismatches before that became obvious as you zoomed in.

IMO we should be using REMs for this stuff 😞  I think it would be less error prone than mixing pixel values all over the place.

### Before

<img width="158" alt="Screen Shot 2023-04-02 at 8 48 06 PM" src="https://user-images.githubusercontent.com/29597/229388912-f836249b-3579-4d87-89ed-c8acc5bd50d3.png">

### After

<img width="117" alt="Screen Shot 2023-04-02 at 8 48 10 PM" src="https://user-images.githubusercontent.com/29597/229388913-95827eec-7fbf-42ed-8e92-44a431e84df1.png">
