### PR TITLE
Add "Jump to Code" into Passport

### DIFF
--- a/src/ui/components/Passport/Passport.tsx
+++ b/src/ui/components/Passport/Passport.tsx
@@ -115,6 +115,12 @@ const Passport = () => {
       videoUrl: "https://vercel.replay.io/passport/inspect_a_network_request.gif",
       imageBaseName: "inspect_network_request",
     },
+    {
+      label: "Jump to code",
+      completed: !showJumpToCode,
+      videoUrl: "https://vercel.replay.io/passport/jump_to_code.gif",
+      imageBaseName: "jump_to_code",
+    },
   ];
 
   const swissArmyItems = [


### PR DESCRIPTION
As we've reorganised the list of items in Passport, Jump to Code fell out temporarily. Adding it back in because it's such an important feature for us.