### PR TITLE
Add a longer timeout for error stacks

### DIFF
--- a/packages/e2e-tests/tests/sourcemap_stacktrace.test.ts
+++ b/packages/e2e-tests/tests/sourcemap_stacktrace.test.ts
@@ -24,16 +24,19 @@ test("sourcemap_stacktrace: Test that stacktraces are sourcemapped", async ({ pa
     "asyncToGenerator.js:3",
     "asyncToGenerator.js:22",
   ]);
-  await waitFor(async () => {
-    const errorLocations = await getErrorFrameLocationsFromMessage(message);
-    expect(errorLocations.slice(0, 7)).toEqual([
-      "App.js:9",
-      "App.js:33",
-      "regeneratorRuntime.js:44",
-      "regeneratorRuntime.js:125",
-      "regeneratorRuntime.js:69",
-      "asyncToGenerator.js:3",
-      "asyncToGenerator.js:22",
-    ]);
-  });
+  await waitFor(
+    async () => {
+      const errorLocations = await getErrorFrameLocationsFromMessage(message);
+      expect(errorLocations.slice(0, 7)).toEqual([
+        "App.js:9",
+        "App.js:33",
+        "regeneratorRuntime.js:44",
+        "regeneratorRuntime.js:125",
+        "regeneratorRuntime.js:69",
+        "asyncToGenerator.js:3",
+        "asyncToGenerator.js:22",
+      ]);
+    },
+    { timeout: 10000 }
+  );
 });


### PR DESCRIPTION
I am not sure why this is taking so long, that would be worth investigating, but I am pretty sure this will at least make the test pass.

Example failure: https://app.replay.io/recording/a3e22dbb-61de-4c6c-a5d6-11769ba4a49d