### PR TITLE
Update suspense@0.0.34

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "reselect": "^4.1.5",
     "shared": "workspace:*",
     "slugify": "^1.6.5",
-    "suspense": "^0.0.32"
+    "suspense": "^0.0.34"
   },
   "devDependencies": {
     "@babel/core": "^7.17.8",

--- a/packages/replay-next/package.json
+++ b/packages/replay-next/package.json
@@ -24,7 +24,7 @@
     "react-dom": "0.0.0-experimental-e7d0053e6-20220325",
     "react-virtualized-auto-sizer": "^1.0.7",
     "shared": "workspace:*",
-    "suspense": "^0.0.32",
+    "suspense": "^0.0.34",
     "uuid": "^7.0.3"
   },
   "devDependencies": {

--- a/packages/replay-next/src/suspense/AnalysisCache.ts
+++ b/packages/replay-next/src/suspense/AnalysisCache.ts
@@ -1,6 +1,11 @@
 import { ExecutionPoint, PauseId, PointDescription, TimeStampedPoint } from "@replayio/protocol";
 import { PointSelector, Value } from "@replayio/protocol";
-import { Cache, IntervalCache, createExternallyManagedCache } from "suspense";
+import {
+  Cache,
+  ExternallyManagedCache,
+  IntervalCache,
+  createExternallyManagedCache,
+} from "suspense";
 
 import { compareNumericStrings } from "protocol/utils";
 import { ReplayClientInterface } from "shared/client/types";
@@ -29,7 +34,10 @@ export interface AnalysisCache<T extends { point: ExecutionPoint }, TParams exte
     [client: ReplayClientInterface, ...params: TParams],
     T
   >;
-  resultsCache: Cache<[executionPoint: ExecutionPoint, ...params: TParams], RemoteAnalysisResult>;
+  resultsCache: ExternallyManagedCache<
+    [executionPoint: ExecutionPoint, ...params: TParams],
+    RemoteAnalysisResult
+  >;
 }
 
 export function createAnalysisCache<
@@ -51,7 +59,7 @@ export function createAnalysisCache<
   ) => AnalysisParams | Promise<AnalysisParams>,
   transformPoint: (point: PointDescription, ...params: TParams) => TPoint
 ): AnalysisCache<TPoint, TParams> {
-  const resultsCache: Cache<
+  const resultsCache: ExternallyManagedCache<
     [executionPoint: ExecutionPoint, ...params: TParams],
     RemoteAnalysisResult
   > = createExternallyManagedCache({
@@ -119,7 +127,7 @@ export function createAnalysisCache<
                 values = (await Promise.all(promises)).filter(value => !!value) as Value[];
               }
 
-              resultsCache.cache(
+              resultsCache.cacheValue(
                 {
                   pauseId: result.pauseId,
                   point: result.point.point,

--- a/yarn.lock
+++ b/yarn.lock
@@ -20739,7 +20739,7 @@ __metadata:
     style-loader: ^3.3.1
     stylelint: ^14.16.0
     stylelint-config-prettier: ^9.0.4
-    suspense: ^0.0.32
+    suspense: ^0.0.34
     tailwindcss: ^3.2.4
     ts-node: ^10.7.0
     tsconfig-paths: ^3.14.1
@@ -21093,7 +21093,7 @@ __metadata:
     react-dom: 0.0.0-experimental-e7d0053e6-20220325
     react-virtualized-auto-sizer: ^1.0.7
     shared: "workspace:*"
-    suspense: ^0.0.32
+    suspense: ^0.0.34
     typescript: 5.0.2
     uuid: ^7.0.3
   languageName: unknown
@@ -22904,16 +22904,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"suspense@npm:^0.0.32":
-  version: 0.0.32
-  resolution: "suspense@npm:0.0.32"
+"suspense@npm:^0.0.34":
+  version: 0.0.34
+  resolution: "suspense@npm:0.0.34"
   dependencies:
     interval-utilities: ^0.0.1
     point-utilities: ^0.0.2
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 0b2bd3370d8876721e40b81e5fb7b9daf3e3ef24b20690cafcac1c65904a2e1b17ee8d98a9608efe278127f6935ccf5d6911eef9d17a3f0afa9f860c325271a0
+  checksum: 040acff94585985fe329aaeeeb701e2a9ac73c03f674f7fbeefb80e0fe80efe7622703cc7f660fbf20c7c6feaa97b4e95a0539831c3117d203936eaf05c7d7e6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Externally managed caches (`createExternallyManagedCache`) now expose `cacheError` method (as well as `cacheValue`): https://suspense.vercel.app/createExternallyManagedCache

This may be useful for our analysis caches, specifically when there are "too many points" to run analysis.