### PR TITLE
Check for correct React annotations kind before showing tab

### DIFF
--- a/src/ui/components/Events/Event.tsx
+++ b/src/ui/components/Events/Event.tsx
@@ -137,11 +137,6 @@ export const nextInteractionEventCache: Cache<
       if (ep.frame?.length) {
         const preferredLocation = getPreferredLocation(sourcesState, ep.frame);
         const matchingSource = sourcesState.sourceDetails.entities[preferredLocation.sourceId];
-        console.log("Entry point source: ", {
-          url: matchingSource?.url,
-          matchingSource,
-          preferredLocation,
-        });
 
         // Find the first event that seems useful to jump to
         return !shouldIgnoreEventFromSource(matchingSource, USER_INTERACTION_IGNORABLE_URLS);

--- a/src/ui/components/SecondaryToolbox/index.tsx
+++ b/src/ui/components/SecondaryToolbox/index.tsx
@@ -172,7 +172,7 @@ function SecondaryToolbox({
   const { value: chromiumNetMonitorEnabled } = useFeature("chromiumNetMonitor");
 
   const kindsSet = new Set(annotationKinds);
-  const hasReactComponents = kindsSet.has("react-devtools-hook");
+  const hasReactComponents = kindsSet.has("react-devtools-bridge");
   const hasReduxAnnotations = kindsSet.has("redux-devtools-data");
 
   useLayoutEffect(() => {


### PR DESCRIPTION
Seems like I had used the annotation type `"react-devtools-hook"`, which is what we're using in Chromium to mark _initial_ interesting RDT points, when it should have been `"react-devtools-bridge"`, which is what we're using for the _actual_ RDT operations data annotations.