### PR TITLE
Jest mock extendded

### DIFF
--- a/packages/replay-next/package.json
+++ b/packages/replay-next/package.json
@@ -16,6 +16,7 @@
     "design": "workspace:*",
     "escape-html": "^1.0.3",
     "idb": "^7.1.1",
+    "jest-mock-extended": "^3.0.4",
     "lodash": "^4.17.21",
     "next": "^13.2",
     "pretty-ms": "^7.0.1",

--- a/packages/replay-next/src/suspense/SourceHitCountsCache.test.ts
+++ b/packages/replay-next/src/suspense/SourceHitCountsCache.test.ts
@@ -3,7 +3,7 @@ import { IntervalCache } from "suspense";
 
 import { LineHitCounts, ReplayClientInterface, SourceLocationRange } from "shared/client/types";
 
-import { createMockReplayClient } from "../utils/testing";
+import { MockReplayClientInterface, createMockReplayClient } from "../utils/testing";
 
 const DEFAULT_SOURCE_ID = "fake-source-id";
 const DEFAULT_FOCUS_RANGE = {
@@ -12,7 +12,7 @@ const DEFAULT_FOCUS_RANGE = {
 };
 
 describe("SourceHitCountsCache", () => {
-  let mockClient: { [key: string]: jest.Mock };
+  let mockClient: MockReplayClientInterface;
   let replayClient: ReplayClientInterface;
 
   let sourceHitCountsCache: IntervalCache<
@@ -22,7 +22,7 @@ describe("SourceHitCountsCache", () => {
   >;
 
   beforeEach(() => {
-    mockClient = createMockReplayClient() as any;
+    mockClient = createMockReplayClient();
     replayClient = mockClient as any as ReplayClientInterface;
 
     // Clear and recreate cached data between tests.

--- a/packages/replay-next/src/utils/testing.tsx
+++ b/packages/replay-next/src/utils/testing.tsx
@@ -1,5 +1,6 @@
 import { RenderResult, act, render as rtlRender } from "@testing-library/react";
 import fetch from "isomorphic-fetch";
+import { mock } from "jest-mock-extended";
 import { ReactNode } from "react";
 
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
@@ -173,70 +174,5 @@ export function setupWindow(): void {
 // This mock client is mostly useless by itself,
 // but its methods can be overridden individually (or observed/inspected) by test code.
 export function createMockReplayClient() {
-  return {
-    get loadedRegions() {
-      return null;
-    },
-    addEventListener: jest.fn(),
-    breakpointAdded: jest.fn(),
-    breakpointRemoved: jest.fn(),
-    configure: jest.fn().mockImplementation(async () => {}),
-    createPause: jest.fn().mockImplementation(async () => ({
-      frames: [],
-      data: {},
-    })),
-    evaluateExpression: jest.fn().mockImplementation(async () => ({ data: {} })),
-    findKeyboardEvents: jest.fn().mockImplementation(async () => []),
-    findMessages: jest.fn().mockImplementation(async () => ({ messages: [], overflow: false })),
-    findNavigationEvents: jest.fn().mockImplementation(async () => []),
-    findNetworkRequests: jest.fn().mockImplementation(async () => undefined),
-    findPoints: jest.fn().mockImplementation(async () => []),
-    findSources: jest.fn().mockImplementation(async () => []),
-    getAllFrames: jest.fn().mockImplementation(async () => ({ frames: [], data: {} })),
-    getAnnotationKinds: jest.fn().mockImplementation(async () => []),
-    getBuildId: jest.fn().mockImplementation(async () => ""),
-    getBreakpointPositions: jest.fn().mockImplementation(async () => []),
-    getCorrespondingSourceIds: jest.fn().mockImplementation(() => []),
-    getCorrespondingLocations: jest.fn().mockImplementation(() => []),
-    getEventCountForTypes: jest.fn().mockImplementation(async () => {}),
-    getAllEventHandlerCounts: jest.fn().mockImplementation(async () => {}),
-    getEventCountForType: jest.fn().mockImplementation(async () => 0),
-    getExceptionValue: jest.fn().mockImplementation(async () => ({})),
-    getFocusWindow: jest.fn().mockImplementation(async () => ({})),
-    getFrameSteps: jest.fn().mockImplementation(async () => []),
-    getHitPointsForLocation: jest.fn().mockImplementation(async () => []),
-    getMappedLocation: jest.fn().mockImplementation(async () => []),
-    getObjectWithPreview: jest.fn().mockImplementation(async () => ({})),
-    getObjectProperty: jest.fn().mockImplementation(async () => ({})),
-    getPointNearTime: jest.fn().mockImplementation(async () => ({ point: "0", time: 0 })),
-    getPointsBoundingTime: jest.fn().mockImplementation(async time => ({
-      before: { point: String(time), time },
-      after: { point: String(time), time },
-    })),
-    getPreferredLocation: jest.fn().mockImplementation(async () => ({})),
-    getRecordingId: jest.fn().mockImplementation(async () => "fake-recording-id"),
-    getScope: jest.fn().mockImplementation(async () => {}),
-    getScopeMap: jest.fn().mockImplementation(async () => {}),
-    getSessionEndpoint: jest.fn().mockImplementation(async () => ({
-      point: "1000",
-      time: 1000,
-    })),
-    getSessionId: jest.fn().mockImplementation(async () => "fake-session-id"),
-    getSourceHitCounts: jest.fn().mockImplementation(async () => new Map()),
-    getSourceOutline: jest.fn().mockImplementation(async () => {}),
-    getTopFrame: jest.fn().mockImplementation(async () => undefined),
-    initialize: jest.fn().mockImplementation(async () => {}),
-    isOriginalSource: jest.fn().mockImplementation(async () => false),
-    isPrettyPrintedSource: jest.fn().mockImplementation(async () => false),
-    mapExpressionToGeneratedScope: jest.fn().mockImplementation(async () => ""),
-    requestFocusRange: jest.fn().mockImplementation(async () => {}),
-    removeEventListener: jest.fn(),
-    repaintGraphics: jest.fn().mockImplementation(async () => {}),
-    runEvaluation: jest.fn().mockImplementation(async () => {}),
-    searchFunctions: jest.fn().mockImplementation(async () => {}),
-    searchSources: jest.fn().mockImplementation(async () => {}),
-    streamSourceContents: jest.fn().mockImplementation(async () => {}),
-    waitForLoadedSources: jest.fn().mockImplementation(async () => undefined),
-    waitForTimeToBeLoaded: jest.fn().mockImplementation(async () => undefined),
-  };
+  return mock<ReplayClientInterface>();
 }

--- a/packages/replay-next/src/utils/testing.tsx
+++ b/packages/replay-next/src/utils/testing.tsx
@@ -174,5 +174,29 @@ export function setupWindow(): void {
 // This mock client is mostly useless by itself,
 // but its methods can be overridden individually (or observed/inspected) by test code.
 export function createMockReplayClient() {
-  return mock<ReplayClientInterface>();
+  const mockClient = mock<ReplayClientInterface>();
+  mockClient.addEventListener.mockImplementation(() => {});
+  mockClient.createPause.mockImplementation(async () => ({
+    data: {},
+    pauseId: "fake",
+  }));
+  mockClient.getAllFrames.mockImplementation(async () => ({ frames: [], data: {} }));
+  mockClient.getBreakpointPositions.mockImplementation(async () => []);
+  mockClient.getPointsBoundingTime.mockImplementation(async time => ({
+    before: { point: String(time), time },
+    after: { point: String(time), time },
+  }));
+  mockClient.getPointNearTime.mockImplementation(async time => ({ point: String(time), time })),
+    mockClient.getSessionEndpoint.mockImplementation(async () => ({
+      point: "1000",
+      time: 1000,
+    }));
+  mockClient.findKeyboardEvents.mockImplementation(async () => {});
+  mockClient.findNavigationEvents.mockImplementation(async () => {});
+  mockClient.findSources.mockImplementation(async () => []);
+  mockClient.removeEventListener.mockImplementation(() => {});
+
+  return mockClient;
 }
+
+export type MockReplayClientInterface = ReturnType<typeof createMockReplayClient>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -15793,6 +15793,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-mock-extended@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "jest-mock-extended@npm:3.0.4"
+  dependencies:
+    ts-essentials: ^7.0.3
+  peerDependencies:
+    jest: ^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0
+    typescript: ^3.0.0 || ^4.0.0 || ^5.0.0
+  checksum: f861253c63508b30d971fbbbc1bf2911ff4406cd260d0e23483a1d4514898b18ba5efbd43fbdf6d94996dc09b20eb1aad1b46aeaea9c99244ba12dc99814fd3f
+  languageName: node
+  linkType: hard
+
 "jest-mock@npm:^28.1.1":
   version: 28.1.1
   resolution: "jest-mock@npm:28.1.1"
@@ -21083,6 +21095,7 @@ __metadata:
     idb: ^7.1.1
     jest: ^28.0.2
     jest-environment-jsdom: ^28.0.2
+    jest-mock-extended: ^3.0.4
     lodash: ^4.17.21
     next: ^13.2
     node-fetch: ^2.0.0
@@ -23494,6 +23507,15 @@ __metadata:
   version: 2.2.0
   resolution: "ts-dedent@npm:2.2.0"
   checksum: 93ed8f7878b6d5ed3c08d99b740010eede6bccfe64bce61c5a4da06a2c17d6ddbb80a8c49c2d15251de7594a4f93ffa21dd10e7be75ef66a4dc9951b4a94e2af
+  languageName: node
+  linkType: hard
+
+"ts-essentials@npm:^7.0.3":
+  version: 7.0.3
+  resolution: "ts-essentials@npm:7.0.3"
+  peerDependencies:
+    typescript: ">=3.7.0"
+  checksum: 74d75868acf7f8b95e447d8b3b7442ca21738c6894e576df9917a352423fde5eb43c5651da5f78997da6061458160ae1f6b279150b42f47ccc58b73e55acaa2f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
When working on #9098, I noticed that the TypeScript for our mock `ReplayClientInterface` methods were all `any` – which isn't great, but also that mock was getting pretty unwieldy to maintain.

To address both of these issues, I added the [jest-mock-extended](https://www.npmjs.com/package/jest-mock-extended) package to generate this mock with proper types. Also found and fixed a few minor type errors along the way.