### PR TITLE
Change regex in E2E test detection of CodeTypeAhead

### DIFF
--- a/packages/e2e-tests/helpers/lexical.ts
+++ b/packages/e2e-tests/helpers/lexical.ts
@@ -24,7 +24,7 @@ export async function focus(page: Page, selector: string) {
 }
 
 export async function hideTypeAheadSuggestions(page: Page, selector: string) {
-  const list = page.locator('[data-test-name="CodeTypeAhead"]');
+  const list = page.locator('[data-test-name$="CodeTypeAhead"]');
 
   if (await list.isVisible()) {
     const input = page.locator(selector);


### PR DESCRIPTION
In this replay of a failing E2E test: https://app.replay.io/recording/logpoints-02-conditional-log-points--0bafa800-dcb1-4a27-9c9f-b4251317d833?point=37644152233979824960128594120545102&time=13798&focusRegion=eyJiZWdpbiI6eyJwb2ludCI6IjAiLCJ0aW1lIjowfSwiZW5kIjp7InBvaW50IjoiNjEzMzQwMDY2NTEzMTgzMTk4Njg5ODMyMTE3NTg0NTI3MzYiLCJ0aW1lIjoyODQ3NX19

It looks like maybe we did not close the autocomplete because `page.locator('[data-test-name="CodeTypeAhead"]')` did not return anything because the actual component was `PointPanel-20-CodeTypeAhead`?

Might fix: https://linear.app/replay/issue/FE-1434/failing-logpoints-02