### PR TITLE
Message list should not filter by loaded region

### DIFF
--- a/packages/replay-next/components/console/MessagesList.module.css
+++ b/packages/replay-next/components/console/MessagesList.module.css
@@ -1,5 +1,4 @@
-.Container,
-.ContainerPending {
+.Container {
   flex: 1 1 auto;
   position: relative;
   overflow-y: auto;
@@ -14,12 +13,8 @@
   /* Account for -1px margin-top offset of rows (to align top/bottom borders) */
   padding-top: 1px;
 }
-.ContainerPending {
-  opacity: 0.5;
-}
 
-.Container:focus,
-.ContainerPending:focus {
+.Container:focus {
   outline: none;
 }
 

--- a/packages/replay-next/components/console/MessagesList.tsx
+++ b/packages/replay-next/components/console/MessagesList.tsx
@@ -1,16 +1,8 @@
-import React, {
-  ForwardedRef,
-  MutableRefObject,
-  ReactNode,
-  forwardRef,
-  useContext,
-  useMemo,
-} from "react";
+import { ForwardedRef, MutableRefObject, ReactNode, forwardRef, useContext, useMemo } from "react";
 
 import Icon from "replay-next/components/Icon";
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
 import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
-import useLoadedRegions from "replay-next/src/hooks/useRegions";
 import { useStreamingMessages } from "replay-next/src/hooks/useStreamingMessages";
 import {
   getLoggableExecutionPoint,
@@ -21,8 +13,6 @@ import {
   isUncaughtException,
 } from "replay-next/src/utils/loggables";
 import { isExecutionPointsLessThan } from "replay-next/src/utils/time";
-import { ReplayClientContext } from "shared/client/ReplayClientContext";
-import { isPointInRegions } from "shared/utils/time";
 
 import _ErrorBoundary from "../ErrorBoundary";
 import { ConsoleSearchContext } from "./ConsoleSearchContext";
@@ -58,11 +48,8 @@ function MessagesList({ forwardedRef }: { forwardedRef: ForwardedRef<HTMLElement
   const { isTransitionPending: isFocusTransitionPending, range: focusRange } =
     useContext(FocusContext);
   const loggables = useContext(LoggablesContext);
-  const replayClient = useContext(ReplayClientContext);
   const [searchState] = useContext(ConsoleSearchContext);
   const { executionPoint: currentExecutionPoint } = useContext(TimelineContext);
-
-  const loadedRegions = useLoadedRegions(replayClient);
 
   // The Console should render a line indicating the current execution point.
   // This point might match multiple logs– or it might be between logs, or after the last log, etc.
@@ -105,71 +92,63 @@ function MessagesList({ forwardedRef }: { forwardedRef: ForwardedRef<HTMLElement
       listItems.push(currentTimeIndicator);
     }
 
-    const loggableExecutionPoint = getLoggableExecutionPoint(loggable);
-    const isLoaded =
-      loadedRegions !== null && isPointInRegions(loggableExecutionPoint, loadedRegions.loaded);
-
-    if (isLoaded) {
-      if (isEventLog(loggable)) {
-        listItems.push(
-          <ErrorBoundary key={`event-${loggable.eventType}-${loggable.point}`}>
-            <EventLogRenderer
-              key={index}
-              index={index}
-              isFocused={loggable === currentSearchResult}
-              eventLog={loggable}
-            />
-          </ErrorBoundary>
-        );
-      } else if (isPointInstance(loggable)) {
-        listItems.push(
-          <ErrorBoundary
-            key={`logpoint-${loggable.point.key}-${loggable.timeStampedHitPoint.point}`}
-          >
-            <LogPointRenderer
-              key={index}
-              index={index}
-              isFocused={loggable === currentSearchResult}
-              logPointInstance={loggable}
-            />
-          </ErrorBoundary>
-        );
-      } else if (isProtocolMessage(loggable)) {
-        listItems.push(
-          <ErrorBoundary key={`message-${loggable.point.point}`}>
-            <MessageRenderer
-              key={index}
-              index={index}
-              isFocused={loggable === currentSearchResult}
-              message={loggable}
-            />
-          </ErrorBoundary>
-        );
-      } else if (isTerminalExpression(loggable)) {
-        listItems.push(
-          <ErrorBoundary key={`evaluation-${loggable.id}`}>
-            <TerminalExpressionRenderer
-              key={index}
-              index={index}
-              isFocused={loggable === currentSearchResult}
-              terminalExpression={loggable}
-            />
-          </ErrorBoundary>
-        );
-      } else if (isUncaughtException(loggable)) {
-        listItems.push(
-          <ErrorBoundary key={`exception-${loggable.point}`}>
-            <UncaughtExceptionRenderer
-              key={loggable.point}
-              index={index}
-              isFocused={loggable === currentSearchResult}
-              uncaughtException={loggable}
-            />
-          </ErrorBoundary>
-        );
-      } else {
-        throw Error("Unsupported loggable type");
-      }
+    if (isEventLog(loggable)) {
+      listItems.push(
+        <ErrorBoundary key={`event-${loggable.eventType}-${loggable.point}`}>
+          <EventLogRenderer
+            key={index}
+            index={index}
+            isFocused={loggable === currentSearchResult}
+            eventLog={loggable}
+          />
+        </ErrorBoundary>
+      );
+    } else if (isPointInstance(loggable)) {
+      listItems.push(
+        <ErrorBoundary key={`logpoint-${loggable.point.key}-${loggable.timeStampedHitPoint.point}`}>
+          <LogPointRenderer
+            key={index}
+            index={index}
+            isFocused={loggable === currentSearchResult}
+            logPointInstance={loggable}
+          />
+        </ErrorBoundary>
+      );
+    } else if (isProtocolMessage(loggable)) {
+      listItems.push(
+        <ErrorBoundary key={`message-${loggable.point.point}`}>
+          <MessageRenderer
+            key={index}
+            index={index}
+            isFocused={loggable === currentSearchResult}
+            message={loggable}
+          />
+        </ErrorBoundary>
+      );
+    } else if (isTerminalExpression(loggable)) {
+      listItems.push(
+        <ErrorBoundary key={`evaluation-${loggable.id}`}>
+          <TerminalExpressionRenderer
+            key={index}
+            index={index}
+            isFocused={loggable === currentSearchResult}
+            terminalExpression={loggable}
+          />
+        </ErrorBoundary>
+      );
+    } else if (isUncaughtException(loggable)) {
+      listItems.push(
+        <ErrorBoundary key={`exception-${loggable.point}`}>
+          <UncaughtExceptionRenderer
+            key={loggable.point}
+            index={index}
+            isFocused={loggable === currentSearchResult}
+            uncaughtException={loggable}
+          />
+        </ErrorBoundary>
+      );
+    } else {
+      throw Error("Unsupported loggable type");
     }
   });
   if (currentTimeIndicatorPlacement === "end") {

--- a/packages/replay-next/components/console/MessagesList.tsx
+++ b/packages/replay-next/components/console/MessagesList.tsx
@@ -183,7 +183,7 @@ function MessagesList({ forwardedRef }: { forwardedRef: ForwardedRef<HTMLElement
         </div>
       )}
       <div
-        className={isTransitionPending ? styles.ContainerPending : styles.Container}
+        className={styles.Container}
         data-test-name="Messages"
         ref={forwardedRef as MutableRefObject<HTMLDivElement>}
         role="list"

--- a/src/ui/components/FocusContextReduxAdapter.tsx
+++ b/src/ui/components/FocusContextReduxAdapter.tsx
@@ -1,5 +1,5 @@
 import { TimeStampedPointRange } from "@replayio/protocol";
-import { PropsWithChildren, useCallback, useEffect, useMemo, useState, useTransition } from "react";
+import { PropsWithChildren, useCallback, useDeferredValue, useMemo } from "react";
 
 import { FocusContext, UpdateOptions } from "replay-next/src/contexts/FocusContext";
 import { TimeRange } from "replay-next/src/types";
@@ -9,26 +9,17 @@ import {
   syncFocusedRegion,
   updateFocusRegionParam,
 } from "ui/actions/timeline";
-import { getLoadedRegions } from "ui/reducers/app";
 import { getFocusRegion } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
-import { FocusRegion } from "ui/state/timeline";
 import { rangeForFocusRegion } from "ui/utils/timeline";
 
 // Adapter that reads focus region (from Redux) and passes it to the FocusContext.
 export default function FocusContextReduxAdapter({ children }: PropsWithChildren) {
   const dispatch = useAppDispatch();
-  const loadedRegions = useAppSelector(getLoadedRegions);
   const focusRegion = useAppSelector(getFocusRegion);
 
-  const [isPending, startTransition] = useTransition();
-  const [deferredFocusRegion, setDeferredFocusRegion] = useState<FocusRegion | null>(focusRegion);
-
-  useEffect(() => {
-    startTransition(() => {
-      setDeferredFocusRegion(focusRegion);
-    });
-  }, [focusRegion, loadedRegions]);
+  const deferredFocusRegion = useDeferredValue(focusRegion);
+  const isPending = deferredFocusRegion !== focusRegion;
 
   const update = useCallback(
     async (value: TimeStampedPointRange | null, options: UpdateOptions) => {


### PR DESCRIPTION
- [x] Render console messages as early as possible; don't filter by loaded region any more.
- [x] Fix bug in `FocusContextAdapter` that was causing us to over-sync the focus region (causing a lot of unnecessary "transition" updates, which caused the Console to flicker).
- [x] Remove pending _dimmed_ state from the Console when the focus region is changing. This isn't really necessary. Console messages stream in as things load– both initially, and as focus region changes. The flicker was just an unpleasant artifact.

[Best viewed with whitespace disabled.](https://github.com/replayio/devtools/pull/9167/files?w=1)

---

Here is a demo of production vs this branch: https://www.loom.com/share/550b2c40f3694dee989f0d7e2a04637a

Note a couple of changes:
* Time to load all messages down from ~21s to 9s
* Console flickering during load has been fixed

---

### Back story

Looking at Josh's [original Replay](https://app.replay.io/recording/console-still-loading-a-bit-strangely--ae37beb4-604b-4c87-bb1b-7fa0ad6cf4c3?point=96382010448550258086622063044334517&time=38603.980544747086&focusRegion=eyJiZWdpbiI6eyJwb2ludCI6IjAiLCJ0aW1lIjowfSwiZW5kIjp7InBvaW50IjoiMTA1NDY4NTI5OTUxMjkwOTYzOTQyNDcwNjgyNTE1ODY1NjAwIiwidGltZSI6NDM0NjR9fQ%253D%253D) I found [this to be the cause](https://www.loom.com/share/993aeb43a05f4551ad5036efae623d2a):
* The messages are loading early, but we don't render them until they're within a loaded region, because:
  * The Console might need to fetch preview data to render messages fully
  * The backend used to throw if preview data was requested for a region that wasn't loaded/indexed (seems like maybe this is no longer the case)
*  We can speed things up a lot if we remove this in-memory filter (the loaded regions check) and rely on individual messages to just suspend on loading data if necessary.

---

Note that there's a "flickering" I see on both this branch _and_ production: [fc15e4cf-7b3a-4b55-b5fb-1367afedb141](https://app.replay.io/recording/fe-1457-console-flicker-during-load--fc15e4cf-7b3a-4b55-b5fb-1367afedb141)

The flickering is because we're updating the deferred focus region too often (within a transition, which causes the console to dim its opacity). I think we should both fix the underlying over-update issue _and_ remove that dimmed effect as unnecessary.