### PR TITLE
Allow the Playwright test suite panel to be shown

### DIFF
--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -15,7 +15,6 @@ import { useGetRecording, useGetRecordingId } from "ui/hooks/recordings";
 import { useFeature } from "ui/hooks/settings";
 import { getFilteredEventsForFocusRegion } from "ui/reducers/app";
 import { getSelectedPrimaryPanel } from "ui/reducers/layout";
-import { getViewMode } from "ui/reducers/layout";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { shouldShowTour } from "ui/utils/onboarding";
 import useAuth0 from "ui/utils/useAuth0";
@@ -57,8 +56,6 @@ export default function SidePanel() {
   const [eventsCollapsed, setEventsCollapsed] = useState(false);
   const events = useAppSelector(getFilteredEventsForFocusRegion);
   const { isAuthenticated } = useAuth0();
-  const viewMode = useAppSelector(getViewMode);
-  const { nags } = hooks.useGetUserInfo();
 
   const launchQuickstart = (url: string) => {
     window.open(url, "_blank");

--- a/src/ui/components/TestSuite/views/TestItem/TestError.module.css
+++ b/src/ui/components/TestSuite/views/TestItem/TestError.module.css
@@ -20,4 +20,5 @@
   font-family: var(--font-family-monospace);
   color: var(--testsuites-error-color);
   margin-top: 0.75rem;
+  white-space: pre-wrap;
 }

--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -211,13 +211,22 @@ export default function Toolbar() {
             onClick={handleButtonClick}
           />
         ) : null}
-        {recording?.metadata?.test?.runner?.name == "cypress" ? (
-          <ToolbarButton
-            icon="cypress"
-            label="Cypress Panel"
-            name="cypress"
-            onClick={handleButtonClick}
-          />
+        {recording?.metadata?.test?.runner ? (
+          recording?.metadata?.test?.runner?.name === "cypress" ? (
+            <ToolbarButton
+              icon="cypress"
+              label="Cypress Panel"
+              name="cypress"
+              onClick={handleButtonClick}
+            />
+          ) : (
+            <ToolbarButton
+              icon="folder"
+              label="Test Info"
+              name="cypress"
+              onClick={handleButtonClick}
+            />
+          )
         ) : (
           <ToolbarButton
             icon="info"


### PR DESCRIPTION
We will open the test suite panel by default if the recording is a test recording, but if it's a *playwright* recording then it's impossible to ever return to the test suite panel if you've ever navigated away. We use playwright tests for our E2E test suites, so this gets me all the time. I understand we might not want to show the Cypress logo so I've just thrown in a random logo instead (and I'd be happy to change it to something else if someone has a different suggestion).

Also, it's common for error messages to have white space breaks in them to show things like diffs, so we should display those rather than letting everything get crammed onto one line.


### Before
![CleanShot 2023-04-29 at 12 01 52](https://user-images.githubusercontent.com/5903784/235319879-e4630dfb-fb7b-49c9-91f0-f6ebe27f1195.png)


### After

![CleanShot 2023-04-29 at 12 01 08](https://user-images.githubusercontent.com/5903784/235319809-30f34271-2ba9-4443-8bc7-599907698aef.png)
