### PR TITLE
Minimal repro for unnecessary renders caused by a suspense cache

### DIFF
--- a/src/ui/components/SecondaryToolbox/index.tsx
+++ b/src/ui/components/SecondaryToolbox/index.tsx
@@ -11,6 +11,7 @@ import React, {
   useState,
 } from "react";
 import { ImperativePanelHandle } from "react-resizable-panels";
+import { createSingleEntryCache } from "suspense";
 
 import { EditorPane } from "devtools/client/debugger/src/components/Editor/EditorPane";
 import { RecordingCapabilities } from "protocol/thread/thread";
@@ -155,6 +156,8 @@ export default function SecondaryToolboxSuspenseWrapper({
   );
 }
 
+const dummyCache = createSingleEntryCache<[], string>({ load: () => "Hi" });
+
 function SecondaryToolbox({
   videoPanelCollapsed,
   videoPanelRef,
@@ -162,6 +165,14 @@ function SecondaryToolbox({
   videoPanelCollapsed: Boolean;
   videoPanelRef: RefObject<ImperativePanelHandle>;
 }) {
+  try {
+    console.log("reading value from dummy cache");
+    const dummyValue = dummyCache.read();
+    console.log(`dummy cache returned "${dummyValue}"`);
+  } catch (error) {
+    console.error("WAT?", error);
+  }
+
   const selectedPanel = useAppSelector(getSelectedPanel);
   const toolboxLayout = useAppSelector(getToolboxLayout);
   const [annotationKinds, setAnnotationKinds] = useState<string[]>([]);


### PR DESCRIPTION
A cache created with the `suspense` package causes the RDT panel to rerender unnecessarily (which resets RDT, causing the UI issue that made me notice this in the first place).
STR:
- open http://localhost:8080/recording/replay-of-localhost8080--19fe1893-b9ea-41a5-a90a-90a209064c0b?point=5192296858539304422732884716028029&time=2720 (and ignore the errors from the backend - see [BAC-3105](https://linear.app/replay/issue/BAC-3105/assertionfailure-assertion-failed-missing-mapped-location)) or https://devtools-git-hbenl-rdt-render-repro-recordreplay.vercel.app/recording/replay-of-localhost8080--19fe1893-b9ea-41a5-a90a-90a209064c0b?point=5192296858539304422732884716028029&time=2720
- open the RDT panel
- select the "h" component
- expand the state hook
- expand the object in the state hook

-> RDT is reset and forgets the selection