### PR TITLE
Add "inspect element" context menu to Passport

### DIFF
--- a/src/ui/components/Tour/Tour.tsx
+++ b/src/ui/components/Tour/Tour.tsx
@@ -40,7 +40,6 @@ interface HelloAgainProps {
 }
 
 interface CompletedTourProps {
-  setShowConfetti: React.Dispatch<React.SetStateAction<boolean>>;
   setShowPassport: (newValue: boolean) => void;
   dismissTourNag: () => void;
 }
@@ -54,8 +53,6 @@ const Tour: React.FC = () => {
   const showConsoleNavigate = shouldShowConsoleNavigate(nags);
   const showBreakpointAdd = shouldShowBreakpointAdd(nags);
   const showBreakpointEdit = shouldShowBreakpointEdit(nags);
-
-  const [showConfetti, setShowConfetti] = useState(false);
 
   const isNewUser =
     showDevtoolsNag && showConsoleNavigate && showBreakpointAdd && showBreakpointEdit;

--- a/src/ui/components/Tour/Tour.tsx
+++ b/src/ui/components/Tour/Tour.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 
 import { setSelectedPrimaryPanel } from "ui/actions/layout";
 import { shouldShowDevToolsNag } from "ui/components/Header/ViewToggle";
-import Confetti from "ui/components/shared//Confetti";
 import { isTestSuiteReplay } from "ui/components/TestSuite/utils/isTestSuiteReplay";
 import hooks from "ui/hooks";
 import { useGetRecording, useGetRecordingId } from "ui/hooks/recordings";
@@ -145,11 +144,7 @@ const Tour: React.FC = () => {
     <img src="https://vercel.replay.io/tour/editlogs.gif" className={styles.videoExample} />
   );
 
-  const CompletedTour: React.FC<CompletedTourProps> = ({
-    setShowConfetti,
-    setShowPassport,
-    dismissTourNag,
-  }) => (
+  const CompletedTour: React.FC<CompletedTourProps> = ({ setShowPassport, dismissTourNag }) => (
     <div className={styles.intro}>
       <div className={styles.h1}>Check the console! 😎</div>
       <p>Take a look at the console.</p>
@@ -163,10 +158,8 @@ const Tour: React.FC = () => {
           href="#"
           onClick={e => {
             e.stopPropagation();
-            setShowConfetti(true);
             setShowPassport(true);
             setTimeout(() => {
-              setShowConfetti(false);
               dismissTourNag();
             }, 2500);
           }}
@@ -174,7 +167,6 @@ const Tour: React.FC = () => {
         >
           Thanks!
         </a>
-        {showConfetti ? <Confetti /> : null}
       </p>
       <img
         src={`/images/passport/tour_grad-default.png`}
@@ -214,7 +206,6 @@ const Tour: React.FC = () => {
                     {!showConsoleNavigate && !showBreakpointAdd && showBreakpointEdit && editLogs}
                     {hasCompletedTour && (
                       <CompletedTour
-                        setShowConfetti={setShowConfetti}
                         setShowPassport={setShowPassport}
                         dismissTourNag={dismissTourNag}
                       />

--- a/src/ui/components/Tour/Tour.tsx
+++ b/src/ui/components/Tour/Tour.tsx
@@ -146,7 +146,7 @@ const Tour: React.FC = () => {
 
   const CompletedTour: React.FC<CompletedTourProps> = ({ setShowPassport, dismissTourNag }) => (
     <div className={styles.intro}>
-      <div className={styles.h1}>Check the console! 😎</div>
+      <div className={styles.h1}>😎</div>
       <p>Take a look at the console.</p>
       <p>
         Replay just re-ran your recording and retroactively added your print statement each time
@@ -161,7 +161,7 @@ const Tour: React.FC = () => {
             setShowPassport(true);
             setTimeout(() => {
               dismissTourNag();
-            }, 2500);
+            }, 200);
           }}
           className="hover:cursor-hand whitespace-nowrap rounded-lg bg-white px-3 py-1 font-medium text-primaryAccent shadow-lg hover:bg-blue-50"
         >

--- a/src/ui/components/useVideoContextMenu.tsx
+++ b/src/ui/components/useVideoContextMenu.tsx
@@ -11,6 +11,8 @@ import useContextMenu from "replay-next/components/context-menu/useContextMenu";
 import { createTypeDataForVisualComment } from "replay-next/components/sources/utils/comments";
 import { InspectorContext } from "replay-next/src/contexts/InspectorContext";
 import { SessionContext } from "replay-next/src/contexts/SessionContext";
+import { useNag } from "replay-next/src/hooks/useNag";
+import { Nag } from "shared/graphql/types";
 import { fetchMouseTargetsForPause } from "ui/actions/app";
 import { createFrameComment } from "ui/actions/comments";
 import { setSelectedPanel, setViewMode } from "ui/actions/layout";
@@ -58,7 +60,9 @@ export default function useVideoContextMenu({
     }
   };
 
+  const [, dismissInspectElementNag] = useNag(Nag.INSPECT_ELEMENT); // Replay Passport
   const inspectElement = () => {
+    dismissInspectElementNag();
     const nodeId = mouseEventDataRef.current.targetNodeId;
     if (nodeId !== null) {
       dispatch(setViewMode("dev"));


### PR DESCRIPTION
The nag wasn't previously paying attention to this entry point for inspect element, but now it is.

I also removed the confetti, it wasn't showing up right and causing an awkward delay.

<img width="444" alt="image" src="https://user-images.githubusercontent.com/9154902/233315026-e8c60884-633e-409f-8489-52e89b24df0a.png">