### PR TITLE
Adding docs links to Passport

### DIFF
--- a/src/ui/components/Passport/Passport.module.css
+++ b/src/ui/components/Passport/Passport.module.css
@@ -45,6 +45,13 @@
   text-overflow: ellipsis;
 }
 
+.checklistItemLabelWrapper {
+  display: flex;
+  align-items: center;
+  flex-grow: 1;
+  overflow: hidden;
+}
+
 .checklistItem:hover {
   background-color: rgba(63, 150, 238, 0.15);
   cursor: pointer;
@@ -62,11 +69,6 @@
 .checklistItem.selectedItem:hover {
   background-color: rgba(63, 150, 238, 0.4);
   z-index: 1000;
-}
-
-.checklist div:hover {
-  background-color: rgba(63, 150, 238, 0.15);
-  cursor: pointer;
 }
 
 .stepIcon {
@@ -112,4 +114,17 @@
 
 .ml2 {
   margin-left: 0.5rem;
+}
+
+.checklist div:hover {
+  cursor: pointer;
+}
+
+.checklist .docsIcon {
+  position: absolute;
+  right: 0;
+}
+
+.checklist div.docsIcon:hover {
+  color: #2257a7;
 }

--- a/src/ui/components/Passport/Passport.tsx
+++ b/src/ui/components/Passport/Passport.tsx
@@ -253,7 +253,7 @@ const Passport = () => {
                     className={styles.docsIcon}
                     onClick={e => {
                       e.stopPropagation();
-                      handleDocsClick(item.docsLink);
+                      handleDocsClick(item.docsLink ?? "");
                     }}
                   >
                     <div className="flex items-center space-x-1">

--- a/src/ui/components/Passport/Passport.tsx
+++ b/src/ui/components/Passport/Passport.tsx
@@ -207,7 +207,7 @@ const Passport = () => {
     completed: boolean;
     videoUrl: string;
     imageBaseName: string;
-    docsLink: string;
+    docsLink?: string;
   }
 
   interface Section {

--- a/src/ui/components/Passport/Passport.tsx
+++ b/src/ui/components/Passport/Passport.tsx
@@ -89,18 +89,24 @@ const Passport = () => {
       completed: !showConsoleNavigate,
       videoUrl: "https://vercel.replay.io/passport/time_travel_in_console.gif",
       imageBaseName: "time_travel_in_the_console",
+      docsLink:
+        "https://www.notion.so/replayio/Debugging-1c18f02c9f1d455188e3f202ef5f5c08?pvs=4#5df63e4995a749eab6a04e266db98df0",
     },
     {
       label: "Add a console log",
       completed: !showBreakpointEdit,
       videoUrl: "https://vercel.replay.io/passport/set_print_statement.gif",
       imageBaseName: "set_a_print_statement",
+      docsLink:
+        "https://www.notion.so/replayio/Debugging-1c18f02c9f1d455188e3f202ef5f5c08?pvs=4#e52695c558884780a93be039ae42867a",
     },
     {
       label: "Jump to event",
       completed: !showJumpToEvent,
       videoUrl: "https://vercel.replay.io/passport/jump_to_an_event.gif",
       imageBaseName: "jump_to_event",
+      docsLink:
+        "https://www.notion.so/replayio/Debugging-1c18f02c9f1d455188e3f202ef5f5c08#c9aab3ee9d564e098b28096c9a6cda83",
     },
   ];
 
@@ -110,18 +116,24 @@ const Passport = () => {
       completed: !showInspectElement,
       videoUrl: "https://vercel.replay.io/passport/inspect_an_element.gif",
       imageBaseName: "inspect_element",
+      docsLink:
+        "https://www.notion.so/replayio/Debugging-1c18f02c9f1d455188e3f202ef5f5c08?pvs=4#904253ec80e542f0bb77d2c5a9bb8a4e",
     },
     {
       label: "Inspect network requests",
       completed: !showInspectNetworkRequest,
       videoUrl: "https://vercel.replay.io/passport/inspect_a_network_request.gif",
       imageBaseName: "inspect_network_request",
+      docsLink:
+        "https://www.notion.so/replayio/Debugging-1c18f02c9f1d455188e3f202ef5f5c08?pvs=4#f2ae6cfcef014d9fa8dce383c2a9a7fa",
     },
     {
       label: "Inspect React components",
       completed: !showInspectReactComponent,
       videoUrl: "https://vercel.replay.io/passport/inspect_a_react_component.gif",
       imageBaseName: "inspect_react_component",
+      docsLink:
+        "https://www.notion.so/replayio/Debugging-1c18f02c9f1d455188e3f202ef5f5c08?pvs=4#a10146a9ed2c45f5bf34a59d7e1ea7b9",
     },
     {
       label: "Jump to code",
@@ -143,12 +155,15 @@ const Passport = () => {
       completed: !showSearchSourceText,
       videoUrl: "https://vercel.replay.io/passport/search_source_text.gif",
       imageBaseName: "search_source_text",
+      docsLink:
+        "https://www.notion.so/replayio/Search-4bd72377ac3d498d96bb7bcb33722a75?pvs=4#167521cd6a0f44dabc257eb3fd8ca48b",
     },
     {
       label: "Set a focus window",
       completed: !showUseFocusMode,
       videoUrl: "https://vercel.replay.io/passport/use_focus_mode.gif",
       imageBaseName: "use_focus_mode",
+      docsLink: "https://www.notion.so/replayio/Focus-Mode-bd7783ea740f40f1b25383b6aaa78471?pvs=4",
     },
   ];
 
@@ -158,6 +173,7 @@ const Passport = () => {
       completed: !showAddComment,
       videoUrl: "https://vercel.replay.io/passport/add_a_comment.gif",
       imageBaseName: "add_a_comment",
+      docsLink: "https://www.notion.so/replayio/Comments-0a140c06524d428681cadd78acf44661?pvs=4",
     },
     {
       label: "Share",
@@ -191,6 +207,7 @@ const Passport = () => {
     completed: boolean;
     videoUrl: string;
     imageBaseName: string;
+    docsLink: string;
   }
 
   interface Section {
@@ -208,6 +225,10 @@ const Passport = () => {
   const [randomRight, setRandomRight] = useState(rand(-50, 0));
   const [randomRotation, setRandomRotation] = useState(rand(-20, 20));
 
+  const handleDocsClick = (link: string) => {
+    window.open(link, "_blank");
+  };
+
   const renderSection = (section: Section, sectionIndex: number) => {
     return (
       <div className={styles.section}>
@@ -221,9 +242,25 @@ const Passport = () => {
               key={itemIndex}
               className={`flex ${getItemStyle(sectionIndex, itemIndex)} ${styles.checklistItem}`}
               onClick={() => handleClick(sectionIndex, itemIndex)}
+              style={{ position: "relative" }}
             >
               <Icon className={styles.stepIcon} type={renderCheckmarkIcon(item.completed)} />
               <span className={styles.ml2}>{item.label}</span>
+              {sectionIndex === selectedIndices.sectionIndex &&
+                itemIndex === selectedIndices.itemIndex &&
+                item.docsLink && (
+                  <div
+                    className={styles.docsIcon}
+                    onClick={e => {
+                      e.stopPropagation();
+                      handleDocsClick(item.docsLink);
+                    }}
+                  >
+                    <div className="flex items-center space-x-1">
+                      <Icon type="document" className="mr-2 w-4" />
+                    </div>
+                  </div>
+                )}
             </div>
           ))}
         </div>
@@ -273,7 +310,13 @@ const Passport = () => {
           />
         )}
         <div className={styles.videoExampleWrapper}>
-          <img src={selectedItem.videoUrl} className={styles.videoExample} ref={videoExampleRef} />
+          <div style={{ position: "relative" }}>
+            <img
+              src={selectedItem.videoUrl}
+              className={styles.videoExample}
+              ref={videoExampleRef}
+            />
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Passport is performing well even without links to docs, but this makes the experience that much more robust for people trying to learn about our features. 

![image](https://github.com/replayio/devtools/assets/9154902/e5a50890-c12d-442b-9f69-f035e708581b)

Here's what the code does:

1. If there's a docs link, show it when a line item is selected
2. When clicking on the link, open the docs into a new tab
3. If there's no docs link, don't show the icon (we'll be writing these docs links later)

