### PR TITLE
Re-add missing MixPanel events for Console

### DIFF
--- a/packages/replay-next/components/console/ConsoleActionsRow.tsx
+++ b/packages/replay-next/components/console/ConsoleActionsRow.tsx
@@ -1,4 +1,7 @@
+import { useContext } from "react";
+
 import Icon from "replay-next/components/Icon";
+import { SessionContext } from "replay-next/src/contexts/SessionContext";
 
 import styles from "./ConsoleActionsRow.module.css";
 
@@ -15,6 +18,8 @@ export default function ConsoleActionsRow({
   setIsMenuOpen: (value: boolean) => void;
   setMenuValueHasBeenToggled: (value: boolean) => void;
 }) {
+  const { trackEvent } = useContext(SessionContext);
+
   return (
     <div className={styles.ConsoleActions}>
       <button
@@ -37,7 +42,11 @@ export default function ConsoleActionsRow({
         <button
           className={styles.DeleteTerminalExpressionButton}
           data-test-id="ClearConsoleEvaluationsButton"
-          onClick={clearConsoleEvaluations}
+          onClick={() => {
+            trackEvent("console.clear_messages");
+
+            clearConsoleEvaluations();
+          }}
           title="Clear console evaluations"
         >
           <Icon className={styles.DeleteTerminalExpressionIcon} type="delete" />

--- a/packages/replay-next/components/console/ConsoleSearch.tsx
+++ b/packages/replay-next/components/console/ConsoleSearch.tsx
@@ -1,5 +1,7 @@
 import { MutableRefObject, useContext, useState } from "react";
 
+import { SessionContext } from "replay-next/src/contexts/SessionContext";
+
 import Icon from "../Icon";
 import { ConsoleSearchContext } from "./ConsoleSearchContext";
 import styles from "./ConsoleSearch.module.css";
@@ -14,10 +16,12 @@ export default function ConsoleSearch({
   searchInputRef: MutableRefObject<HTMLInputElement | null>;
 }) {
   const [searchState, searchActions] = useContext(ConsoleSearchContext);
+  const { trackEvent } = useContext(SessionContext);
 
   const [inputFocused, setInputFocused] = useState(false);
 
   const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    trackEvent("console.search.start");
     searchActions.search(event.currentTarget.value);
   };
 

--- a/packages/replay-next/components/console/MessageHoverButton.tsx
+++ b/packages/replay-next/components/console/MessageHoverButton.tsx
@@ -43,7 +43,7 @@ export default function MessageHoverButton({
   const [isHovered, setIsHovered] = useState(false);
 
   const { inspectFunctionDefinition, showCommentsPanel } = useContext(InspectorContext);
-  const { accessToken, recordingId } = useContext(SessionContext);
+  const { accessToken, recordingId, trackEvent } = useContext(SessionContext);
   const graphQLClient = useContext(GraphQLClientContext);
   const { executionPoint: currentExecutionPoint, update } = useContext(TimelineContext);
   const { canShowConsoleAndSources } = useContext(LayoutContext);
@@ -59,10 +59,12 @@ export default function MessageHoverButton({
   let button = null;
   if (isCurrentlyPausedAt) {
     if (showAddCommentButton && accessToken && location !== null) {
-      const addCommentTransition = () => {
+      const onClick = () => {
         if (location === null) {
           return;
         }
+
+        trackEvent("console.add_comment");
 
         startTransition(async () => {
           if (showCommentsPanel !== null) {
@@ -95,7 +97,7 @@ export default function MessageHoverButton({
           className={styles.AddCommentButton}
           data-test-id="AddCommentButton"
           disabled={isPending}
-          onClick={addCommentTransition}
+          onClick={onClick}
           onMouseEnter={() => setIsHovered(true)}
           onMouseLeave={() => setIsHovered(false)}
           ref={ref}
@@ -109,6 +111,9 @@ export default function MessageHoverButton({
     const onClick = (event: MouseEvent) => {
       event.preventDefault();
       event.stopPropagation();
+
+      trackEvent("console.seek");
+      trackEvent("console.select_source");
 
       // we only want to open the source if this doesn't hide the console
       update(time, executionPoint, canShowConsoleAndSources);

--- a/packages/replay-next/components/console/Source.tsx
+++ b/packages/replay-next/components/console/Source.tsx
@@ -2,6 +2,7 @@ import { Location as ProtocolLocation } from "@replayio/protocol";
 import { MouseEvent, useContext } from "react";
 
 import { InspectorContext } from "replay-next/src/contexts/InspectorContext";
+import { SessionContext } from "replay-next/src/contexts/SessionContext";
 import { getSourceSuspends } from "replay-next/src/suspense/SourcesCache";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
@@ -16,6 +17,7 @@ export default function Source({
 }) {
   const { inspectFunctionDefinition } = useContext(InspectorContext);
   const client = useContext(ReplayClientContext);
+  const { trackEvent } = useContext(SessionContext);
 
   const location = client.getPreferredLocation(locations);
   if (location == null) {
@@ -32,6 +34,8 @@ export default function Source({
   const openSource = (event: MouseEvent) => {
     event.preventDefault();
     event.stopPropagation();
+
+    trackEvent("console.select_source");
 
     if (inspectFunctionDefinition !== null) {
       inspectFunctionDefinition([location]);

--- a/packages/replay-next/components/console/filters/EventsList.tsx
+++ b/packages/replay-next/components/console/filters/EventsList.tsx
@@ -11,6 +11,7 @@ import { STATUS_RESOLVED, useCacheStatus } from "suspense";
 
 import Loader from "replay-next/components/Loader";
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
+import { SessionContext } from "replay-next/src/contexts/SessionContext";
 import { eventCountsCache } from "replay-next/src/suspense/EventsCache";
 import type { EventCategory as EventCategoryType } from "replay-next/src/suspense/EventsCache";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
@@ -19,11 +20,15 @@ import EventCategory from "./EventCategory";
 import styles from "./EventsList.module.css";
 
 export default function EventsList() {
+  const { trackEvent } = useContext(SessionContext);
+
   const [filterByDisplayText, setFilterByDisplayText] = useState("");
   const [filterByText, setFilterByText] = useState("");
   const [isPending, startTransition] = useTransition();
 
   const onFilterTextChange = (event: ChangeEvent<HTMLInputElement>) => {
+    trackEvent("console.events.search");
+
     const newFilterByText = event.currentTarget.value;
     setFilterByDisplayText(newFilterByText);
     startTransition(() => {
@@ -58,6 +63,8 @@ function EventsListCategories({
 }) {
   const client = useContext(ReplayClientContext);
   const { range } = useContext(FocusContext);
+  const { trackEvent } = useContext(SessionContext);
+
   const pointRange = range ? { begin: range.begin.point, end: range.end.point } : null;
   const eventCategoryCounts = eventCountsCache.read(client, pointRange);
 
@@ -107,7 +114,10 @@ function EventsListCategories({
           disabled={disabled}
           eventCategory={eventCategory}
           filterByText={filterByText}
-          onChange={expanded => toggleExpanded(eventCategory.category, expanded)}
+          onChange={expanded => {
+            trackEvent("console.events.category_toggle");
+            toggleExpanded(eventCategory.category, expanded);
+          }}
         />
       ))}
       <div className={styles.Header}>Other Events</div>
@@ -118,7 +128,10 @@ function EventsListCategories({
           disabled={disabled}
           eventCategory={eventCategory}
           filterByText={filterByText}
-          onChange={expanded => toggleExpanded(eventCategory.category, expanded)}
+          onChange={expanded => {
+            trackEvent("console.events.category_toggle");
+            toggleExpanded(eventCategory.category, expanded);
+          }}
         />
       ))}
     </>

--- a/packages/replay-next/components/console/filters/FilterToggles.tsx
+++ b/packages/replay-next/components/console/filters/FilterToggles.tsx
@@ -27,9 +27,39 @@ export default function FilterToggles() {
     showWarnings,
     update,
   } = useContext(ConsoleFiltersContext);
-
+  const { trackEvent } = useContext(SessionContext);
   const replayClient = useContext(ReplayClientContext);
   const recordingCapabilities = recordingCapabilitiesCache.read(replayClient);
+
+  const onShowErrorsChange = (showErrors: boolean) => {
+    trackEvent("console.settings.toggle_errors");
+    update({ showErrors });
+  };
+
+  const onShowExceptionsChange = (showExceptions: boolean) => {
+    trackEvent("console.settings.toggle_log_exceptions");
+    update({ showExceptions });
+  };
+
+  const onShowLogsChange = (showLogs: boolean) => {
+    trackEvent("console.settings.toggle_logs");
+    update({ showLogs });
+  };
+
+  const onShowNodeModulesChange = (showNodeModules: boolean) => {
+    trackEvent("console.settings.toggle_node_modules");
+    update({ showNodeModules });
+  };
+
+  const onShowTimestampsChange = (showTimestamps: boolean) => {
+    trackEvent("console.settings.toggle_timestamp");
+    update({ showTimestamps });
+  };
+
+  const onShowWarningsChange = (showWarnings: boolean) => {
+    trackEvent("console.settings.toggle_warnings");
+    update({ showWarnings });
+  };
 
   return (
     <div className={styles.Filters} data-test-id="ConsoleFilterToggles">
@@ -41,7 +71,7 @@ export default function FilterToggles() {
         }
         checked={showExceptions}
         label="Exceptions"
-        onChange={showExceptions => update({ showExceptions })}
+        onChange={onShowExceptionsChange}
       />
       <Toggle
         afterContent={
@@ -51,7 +81,7 @@ export default function FilterToggles() {
         }
         checked={showLogs}
         label="Logs"
-        onChange={showLogs => update({ showLogs })}
+        onChange={onShowLogsChange}
       />
       <Toggle
         afterContent={
@@ -61,7 +91,7 @@ export default function FilterToggles() {
         }
         checked={showWarnings}
         label="Warnings"
-        onChange={showWarnings => update({ showWarnings })}
+        onChange={onShowWarningsChange}
       />
       <Toggle
         afterContent={
@@ -71,7 +101,7 @@ export default function FilterToggles() {
         }
         checked={showErrors}
         label="Errors"
-        onChange={showErrors => update({ showErrors })}
+        onChange={onShowErrorsChange}
       />
       {recordingCapabilities.supportsEventTypes && (
         <>
@@ -90,13 +120,9 @@ export default function FilterToggles() {
         }
         checked={showNodeModules}
         label="Node modules"
-        onChange={showNodeModules => update({ showNodeModules })}
+        onChange={onShowNodeModulesChange}
       />
-      <Toggle
-        checked={showTimestamps}
-        label="Timestamps"
-        onChange={showTimestamps => update({ showTimestamps })}
-      />
+      <Toggle checked={showTimestamps} label="Timestamps" onChange={onShowTimestampsChange} />
     </div>
   );
 }


### PR DESCRIPTION
I used Git search (`git log -S <string>`) to grep for when each of the following Mixpanel events were added to DevTools in order to re-add them with similar functionality.

| Event | Added in | Re-added?
|:--- |:--- |:---:
| `console.seek` ¹| 93d8e321d0ba3c2c268b5f064af6311e96a8535d | ✅
| `console.add_comment`| 93d8e321d0ba3c2c268b5f064af6311e96a8535d | ✅
| `console.clear_messages`| 93d8e321d0ba3c2c268b5f064af6311e96a8535d | ✅
| `console.events.category_toggle`| 93d8e321d0ba3c2c268b5f064af6311e96a8535d | ✅
| `console.events.expand` |  | ❌
| `console.events.open` ² | 93d8e321d0ba3c2c268b5f064af6311e96a8535d | ❌
| `console.events.search` ³| 93d8e321d0ba3c2c268b5f064af6311e96a8535d | ✅
| `console.events.toggle_expand` |  | ❌
| `console.search.start` ³| 93d8e321d0ba3c2c268b5f064af6311e96a8535d | ✅
| `console.seek`| 93d8e321d0ba3c2c268b5f064af6311e96a8535d | ✅
| `console.select_source` ⁴| 93d8e321d0ba3c2c268b5f064af6311e96a8535d | ✅
| `console.settings.toggle_error` ⁵ | 93d8e321d0ba3c2c268b5f064af6311e96a8535d | ❌
| `console.settings.toggle_errors`| 93d8e321d0ba3c2c268b5f064af6311e96a8535d | ✅
| `console.settings.toggle_exception` |  | ❌
| `console.settings.toggle_log_exceptions`| 93d8e321d0ba3c2c268b5f064af6311e96a8535d | ✅
| `console.settings.toggle_logs`| 93d8e321d0ba3c2c268b5f064af6311e96a8535d | ✅
| `console.settings.toggle_node_modules`| 93d8e321d0ba3c2c268b5f064af6311e96a8535d | ✅
| `console.settings.toggle_timestamp`| 93d8e321d0ba3c2c268b5f064af6311e96a8535d | ✅
| `console.settings.toggle_warn` ⁶ | 93d8e321d0ba3c2c268b5f064af6311e96a8535d | ✅

---

¹ Note this event is logged as `"console.seek"` and not `"console seek"`.
² We no longer hide events behind a toggle; if the sidebar filter is open, events are visible. So the trigger for logging this event (expanding the "Events" section) no longer exists.
³ These events used to be logged on _focus_ but now they are logged on _change_ (when a search is actual started).
⁴ This event is now logged when the "Rewind" (hover) button is clicked _as well as_ if the source location string is clicked.
⁵ This type was originally added in 2021-10-21 (93d8e321d0ba3c2c268b5f064af6311e96a8535d) as `"console.settings.toggle_error"` and later renamed on 2021-11-07 (8f1308e8a9daa16a59a74cdab5f14fa9a0cce00e) to `"console.settings.toggle_error"`; I re-added it as `"console.settings.toggle_errors"` though because the naming convention more closely matched our other events.
⁶ This event has been re-added as `"console.settings.toggle_warnings"` to better match the naming convention of our other events.