### PR TITLE
Update title using Next's <Head> component

### DIFF
--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -176,9 +176,6 @@ export function createSocket(
       ]);
       assert(recording, "failed to load recording");
 
-      if (recording.title) {
-        document.title = recording.title;
-      }
       if (recording.workspace) {
         dispatch(actions.setRecordingWorkspace(recording.workspace));
       }

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -1,3 +1,4 @@
+import Head from "next/head";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { ConnectedProps, connect } from "react-redux";
 import {
@@ -216,15 +217,11 @@ function _DevTools({
     }
   }, [loadingFinished, trackLoadingIdleTime, sessionId]);
 
-  useEffect(() => {
-    if (recording?.title && document.title !== recording.title) {
-      document.title = recording.title;
-    }
-  }, [recording]);
-
   if (!loadingFinished) {
     return <LoadingScreen fallbackMessage="Loading..." />;
   }
+
+  const title = recording?.title;
 
   return (
     <SessionContextAdapter apiKey={apiKey ?? null}>
@@ -238,6 +235,11 @@ function _DevTools({
                     <ExpandablesContextRoot>
                       <LayoutContextAdapter>
                         <KeyModifiers>
+                          {title && (
+                            <Head>
+                              <title>{title}</title>
+                            </Head>
+                          )}
                           <Header />
                           <Body />
                           {showCommandPalette ? <CommandPaletteModal /> : null}


### PR DESCRIPTION
The old _imperative_ updates were being overridden by effects code running in Next.js. Based on digging through the Next.js source, and looking at Replay [cabf1d53-90db-460d-bf8e-55e0633937f0](https://app.replay.io/recording/cabf1d53-90db-460d-bf8e-55e0633937f0), it seems like the better way to do this is to use the `<Head>` component from "next/head".