### PR TITLE
CommandBar: resume/rewind buttons

### DIFF
--- a/packages/e2e-tests/helpers/pause-information-panel.ts
+++ b/packages/e2e-tests/helpers/pause-information-panel.ts
@@ -184,18 +184,26 @@ export async function resumeToLine(
   }
 }
 
+export async function clickCommandBarButton(page: Page, title: string): Promise<void> {
+  await debugPrint(page, title, "clickCommandBarButton");
+
+  await openPauseInformationPanel(page);
+
+  const button = page.locator(`[title="${title}"]`);
+  await button.isEnabled();
+  await button.click();
+}
+
 export async function reverseStepOver(page: Page): Promise<void> {
   await debugPrint(page, "Reverse step over", "reverseStepOver");
 
-  await openPauseInformationPanel(page);
-  await page.locator('[title="Reverse Step Over"]').click();
+  await clickCommandBarButton(page, "Reverse Step Over");
 }
 
 export async function reverseStepOverToLine(page: Page, line: number) {
   await debugPrint(page, `Reverse step over to line ${chalk.bold(line)}`, "reverseStepOverToLine");
 
-  await openPauseInformationPanel(page);
-  await page.locator('[title="Reverse Step Over"]').click();
+  await clickCommandBarButton(page, "Reverse Step Over");
 
   await waitForPaused(page, line);
 }
@@ -203,10 +211,7 @@ export async function reverseStepOverToLine(page: Page, line: number) {
 export async function rewind(page: Page) {
   await debugPrint(page, "Rewinding", "rewind");
 
-  await openPauseInformationPanel(page);
-
-  const button = page.locator('[title="Rewind Execution"]');
-  await button.click();
+  await clickCommandBarButton(page, "Rewind Execution");
 }
 
 export async function rewindToLine(
@@ -224,11 +229,8 @@ export async function rewindToLine(
     await openSource(page, url);
   }
 
-  await openPauseInformationPanel(page);
-
   while (true) {
-    const button = page.locator('[title="Rewind Execution"]');
-    await button.click();
+    await clickCommandBarButton(page, "Rewind Execution");
 
     if (lineNumber === null) {
       return;
@@ -256,8 +258,7 @@ export async function selectFrame(page: Page, index: number): Promise<void> {
 export async function stepInToLine(page: Page, line: number) {
   await debugPrint(page, `Step in to line ${chalk.bold(line)}`, "stepInToLine");
 
-  await openPauseInformationPanel(page);
-  await page.locator('[title="Step In"]').click();
+  await clickCommandBarButton(page, "Step In");
 
   await waitForPaused(page, line);
 }
@@ -265,8 +266,7 @@ export async function stepInToLine(page: Page, line: number) {
 export async function stepOutToLine(page: Page, line: number) {
   await debugPrint(page, `Step out to line ${chalk.bold(line)}`, "stepOutToLine");
 
-  await openPauseInformationPanel(page);
-  await page.locator('[title="Step Out"]').click();
+  await clickCommandBarButton(page, "Step Out");
 
   await waitForPaused(page, line);
 }
@@ -274,8 +274,7 @@ export async function stepOutToLine(page: Page, line: number) {
 export async function stepOverToLine(page: Page, line: number) {
   await debugPrint(page, `Step over to line ${chalk.bold(line)}`, "stepOverToLine");
 
-  await openPauseInformationPanel(page);
-  await page.locator('[title="Step Over"]').click();
+  await clickCommandBarButton(page, "Step Over");
 
   await waitForPaused(page, line);
 }
@@ -283,8 +282,7 @@ export async function stepOverToLine(page: Page, line: number) {
 export async function stepOver(page: Page): Promise<void> {
   await debugPrint(page, "Step over", "stepOver");
 
-  await openPauseInformationPanel(page);
-  await page.locator('[title="Step Over"]').click();
+  await clickCommandBarButton(page, "Step Over");
 }
 
 export async function verifyFramesCount(page: Page, expectedCount: number) {

--- a/packages/replay-next/src/contexts/points/hooks/useAddPoint.ts
+++ b/packages/replay-next/src/contexts/points/hooks/useAddPoint.ts
@@ -3,7 +3,7 @@ import { useCallback } from "react";
 import { v4 as uuid } from "uuid";
 
 import { TrackEvent } from "replay-next/src/contexts/SessionContext";
-import { POINT_BEHAVIOR_DISABLED, Point, PointBehavior, PointKey } from "shared/client/types";
+import { POINT_BEHAVIOR_DISABLED, Point, PointBehavior } from "shared/client/types";
 import { GraphQLClientInterface } from "shared/graphql/GraphQLClient";
 import { addPoint as addPointGraphQL } from "shared/graphql/Points";
 import { UserInfo } from "shared/graphql/types";

--- a/src/devtools/client/debugger/src/actions/pause/commands.ts
+++ b/src/devtools/client/debugger/src/actions/pause/commands.ts
@@ -11,7 +11,7 @@ export function command(cx: ThreadContext, type: ValidCommand): UIThunkAction {
     if (!type) {
       return;
     }
-    dispatch(executeCommandOperation({ cx, command: type }));
+    await dispatch(executeCommandOperation({ cx, command: type }));
   };
 }
 

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/CommandBar.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/CommandBar.tsx
@@ -182,8 +182,15 @@ function CommandBarSuspends() {
 
   return (
     <div className="command-bar">
-      <CommandBarButton key="rewind" onClick={onRewind} tooltip="Rewind Execution" type="rewind" />
       <CommandBarButton
+        disabled={disabled}
+        key="rewind"
+        onClick={onRewind}
+        tooltip="Rewind Execution"
+        type="rewind"
+      />
+      <CommandBarButton
+        disabled={disabled}
         key="resume"
         onClick={onResume}
         tooltip={`Resume ${formatKey("resume")}`}

--- a/src/devtools/client/debugger/src/components/shared/Button/CommandBarButton.tsx
+++ b/src/devtools/client/debugger/src/components/shared/Button/CommandBarButton.tsx
@@ -4,13 +4,13 @@ import { MouseEvent } from "react";
 import AccessibleImage from "../AccessibleImage";
 
 export default function CommandBarButton({
-  disabled = false,
+  disabled,
   disabledTooltip = "",
   onClick,
   tooltip,
   type,
 }: {
-  disabled?: boolean;
+  disabled: boolean;
   disabledTooltip?: string;
   onClick: (event: MouseEvent) => void;
   tooltip: string;


### PR DESCRIPTION
Disable `CommandBar` resume/rewind buttons unless paused and loaded frames.

I don't know the historical reason for why these buttons are always enabled, but the underlying Redux actions don't seem to do anything meaningful unless frame steps are available:

https://github.com/replayio/devtools/blob/44ecbe1943c7dc55d44ed56eb608dbda29afb2ea/src/devtools/client/debugger/src/reducers/pause.ts#L356-L364

Also updated the pause-info test helper to await for `button.isEnabled()` before clicking.

cc @jcmorrow 