### PR TITLE
Rewrite rewind/resumeToLine test helpers

### DIFF
--- a/packages/e2e-tests/tests/breakpoints-01.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-01.test.ts
@@ -13,24 +13,22 @@ test(`breakpoints-01: Test basic breakpoint functionality`, async ({ page }) => 
 
   await addBreakpoint(page, { lineNumber: 21, url });
 
-  await rewindToLine(page, {
-    lineNumber: 21,
-  });
+  await rewindToLine(page, 21);
   await executeAndVerifyTerminalExpression(page, "number", "10");
-  await rewindToLine(page, { lineNumber: 21 });
+  await rewindToLine(page, 21);
   await executeAndVerifyTerminalExpression(page, "number", "9");
-  await rewindToLine(page, { lineNumber: 21 });
+  await rewindToLine(page, 21);
   await executeAndVerifyTerminalExpression(page, "number", "8");
-  await rewindToLine(page, { lineNumber: 21 });
+  await rewindToLine(page, 21);
   await executeAndVerifyTerminalExpression(page, "number", "7");
-  await rewindToLine(page, { lineNumber: 21 });
+  await rewindToLine(page, 21);
   await executeAndVerifyTerminalExpression(page, "number", "6");
-  await resumeToLine(page, { lineNumber: 21 });
+  await resumeToLine(page, 21);
   await executeAndVerifyTerminalExpression(page, "number", "7");
-  await resumeToLine(page, { lineNumber: 21 });
+  await resumeToLine(page, 21);
   await executeAndVerifyTerminalExpression(page, "number", "8");
-  await resumeToLine(page, { lineNumber: 21 });
+  await resumeToLine(page, 21);
   await executeAndVerifyTerminalExpression(page, "number", "9");
-  await resumeToLine(page, { lineNumber: 21 });
+  await resumeToLine(page, 21);
   await executeAndVerifyTerminalExpression(page, "number", "10");
 });

--- a/packages/e2e-tests/tests/breakpoints-02.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-02.test.ts
@@ -15,7 +15,7 @@ test(`breakpoints-02: Test unhandled divergence while evaluating at a breakpoint
 
   await addBreakpoint(page, { lineNumber: 21, url });
 
-  await rewindToLine(page, { lineNumber: 21 });
+  await rewindToLine(page, 21);
 
   await executeAndVerifyTerminalExpression(page, "number", "10");
   await executeAndVerifyTerminalExpression(

--- a/packages/e2e-tests/tests/breakpoints-03.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-03.test.ts
@@ -15,15 +15,15 @@ test(`breakpoints-03: Test stepping forward through breakpoints when rewound bef
 
   await addBreakpoint(page, { lineNumber: 9, url });
   // Rewind to when the point was hit
-  await rewindToLine(page, { lineNumber: 9 });
+  await rewindToLine(page, 9);
   // Rewind further (past the first hit)
   await rewind(page);
 
   await removeBreakpoint(page, { lineNumber: 9, url });
 
   await addBreakpoint(page, { lineNumber: 21, url });
-  await resumeToLine(page, { lineNumber: 21 });
+  await resumeToLine(page, 21);
   await executeAndVerifyTerminalExpression(page, "number", "1");
-  await resumeToLine(page, { lineNumber: 21 });
+  await resumeToLine(page, 21);
   await executeAndVerifyTerminalExpression(page, "number", "2");
 });

