### PR TITLE
Fix Tour edgecase

### DIFF
--- a/src/ui/components/Tour/Tour.tsx
+++ b/src/ui/components/Tour/Tour.tsx
@@ -200,6 +200,12 @@ const Tour: React.FC = () => {
                       showBreakpointAdd &&
                       showBreakpointEdit &&
                       oneClickLogs}
+
+                    {!showConsoleNavigate &&
+                      showBreakpointAdd &&
+                      !showBreakpointEdit &&
+                      oneClickLogs}
+
                     {!showConsoleNavigate && !showBreakpointAdd && showBreakpointEdit && editLogs}
                     {hasCompletedTour && (
                       <CompletedTour
@@ -224,7 +230,13 @@ const Tour: React.FC = () => {
           <>
             {showConsoleNavigate && showBreakpointAdd && showBreakpointEdit && <TimeTravelGif />}
             {!showConsoleNavigate && showBreakpointAdd && showBreakpointEdit && <OneClickLogsGif />}
+
             {!showConsoleNavigate && !showBreakpointAdd && showBreakpointEdit && <EditLogsGif />}
+
+            {!showConsoleNavigate && showBreakpointAdd && !showBreakpointEdit && (
+              <OneClickLogsGif />
+            )}
+
             {hasCompletedTour && <CompletedTourGif />}
           </>
         )}


### PR DESCRIPTION
If people go through the Tour in the wrong order*, it results in a blank screen. This fixes that.

*Specifically, if a person commits a print statement before *adding* a print statement.

Addresses [DES-562](https://linear.app/replay/issue/DES-562/its-possible-to-make-the-tour-completely-blank)