### PR TITLE
More precise focus windows

### DIFF
--- a/packages/replay-next/components/console/Focuser.test.tsx
+++ b/packages/replay-next/components/console/Focuser.test.tsx
@@ -55,7 +55,7 @@ describe("Focuser", () => {
 
   it("should allow the focus region to be toggled on and off", async () => {
     const {
-      focusContext: { update },
+      focusContext: { updateForTimelineImprecise },
     } = await renderFocused(<Focuser />, {
       focusContext: {
         range: null,
@@ -66,10 +66,10 @@ describe("Focuser", () => {
       },
     });
 
-    expect(update).not.toHaveBeenCalled();
+    expect(updateForTimelineImprecise).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByText("Focus off"));
 
-    expect(update).toHaveBeenCalledWith([0, 60_000], false);
+    expect(updateForTimelineImprecise).toHaveBeenCalledWith([0, 60_000], false);
   });
 });

--- a/packages/replay-next/components/console/Focuser.tsx
+++ b/packages/replay-next/components/console/Focuser.tsx
@@ -11,7 +11,7 @@ import styles from "./Focuser.module.css";
 
 export default function Focuser() {
   const { duration } = useContext(SessionContext);
-  const { rangeForDisplay, update } = useContext(FocusContext);
+  const { rangeForDisplay, updateForTimelineImprecise: update } = useContext(FocusContext);
 
   const begin = rangeForDisplay === null ? 0 : rangeForDisplay.begin.time / duration;
   const end = rangeForDisplay === null ? 1 : rangeForDisplay.end.time / duration;

--- a/packages/replay-next/components/console/useConsoleContextMenu.tsx
+++ b/packages/replay-next/components/console/useConsoleContextMenu.tsx
@@ -8,7 +8,11 @@ import Icon from "replay-next/components/Icon";
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
 import { PointsContext } from "replay-next/src/contexts/points/PointsContext";
 import { SessionContext } from "replay-next/src/contexts/SessionContext";
-import { getLoggableTime, isPointInstance } from "replay-next/src/utils/loggables";
+import {
+  getLoggableExecutionPoint,
+  getLoggableTime,
+  isPointInstance,
+} from "replay-next/src/utils/loggables";
 import { Badge, POINT_BEHAVIOR_DISABLED_TEMPORARILY } from "shared/client/types";
 
 import { Loggable } from "./LoggablesContext";
@@ -19,20 +23,38 @@ const BADGES: Badge[] = ["green", "yellow", "orange", "purple"];
 export default function useConsoleContextMenu(loggable: Loggable) {
   const { rangeForDisplay, update } = useContext(FocusContext);
   const { editPointBadge, editPointBehavior } = useContext(PointsContext);
-  const { currentUserInfo, duration } = useContext(SessionContext);
+  const { currentUserInfo, duration, endpoint } = useContext(SessionContext);
 
   const setFocusBegin = () => {
-    const begin = getLoggableTime(loggable);
-    const end = rangeForDisplay !== null ? rangeForDisplay.end.time : duration;
-
-    update([begin, end], true);
+    update(
+      {
+        begin: {
+          point: getLoggableExecutionPoint(loggable),
+          time: getLoggableTime(loggable),
+        },
+        end: rangeForDisplay?.end ?? {
+          point: endpoint,
+          time: duration,
+        },
+      },
+      true
+    );
   };
 
   const setFocusEnd = () => {
-    const end = getLoggableTime(loggable);
-    const begin = rangeForDisplay !== null ? rangeForDisplay.begin.time : 0;
-
-    update([begin, end], true);
+    update(
+      {
+        begin: rangeForDisplay?.begin ?? {
+          point: "0",
+          time: 0,
+        },
+        end: {
+          point: getLoggableExecutionPoint(loggable),
+          time: getLoggableTime(loggable),
+        },
+      },
+      true
+    );
   };
 
   const setBadge = (badge: Badge | null) => {

--- a/packages/replay-next/components/sources/log-point-panel/useLogPointPanelContextMenu.tsx
+++ b/packages/replay-next/components/sources/log-point-panel/useLogPointPanelContextMenu.tsx
@@ -28,17 +28,23 @@ export default function useLogPointPanelContextMenu({
   toggleShouldLog: () => void;
 }) {
   const { rangeForDisplay, update } = useContext(FocusContext);
-  const { duration } = useContext(SessionContext);
+  const { duration, endpoint } = useContext(SessionContext);
 
   const setFocusBegin = () => {
     if (currentHitPoint == null) {
       return;
     }
 
-    const begin = currentHitPoint.time;
-    const end = rangeForDisplay !== null ? rangeForDisplay.end.time : duration;
-
-    update([begin, end], true);
+    update(
+      {
+        begin: currentHitPoint,
+        end: rangeForDisplay?.end ?? {
+          point: endpoint,
+          time: duration,
+        },
+      },
+      true
+    );
   };
 
   const setFocusEnd = () => {
@@ -46,10 +52,16 @@ export default function useLogPointPanelContextMenu({
       return;
     }
 
-    const end = currentHitPoint.time;
-    const begin = rangeForDisplay !== null ? rangeForDisplay.begin.time : 0;
-
-    update([begin, end], true);
+    update(
+      {
+        begin: rangeForDisplay?.begin ?? {
+          point: "0",
+          time: 0,
+        },
+        end: currentHitPoint,
+      },
+      true
+    );
   };
 
   return useContextMenu(

--- a/packages/replay-next/src/contexts/FocusContext.tsx
+++ b/packages/replay-next/src/contexts/FocusContext.tsx
@@ -18,7 +18,7 @@ import {
   imperativelyGetClosestPointForTime,
   preCacheExecutionPointForTime,
 } from "../suspense/ExecutionPointsCache";
-import { Range } from "../types";
+import { TimeRange } from "../types";
 import { SessionContext } from "./SessionContext";
 
 const FOCUS_DEBOUNCE_DURATION = 250;
@@ -30,7 +30,13 @@ export type FocusContextType = {
   isTransitionPending: boolean;
   range: TimeStampedPointRange | null;
   rangeForDisplay: TimeStampedPointRange | null;
-  update: (value: Range | null, debounce: boolean) => void;
+
+  // Set focus window to a range of execution points (or null to clear).
+  update: (value: TimeStampedPointRange | null, debounce: boolean) => void;
+
+  // Set focus window to a range of times (or null to clear).
+  // Note this value is imprecise and should only be used by the Timeline focuser UI.
+  updateForTimelineImprecise: (value: TimeRange | null, debounce: boolean) => void;
 };
 
 export const FocusContext = createContext<FocusContextType>(null as any);
@@ -94,33 +100,43 @@ export function FocusContextRoot({ children }: PropsWithChildren<{}>) {
   }, [loadedRegions]);
 
   const updateFocusRange = useCallback(
-    async (value: Range | null, debounce: boolean) => {
-      let newRange: TimeStampedPointRange | null = null;
-      if (value) {
-        const [timeBegin, timeEnd] = value;
-        const pointBegin = await imperativelyGetClosestPointForTime(client, timeBegin);
-        const pointEnd = await imperativelyGetClosestPointForTime(client, timeEnd);
-
-        newRange = {
-          begin: { point: pointBegin, time: timeBegin },
-          end: { point: pointEnd, time: timeEnd },
-        };
-      }
-
-      setRange(newRange);
+    async (range: TimeStampedPointRange | null, debounce: boolean) => {
+      setRange(range);
 
       // Focus values may change rapidly (e.g. during a click-and-drag)
       // In this case, React's default high/low priority split is helpful, but we can do more.
       // Debouncing a little before starting the transition helps avoid sending a lot of unused requests to the backend.
       if (debounce) {
-        debouncedSetDeferredRange(newRange);
+        debouncedSetDeferredRange(range);
       } else {
         startTransition(() => {
-          setDeferredRange(newRange);
+          setDeferredRange(range);
         });
       }
     },
-    [client, debouncedSetDeferredRange]
+    [debouncedSetDeferredRange]
+  );
+
+  const updateForTimelineImprecise = useCallback(
+    async (value: TimeRange | null, debounce: boolean) => {
+      if (value) {
+        const [timeBegin, timeEnd] = value;
+
+        const pointBegin = await imperativelyGetClosestPointForTime(client, timeBegin);
+        const pointEnd = await imperativelyGetClosestPointForTime(client, timeEnd);
+
+        updateFocusRange(
+          {
+            begin: { point: pointBegin, time: timeBegin },
+            end: { point: pointEnd, time: timeEnd },
+          },
+          debounce
+        );
+      } else {
+        updateFocusRange(null, debounce);
+      }
+    },
+    [client, updateFocusRange]
   );
 
   const focusContext = useMemo<FocusContextType>(
@@ -130,8 +146,9 @@ export function FocusContextRoot({ children }: PropsWithChildren<{}>) {
       rangeForDisplay: range,
       range: deferredRange,
       update: updateFocusRange,
+      updateForTimelineImprecise,
     }),
-    [deferredRange, isTransitionPending, range, updateFocusRange]
+    [deferredRange, isTransitionPending, range, updateFocusRange, updateForTimelineImprecise]
   );
 
   return (

--- a/packages/replay-next/src/contexts/FocusContext.tsx
+++ b/packages/replay-next/src/contexts/FocusContext.tsx
@@ -122,8 +122,10 @@ export function FocusContextRoot({ children }: PropsWithChildren<{}>) {
       if (value) {
         const [timeBegin, timeEnd] = value;
 
-        const pointBegin = await imperativelyGetClosestPointForTime(client, timeBegin);
-        const pointEnd = await imperativelyGetClosestPointForTime(client, timeEnd);
+        const [pointBegin, pointEnd] = await Promise.all([
+          imperativelyGetClosestPointForTime(client, timeBegin),
+          imperativelyGetClosestPointForTime(client, timeEnd),
+        ]);
 
         updateFocusRange(
           {

--- a/packages/replay-next/src/types.ts
+++ b/packages/replay-next/src/types.ts
@@ -1,1 +1,4 @@
-export type Range = [number, number];
+import { ExecutionPoint } from "@replayio/protocol";
+
+export type ExecutionPointRange = [start: ExecutionPoint, end: ExecutionPoint];
+export type TimeRange = [start: number, end: number];

--- a/packages/replay-next/src/utils/testing.tsx
+++ b/packages/replay-next/src/utils/testing.tsx
@@ -112,6 +112,7 @@ export async function renderFocused(
     range: null,
     rangeForDisplay: null,
     update: jest.fn(),
+    updateForTimelineImprecise: jest.fn(),
     ...options?.focusContext,
   };
 

--- a/src/ui/components/FocusContextReduxAdapter.tsx
+++ b/src/ui/components/FocusContextReduxAdapter.tsx
@@ -1,7 +1,8 @@
+import { TimeStampedPointRange } from "@replayio/protocol";
 import { PropsWithChildren, useCallback, useEffect, useMemo, useState, useTransition } from "react";
 
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
-import { Range } from "replay-next/src/types";
+import { TimeRange } from "replay-next/src/types";
 import { enterFocusMode, setFocusRegionFromTimeRange } from "ui/actions/timeline";
 import { getLoadedRegions } from "ui/reducers/app";
 import { getFocusRegion } from "ui/reducers/timeline";
@@ -25,7 +26,23 @@ export default function FocusContextReduxAdapter({ children }: PropsWithChildren
   }, [focusRegion, loadedRegions]);
 
   const update = useCallback(
-    (value: Range | null, _: boolean) => {
+    (value: TimeStampedPointRange | null, _: boolean) => {
+      dispatch(
+        setFocusRegionFromTimeRange(
+          value !== null
+            ? {
+                begin: value.begin.time,
+                end: value.end.time,
+              }
+            : null
+        )
+      );
+    },
+    [dispatch]
+  );
+
+  const updateForTimelineImprecise = useCallback(
+    (value: TimeRange | null, _: boolean) => {
       dispatch(
         setFocusRegionFromTimeRange(
           value !== null
@@ -49,8 +66,9 @@ export default function FocusContextReduxAdapter({ children }: PropsWithChildren
       range: deferredFocusRegion ? rangeForFocusRegion(deferredFocusRegion) : null,
       rangeForDisplay: focusRegion ? rangeForFocusRegion(focusRegion) : null,
       update,
+      updateForTimelineImprecise,
     };
-  }, [deferredFocusRegion, dispatch, isPending, focusRegion, update]);
+  }, [deferredFocusRegion, dispatch, isPending, focusRegion, update, updateForTimelineImprecise]);
 
   return <FocusContext.Provider value={context}>{children}</FocusContext.Provider>;
 }


### PR DESCRIPTION
- [x] `FocusContext` supports two methods for refining focus: `update` (preferred) receives a `TimeStampedPointRange` and `updateForTimelineImprecise` (only used by the Timeline focuser UI) receives a range of times (which get mapped to execution points using `Session.getPointNearTime` or `Session.getPointsBoundingTime`)
  * Also updated the Log Point panel and Console context menu to both use execution points rather than times.
- [ ] ~~Update Redux actions (`updateFocusRegion`, `syncFocusedRegion`) to require execution points.~~
  * [`Session.requestFocusRange`](https://static.replay.io/protocol/tot/Session/#method-requestFocusRange) only accepts a time range, so I think this change maybe isn't worth making for the time being.