--- a/packages/e2e-tests/tests/breakpoints-04.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-04.test.ts
@@ -17,8 +17,8 @@ test(`breakpoints-04: catch, finally, generators, and async/await`, async ({ pag
   await resumeToBreakpoint(page, 20);
   await resumeToBreakpoint(page, 32);
   await resumeToBreakpoint(page, 27);
-  await resumeToLine(page, { lineNumber: 32 });
-  await resumeToLine(page, { lineNumber: 27 });
+  await resumeToLine(page, 32);
+  await resumeToLine(page, 27);
   await resumeToBreakpoint(page, 42);
   await resumeToBreakpoint(page, 44);
   await resumeToBreakpoint(page, 50);
@@ -28,11 +28,11 @@ test(`breakpoints-04: catch, finally, generators, and async/await`, async ({ pag
 
   async function rewindToBreakpoint(page: Page, lineNumber: number) {
     await addBreakpoint(page, { lineNumber, url });
-    await rewindToLine(page, { lineNumber });
+    await rewindToLine(page, lineNumber);
   }
 
   async function resumeToBreakpoint(page: Page, lineNumber: number) {
     await addBreakpoint(page, { lineNumber, url });
-    await resumeToLine(page, { lineNumber });
+    await resumeToLine(page, lineNumber);
   }
 });

--- a/packages/e2e-tests/tests/breakpoints-05.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-05.test.ts
@@ -20,15 +20,15 @@ test(`breakpoints-05: Test interaction of breakpoints with debugger statements`,
   await page.locator('[data-test-id="FocusInputs"]').waitFor();
 
   // Without any breakpoints, this test should rewind to the closest debugger statement.
-  await rewindToLine(page, { lineNumber: 9 });
+  await rewindToLine(page, 9);
 
   // Without a breakpoints being the next nearest thing, we should rewind to it.
   await addBreakpoint(page, {
     lineNumber: 8,
     url,
   });
-  await rewindToLine(page, { lineNumber: 8 });
-  await resumeToLine(page, { lineNumber: 9 });
+  await rewindToLine(page, 8);
+  await resumeToLine(page, 9);
 
   // Without any breakpoints (again), we should rewind to debugger statements.
   await removeBreakpoint(page, {
@@ -36,6 +36,6 @@ test(`breakpoints-05: Test interaction of breakpoints with debugger statements`,
     url,
   });
 
-  await rewindToLine(page, { lineNumber: 7 });
-  await resumeToLine(page, { lineNumber: 9 });
+  await rewindToLine(page, 7);
+  await resumeToLine(page, 9);
 });

--- a/packages/e2e-tests/tests/breakpoints-07.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-07.test.ts
@@ -28,9 +28,9 @@ test(`breakpoints-07: rewind and seek using command bar and console messages`, a
   await addLogpoint(page, { lineNumber: 5, url: "bundle_input.js" });
 
   // Verify that the command bar can be used to fast forward and rewind to log points.
-  await rewindToLine(page, { lineNumber: 5 });
+  await rewindToLine(page, 5);
   await verifyLogpointStep(page, "2/2", { lineNumber: 5 });
-  await rewindToLine(page, { lineNumber: 5 });
+  await rewindToLine(page, 5);
   await verifyLogpointStep(page, "1/2", { lineNumber: 5 });
 
   await closeSource(page, "bundle_input.js");

--- a/packages/e2e-tests/tests/console_warp-01.test.ts
+++ b/packages/e2e-tests/tests/console_warp-01.test.ts
@@ -24,9 +24,9 @@ test(`console_warp-01: should support warping to console messages`, async ({ pag
   await executeAndVerifyTerminalExpression(page, "number", 5);
 
   await addBreakpoint(page, { lineNumber: 12, url });
-  await rewindToLine(page, { lineNumber: 12, url });
+  await rewindToLine(page, 12);
   await executeAndVerifyTerminalExpression(page, "number", 4);
-  await resumeToLine(page, { lineNumber: 12, url });
+  await resumeToLine(page, 12);
   await executeAndVerifyTerminalExpression(page, "number", 5);
 
   // This error message has different text on gecko vs. chromium.

--- a/packages/e2e-tests/tests/inspector-01.test.ts
+++ b/packages/e2e-tests/tests/inspector-01.test.ts
@@ -29,7 +29,7 @@ test("inspector-01: Test that scopes are rerendered", async ({ page }) => {
   await node.waitFor();
 
   await addBreakpoint(page, { url: "doc_inspector_basic.html", lineNumber: 9 });
-  await rewindToLine(page, { lineNumber: 9 });
+  await rewindToLine(page, 9);
 
   node = await getElementsRowWithText(page, '<div id="maindiv" style="color: red"');
   await node.waitFor();

--- a/packages/e2e-tests/tests/inspector-03.test.ts
+++ b/packages/e2e-tests/tests/inspector-03.test.ts
@@ -24,7 +24,7 @@ test("inspector-03: Test that styles for elements can be viewed", async ({ page 
   await checkComputedStyle(page, "background-color", "rgb(0, 0, 255)");
 
   await addBreakpoint(page, { url: "doc_inspector_styles.html", lineNumber: 11 });
-  await rewindToLine(page, { lineNumber: 11 });
+  await rewindToLine(page, 11);
 
   await selectElementsRowWithText(page, "maindiv");
   await checkComputedStyle(page, "background-color", "rgb(255, 0, 0)");

--- a/packages/e2e-tests/tests/logpoints-01.test.ts
+++ b/packages/e2e-tests/tests/logpoints-01.test.ts
@@ -53,5 +53,5 @@ test(`logpoints-01: log-points appear in the correct order and allow time warpin
   await executeAndVerifyTerminalExpression(page, "number", 5);
   await reverseStepOverToLine(page, 19);
 
-  await resumeToLine(page, { lineNumber: 20 });
+  await resumeToLine(page, 20);
 });

--- a/packages/e2e-tests/tests/node_control_flow.test.ts
+++ b/packages/e2e-tests/tests/node_control_flow.test.ts
@@ -7,7 +7,7 @@ import { addBreakpoint } from "../helpers/source-panel";
 
 async function resumeToBreakpoint(page: Page, line: number) {
   await addBreakpoint(page, { url: "control_flow.js", lineNumber: line });
-  await resumeToLine(page, { lineNumber: line });
+  await resumeToLine(page, line);
 }
 
 test("node_control_flow: catch, finally, generators, and async/await", async ({ page }) => {
@@ -18,7 +18,7 @@ test("node_control_flow: catch, finally, generators, and async/await", async ({ 
 
   await openSource(page, "control_flow.js");
 
-  await rewindToLine(page, { lineNumber: 84 });
+  await rewindToLine(page, 84);
 
   await resumeToBreakpoint(page, 10);
   await resumeToBreakpoint(page, 12);
@@ -27,8 +27,8 @@ test("node_control_flow: catch, finally, generators, and async/await", async ({ 
   await resumeToBreakpoint(page, 32);
   await resumeToBreakpoint(page, 27);
 
-  await resumeToLine(page, { lineNumber: 32 });
-  await resumeToLine(page, { lineNumber: 27 });
+  await resumeToLine(page, 32);
+  await resumeToLine(page, 27);
 
   await resumeToBreakpoint(page, 42);
   await resumeToBreakpoint(page, 44);

--- a/packages/e2e-tests/tests/node_worker-01.test.ts
+++ b/packages/e2e-tests/tests/node_worker-01.test.ts
@@ -14,8 +14,8 @@ test("node_worker-01: make sure node workers don't cause crashes", async ({ page
   await stepOverToLine(page, 18);
 
   await addBreakpoint(page, { url: "run_worker.js", lineNumber: 13 });
-  await rewindToLine(page, { lineNumber: 13 });
+  await rewindToLine(page, 13);
 
   await addBreakpoint(page, { url: "run_worker.js", lineNumber: 6 });
-  await rewindToLine(page, { lineNumber: 6 });
+  await rewindToLine(page, 6);
 });

--- a/packages/e2e-tests/tests/object_preview-03.test.ts
+++ b/packages/e2e-tests/tests/object_preview-03.test.ts
@@ -30,7 +30,7 @@ test(`object_preview-03: Test previews when switching between frames and steppin
   const target = await getRecordingTarget(page);
 
   await addBreakpoint(page, { lineNumber: 17, url });
-  await rewindToLine(page, { lineNumber: 17, url });
+  await rewindToLine(page, 17);
 
   await expandAllScopesBlocks(page);
 

--- a/packages/e2e-tests/tests/repaint.test.ts
+++ b/packages/e2e-tests/tests/repaint.test.ts
@@ -14,7 +14,7 @@ test("repaint: repaints the screen screen when stepping over code that modifies 
   await openDevToolsTab(page);
 
   await addBreakpoint(page, { lineNumber: 50, url });
-  await rewindToLine(page, { lineNumber: 50, url });
+  await rewindToLine(page, 50);
 
   const prevDataUrl = await getCanvasDataUrl(page);
 

--- a/packages/e2e-tests/tests/stepping-01.test.ts
+++ b/packages/e2e-tests/tests/stepping-01.test.ts
@@ -23,7 +23,7 @@ test("stepping-01: Test basic step-over/back functionality", async ({ page }) =>
 
   // Pause on line 20
   await addBreakpoint(page, { lineNumber: 20, url });
-  await rewindToLine(page, { lineNumber: 20 });
+  await rewindToLine(page, 20);
 
   // Should get ten when evaluating number.
   await executeAndVerifyTerminalExpression(page, "number", "10");

--- a/packages/e2e-tests/tests/stepping-02.test.ts
+++ b/packages/e2e-tests/tests/stepping-02.test.ts
@@ -24,7 +24,7 @@ test("stepping-02: Test fixes for some simple stepping bugs", async ({ page }) =
   await clickSourceTreeNode(page, url);
 
   await addBreakpoint(page, { lineNumber: 21, url });
-  await rewindToLine(page, { lineNumber: 21 });
+  await rewindToLine(page, 21);
 
   await stepInToLine(page, 24);
   await stepOverToLine(page, 25);

--- a/packages/e2e-tests/tests/stepping-03.test.ts
+++ b/packages/e2e-tests/tests/stepping-03.test.ts
@@ -25,7 +25,7 @@ test(`stepping-03: Stepping past the beginning or end of a frame should act like
 
   await addBreakpoint(page, { lineNumber: 20, url });
 
-  await rewindToLine(page, { lineNumber: 20 });
+  await rewindToLine(page, 20);
   await executeAndVerifyTerminalExpression(page, "number", "10");
   await reverseStepOverToLine(page, 19);
   await reverseStepOverToLine(page, 11);

--- a/packages/e2e-tests/tests/stepping-05.test.ts
+++ b/packages/e2e-tests/tests/stepping-05.test.ts
@@ -23,12 +23,12 @@ test(`stepping-05: Test stepping in pretty-printed code`, async ({ page }) => {
   await openDevToolsTab(page);
 
   await addBreakpoint(page, { url: "bundle_input.js", lineNumber: 4 });
-  await rewindToLine(page, { lineNumber: 4 });
+  await rewindToLine(page, 4);
   await stepInToLine(page, 1);
 
   // Add a breakpoint in minified.html and resume to there
   await addBreakpoint(page, { url, lineNumber: 8 });
-  await resumeToLine(page, { lineNumber: 8 });
+  await resumeToLine(page, 8);
   await stepOverToLine(page, 8);
   await stepOverToLine(page, 9);
 

--- a/packages/e2e-tests/tests/stepping-05_chromium.test.ts
+++ b/packages/e2e-tests/tests/stepping-05_chromium.test.ts
@@ -23,12 +23,12 @@ test(`stepping-05_chromium: Test stepping in pretty-printed code`, async ({ page
   await openDevToolsTab(page);
 
   await addBreakpoint(page, { url: "bundle_input.js", lineNumber: 4 });
-  await rewindToLine(page, { lineNumber: 4 });
+  await rewindToLine(page, 4);
   await stepInToLine(page, 1);
 
   // Add a breakpoint in minified.html and resume to there
   await addBreakpoint(page, { url, lineNumber: 8 });
-  await resumeToLine(page, { lineNumber: 8 });
+  await resumeToLine(page, 8);
   await stepOverToLine(page, 8);
 
   // TODO Stepping here hangs


### PR DESCRIPTION
Rewrite these test helpers to work like the other `...ToLine()` helpers:
`rewindToLine()` and `resumeToLine()` used to click the rewind/resume buttons *repeatedly* until the recording was paused at the given line number. But we didn't actually use this capability, in all our tests only one click was expected/needed. And the implementation created some flakiness (seen in Backend CI), sometimes the rewind/resume button was clicked twice.