### PR TITLE
Improve stability of some e2e tests

### DIFF
--- a/packages/e2e-tests/helpers/pause-information-panel.ts
+++ b/packages/e2e-tests/helpers/pause-information-panel.ts
@@ -212,9 +212,9 @@ export async function rewind(page: Page) {
 export async function rewindToLine(
   page: Page,
   options: {
-    lineNumber?: number;
+    lineNumber: number;
     url?: string;
-  } = {}
+  }
 ): Promise<void> {
   const { url = null, lineNumber = null } = options;
 
@@ -333,17 +333,23 @@ export async function waitForPaused(page: Page, line?: number): Promise<void> {
 
   await openPauseInformationPanel(page);
 
-  await waitFor(async () => {
-    const scopesPanel = getScopesPanel(page);
-    const framesPanel = getFramesPanel(page);
+  await waitFor(
+    async () => {
+      const scopesPanel = getScopesPanel(page);
+      const framesPanel = getFramesPanel(page);
 
-    const frameListItems = framesPanel.locator(".frame");
-    const scopeBlocks = scopesPanel.locator('[data-test-name="Expandable"]');
-    const [numFrames, numScopes] = await Promise.all([frameListItems.count(), scopeBlocks.count()]);
+      const frameListItems = framesPanel.locator(".frame");
+      const scopeBlocks = scopesPanel.locator('[data-test-name="Expandable"]');
+      const [numFrames, numScopes] = await Promise.all([
+        frameListItems.count(),
+        scopeBlocks.count(),
+      ]);
 
-    expect(numFrames).toBeGreaterThan(0);
-    expect(numScopes).toBeGreaterThan(0);
-  });
+      expect(numFrames).toBeGreaterThan(0);
+      expect(numScopes).toBeGreaterThan(0);
+    },
+    { timeout: 10_000 }
+  );
 
   if (line) {
     await waitFor(async () => {

--- a/packages/e2e-tests/tests/breakpoints-03.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-03.test.ts
@@ -2,7 +2,7 @@ import test from "@playwright/test";
 
 import { openDevToolsTab, startTest } from "../helpers";
 import { executeAndVerifyTerminalExpression } from "../helpers/console-panel";
-import { resumeToLine, rewindToLine } from "../helpers/pause-information-panel";
+import { resumeToLine, rewind, rewindToLine } from "../helpers/pause-information-panel";
 import { addBreakpoint, removeBreakpoint } from "../helpers/source-panel";
 
 const url = "doc_rr_basic.html";
@@ -17,7 +17,7 @@ test(`breakpoints-03: Test stepping forward through breakpoints when rewound bef
   // Rewind to when the point was hit
   await rewindToLine(page, { lineNumber: 9 });
   // Rewind further (past the first hit)
-  await rewindToLine(page);
+  await rewind(page);
 
   await removeBreakpoint(page, { lineNumber: 9, url });
 

--- a/packages/e2e-tests/tests/stepping-01.test.ts
+++ b/packages/e2e-tests/tests/stepping-01.test.ts
@@ -2,7 +2,7 @@ import test from "@playwright/test";
 
 import { openDevToolsTab, startTest } from "../helpers";
 import { executeAndVerifyTerminalExpression } from "../helpers/console-panel";
-import { reverseStepOver, rewindToLine, stepOver } from "../helpers/pause-information-panel";
+import { reverseStepOver, rewind, stepOver } from "../helpers/pause-information-panel";
 import { clickSourceTreeNode } from "../helpers/source-explorer-panel";
 import { addBreakpoint } from "../helpers/source-panel";
 
@@ -19,7 +19,7 @@ test("stepping-01: Test basic step-over/back functionality", async ({ page }) =>
 
   // Pause on line 20
   await addBreakpoint(page, { lineNumber: 20, url });
-  await rewindToLine(page);
+  await rewind(page);
 
   // Should get ten when evaluating number.
   await executeAndVerifyTerminalExpression(page, "number", "10");


### PR DESCRIPTION
- the `rewindToLine()` helper could be called without a `lineNumber`, in that case it would click the rewind button without waiting for the new pause, so the next test step could be executed at the old pause. I've made the `lineNumber` mandatory and changed `rewindToLine()` calls without a `lineNumber` to `rewind()` which does wait for the new pause.
- increased the timeout in the `waitForPaused()` helper