### PR TITLE
Properly render multi-line Terminal expressions in the console

### DIFF
--- a/packages/replay-next/components/console/renderers/TerminalExpressionRenderer.tsx
+++ b/packages/replay-next/components/console/renderers/TerminalExpressionRenderer.tsx
@@ -23,7 +23,6 @@ import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
 import { pauseEvaluationsCache } from "replay-next/src/suspense/PauseCache";
 import { parse } from "replay-next/src/suspense/SyntaxParsingCache";
 import { primitiveToClientValue } from "replay-next/src/utils/protocol";
-import { ParsedToken, parsedTokensToHtml } from "replay-next/src/utils/syntax-parser";
 import { formatTimestamp } from "replay-next/src/utils/time";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
@@ -45,9 +44,6 @@ function TerminalExpressionRenderer({
   const { contextMenu, onContextMenu } = useConsoleContextMenu(terminalExpression);
 
   const [isHovered, setIsHovered] = useState(false);
-
-  // Reformat expressions to remove unnecessary quotation marks.
-  const expression = useMemo(() => terminalExpression.expression, [terminalExpression.expression]);
 
   const ref = useRef<HTMLDivElement>(null);
 
@@ -130,19 +126,23 @@ function SyntaxHighlightedExpression({
 }: {
   terminalExpression: TerminalExpression;
 }) {
-  const parsed = parse(terminalExpression.expression, "js");
-
-  let tokens: ParsedToken[] = [];
-  if (parsed && parsed.length > 0) {
-    tokens = parsed[0].map(formatExpressionToken);
-  }
+  const parsedTokens = parse(terminalExpression.expression, "js");
+  const formattedTokens = useMemo(
+    () => parsedTokens.map(tokens => tokens.map(formatExpressionToken)),
+    [parsedTokens]
+  );
 
   return (
-    <SyntaxHighlightedLine
-      code={terminalExpression.expression}
-      fileExtension="js"
-      tokens={tokens}
-    />
+    <div className={styles.TerminalExpressionLines}>
+      {formattedTokens.map((tokens, index) => (
+        <SyntaxHighlightedLine
+          code={terminalExpression.expression}
+          fileExtension="js"
+          key={index}
+          tokens={tokens}
+        />
+      ))}
+    </div>
   );
 }
 

--- a/packages/replay-next/components/console/renderers/shared.module.css
+++ b/packages/replay-next/components/console/renderers/shared.module.css
@@ -123,6 +123,11 @@
   min-height: 1rem;
 }
 
+.TerminalExpressionLines {
+  display: flex;
+  flex-direction: column;
+}
+
 .TerminalLogContents {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Before 
<img width="665" alt="Screen Shot 2023-04-26 at 3 37 02 PM" src="https://user-images.githubusercontent.com/29597/234684199-79db4424-e2a2-4226-82a9-5b7c8c44658a.png">

## After
<img width="642" alt="Screen Shot 2023-04-26 at 3 35 02 PM" src="https://user-images.githubusercontent.com/29597/234684198-d205e943-0cd1-4ad9-9876-e1e0d047e0ac.png">

cc @Andarist 