### PR TITLE
Update Devtools Suspense caches to be immutable

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "reselect": "^4.1.5",
     "shared": "workspace:*",
     "slugify": "^1.6.5",
-    "suspense": "^0.0.30"
+    "suspense": "^0.0.31"
   },
   "devDependencies": {
     "@babel/core": "^7.17.8",

--- a/packages/replay-next/package.json
+++ b/packages/replay-next/package.json
@@ -24,7 +24,7 @@
     "react-dom": "0.0.0-experimental-e7d0053e6-20220325",
     "react-virtualized-auto-sizer": "^1.0.7",
     "shared": "workspace:*",
-    "suspense": "^0.0.30",
+    "suspense": "^0.0.31",
     "uuid": "^7.0.3"
   },
   "devDependencies": {

--- a/packages/replay-next/src/suspense/BreakpointPositionsCache.ts
+++ b/packages/replay-next/src/suspense/BreakpointPositionsCache.ts
@@ -15,6 +15,7 @@ export const breakpointPositionsCache: Cache<
   [replayClient: ReplayClientInterface, sourceId: ProtocolSourceId],
   BreakpointPositionsResult
 > = createCache({
+  config: { immutable: true },
   debugLabel: "BreakpointPositions",
   getKey: ([client, sourceId]) => sourceId,
   load: async ([client, sourceId]) => {

--- a/packages/replay-next/src/suspense/CommentsCache.ts
+++ b/packages/replay-next/src/suspense/CommentsCache.ts
@@ -9,6 +9,7 @@ export const commentsCache: Cache<
   [graphQLClient: GraphQLClientInterface, accessToken: string | null, recordingId: RecordingId],
   Comment[]
 > = createCache({
+  config: { immutable: true },
   debugLabel: "CommentsGraphQL",
   getKey: ([graphQLClient, accessToken, recordingId]) => recordingId,
   load: async ([graphQLClient, accessToken, recordingId]) =>

--- a/packages/replay-next/src/suspense/EventsCache.ts
+++ b/packages/replay-next/src/suspense/EventsCache.ts
@@ -41,6 +41,7 @@ export const eventCountsCache: Cache<
   [client: ReplayClientInterface, range: PointRange | null],
   EventCategory[]
 > = createCache({
+  config: { immutable: true },
   debugLabel: "EventCounts",
   getKey: ([client, range]) => (range ? `${range.begin}:${range.end}` : ""),
   load: async ([client, range]) => {

--- a/packages/replay-next/src/suspense/ExceptionsCache.ts
+++ b/packages/replay-next/src/suspense/ExceptionsCache.ts
@@ -34,6 +34,7 @@ export const exceptionValueCache = createCache<
   [client: ReplayClientInterface, pauseId: PauseId],
   Value | undefined
 >({
+  config: { immutable: true },
   debugLabel: "ExceptionValueCache",
   getKey: ([client, pauseId]) => pauseId,
   load: async ([client, pauseId]) => {

--- a/packages/replay-next/src/suspense/ExecutionPointsCache.ts
+++ b/packages/replay-next/src/suspense/ExecutionPointsCache.ts
@@ -297,6 +297,7 @@ export const pointsBoundingTimeCache: Cache<
   [replayClient: ReplayClientInterface, time: number],
   PointsBoundingTime
 > = createCache({
+  config: { immutable: true },
   debugLabel: "PointsBoundingTime",
   getKey: ([client, time]) => `${time}`,
   load: async ([client, time]) => client.getPointsBoundingTime(time),

--- a/packages/replay-next/src/suspense/FrameCache.ts
+++ b/packages/replay-next/src/suspense/FrameCache.ts
@@ -10,6 +10,7 @@ export const framesCache: Cache<
   [replayClient: ReplayClientInterface, pauseId: PauseId],
   Frame[] | undefined
 > = createCache({
+  config: { immutable: true },
   debugLabel: "FramesCache",
   getKey: ([client, pauseId]) => pauseId,
   load: async ([client, pauseId]) => {
@@ -35,6 +36,7 @@ export const topFrameCache: Cache<
   [replayClient: ReplayClientInterface, pauseId: PauseId],
   Frame | undefined
 > = createCache({
+  config: { immutable: true },
   debugLabel: "TopFrame",
   getKey: ([client, pauseId]) => pauseId,
   load: async ([client, pauseId]) => {

--- a/packages/replay-next/src/suspense/FrameStepsCache.ts
+++ b/packages/replay-next/src/suspense/FrameStepsCache.ts
@@ -10,6 +10,7 @@ export const frameStepsCache: Cache<
   [replayClient: ReplayClientInterface, pauseId: PauseId, frameId: FrameId],
   PointDescription[] | undefined
 > = createCache({
+  config: { immutable: true },
   debugLabel: "frameStepsCache",
   getKey: ([client, pauseId, frameId]) => `${pauseId}:${frameId}`,
   load: async ([client, pauseId, frameId]) => {

--- a/packages/replay-next/src/suspense/LogPointAnalysisCache.ts
+++ b/packages/replay-next/src/suspense/LogPointAnalysisCache.ts
@@ -143,6 +143,7 @@ export function canRunLocalAnalysis(code: string, condition: string | null): boo
 }
 
 export const localAnalysisCache: Cache<[code: string], any[]> = createCache({
+  config: { immutable: true },
   debugLabel: "localAnalysisCache",
   getKey: ([code]) => code,
   load: async ([code]) =>

--- a/packages/replay-next/src/suspense/MappedExpressionCache.ts
+++ b/packages/replay-next/src/suspense/MappedExpressionCache.ts
@@ -7,6 +7,7 @@ export const mappedExpressionCache = createCache<
   [client: ReplayClientInterface, expression: string, location: Location],
   string
 >({
+  config: { immutable: true },
   debugLabel: "MappedExpressionCache",
   getKey: ([client, expression, location]) =>
     `${location.sourceId}:${location.line}:${location.column}:${expression}`,

--- a/packages/replay-next/src/suspense/MappedLocationCache.ts
+++ b/packages/replay-next/src/suspense/MappedLocationCache.ts
@@ -10,6 +10,7 @@ export const mappedLocationCache: Cache<
   [replayClient: ReplayClientInterface, location: ProtocolLocation],
   ProtocolMappedLocation
 > = createCache({
+  config: { immutable: true },
   debugLabel: "MappedLocationCache",
   getKey: ([client, location]) => `${location.sourceId}:${location.line}:${location.column}`,
   load: async ([client, location]) => client.getMappedLocation(location),

--- a/packages/replay-next/src/suspense/ObjectPreviews.ts
+++ b/packages/replay-next/src/suspense/ObjectPreviews.ts
@@ -22,6 +22,7 @@ export const objectCache: Cache<
   ],
   Object
 > = createCache({
+  config: { immutable: true },
   debugLabel: "objectCache",
   getKey: ([client, pauseId, objectId, previewLevel]) => `${pauseId}:${objectId}:${previewLevel}`,
   load: async ([client, pauseId, objectId, previewLevel]) => {
@@ -39,6 +40,7 @@ export const objectPropertyCache: Cache<
   [client: ReplayClientInterface, pauseId: PauseId, objectId: ObjectId, propertyName: string],
   ProtocolValue | null
 > = createCache({
+  config: { immutable: true },
   debugLabel: "objectPropertyCache",
   getKey: ([client, pauseId, objectId, propertyName]) => `${pauseId}:${objectId}:${propertyName}`,
   load: async ([client, pauseId, objectId, propertyName]) => {

--- a/packages/replay-next/src/suspense/PauseCache.ts
+++ b/packages/replay-next/src/suspense/PauseCache.ts
@@ -24,6 +24,7 @@ export const pauseIdCache: Cache<
   [replayClient: ReplayClientInterface, executionPoint: ExecutionPoint, time: number],
   PauseId
 > = createCache({
+  config: { immutable: true },
   debugLabel: "PauseIdForExecutionPoint",
   getKey: ([replayClient, executionPoint, time]) => `${executionPoint}:${time}`,
   load: async ([replayClient, executionPoint, time]) => {
@@ -59,6 +60,7 @@ export const pauseEvaluationsCache: Cache<
   ],
   Omit<Result, "data">
 > = createCache({
+  config: { immutable: true },
   debugLabel: "PauseEvaluations",
   getKey: ([replayClient, pauseId, frameId, expression, uid = ""]) =>
     `${pauseId}:${frameId}:${expression}:${uid}`,

--- a/packages/replay-next/src/suspense/PointsCache.ts
+++ b/packages/replay-next/src/suspense/PointsCache.ts
@@ -9,6 +9,7 @@ export const pointsCache: Cache<
   [graphQLClient: GraphQLClientInterface, accessToken: string | null, recordingId: RecordingId],
   Point[]
 > = createCache({
+  config: { immutable: true },
   debugLabel: "Points",
   getKey: ([graphQLClient, accessToken, recordingId]) => recordingId,
   load: async ([graphQLClient, accessToken, recordingId]) =>

--- a/packages/replay-next/src/suspense/ScopeCache.ts
+++ b/packages/replay-next/src/suspense/ScopeCache.ts
@@ -17,6 +17,7 @@ export const scopesCache: Cache<
   [replayClient: ReplayClientInterface, pauseId: PauseId, scopeId: ScopeId],
   Scope
 > = createCache({
+  config: { immutable: true },
   debugLabel: "Scopes",
   getKey: ([replayClient, pauseId, scopeId]) => `${pauseId}:${scopeId}`,
   load: async ([replayClient, pauseId, scopeId]) => {
@@ -37,6 +38,7 @@ export const frameScopesCache: Cache<
   [replayClient: ReplayClientInterface, pauseId: PauseId, frameId: FrameId],
   FrameScopes
 > = createCache({
+  config: { immutable: true },
   debugLabel: "FrameScopes",
   getKey: ([replayClient, pauseId, frameId]) => `${pauseId}:${frameId}`,
   load: async ([replayClient, pauseId, frameId]) => {

--- a/packages/replay-next/src/suspense/ScopeMapCache.ts
+++ b/packages/replay-next/src/suspense/ScopeMapCache.ts
@@ -7,6 +7,7 @@ export const scopeMapCache: Cache<
   [replayClient: ReplayClientInterface, location: Location],
   VariableMapping[] | undefined
 > = createCache({
+  config: { immutable: true },
   debugLabel: "ScopeMap",
   getKey: ([client, location]) => `${location.sourceId}:${location.line}:${location.column}`,
   load: async ([client, location]) => client.getScopeMap(location),

--- a/packages/replay-next/src/suspense/SearchCache.ts
+++ b/packages/replay-next/src/suspense/SearchCache.ts
@@ -51,6 +51,7 @@ export const searchCache: Cache<
   [replayClient: ReplayClientInterface, query: string, includeNodeModules: boolean, limit?: number],
   StreamingSourceSearchResults
 > = createCache({
+  config: { immutable: true },
   debugLabel: "Search",
   getKey: ([replayClient, query, includeNodeModules, limit = MAX_SEARCH_RESULTS_TO_DISPLAY]) =>
     `${includeNodeModules}:${limit || "-"}:${query}`,

--- a/packages/replay-next/src/suspense/SourceOutlineCache.ts
+++ b/packages/replay-next/src/suspense/SourceOutlineCache.ts
@@ -7,6 +7,7 @@ export const sourceOutlineCache = createCache<
   [replayClient: ReplayClientInterface, sourceId: SourceId | undefined],
   getSourceOutlineResult
 >({
+  config: { immutable: true },
   debugLabel: "sourceOutlineCache",
   getKey: ([replayClient, sourceId]) => sourceId ?? "",
   load: ([replayClient, sourceId]) =>

--- a/src/ui/actions/event-listeners.ts
+++ b/src/ui/actions/event-listeners.ts
@@ -306,6 +306,7 @@ export const eventListenerLocationCache: Cache<
   ],
   Location | undefined
 > = createCache({
+  config: { immutable: true },
   debugLabel: "EventListenerLocation",
   getKey: ([threadFront, replayClient, getState, pauseId, replayEventType]) =>
     `${pauseId}:${replayEventType}`,

--- a/src/ui/components/Events/Event.tsx
+++ b/src/ui/components/Events/Event.tsx
@@ -81,6 +81,7 @@ export const nextInteractionEventCache: Cache<
   ],
   PointDescription | undefined
 > = createCache({
+  config: { immutable: true },
   debugLabel: "NextInteractionEvent",
   getKey: ([replayClient, threadFront, point, replayEventType, endTime]) => point,
   load: async ([replayClient, threadFront, point, replayEventType, endTime, sourcesState]) => {

--- a/src/ui/components/ProtocolViewer.tsx
+++ b/src/ui/components/ProtocolViewer.tsx
@@ -499,6 +499,7 @@ export const recordedProtocolMessagesCache: Cache<
   [replayClient: ReplayClientInterface, sourceDetails: SourceDetails[], range: PointRange],
   AllProtocolMessages
 > = createCache({
+  config: { immutable: true },
   debugLabel: "RecordedPotocolMessages",
   getKey: ([replayClient, sourceDetails, range]) => `${range.begin}-${range.end}`,
   load: async ([replayClient, sourceDetails, range]) => {

--- a/src/ui/components/ReactPanel.tsx
+++ b/src/ui/components/ReactPanel.tsx
@@ -80,6 +80,7 @@ export const reactRenderQueuedJumpLocationCache: Cache<
   ],
   PointWithLocation | undefined
 > = createCache({
+  config: { immutable: true },
   debugLabel: "NextInteractionEvent",
   getKey: ([replayClient, earliestAppCodeFrame, sourcesState]) => earliestAppCodeFrame.pauseId,
   load: async ([replayClient, earliestAppCodeFrame, sourcesState]) => {

--- a/src/ui/components/SecondaryToolbox/redux-devtools/injectReduxDevtoolsProcessing.ts
+++ b/src/ui/components/SecondaryToolbox/redux-devtools/injectReduxDevtoolsProcessing.ts
@@ -129,6 +129,7 @@ export const actionStateValuesCache: Cache<
   [replayClient: ReplayClientInterface, point: ExecutionPoint, time: number],
   ReduxActionStateValues | undefined
 > = createCache({
+  config: { immutable: true },
   debugLabel: "ActionStateValues",
   getKey: ([replayClient, point, time]) => point,
   load: async ([replayClient, point, time]) => {
@@ -169,6 +170,7 @@ export const diffCache: Cache<
   [replayClient: ReplayClientInterface, point: ExecutionPoint, time: number],
   Delta | undefined
 > = createCache({
+  config: { immutable: true },
   debugLabel: "Diff",
   getKey: ([replayClient, point, time]) => point,
   load: async ([replayClient, point, time]) => {

--- a/src/ui/suspense/nodeCaches.ts
+++ b/src/ui/suspense/nodeCaches.ts
@@ -53,6 +53,7 @@ export const nodeDataCache: Cache<
   ],
   ProtocolObject[]
 > = createCache({
+  config: { immutable: true },
   debugLabel: "NodeData",
   getKey: ([protocolClient, replayClient, sessionId, pauseId, options]) => {
     let typeKey = "";
@@ -180,6 +181,7 @@ export const nodeEventListenersCache: Cache<
   ],
   EventListener[] | undefined
 > = createCache({
+  config: { immutable: true },
   debugLabel: "NodeEventListeners",
   getKey: ([protocolClient, replayClient, sessionId, pauseId, nodeId]) => `${pauseId}:${nodeId}`,
   load: async ([protocolClient, replayClient, sessionId, pauseId, nodeId]) => {
@@ -200,6 +202,7 @@ export const boundingRectsCache: Cache<
   [protocolClient: ProtocolClient, sessionId: string, pauseId: PauseId],
   NodeBounds[]
 > = createCache({
+  config: { immutable: true },
   debugLabel: "BoundingRects",
   getKey: ([protocolClient, sessionId, pauseId]) => pauseId,
   load: async ([protocolClient, sessionId, pauseId]) => {
@@ -212,6 +215,7 @@ export const boxModelCache: Cache<
   [protocolClient: ProtocolClient, sessionId: string, pauseId: PauseId, nodeId: string],
   BoxModel
 > = createCache({
+  config: { immutable: true },
   debugLabel: "BoxModel",
   getKey: ([protocolClient, sessionId, pauseId, nodeId]) => `${pauseId}:${nodeId}`,
   load: async ([protocolClient, sessionId, pauseId, nodeId]) => {

--- a/src/ui/suspense/styleCaches.ts
+++ b/src/ui/suspense/styleCaches.ts
@@ -22,6 +22,7 @@ export const appliedRulesCache: Cache<
   ],
   WiredAppliedRule[]
 > = createCache({
+  config: { immutable: true },
   debugLabel: "AppliedRules",
   getKey: ([protocolClient, replayClient, sessionId, pauseId, nodeId]) => `${pauseId}:${nodeId}`,
   load: async ([protocolClient, replayClient, sessionId, pauseId, nodeId]) => {
@@ -85,6 +86,7 @@ export const computedStyleCache: Cache<
   [client: ProtocolClient, sessionId: string, pauseId: PauseId, nodeId: string],
   Map<string, string> | undefined
 > = createCache({
+  config: { immutable: true },
   debugLabel: "ComputedStyle",
   getKey: ([protocolClient, sessionId, pauseId, nodeId]) => `${pauseId}:${nodeId}`,
   load: async ([protocolClient, sessionId, pauseId, nodeId]) => {
@@ -113,6 +115,7 @@ export const boundingRectCache: Cache<
   [protocolClient: ProtocolClient, sessionId: string, pauseId: PauseId, nodeId: string],
   DOMRect | undefined
 > = createCache({
+  config: { immutable: true },
   debugLabel: "BoundingRect",
   getKey: ([protocolClient, sessionId, pauseId, nodeId]) => `${pauseId}:${nodeId}`,
   load: async ([protocolClient, sessionId, pauseId, nodeId]) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -20739,7 +20739,7 @@ __metadata:
     style-loader: ^3.3.1
     stylelint: ^14.16.0
     stylelint-config-prettier: ^9.0.4
-    suspense: ^0.0.30
+    suspense: ^0.0.31
     tailwindcss: ^3.2.4
     ts-node: ^10.7.0
     tsconfig-paths: ^3.14.1
@@ -21093,7 +21093,7 @@ __metadata:
     react-dom: 0.0.0-experimental-e7d0053e6-20220325
     react-virtualized-auto-sizer: ^1.0.7
     shared: "workspace:*"
-    suspense: ^0.0.30
+    suspense: ^0.0.31
     typescript: 5.0.2
     uuid: ^7.0.3
   languageName: unknown
@@ -22904,16 +22904,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"suspense@npm:^0.0.30":
-  version: 0.0.30
-  resolution: "suspense@npm:0.0.30"
+"suspense@npm:^0.0.31":
+  version: 0.0.31
+  resolution: "suspense@npm:0.0.31"
   dependencies:
     interval-utilities: ^0.0.1
     point-utilities: ^0.0.2
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: f0d0bf995a49df8795b638ca67140d5d6a623abc8d364a71a534478cf8de10469171e53f9858177edcccac5aba2943e00828a69b0871806bfdd2102c49313d10
+  checksum: 2e0b963e63864bb2e53b122bed37bb087b2d93958c22a5ec3e2bf1fea03b570c627cd338e93d2480040383a775853f1e0437742a01a9481806ae73d4c00acdd0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- [x] Update to `suspense@0.0.31` which adds new "immutable" configuration setting (see https://github.com/bvaughn/suspense/pull/26)
- [x] Update all of our caches _except_ the IndexedDB ones to be _immutable_ to avoid unnecessary rendering (see [Loom](https://www.loom.com/share/dde355b8a9e643adb146768cbd943d39))

Smoke test seems fine. Adding a log point only re-renders the Source viewer portion of the tree (expected).
<img width="860" alt="Screen Shot 2023-04-13 at 3 12 08 PM" src="https://user-images.githubusercontent.com/29597/231859919-ed45ff66-d9ff-45bd-a5d6-2599247e4432.png">
