### PR TITLE
Pointing to React version of our demo

### DIFF
--- a/src/ui/components/shared/FirstReplayModal/FirstReplayModal.tsx
+++ b/src/ui/components/shared/FirstReplayModal/FirstReplayModal.tsx
@@ -18,7 +18,7 @@ import {
   OnboardingModalContainer,
 } from "../Onboarding/index";
 
-export const REPLAY_DEMO_URL = "https://static.replay.io/demo/";
+export const REPLAY_DEMO_URL = "https://first.replay.io/";
 export const REPLAY_LIBRARY_URL = "https://app.replay.io/";
 
 function FirstReplayModal({ hideModal }: PropsFromRedux) {


### PR DESCRIPTION
We were pointing to https://static.replay.io/demo, now pointing to https://first.replay.io