### PR TITLE
Stream Console messages when possible

### DIFF
--- a/packages/e2e-tests/tests/focus_mode-01.test.ts
+++ b/packages/e2e-tests/tests/focus_mode-01.test.ts
@@ -38,14 +38,14 @@ test("focus_mode-01: should filter messages as regions based on the active focus
 
   // Verify fewer messages
   await verifyConsoleMessage(page, "Log point", "log-point", 17);
-  await verifyTrimmedConsoleMessages(page, { expectedBefore: 1, expectedAfter: 0 });
+  await verifyTrimmedConsoleMessages(page, { expectedBefore: 2, expectedAfter: 0 });
 
   // Set end of focus region to force-unload the end of the recording.
   await setConsoleMessageAsFocusEnd(page, await findConsoleMessage(page, "44", "log-point"));
 
   // Verify fewer messages
   await verifyConsoleMessage(page, "Log point", "log-point", 11);
-  await verifyTrimmedConsoleMessages(page, { expectedBefore: 1, expectedAfter: 1 });
+  await verifyTrimmedConsoleMessages(page, { expectedBefore: 2, expectedAfter: 1 });
 
   // Clear focus region
   await clearFocusRange(page);

--- a/packages/replay-next/components/console/ConsoleInput.module.css
+++ b/packages/replay-next/components/console/ConsoleInput.module.css
@@ -36,6 +36,12 @@
 .Input p {
   margin: 0;
 }
+.Input[data-disabled-reason="loading"] {
+  opacity: 0.5;
+}
+.Input[data-disabled-reason="not-focused"] {
+  color: var(--color-error);
+}
 
 .Icon {
   flex: 0 0 0.75rem;
@@ -54,4 +60,9 @@
   background-color: var(--background-color-error);
   border-top: 1px solid var(--border-color-error);
   color: var(--color-error);
+}
+
+.DisabledMessage {
+  text-decoration: underline;
+  cursor: pointer;
 }

--- a/packages/replay-next/components/console/ConsoleInput.tsx
+++ b/packages/replay-next/components/console/ConsoleInput.tsx
@@ -32,17 +32,33 @@ export default function ConsoleInput({ inputRef }: { inputRef?: RefObject<Impera
   const { executionPoint } = useContext(TimelineContext);
   const { enterFocusMode } = useContext(FocusContext);
 
-  if (!isPointInRegions(executionPoint, loadedRegions?.loaded ?? [])) {
+  let disabledMessage = null;
+  let disabledReason = undefined;
+  if (!isPointInRegions(executionPoint, loadedRegions?.loading ?? [])) {
+    disabledReason = "not-focused";
+    disabledMessage = (
+      <>
+        Paused outside of the{" "}
+        <span className={styles.DisabledMessage} onClick={enterFocusMode}>
+          debugging window
+        </span>
+      </>
+    );
+  } else if (!isPointInRegions(executionPoint, loadedRegions?.loaded ?? [])) {
+    disabledReason = "loading";
+    disabledMessage = <>Disabled while loading</>;
+  }
+
+  if (disabledMessage) {
     return (
-      <div className={styles.FallbackState}>
-        <Icon className={styles.Icon} type="terminal-prompt" />
-        <div>
-          Input disabled because you're paused at a point outside{" "}
-          <span className="cursor-pointer underline" onClick={enterFocusMode}>
-            your debugging window
-          </span>
-          .
+      <div className={styles.Container}>
+        <div className={styles.PromptRow}>
+          <Icon className={styles.Icon} type="terminal-prompt" />
+          <div className={styles.Input} data-disabled-reason={disabledReason}>
+            {disabledMessage}
+          </div>
         </div>
+        <div className={styles.ResultRow}> </div>
       </div>
     );
   }

--- a/packages/replay-next/components/console/MessagesList.tsx
+++ b/packages/replay-next/components/console/MessagesList.tsx
@@ -9,10 +9,9 @@ import React, {
 
 import Icon from "replay-next/components/Icon";
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
-import { SessionContext } from "replay-next/src/contexts/SessionContext";
 import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
 import useLoadedRegions from "replay-next/src/hooks/useRegions";
-import { getMessagesSuspense } from "replay-next/src/suspense/MessagesCache";
+import { useStreamingMessages } from "replay-next/src/hooks/useStreamingMessages";
 import {
   getLoggableExecutionPoint,
   isEventLog,
@@ -62,7 +61,6 @@ function MessagesList({ forwardedRef }: { forwardedRef: ForwardedRef<HTMLElement
   const replayClient = useContext(ReplayClientContext);
   const [searchState] = useContext(ConsoleSearchContext);
   const { executionPoint: currentExecutionPoint } = useContext(TimelineContext);
-  const { endpoint } = useContext(SessionContext);
 
   const loadedRegions = useLoadedRegions(replayClient);
 
@@ -82,13 +80,9 @@ function MessagesList({ forwardedRef }: { forwardedRef: ForwardedRef<HTMLElement
     return nearestLoggable || "end";
   }, [currentExecutionPoint, loggables]);
 
-  // TRICKY
-  // Message filtering is done client-side, but overflow/counts are server-side so it comes from Suspense.
-  const { countAfter, countBefore, didOverflow } = getMessagesSuspense(
-    replayClient,
-    focusRange,
-    endpoint
-  );
+  const {
+    messageMetadata: { countAfter, countBefore, didOverflow },
+  } = useStreamingMessages();
 
   // This component only needs to render a pending UI when a focus changes,
   // because this might require an async backend request.

--- a/packages/replay-next/components/console/filters/EventType.tsx
+++ b/packages/replay-next/components/console/filters/EventType.tsx
@@ -4,8 +4,7 @@ import { STATUS_PENDING, STATUS_REJECTED, useIntervalCacheStatus } from "suspens
 import { Badge, Checkbox } from "design";
 import Icon from "replay-next/components/Icon";
 import { ConsoleFiltersContext } from "replay-next/src/contexts/ConsoleFiltersContext";
-import { FocusContext } from "replay-next/src/contexts/FocusContext";
-import { SessionContext } from "replay-next/src/contexts/SessionContext";
+import { useCurrentFocusPointRange } from "replay-next/src/hooks/useCurrentFocusPointRange";
 import useTooltip from "replay-next/src/hooks/useTooltip";
 import { Event, eventsCache } from "replay-next/src/suspense/EventsCache";
 import { MAX_POINTS_TO_RUN_EVALUATION } from "shared/client/ReplayClient";
@@ -23,14 +22,14 @@ export default function EventType({
   event: Event;
 }) {
   const { eventTypesForDisplay: eventTypes, update } = useContext(ConsoleFiltersContext);
-  const { range: focusRange } = useContext(FocusContext);
   const client = useContext(ReplayClientContext);
-  const { endpoint } = useContext(SessionContext);
+
+  const focusPointRange = useCurrentFocusPointRange();
 
   const status = useIntervalCacheStatus(
     eventsCache.pointsIntervalCache,
-    BigInt(focusRange?.begin.point ?? "0"),
-    BigInt(focusRange?.end.point ?? endpoint),
+    BigInt(focusPointRange.begin),
+    BigInt(focusPointRange.end),
     client,
     event.type
   );

--- a/packages/replay-next/components/console/renderers/MessageRenderer.tsx
+++ b/packages/replay-next/components/console/renderers/MessageRenderer.tsx
@@ -3,6 +3,7 @@ import { Fragment, useMemo, useRef, useState } from "react";
 import { useLayoutEffect } from "react";
 import { Suspense, memo, useContext } from "react";
 
+import { ProtocolMessage } from "replay-next/components/console/LoggablesContext";
 import useConsoleContextMenu from "replay-next/components/console/useConsoleContextMenu";
 import ErrorBoundary from "replay-next/components/ErrorBoundary";
 import Expandable from "replay-next/components/Expandable";
@@ -12,7 +13,6 @@ import Loader from "replay-next/components/Loader";
 import { ConsoleFiltersContext } from "replay-next/src/contexts/ConsoleFiltersContext";
 import { InspectableTimestampedPointContext } from "replay-next/src/contexts/InspectorContext";
 import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
-import { ProtocolMessage } from "replay-next/src/suspense/MessagesCache";
 import { protocolValueToClientValue } from "replay-next/src/utils/protocol";
 import { formatTimestamp } from "replay-next/src/utils/time";
 

--- a/packages/replay-next/src/hooks/useCurrentFocusPointRange.ts
+++ b/packages/replay-next/src/hooks/useCurrentFocusPointRange.ts
@@ -1,0 +1,18 @@
+import { PointRange } from "@replayio/protocol";
+import { useContext, useMemo } from "react";
+
+import { FocusContext } from "replay-next/src/contexts/FocusContext";
+import { SessionContext } from "replay-next/src/contexts/SessionContext";
+
+export function useCurrentFocusPointRange(): PointRange {
+  const { range: focusRange } = useContext(FocusContext);
+  const { endpoint } = useContext(SessionContext);
+
+  return useMemo<PointRange>(
+    () => ({
+      begin: focusRange?.begin.point ?? "0",
+      end: focusRange?.end.point ?? endpoint,
+    }),
+    [endpoint, focusRange]
+  );
+}

--- a/packages/replay-next/src/hooks/useStreamingMessages.ts
+++ b/packages/replay-next/src/hooks/useStreamingMessages.ts
@@ -1,0 +1,34 @@
+import { useContext } from "react";
+import { useStreamingValue } from "suspense";
+
+import { useCurrentFocusPointRange } from "replay-next/src/hooks/useCurrentFocusPointRange";
+import { MessageMetadata, streamingMessagesCache } from "replay-next/src/suspense/MessagesCache";
+import { ReplayClientContext } from "shared/client/ReplayClientContext";
+
+const EMPTY_ARRAY: any[] = [];
+const EMPTY_MESSAGE_METADATA: MessageMetadata = {
+  categoryCounts: {
+    errors: 0,
+    logs: 0,
+    warnings: 0,
+  },
+  countAfter: 0,
+  countBefore: 0,
+  didOverflow: false,
+};
+
+export function useStreamingMessages() {
+  const replayClient = useContext(ReplayClientContext);
+
+  const focusPointRange = useCurrentFocusPointRange();
+
+  const stream = streamingMessagesCache.stream(replayClient, focusPointRange);
+  const { complete, data, status, value } = useStreamingValue(stream);
+
+  return {
+    complete,
+    messages: value ?? EMPTY_ARRAY,
+    messageMetadata: data ?? EMPTY_MESSAGE_METADATA,
+    status,
+  };
+}

--- a/packages/replay-next/src/suspense/FocusIntervalCache.ts
+++ b/packages/replay-next/src/suspense/FocusIntervalCache.ts
@@ -1,6 +1,5 @@
 import { ExecutionPoint } from "@replayio/protocol";
 import {
-  ComparisonFunction,
   GetPointForValue,
   IntervalCache,
   IntervalCacheLoadOptions,

--- a/packages/replay-next/src/suspense/MessagesCache.test.ts
+++ b/packages/replay-next/src/suspense/MessagesCache.test.ts
@@ -1,14 +1,10 @@
-import {
-  ExecutionPoint,
-  Message,
-  TimeStampedPoint,
-  TimeStampedPointRange,
-} from "@replayio/protocol";
-
-import { ReplayClientInterface } from "shared/client/types";
+import { ExecutionPoint, Message, PointRange, TimeStampedPoint } from "@replayio/protocol";
 
 import { MockReplayClientInterface, createMockReplayClient } from "../utils/testing";
-import { MessageData } from "./MessagesCache";
+import type {
+  MessageMetadata,
+  streamingMessagesCache as StreamingMessagesCache,
+} from "./MessagesCache";
 
 describe("MessagesCache", () => {
   function createM(time: number): Message {
@@ -22,21 +18,35 @@ describe("MessagesCache", () => {
     };
   }
 
-  async function getMessagesHelper(
-    range: TimeStampedPointRange | null,
-    endpoint: ExecutionPoint
-  ): Promise<MessageData> {
-    try {
-      return getMessagesSuspense(mockClient as any as ReplayClientInterface, range, endpoint);
-    } catch (promise) {
-      await promise;
+  async function getMessagesHelper(pointRange: PointRange): Promise<{
+    messageMetadata: MessageMetadata;
+    messages: Message[];
+  }> {
+    const stream = streamingMessagesCache.stream(mockClient, pointRange);
 
-      return getMessagesSuspense(mockClient as any as ReplayClientInterface, range, endpoint);
-    }
+    await stream.resolver;
+
+    return {
+      messageMetadata: stream.data!,
+      messages: stream.value!,
+    };
   }
 
-  function mockHelper(messages: Message[], overflow: boolean = false): void {
-    mockClient.findMessages.mockImplementation(() =>
+  function mockFindMessages(messages: Message[], overflow: boolean = false): void {
+    mockClient.findMessages.mockImplementation(async onMessage => {
+      if (onMessage) {
+        messages.forEach(onMessage);
+      }
+
+      return {
+        messages,
+        overflow,
+      };
+    });
+  }
+
+  function mockFindMessagesInRange(messages: Message[], overflow: boolean = false): void {
+    mockClient.findMessagesInRange.mockImplementation(() =>
       Promise.resolve({
         messages,
         overflow,
@@ -48,291 +58,156 @@ describe("MessagesCache", () => {
     return { time, point: `${time}` };
   }
 
-  function toTSPR(beginTime: number, endTime: number): TimeStampedPointRange {
-    return { begin: toTSP(beginTime), end: toTSP(endTime) };
+  function toPR(beginTime: number, endTime: number): PointRange {
+    return { begin: `${beginTime}`, end: `${endTime}` };
   }
 
   let mockClient: MockReplayClientInterface;
-  let getMessagesSuspense: (
-    client: ReplayClientInterface,
-    range: TimeStampedPointRange | null,
-    endpoint: ExecutionPoint
-  ) => Promise<MessageData>;
-  let endpoint: ExecutionPoint;
+  let streamingMessagesCache: typeof StreamingMessagesCache;
+  let endpoint: ExecutionPoint = "1000";
 
   beforeEach(async () => {
+    jest.resetModules();
+
     mockClient = createMockReplayClient();
 
     // Clear and recreate cached data between tests.
     const module = require("./MessagesCache");
-    getMessagesSuspense = module.getMessagesSuspense;
-    endpoint = (await mockClient.getSessionEndpoint()).point;
-  });
-
-  afterEach(() => {
-    jest.resetModules();
+    streamingMessagesCache = module.streamingMessagesCache;
   });
 
   it("should handle empty range", async () => {
-    const data = await getMessagesHelper(toTSPR(1, 1), "1000");
+    const data = await getMessagesHelper(toPR(1, 1));
     expect(data.messages).toEqual([]);
-    expect(mockClient.findMessages).not.toHaveBeenCalled();
+    expect(mockClient.findMessages).toHaveBeenCalledTimes(1);
+    expect(mockClient.findMessagesInRange).not.toHaveBeenCalled();
 
-    const newData = await getMessagesHelper(toTSPR(1, 1), "1000");
+    const newData = await getMessagesHelper(toPR(1, 1));
     expect(data.messages).toBe(newData.messages);
-    expect(mockClient.findMessages).not.toHaveBeenCalled();
+    expect(mockClient.findMessages).toHaveBeenCalledTimes(1);
+    expect(mockClient.findMessagesInRange).not.toHaveBeenCalled();
   });
 
   it("should handle an empty array of messages", async () => {
-    mockHelper([]);
+    mockFindMessages([]);
 
-    const data = await getMessagesHelper(toTSPR(0, 1), endpoint);
+    const data = await getMessagesHelper(toPR(0, 1));
     expect(data.messages).toEqual([]);
-    expect(data.didOverflow).toBe(false);
+    expect(data.messageMetadata.didOverflow).toBe(false);
     expect(mockClient.findMessages).toHaveBeenCalledTimes(1);
 
-    const newData = await getMessagesHelper(toTSPR(0, 1), endpoint);
-    expect(data.messages).toBe(newData.messages);
-    expect(mockClient.findMessages).toHaveBeenCalledTimes(1);
-  });
-
-  it("should reuse cached messages with a maximal focus range", async () => {
-    mockHelper([createM(0), createM(1), createM(2)]);
-
-    const data = await getMessagesHelper(toTSPR(0, +endpoint), endpoint);
-    expect(data.categoryCounts).toEqual({ errors: 0, logs: 3, warnings: 0 });
-    expect(data.countAfter).toBe(0);
-    expect(data.countBefore).toBe(0);
-    expect(data.messages!.map(({ point }) => point.time)).toEqual([0, 1, 2]);
-    expect(data.didOverflow).toBe(false);
-    expect(mockClient.findMessages).toHaveBeenCalledTimes(1);
-
-    const newData = await getMessagesHelper(toTSPR(0, +endpoint), endpoint);
+    const newData = await getMessagesHelper(toPR(0, 1));
     expect(data.messages).toBe(newData.messages);
     expect(mockClient.findMessages).toHaveBeenCalledTimes(1);
   });
 
   it("should reuse cached messages for the same focus range", async () => {
-    mockHelper([createM(0), createM(1), createM(2), createM(3)]);
+    mockFindMessages([createM(0), createM(1), createM(2), createM(3)]);
 
-    const data = await getMessagesHelper(toTSPR(1, 2), endpoint);
-    expect(data.categoryCounts).toEqual({ errors: 0, logs: 2, warnings: 0 });
-    expect(data.countAfter).toBe(-1);
-    expect(data.countBefore).toBe(-1);
+    const data = await getMessagesHelper(toPR(1, 2));
+    expect(data.messageMetadata.categoryCounts).toEqual({ errors: 0, logs: 2, warnings: 0 });
+    expect(data.messageMetadata.countAfter).toBe(1);
+    expect(data.messageMetadata.countBefore).toBe(1);
     expect(data.messages!.map(({ point }) => point.time)).toEqual([1, 2]);
-    expect(data.didOverflow).toBe(false);
+    expect(data.messageMetadata.didOverflow).toBe(false);
     expect(mockClient.findMessages).toHaveBeenCalledTimes(1);
 
-    const newData = await getMessagesHelper(toTSPR(1, 2), endpoint);
+    const newData = await getMessagesHelper(toPR(1, 2));
     expect(data.messages).toBe(newData.messages);
     expect(mockClient.findMessages).toHaveBeenCalledTimes(1);
   });
 
   it("should report overflow", async () => {
-    mockHelper([createM(1)], true);
+    mockFindMessages([createM(1)], true);
+    mockFindMessagesInRange([createM(1)], true);
 
-    const data = await getMessagesHelper(null, endpoint);
+    const data = await getMessagesHelper(toPR(0, 2));
     expect(data.messages!.map(({ point }) => point.time)).toEqual([1]);
-    expect(data.didOverflow).toBe(true);
+    expect(data.messageMetadata.didOverflow).toBe(true);
     expect(mockClient.findMessages).toHaveBeenCalledTimes(1);
   });
 
-  it("should filter within memory if focus range contracts from previously maximal", async () => {
-    mockHelper([createM(0), createM(1), createM(2), createM(3)]);
+  it("should filter within memory if non-overflowing focus range contracts", async () => {
+    mockFindMessages([createM(0), createM(1), createM(2), createM(3)]);
 
-    let data = await getMessagesHelper(toTSPR(0, +endpoint), endpoint);
+    let data = await getMessagesHelper(toPR(0, +endpoint));
     expect(data.messages!.map(({ point }) => point.time)).toEqual([0, 1, 2, 3]);
-    expect(data.categoryCounts).toEqual({ errors: 0, logs: 4, warnings: 0 });
-    expect(data.countAfter).toBe(0);
-    expect(data.countBefore).toBe(0);
+    expect(data.messageMetadata.categoryCounts).toEqual({ errors: 0, logs: 4, warnings: 0 });
+    expect(data.messageMetadata.didOverflow).toBe(false);
+    expect(data.messageMetadata.countAfter).toBe(0);
+    expect(data.messageMetadata.countBefore).toBe(0);
     expect(mockClient.findMessages).toHaveBeenCalledTimes(1);
 
-    data = await getMessagesHelper(toTSPR(1, 2), endpoint);
-    expect(data.categoryCounts).toEqual({ errors: 0, logs: 2, warnings: 0 });
-    expect(data.countAfter).toBe(1);
-    expect(data.countBefore).toBe(1);
+    data = await getMessagesHelper(toPR(1, 2));
+    expect(data.messageMetadata.categoryCounts).toEqual({ errors: 0, logs: 2, warnings: 0 });
+    expect(data.messageMetadata.didOverflow).toBe(false);
+    expect(data.messageMetadata.countAfter).toBe(1);
+    expect(data.messageMetadata.countBefore).toBe(1);
     expect(data.messages!.map(({ point }) => point.time)).toEqual([1, 2]);
     expect(mockClient.findMessages).toHaveBeenCalledTimes(1);
   });
 
-  it("should filter within memory if focus range contracts from previously focused", async () => {
-    mockHelper([createM(0), createM(1), createM(2), createM(3)]);
+  it("should filter within memory if non-overflowing focus range expands", async () => {
+    mockFindMessages([createM(0), createM(1), createM(2), createM(3)]);
 
-    let data = await getMessagesHelper(toTSPR(0, 3), endpoint);
-    expect(data.messages!.map(({ point }) => point.time)).toEqual([0, 1, 2, 3]);
-    expect(data.categoryCounts).toEqual({ errors: 0, logs: 4, warnings: 0 });
-    expect(data.countAfter).toBe(-1);
-    expect(data.countBefore).toBe(-1);
+    let data = await getMessagesHelper(toPR(1, 2));
+    expect(data.messages!.map(({ point }) => point.time)).toEqual([1, 2]);
+    expect(data.messageMetadata.didOverflow).toBe(false);
     expect(mockClient.findMessages).toHaveBeenCalledTimes(1);
 
-    data = await getMessagesHelper(toTSPR(1, 2), endpoint);
-    expect(data.messages!.map(({ point }) => point.time)).toEqual([1, 2]);
-    expect(data.categoryCounts).toEqual({ errors: 0, logs: 2, warnings: 0 });
-    expect(data.countAfter).toBe(-1);
-    expect(data.countBefore).toBe(-1);
+    data = await getMessagesHelper(toPR(0, 3));
+    expect(data.messages!.map(({ point }) => point.time)).toEqual([0, 1, 2, 3]);
+    expect(data.messageMetadata.didOverflow).toBe(false);
     expect(mockClient.findMessages).toHaveBeenCalledTimes(1);
   });
 
-  it("should re-request if focus range expands", async () => {
-    mockHelper([createM(1), createM(2)]);
+  it("should re-request if overflowing focus range contracts", async () => {
+    mockFindMessages([createM(0), createM(1)], true);
+    mockFindMessagesInRange([createM(0), createM(1), createM(2)], true);
 
-    let data = await getMessagesHelper(toTSPR(1, 2), endpoint);
-    expect(data.messages!.map(({ point }) => point.time)).toEqual([1, 2]);
+    let data = await getMessagesHelper(toPR(0, +endpoint));
+    expect(data.messages!.map(({ point }) => point.time)).toEqual([0, 1, 2]);
+    expect(data.messageMetadata.categoryCounts).toEqual({ errors: 0, logs: 3, warnings: 0 });
+    expect(data.messageMetadata.didOverflow).toBe(true);
     expect(mockClient.findMessages).toHaveBeenCalledTimes(1);
+    expect(mockClient.findMessagesInRange).toHaveBeenCalledTimes(1);
 
-    mockHelper([createM(0), createM(1), createM(2), createM(3)]);
+    mockFindMessagesInRange([createM(1), createM(2)], false);
 
-    data = await getMessagesHelper(toTSPR(0, 3), endpoint);
-    expect(data.messages!.map(({ point }) => point.time)).toEqual([0, 1, 2, 3]);
-    expect(mockClient.findMessages).toHaveBeenCalledTimes(2);
-  });
+    data = await getMessagesHelper(toPR(1, 2));
+    expect(data.messageMetadata.categoryCounts).toEqual({ errors: 0, logs: 2, warnings: 0 });
 
-  it("should re-request if focus range expands to null", async () => {
-    mockHelper([createM(1), createM(2)]);
-
-    let data = await getMessagesHelper(toTSPR(1, 2), endpoint);
+    expect(data.messageMetadata.didOverflow).toBe(false);
     expect(data.messages!.map(({ point }) => point.time)).toEqual([1, 2]);
     expect(mockClient.findMessages).toHaveBeenCalledTimes(1);
-
-    mockHelper([createM(0), createM(1), createM(2), createM(3)]);
-
-    data = await getMessagesHelper(null, endpoint);
-    expect(data.messages!.map(({ point }) => point.time)).toEqual([0, 1, 2, 3]);
-    expect(mockClient.findMessages).toHaveBeenCalledTimes(2);
+    expect(mockClient.findMessagesInRange).toHaveBeenCalledTimes(2);
   });
 
-  it("should always re-request if focus region changes after overflow", async () => {
-    mockHelper([createM(1)], true);
+  it("should re-request if overflowing focus range expands", async () => {
+    mockFindMessages([createM(0), createM(1)], true);
+    mockFindMessagesInRange([createM(1), createM(2)], true);
 
-    let data = await getMessagesHelper(toTSPR(0, 3), endpoint);
-    expect(data.messages!.map(({ point }) => point.time)).toEqual([1]);
-    expect(data.didOverflow).toBe(true);
+    let data = await getMessagesHelper(toPR(1, 2));
+    expect(data.messages!.map(({ point }) => point.time)).toEqual([1, 2]);
+
+    expect(data.messageMetadata.didOverflow).toBe(true);
     expect(mockClient.findMessages).toHaveBeenCalledTimes(1);
 
-    data = await getMessagesHelper(toTSPR(1, 3), endpoint);
-    expect(data.messages!.map(({ point }) => point.time)).toEqual([1]);
-    expect(data.didOverflow).toBe(true);
-    expect(mockClient.findMessages).toHaveBeenCalledTimes(2);
+    mockFindMessagesInRange([createM(0), createM(1), createM(2)], true);
+    data = await getMessagesHelper(toPR(0, 3));
+    expect(data.messages!.map(({ point }) => point.time)).toEqual([0, 1, 2]);
 
-    data = await getMessagesHelper(toTSPR(1, 2), endpoint);
-    expect(data.messages!.map(({ point }) => point.time)).toEqual([1]);
-    expect(data.didOverflow).toBe(true);
-    expect(mockClient.findMessages).toHaveBeenCalledTimes(3);
-  });
-
-  it("should ignore a protocol response if a newer request is in-flight", async () => {
-    let resolvePromise1: any;
-    let resolvePromise2: any;
-
-    const promise1: ReturnType<typeof mockClient.findMessages> = new Promise(resolve => {
-      resolvePromise1 = () =>
-        resolve({
-          messages: [createM(0), createM(1)],
-          overflow: false,
-        });
-    });
-    const promise2: ReturnType<typeof mockClient.findMessages> = new Promise(resolve => {
-      resolvePromise2 = () =>
-        resolve({
-          messages: [createM(2), createM(3)],
-          overflow: false,
-        });
-    });
-
-    mockClient.findMessages.mockImplementation(() => promise1);
-    try {
-      getMessagesSuspense(mockClient as any as ReplayClientInterface, toTSPR(0, 1), endpoint);
-    } catch (promise) {}
+    expect(data.messageMetadata.didOverflow).toBe(true);
     expect(mockClient.findMessages).toHaveBeenCalledTimes(1);
-
-    mockClient.findMessages.mockImplementation(() => promise2);
-    try {
-      getMessagesSuspense(mockClient as any as ReplayClientInterface, toTSPR(2, 3), endpoint);
-    } catch (promise) {}
-    expect(mockClient.findMessages).toHaveBeenCalledTimes(2);
-
-    resolvePromise2();
-    await promise2;
-
-    resolvePromise1();
-    await promise1;
-
-    const data = await getMessagesHelper(toTSPR(2, 3), endpoint);
-    expect(data.messages!.map(({ point }) => point.time)).toEqual([2, 3]);
-    expect(mockClient.findMessages).toHaveBeenCalledTimes(2);
-  });
-
-  it("should re-use the in-flight promise if the same focus range is specified", async () => {
-    const promise: ReturnType<typeof mockClient.findMessages> = Promise.resolve({
-      messages: [],
-      overflow: false,
-    });
-
-    mockClient.findMessages.mockImplementation(() => promise);
-
-    getMessagesHelper(toTSPR(0, 1), endpoint);
-    getMessagesHelper(toTSPR(0, 1), endpoint);
-    getMessagesHelper(toTSPR(0, 1), endpoint);
-
-    expect(mockClient.findMessages).toHaveBeenCalledTimes(1);
-
-    getMessagesHelper(null, endpoint);
-    getMessagesHelper(null, endpoint);
-
-    expect(mockClient.findMessages).toHaveBeenCalledTimes(2);
   });
 
   it("should catch errors and report them in the response data", async () => {
-    const error = new Error("Expected");
-
-    mockClient.findMessages.mockImplementation(() => {
-      throw error;
-    });
-
-    console.error = jest.fn();
-
-    const response = await getMessagesHelper(toTSPR(0, 1), endpoint);
-    expect(response.didError).toBe(true);
-    expect(response.error).toBe(error);
-    expect(response.messages).toBe(null);
-    expect(console.error).toHaveBeenCalledTimes(1);
-  });
-
-  it("should not continue to re-request the same messages after a failure", async () => {
     mockClient.findMessages.mockImplementation(() => {
       throw new Error("Expected");
     });
 
     console.error = jest.fn();
 
-    try {
-      await getMessagesHelper(toTSPR(0, 1), endpoint);
-    } catch (error) {}
-    expect(mockClient.findMessages).toHaveBeenCalledTimes(1);
-    expect(console.error).toHaveBeenCalled();
-
-    try {
-      await getMessagesHelper(toTSPR(0, 1), endpoint);
-    } catch (error) {}
-    expect(mockClient.findMessages).toHaveBeenCalledTimes(1);
-  });
-
-  it("should re-request messages after a failure if parameters change", async () => {
-    mockClient.findMessages.mockImplementation(() => {
-      throw new Error("Expected");
-    });
-
-    console.error = jest.fn();
-
-    try {
-      await getMessagesHelper(toTSPR(0, 1), endpoint);
-    } catch (error) {}
-    expect(mockClient.findMessages).toHaveBeenCalledTimes(1);
-    expect(console.error).toHaveBeenCalled();
-
-    try {
-      await getMessagesHelper(toTSPR(0, 2), endpoint);
-    } catch (error) {}
-    expect(mockClient.findMessages).toHaveBeenCalledTimes(2);
+    await expect(async () => await getMessagesHelper(toPR(0, 1))).rejects.toThrow("Expected");
   });
 });

--- a/packages/replay-next/src/suspense/MessagesCache.ts
+++ b/packages/replay-next/src/suspense/MessagesCache.ts
@@ -1,19 +1,18 @@
-import { ExecutionPoint, Message, TimeStampedPointRange } from "@replayio/protocol";
-import { Deferred, createDeferred } from "suspense";
+import { Message, PointRange } from "@replayio/protocol";
+import {
+  IntervalCacheLoadOptions,
+  StreamingValue,
+  createIntervalCache,
+  createStreamingCache,
+} from "suspense";
 
-import { ReplayClientInterface } from "../../../shared/client/types";
-import { isFirefoxInternalMessage } from "../utils/messages";
 import {
   isExecutionPointsGreaterThan,
   isExecutionPointsLessThan,
-  isRangeEqual,
-  isRangeSubset,
-} from "../utils/time";
-import { cachePauseData } from "./PauseCache";
+} from "replay-next/src/utils/time";
+import type { ReplayClientInterface } from "shared/client/types";
 
-export type ProtocolMessage = Message & {
-  type: "ProtocolMessage";
-};
+import { cachePauseData } from "./PauseCache";
 
 export type CategoryCounts = {
   errors: number;
@@ -21,274 +20,238 @@ export type CategoryCounts = {
   warnings: number;
 };
 
-export type MessageData = {
+export type MessageMetadata = {
   categoryCounts: CategoryCounts;
   countAfter: number;
   countBefore: number;
-  didError: boolean;
   didOverflow: boolean;
-  error: Error | null;
-  messages: ProtocolMessage[] | null;
 };
 
-const EMPTY_ARRAY: any[] = [];
+const findMessagesInRangeIntervalCache = createIntervalCache<
+  bigint,
+  [client: ReplayClientInterface],
+  Message
+>({
+  debugLabel: "Console.findMessagesInRange",
+  load: async (
+    begin: BigInt,
+    end: BigInt,
+    client: ReplayClientInterface,
+    options: IntervalCacheLoadOptions<Message>
+  ) => {
+    const { messages, overflow } = await client.findMessagesInRange({
+      begin: begin.toString(),
+      end: end.toString(),
+    });
+    return overflow ? options.returnAsPartial(messages) : messages;
+  },
+  getPointForValue: (value: Message): bigint => {
+    return BigInt(value.point.point);
+  },
+});
 
-// TODO Should I use React's Suspense cache APIs here?
-// It's tempting to think that I don't need to, because the recording session data is global,
-// but could this cause problems if React wants to render a high-priority update while a lower one is suspended?
-
-let inFlightDeferred: Deferred<ProtocolMessage[] | null> | null = null;
-let inFlightFocusRange: TimeStampedPointRange | null = null;
-
-let lastFetchDidOverflow: boolean = false;
-let lastFetchError: any | null = null;
-let lastFetchedFocusRange: TimeStampedPointRange | null = null;
-let lastFetchedMessages: ProtocolMessage[] | null = null;
-
-let lastFilteredCategoryCounts: CategoryCounts | null = null;
-let lastFilteredCountAfter: number = 0;
-let lastFilteredCountBefore: number = 0;
-let lastFilteredFocusRange: TimeStampedPointRange | null = null;
-let lastFilteredMessages: ProtocolMessage[] | null = null;
-
-// Synchronously returns an array of filtered Messages,
-// or throws a Deferred to be resolved once messages have been fetched.
-//
-// This method is Suspense friendly; it is meant to be called from a React component during render.
-export function getMessagesSuspense(
-  client: ReplayClientInterface,
-  focusRange: TimeStampedPointRange | null,
-  recordingEndpoint: ExecutionPoint
-): MessageData {
-  if (focusRange !== null && focusRange.begin.point === focusRange.end.point) {
-    // Edge case scenario handling.
-    // The backend throws if both points in a range are the same.
-    // Arguably it should handle this more gracefully by just returning an empty array but...
-    return {
-      categoryCounts: {
-        errors: 0,
-        logs: 0,
-        warnings: 0,
-      },
-      countAfter: -1,
-      countBefore: -1,
-      didError: false,
-      didOverflow: false,
-      error: null,
-      messages: EMPTY_ARRAY,
-    };
+const findMessagesStreamingCache = createStreamingCache<
+  [client: ReplayClientInterface],
+  Message[],
+  {
+    overflow: boolean;
   }
+>({
+  debugLabel: "Console.findMessages",
+  getKey: () => "global",
+  load: async (options, client) => {
+    const { update, reject, resolve, signal } = options;
 
-  if (inFlightDeferred !== null) {
-    // If we're already fetching this data, rethrow the same Deferred (for Suspense reasons).
-    // We check equality here rather than subset because it's possible a larger range might overflow.
-    if (isRangeEqual(inFlightFocusRange, focusRange)) {
-      throw inFlightDeferred.promise;
-    }
-  }
+    let messages: Message[] = [];
 
-  // We only need to refetch data if one of the following conditions is true.
-  let shouldFetch = false;
-  if (lastFetchError !== null) {
-    if (!isRangeEqual(lastFetchedFocusRange, focusRange)) {
-      shouldFetch = true;
-    }
-  } else {
-    if (lastFetchedMessages === null) {
-      // We have not yet fetched it at all.
-      shouldFetch = true;
-    } else if (lastFetchDidOverflow && !isRangeEqual(lastFetchedFocusRange, focusRange)) {
-      // The most recent time we fetched it "overflowed" (too many messages to send them all),
-      // and we're trying to fetch a different region.
-      //
-      // There are two things to note about this case.
-      // 1. When devtools is first opened, there is no focused region.
-      //    This is equivalent to focusing on the entire timeline, so we often won't need to refetch messages when focusing for the first time.
-      // 2. We shouldn't compare the new focus region to the most recent focus region,
-      //    but rather to the most recent focus region that we fetched messages for (the entire timeline in many cases).
-      //    If we don't need to refetch after zooming in, then we won't need to refetch after zooming back out either,
-      //    (unless our fetches have overflowed at some point).
-      shouldFetch = true;
-    } else if (!isRangeSubset(lastFetchedFocusRange, focusRange)) {
-      // The new focus region is outside of the most recent region we fetched messages for.
-      shouldFetch = true;
-    }
-  }
+    try {
+      const { overflow } = await client.findMessages(message => {
+        cachePauseData(client, message.pauseId, message.data);
 
-  if (shouldFetch) {
-    inFlightFocusRange = focusRange;
-
-    const deferred = (inFlightDeferred = createDeferred(
-      `getMessagesSuspense: ${
-        focusRange ? `${focusRange.begin.point}-${focusRange.end.point}` : "-"
-      }`
-    ));
-
-    fetchMessages(client, focusRange, deferred);
-
-    if (inFlightDeferred) {
-      throw inFlightDeferred.promise;
-    }
-  }
-
-  if (lastFetchError) {
-    return {
-      categoryCounts: {
-        errors: 0,
-        logs: 0,
-        warnings: 0,
-      },
-      countAfter: -1,
-      countBefore: -1,
-      didError: true,
-      didOverflow: false,
-      error: lastFetchError,
-      messages: null,
-    };
-  }
-
-  // TODO (FE-533) Filter Firefox internal browser exceptions (see isFirefoxInternalMessage)
-
-  // At this point, messages have been fetched but we may still need to filter them.
-  // For performance reasons (both in this function and on things that consume the filtered list)
-  // it's best if we memoize this operation (by comparing ranges) to avoid recreating the filtered array.
-  if (lastFilteredMessages === null || !isRangeEqual(lastFilteredFocusRange, focusRange)) {
-    if (focusRange === null) {
-      lastFilteredFocusRange = null;
-      lastFilteredCountAfter = 0;
-      lastFilteredCountBefore = 0;
-
-      // HACK
-      // Even if we aren't focused, the frontend needs to filter out Firefox internal messages.
-      // This is something the runtime should probably do.
-      // See BAC-2063
-      lastFilteredMessages = lastFetchedMessages!.filter(
-        message => !isFirefoxInternalMessage(message)
-      );
-    } else {
-      const beginPoint = focusRange.begin.point;
-      const endPoint = focusRange.end.point;
-
-      lastFilteredFocusRange = focusRange;
-      lastFilteredCountAfter = 0;
-      lastFilteredCountBefore = 0;
-      lastFilteredMessages = lastFetchedMessages!.filter(message => {
-        // HACK See BAC-2063
-        if (isFirefoxInternalMessage(message)) {
+        if (signal.aborted) {
           return false;
         }
 
-        const point = message.point.point;
-        if (isExecutionPointsLessThan(point, beginPoint)) {
-          lastFilteredCountBefore++;
-          return false;
-        } else if (isExecutionPointsGreaterThan(point, endPoint)) {
-          lastFilteredCountAfter++;
-          return false;
-        } else {
-          return true;
-        }
+        messages = messages.concat(message);
+
+        update(messages);
+
+        return true;
       });
-    }
 
+      if (!signal.aborted) {
+        update(messages, undefined, { overflow });
+        resolve();
+      }
+    } catch (error) {
+      if (!signal.aborted) {
+        reject(error);
+      }
+    }
+  },
+});
+
+let stream: StreamingValue<
+  Message[],
+  {
+    overflow: boolean;
+  }
+> | null = null;
+
+// Composite cache that loads Messages as efficiently as possible for the common case recording
+// First it tries to load them from the streaming Console.findMessages API (findMessagesStreamingCache)
+// If results are found, they are filtered in-memory before being returned
+// If results overflowed, the Console.findMessagesInRange API is used (findMessagesInRangeIntervalCache)
+export const streamingMessagesCache = createStreamingCache<
+  [client: ReplayClientInterface, pointRange: PointRange],
+  Message[],
+  MessageMetadata
+>({
+  debugLabel: "Messages (composite cache)",
+  getKey: (client, pointRange) => `${pointRange.begin}-${pointRange.end}`,
+  load: async (options, client, pointRange) => {
+    const { update, reject, resolve, signal } = options;
+
+    const begin = BigInt(pointRange.begin);
+    const end = BigInt(pointRange.end);
+
+    let countAfter = 0;
+    let countBefore = 0;
+    let didOverflow = false;
     let errors = 0;
     let logs = 0;
+    let messages: Message[] = [];
+    let unsubscribe: Function | null = null;
     let warnings = 0;
 
-    lastFilteredMessages!.forEach(message => {
-      switch (message.level) {
-        case "assert":
-        case "info":
-        case "trace":
-          logs++;
-          break;
-        case "error":
-          errors++;
-          break;
-        case "warning":
-          warnings++;
-          break;
+    try {
+      if (stream === null) {
+        stream = findMessagesStreamingCache.stream(client);
       }
-    });
 
-    lastFilteredCategoryCounts = {
-      errors,
-      logs,
-      warnings,
-    };
-  }
+      // If the streaming API has already overflowed, we can skip it.
+      // This avoids having to unnecessarily filter messages in memory.
+      if (!stream.data || !stream.data.overflow) {
+        let startIndex = 0;
 
-  // Note that the only time when it's safe for us to specify the number of trimmed messages
-  // is when we are trimming from the complete set of messages.
-  // Otherwise even if we do trim some messages locally, the number isn't meaningful.
-  const allMessagesFetched =
-    lastFetchedFocusRange &&
-    lastFetchedFocusRange.begin.point === "0" &&
-    lastFetchedFocusRange.end.point === recordingEndpoint;
-  return {
-    categoryCounts: lastFilteredCategoryCounts!,
-    countAfter: allMessagesFetched ? lastFilteredCountAfter : -1,
-    countBefore: allMessagesFetched ? lastFilteredCountBefore : -1,
-    didOverflow: lastFetchDidOverflow,
-    didError: false,
-    error: null,
-    messages: lastFilteredMessages!,
-  };
-}
+        const processPendingMessages = () => {
+          const newMessages: Message[] = [];
+          if (stream && stream.value) {
+            // Process new messages; filter for the specified range.
+            for (let index = startIndex; index < stream.value.length; index++) {
+              const message = stream.value[index];
 
-async function fetchMessages(
-  client: ReplayClientInterface,
-  focusRange: TimeStampedPointRange | null,
-  deferred: Deferred<ProtocolMessage[] | null>
-) {
-  try {
-    const { messages, overflow } = await client.findMessages(focusRange);
+              const executionPoints = message.point.point;
+              if (isExecutionPointsLessThan(executionPoints, pointRange.begin)) {
+                countBefore++;
+              } else if (isExecutionPointsGreaterThan(executionPoints, pointRange.end)) {
+                countAfter++;
+              } else {
+                newMessages.push(message);
 
-    const protocolMessage: ProtocolMessage[] = messages.map(message => ({
-      ...message,
-      type: "ProtocolMessage",
-    }));
+                switch (message.level) {
+                  case "assert":
+                  case "info":
+                  case "trace":
+                    logs++;
+                    break;
+                  case "error":
+                    errors++;
+                    break;
+                  case "warning":
+                    warnings++;
+                    break;
+                }
+              }
+            }
 
-    // Only update cached values if this request hasn't been superceded by a newer one.
-    //
-    // TODO In the future we could merge new messages over time (assuming no overflow)
-    // to avoid re-fetching previously fetched ranges if a user scrubs around with the focus UI.
-    // We'd have to be careful though to only merge data from overlapping points,
-    // so that we didn't omit messages that happened between points.
-    // I'm still a little unclear on the exact relationship between time and point.
-    if (inFlightDeferred === deferred) {
-      inFlightDeferred = null;
+            if (newMessages.length) {
+              // We use .concat() instead of .push() intentionally
+              // so that updates will trigger React renders
+              messages = messages.concat(...newMessages);
+            }
 
-      lastFetchDidOverflow = overflow;
-      lastFetchError = null;
-      lastFetchedFocusRange = focusRange;
-      lastFetchedMessages = protocolMessage;
+            startIndex = stream.value.length;
+
+            update(messages, undefined, {
+              categoryCounts: { errors, logs, warnings },
+              countBefore,
+              countAfter,
+              didOverflow,
+            });
+          }
+        };
+
+        unsubscribe = stream.subscribe(processPendingMessages);
+
+        await stream.resolver;
+
+        unsubscribe();
+        unsubscribe = null;
+
+        processPendingMessages();
+      }
+
+      if (!stream.data?.overflow) {
+        // If data still hasn't overflowed, we're done.
+        if (!signal.aborted) {
+          resolve();
+        }
+        return;
+      }
+
+      // If we've made it this far, the streaming API has overflowed.
+      // We need to fall back to the non-streaming API.
+      messages = await findMessagesInRangeIntervalCache.readAsync(begin, end, client);
+      didOverflow = findMessagesInRangeIntervalCache.isPartialResult(messages);
+
+      if (!signal.aborted) {
+        update(messages, undefined, {
+          categoryCounts: getCategoryCounts(messages),
+          didOverflow,
+
+          // There's no way to know these counts when we're using the range API
+          countBefore: 0,
+          countAfter: 0,
+        });
+        resolve();
+      }
+    } catch (error) {
+      if (!signal.aborted) {
+        reject(error);
+      }
+    } finally {
+      if (unsubscribe) {
+        unsubscribe();
+      }
     }
+  },
+});
 
-    messages.forEach(message => {
-      cachePauseData(client, message.pauseId, message.data);
-    });
+function getCategoryCounts(messages: Message[]): CategoryCounts {
+  let errors = 0;
+  let logs = 0;
+  let warnings = 0;
 
-    deferred.resolve(protocolMessage);
-  } catch (error) {
-    inFlightFocusRange = null;
-    inFlightDeferred = null;
+  messages.forEach(message => {
+    switch (message.level) {
+      case "assert":
+      case "info":
+      case "trace":
+        logs++;
+        break;
+      case "error":
+        errors++;
+        break;
+      case "warning":
+        warnings++;
+        break;
+    }
+  });
 
-    console.error("getMessage() Error for range", printPointRange(focusRange), error);
-
-    lastFetchDidOverflow = false;
-    lastFetchError = error;
-    lastFetchedFocusRange = focusRange;
-    lastFetchedMessages = null;
-
-    deferred.resolve(null);
-  }
-}
-
-function printPointRange(focusRange: TimeStampedPointRange | null): string {
-  if (focusRange === null) {
-    return "null";
-  } else {
-    return `${focusRange.begin.time}:${focusRange.end.time} (${focusRange.begin.point}:${focusRange.end.point})`;
-  }
+  return {
+    errors,
+    logs,
+    warnings,
+  };
 }

--- a/packages/replay-next/src/suspense/MessagesCache.ts
+++ b/packages/replay-next/src/suspense/MessagesCache.ts
@@ -189,6 +189,9 @@ export const streamingMessagesCache = createStreamingCache<
         unsubscribe();
         unsubscribe = null;
 
+        // If this cache is re-running after the streaming API has already resolved,
+        // the on-change subscription won't have fired;
+        // in that we should process any pending/missed messages before continuing.
         processPendingMessages();
       }
 

--- a/packages/replay-next/src/utils/loggables.ts
+++ b/packages/replay-next/src/utils/loggables.ts
@@ -1,11 +1,11 @@
 import { ExecutionPoint } from "@replayio/protocol";
 
 import { Loggable } from "replay-next/components/console/LoggablesContext";
+import { ProtocolMessage } from "replay-next/components/console/LoggablesContext";
 import { PointInstance } from "replay-next/src/contexts/points/types";
 import { TerminalExpression } from "replay-next/src/contexts/TerminalContext";
 import { EventLog } from "replay-next/src/suspense/EventsCache";
 import { UncaughtException } from "replay-next/src/suspense/ExceptionsCache";
-import { ProtocolMessage } from "replay-next/src/suspense/MessagesCache";
 
 import { compareExecutionPoints } from "./time";
 

--- a/packages/replay-next/src/utils/messages.ts
+++ b/packages/replay-next/src/utils/messages.ts
@@ -1,4 +1,4 @@
-import { ProtocolMessage } from "replay-next/src/suspense/MessagesCache";
+import { ProtocolMessage } from "replay-next/components/console/LoggablesContext";
 import { getSourceIfCached } from "replay-next/src/suspense/SourcesCache";
 
 // Messages with pages that match this expression are internal Firefox errors and we should not display them.

--- a/packages/replay-next/src/utils/testing.tsx
+++ b/packages/replay-next/src/utils/testing.tsx
@@ -186,12 +186,17 @@ export function createMockReplayClient() {
     before: { point: String(time), time },
     after: { point: String(time), time },
   }));
-  mockClient.getPointNearTime.mockImplementation(async time => ({ point: String(time), time })),
-    mockClient.getSessionEndpoint.mockImplementation(async () => ({
-      point: "1000",
-      time: 1000,
-    }));
+  mockClient.getPointNearTime.mockImplementation(async time => ({ point: String(time), time }));
+  mockClient.getSessionEndpoint.mockImplementation(async () => ({
+    point: "1000",
+    time: 1000,
+  }));
   mockClient.findKeyboardEvents.mockImplementation(async () => {});
+  mockClient.findMessages.mockImplementation(async () => ({ messages: [], overflow: false }));
+  mockClient.findMessagesInRange.mockImplementation(async () => ({
+    messages: [],
+    overflow: false,
+  }));
   mockClient.findNavigationEvents.mockImplementation(async () => {});
   mockClient.findSources.mockImplementation(async () => []);
   mockClient.removeEventListener.mockImplementation(() => {});

--- a/packages/shared/client/types.ts
+++ b/packages/shared/client/types.ts
@@ -153,7 +153,11 @@ export interface ReplayClientInterface {
     frameId: FrameId | null
   ): Promise<EvaluationResult>;
   findKeyboardEvents(onKeyboardEvents: (events: keyboardEvents) => void): Promise<void>;
-  findMessages(focusRange: TimeStampedPointRange | null): Promise<{
+  findMessages(onMessage?: (message: Message) => void): Promise<{
+    messages: Message[];
+    overflow: boolean;
+  }>;
+  findMessagesInRange(focusRange: PointRange): Promise<{
     messages: Message[];
     overflow: boolean;
   }>;


### PR DESCRIPTION
## [Loom overview video](https://www.loom.com/share/fdbec033ade0451ba7c7d88357dd62b3)

In this video, we compare production Console loading times to development loading times with the new streaming behavior introduced in this PR. In this case we see the following results:

| Feature | production | development |
|:---|:---:|:---:|
| Console visible | 0:28 | 0:02 |
| First message(s) | 0:28 | 0:06 |

Here's a shorter video that shows how long it takes to load console messages for a fresh controller:

https://user-images.githubusercontent.com/29597/234404161-58984e33-27f8-4134-af48-fac96a9a828e.mp4

And here's messages loading with a reused controller:

https://user-images.githubusercontent.com/29597/234404558-cc77e5a1-9dac-43eb-915c-f7308169829a.mp4

- [x] Add new Console messages Suspense cache that...
  - [x] Attempts to stream (`Console.findMessages`) messages when possible and
  - [x] Falls back to the slower, blocking API (`Console.findMessagesInRange`) if needed
- [x] Tests
  - [x] Update `MessagesCache.test` since that cache has changed so much (hopefully rebase on top of #9101)
  - [x] Update e2e tests
  - [x] ~~Update screenshot e2e test fixture data~~