### PR TITLE
Remove old BACKEND_CI timeouts

### DIFF
--- a/packages/e2e-tests/helpers/console-panel.ts
+++ b/packages/e2e-tests/helpers/console-panel.ts
@@ -321,19 +321,12 @@ export async function verifyEvaluationResult(
 export async function verifyExpectedCount(locator: Locator, expectedCount?: number) {
   if (expectedCount != null) {
     // Verify a specific number of messages
-    await waitFor(
-      async () => {
-        const count = await locator.count();
-        if (count !== expectedCount) {
-          throw `Expected ${expectedCount} messages, but found ${count}`;
-        }
-      },
-      {
-        // For console log points, it can take quite a while for the messages to finish
-        // eval-ing their expressions, so this needs to be much longer than in production.
-        timeout: process.env.BACKEND_CI ? 60_000 : undefined,
+    await waitFor(async () => {
+      const count = await locator.count();
+      if (count !== expectedCount) {
+        throw `Expected ${expectedCount} messages, but found ${count}`;
       }
-    );
+    });
   } else {
     // Or just verify that there was at least one
     const message = locator.first();

--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -1,14 +1,7 @@
 import { PlaywrightTestConfig, devices } from "@playwright/test";
 import { devices as replayDevices } from "@replayio/playwright";
 
-const {
-  CI,
-  // The backend tests run against a self-contained backend that can be
-  // much slower than production, so when this is set, tests should use
-  // much longer timeouts.
-  BACKEND_CI,
-  SLOW_MO,
-} = process.env;
+const { CI, SLOW_MO } = process.env;
 
 const config: PlaywrightTestConfig = {
   use: {
@@ -20,14 +13,14 @@ const config: PlaywrightTestConfig = {
       height: 1024,
     },
     // Don't allow any one action to take more than 15s
-    actionTimeout: BACKEND_CI ? 60_000 : 15_000,
+    actionTimeout: 15_000,
   },
 
   // Retry failed tests on CI to account for some basic flakiness.
   retries: CI ? 5 : 0,
 
   // Give individual tests a while to complete instead of default 30s
-  timeout: BACKEND_CI ? 150_000 : 120_000,
+  timeout: 120_000,
 
   // Limit the number of workers on CI, use default locally
   workers: CI ? 4 : undefined,

--- a/packages/e2e-tests/tests/repaint.test.ts
+++ b/packages/e2e-tests/tests/repaint.test.ts
@@ -21,18 +21,12 @@ test("repaint: repaints the screen screen when stepping over code that modifies 
   await stepOver(page);
   await waitForPaused(page);
 
-  await waitFor(
-    async () => {
-      const nextDataUrl = await getCanvasDataUrl(page);
-      if (prevDataUrl === nextDataUrl) {
-        throw `The screenshot did not change`;
-      }
-    },
-    {
-      // Add a bit of extra time for the backend CI to generate a new screenshot.
-      timeout: process.env.BACKEND_CI ? 30_000 : undefined,
+  await waitFor(async () => {
+    const nextDataUrl = await getCanvasDataUrl(page);
+    if (prevDataUrl === nextDataUrl) {
+      throw `The screenshot did not change`;
     }
-  );
+  });
 });
 
 async function getCanvasDataUrl(page: Page): Promise<string> {

--- a/packages/replay-next/playwright/tests/utils/console.ts
+++ b/packages/replay-next/playwright/tests/utils/console.ts
@@ -233,19 +233,12 @@ export async function verifyConsoleMessage(
 
   if (expectedCount != null) {
     // Verify a specific number of messages
-    await waitFor(
-      async () => {
-        const count = await messages.count();
-        if (count !== expectedCount) {
-          throw `Expected ${expectedCount} messages, but found ${count}`;
-        }
-      },
-      {
-        // For console log points, it can take quite a while for the messages to finish
-        // eval-ing their expressions, so this needs to be much longer than in production.
-        timeout: process.env.BACKEND_CI ? 60_000 : undefined,
+    await waitFor(async () => {
+      const count = await messages.count();
+      if (count !== expectedCount) {
+        throw `Expected ${expectedCount} messages, but found ${count}`;
       }
-    );
+    });
   } else {
     // Or just verify that there was at least one
     const message = messages.first();


### PR DESCRIPTION
This was for when we were running in standalone and creating new recordings for every test. We don't do that anymore, so we no longer need to be as aggressive about waiting around (and making the tests run *forever*, which they do).

Fixes https://linear.app/replay/issue/BAC-3148/turn-down-backend-ci-timeouts