### PR TITLE
Add OutlineHitCountsCache (FE-1301)

### DIFF
--- a/packages/replay-next/src/suspense/OutlineHitCountsCache.ts
+++ b/packages/replay-next/src/suspense/OutlineHitCountsCache.ts
@@ -1,0 +1,80 @@
+import {
+  ClassOutline,
+  FunctionOutline,
+  PointRange,
+  SameLineSourceLocations,
+  SourceId,
+  SourceLocation,
+} from "@replayio/protocol";
+import { Cache, createCache } from "suspense";
+
+import { ReplayClientInterface } from "shared/client/types";
+
+import { sourceOutlineCache } from "./SourceOutlineCache";
+
+export interface FunctionOutlineWithHitCounts extends FunctionOutline {
+  hits: number;
+}
+
+export interface SourceOutlineWithHitCounts {
+  classes: ClassOutline[];
+  functions: FunctionOutlineWithHitCounts[];
+}
+
+export const outlineHitCountsCache: Cache<
+  [
+    replayClient: ReplayClientInterface,
+    sourceId: SourceId | undefined,
+    focusRange: PointRange | null
+  ],
+  SourceOutlineWithHitCounts
+> = createCache({
+  config: { immutable: true },
+  debugLabel: "OutlineHitCountsCache",
+  getKey: ([replayClient, sourceId, focusRange]) =>
+    sourceId && focusRange ? `${sourceId}:${focusRange.begin}-${focusRange.end}` : sourceId ?? "",
+  load: async ([replayClient, sourceId, focusRange]) => {
+    if (!sourceId) {
+      return { classes: [], functions: [] };
+    }
+
+    const { classes, functions } = await sourceOutlineCache.readAsync(replayClient, sourceId);
+
+    const locations: SameLineSourceLocations[] = [];
+    for (const functionOutline of functions) {
+      //TODO update @replayio/protocol
+      const location: SourceLocation | undefined = (functionOutline as any).breakpointLocation;
+      if (location) {
+        locations.push({ line: location.line, columns: [location.column] });
+      }
+    }
+
+    const correspondingSourceIds = replayClient.getCorrespondingSourceIds(sourceId);
+
+    const hitCountsByLocationKey = new Map<string, number>();
+    await Promise.all(
+      correspondingSourceIds.map(async sourceId => {
+        const hitCounts = await replayClient.getSourceHitCounts(sourceId, locations, focusRange);
+
+        hitCounts.forEach(({ hits, location }) => {
+          const locationKey = `${location.line}:${location.column}`;
+          const previous = hitCountsByLocationKey.get(locationKey) ?? 0;
+          hitCountsByLocationKey.set(locationKey, previous + hits);
+        });
+      })
+    );
+
+    const functionsWithHitCounts = functions.map(functionOutline => {
+      //TODO update @replayio/protocol
+      const location: SourceLocation | undefined = (functionOutline as any).breakpointLocation;
+      let hits = 0;
+      if (location) {
+        const locationKey = `${location.line}:${location.column}`;
+        hits = hitCountsByLocationKey.get(locationKey) ?? 0;
+      }
+      return Object.assign({}, functionOutline, { hits });
+    });
+
+    return { classes, functions: functionsWithHitCounts };
+  },
+});

--- a/packages/shared/client/types.ts
+++ b/packages/shared/client/types.ts
@@ -7,6 +7,7 @@ import {
   FocusWindowRequest,
   FrameId,
   FunctionMatch,
+  HitCount,
   KeyboardEvent,
   loadedRegions as LoadedRegions,
   Location,
@@ -205,10 +206,9 @@ export interface ReplayClientInterface {
   getSessionId(): SessionId | null;
   getSourceHitCounts(
     sourceId: SourceId,
-    locationRange: SourceLocationRange,
-    sourceLocations: SameLineSourceLocations[],
+    locations: SameLineSourceLocations[],
     focusRange: PointRange | null
-  ): Promise<LineNumberToHitCountMap>;
+  ): Promise<HitCount[]>;
   getSourceOutline(sourceId: SourceId): Promise<getSourceOutlineResult>;
   getTopFrame(pauseId: PauseId): Promise<getTopFrameResult>;
   initialize(recordingId: string, accessToken: string | null): Promise<SessionId>;

--- a/src/devtools/client/debugger/src/components/SourceOutline/getOutlineSymbols.tsx
+++ b/src/devtools/client/debugger/src/components/SourceOutline/getOutlineSymbols.tsx
@@ -1,13 +1,6 @@
-import {
-  ClassOutline,
-  FunctionOutline,
-  SourceLocationRange,
-  getSourceOutlineResult,
-} from "@replayio/protocol";
+import { ClassOutline, FunctionOutline, getSourceOutlineResult } from "@replayio/protocol";
 import groupBy from "lodash/groupBy";
 import keyBy from "lodash/keyBy";
-
-import { LineNumberToHitCountMap } from "shared/client/types";
 
 import { fuzzySearch } from "../../utils/function";
 
@@ -17,49 +10,12 @@ export type FunctionDeclarationHits = FunctionOutline & {
 
 export type HitCount = number;
 
-function getClosestHitCount(
-  hitCountsMap: LineNumberToHitCountMap,
-  location: SourceLocationRange
-): HitCount | null {
-  const { line: endLine } = location.end;
-  const { line: startLine } = location.begin;
-  for (let line = startLine; line <= endLine; line++) {
-    let hitCounts = hitCountsMap.get(line);
-    if (hitCounts) {
-      if (line === startLine || line === endLine) {
-        return hitCounts.count;
-      }
-    }
-  }
-
-  return null;
-}
-
-function addHitCountsToFunctions(
-  functions: FunctionOutline[],
-  hitCountsMap: LineNumberToHitCountMap | null
-): FunctionDeclarationHits[] {
-  if (!hitCountsMap) {
-    return functions;
-  }
-
-  return functions.map(functionSymbol => {
-    const count = getClosestHitCount(hitCountsMap, functionSymbol.location);
-    return Object.assign({}, functionSymbol, { hits: count || 0 });
-  });
-}
-
-export function getOutlineSymbols(
-  symbols: null | getSourceOutlineResult,
-  filter: string,
-  hitCounts: LineNumberToHitCountMap | null
-) {
+export function getOutlineSymbols(symbols: null | getSourceOutlineResult, filter: string) {
   if (!symbols) {
     return null;
   }
 
   let { classes, functions } = symbols;
-  functions = addHitCountsToFunctions(functions, hitCounts);
   const classNames = new Set(classes.map(s => s.name));
   const functionsByName = keyBy(functions, "name");
   const filteredFunctions = functions.filter(


### PR DESCRIPTION
- move the logic from `ReplayClient.getSourceHitCounts()` to the `SourceHitCountsCache`
- add `OutlineHitCountsCache` (which makes use of the `breakpointLocation` added to `FunctionOutline` in replayio/backend#7656)
- use the new cache in the outline panel
- the @replayio/protocol package still needs to be updated once replayio/backend#7678 has landed
