### PR TITLE
Improve stability of some e2e tests (FE-1412)

### DIFF
--- a/packages/e2e-tests/helpers/source-panel.ts
+++ b/packages/e2e-tests/helpers/source-panel.ts
@@ -159,9 +159,10 @@ export async function addLogpoint(
     content?: string;
     url?: string;
     saveAfterEdit?: boolean;
+    waitForSourceOutline?: boolean;
   }
 ): Promise<void> {
-  const { lineNumber, url } = options;
+  const { lineNumber, url, waitForSourceOutline } = options;
 
   await debugPrint(
     page,
@@ -174,6 +175,9 @@ export async function addLogpoint(
   if (url) {
     await openSourceExplorerPanel(page);
     await openSource(page, url);
+  }
+  if (waitForSourceOutline) {
+    await page.locator(".outline-list").waitFor();
   }
 
   const line = await getSourceLine(page, lineNumber);

--- a/packages/e2e-tests/tests/breakpoints-06.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-06.test.ts
@@ -15,7 +15,7 @@ test(`breakpoints-06: Test log point in a sourcemapped file`, async ({ page }) =
   await openDevToolsTab(page);
 
   // Log point added to line 15 should map to line 15
-  await addLogpoint(page, { lineNumber: 15, url: "bundle_input.js" });
+  await addLogpoint(page, { lineNumber: 15, url: "bundle_input.js", waitForSourceOutline: true });
   await checkMessageLocation(page, "bar 15", "bundle_input.js:15");
 
   // Log point added to line 17 should map to line 17

--- a/packages/e2e-tests/tests/console_warp-01.test.ts
+++ b/packages/e2e-tests/tests/console_warp-01.test.ts
@@ -23,14 +23,6 @@ test(`console_warp-01: should support warping to console messages`, async ({ pag
   await warpToMessage(page, "Number 5", 19);
   await executeAndVerifyTerminalExpression(page, "number", 5);
 
-  const target = await getRecordingTarget(page);
-  if (target == "gecko") {
-    // Initially we are paused inside the 'new Error()' call on line 19. The
-    // first reverse step takes us to the start of that line.
-    await reverseStepOverToLine(page, 19);
-  }
-
-  await reverseStepOverToLine(page, 18);
   await addBreakpoint(page, { lineNumber: 12, url });
   await rewindToLine(page, { lineNumber: 12, url });
   await executeAndVerifyTerminalExpression(page, "number", 4);
@@ -38,6 +30,7 @@ test(`console_warp-01: should support warping to console messages`, async ({ pag
   await executeAndVerifyTerminalExpression(page, "number", 5);
 
   // This error message has different text on gecko vs. chromium.
+  const target = await getRecordingTarget(page);
   const errorText =
     target == "gecko" ? "window.foo is undefined" : "Cannot set property 'bar' of undefined";
   await warpToMessage(page, errorText);

--- a/packages/e2e-tests/tests/logpoints-07.test.ts
+++ b/packages/e2e-tests/tests/logpoints-07.test.ts
@@ -21,7 +21,7 @@ test(`logpoints-07: should use the correct scope in auto-complete`, async ({ pag
   let url = "App.js";
   let lineNumber = 17;
 
-  await addLogpoint(page, { lineNumber, url });
+  await addLogpoint(page, { lineNumber, url, waitForSourceOutline: true });
   await warpToMessage(page, "update", lineNumber);
 
   // Log point should use original source (since we're viewing it)

--- a/packages/e2e-tests/tests/stepping-01.test.ts
+++ b/packages/e2e-tests/tests/stepping-01.test.ts
@@ -2,7 +2,11 @@ import test from "@playwright/test";
 
 import { openDevToolsTab, startTest } from "../helpers";
 import { executeAndVerifyTerminalExpression } from "../helpers/console-panel";
-import { reverseStepOver, rewind, stepOver } from "../helpers/pause-information-panel";
+import {
+  reverseStepOverToLine,
+  rewindToLine,
+  stepOverToLine,
+} from "../helpers/pause-information-panel";
 import { clickSourceTreeNode } from "../helpers/source-explorer-panel";
 import { addBreakpoint } from "../helpers/source-panel";
 
@@ -19,16 +23,16 @@ test("stepping-01: Test basic step-over/back functionality", async ({ page }) =>
 
   // Pause on line 20
   await addBreakpoint(page, { lineNumber: 20, url });
-  await rewind(page);
+  await rewindToLine(page, { lineNumber: 20 });
 
   // Should get ten when evaluating number.
   await executeAndVerifyTerminalExpression(page, "number", "10");
 
   // Should get nine when stepping over.
-  await reverseStepOver(page);
+  await reverseStepOverToLine(page, 19);
   await executeAndVerifyTerminalExpression(page, "number", "9");
 
   // Should get ten when stepping over.
-  await stepOver(page);
+  await stepOverToLine(page, 20);
   await executeAndVerifyTerminalExpression(page, "number", "10");
 });

--- a/packages/e2e-tests/tests/stepping-05_chromium.test.ts
+++ b/packages/e2e-tests/tests/stepping-05_chromium.test.ts
@@ -17,7 +17,7 @@ import { addBreakpoint } from "../helpers/source-panel";
 
 const url = "doc_minified_chromium.html";
 
-test(`stepping-05: Test stepping in pretty-printed code`, async ({ page }) => {
+test(`stepping-05_chromium: Test stepping in pretty-printed code`, async ({ page }) => {
   page.setDefaultTimeout(120000);
   await startTest(page, url);
   await openDevToolsTab(page);


### PR DESCRIPTION
This solves 2 timing issues in some of our e2e tests that showed up in Backend CI:
- breakpoints-06 and logpoints-07: the tests create a logpoint before the source outline has been loaded - as a result the default logpoint message contains the filename of the source instead of the name of the function in which the logpoint is created
- console_warp-01 and stepping-01: the tests step in the recording without waiting until devtools is paused at the new point - as a result the next test step is executed at the wrong pause. In console_warp-01 I removed some unnecessary test steps and in stepping-01 I replaced `rewind`/`stepOver`/`reverseStepOver` with the corresponding functions that wait until the frontend is paused at the given line
