### PR TITLE
Search index should not change when scope or items change, only query (or query data)

### DIFF
--- a/packages/replay-next/components/sources/hooks/useSearch.ts
+++ b/packages/replay-next/components/sources/hooks/useSearch.ts
@@ -285,7 +285,9 @@ export default function useSearch<Item, Result, QueryData = never>(
           index = results.indexOf(prevItem);
         }
 
-        if (index < 0) {
+        // This code may run if items change (e.g. as items stream in)
+        // but we should only re-compute an initial index if the query (or query criteria) have changed.
+        if (index < 0 && (queryChanged || queryDataChanged)) {
           index = findInitialIndex(results);
         }
       }


### PR DESCRIPTION
Supersedes #9019