### PR TITLE
Tweak e2e test helpers

### DIFF
--- a/packages/e2e-tests/helpers/pause-information-panel.ts
+++ b/packages/e2e-tests/helpers/pause-information-panel.ts
@@ -341,7 +341,8 @@ export async function waitForPaused(page: Page, line?: number): Promise<void> {
     const scopeBlocks = scopesPanel.locator('[data-test-name="Expandable"]');
     const [numFrames, numScopes] = await Promise.all([frameListItems.count(), scopeBlocks.count()]);
 
-    expect(numFrames > 0 && numScopes > 0).toBe(true);
+    expect(numFrames).toBeGreaterThan(0);
+    expect(numScopes).toBeGreaterThan(0);
   });
 
   if (line) {

--- a/packages/e2e-tests/helpers/source-explorer-panel.ts
+++ b/packages/e2e-tests/helpers/source-explorer-panel.ts
@@ -54,6 +54,7 @@ export async function openSource(page: Page, url: string): Promise<void> {
       foundSource = true;
 
       // We found the source; open it and then bail.
+      await item.scrollIntoViewIfNeeded();
       await item.click();
 
       break;
@@ -79,9 +80,14 @@ export async function openSource(page: Page, url: string): Promise<void> {
 
 export async function openSourceExplorerPanel(page: Page): Promise<void> {
   const pane = getSourcesPane(page);
-  let isVisible = await pane.isVisible(); // await isSidePaneVisible(pane);
 
+  const isVisible = await pane.isVisible();
   if (!isVisible) {
-    return page.locator('[data-test-name="ToolbarButton-SourceExplorer"]').click();
+    const button = page.locator('[data-test-name="ToolbarButton-SourceExplorer"]');
+    await button.click();
+
+    await waitFor(async () => {
+      await expect(await pane.isVisible()).toBe(true);
+    });
   }
 }


### PR DESCRIPTION
Saw some areas we could improve this afternoon while looking at some unexpected failures.

The `openSourceExplorerPanel` helper in particular seems like it could be causing problems. I'm surprised it hasn't caused _more_ since it's been around for several months.