### PR TITLE
Change E2E test helper for quick open

### DIFF
--- a/packages/e2e-tests/helpers/commands.ts
+++ b/packages/e2e-tests/helpers/commands.ts
@@ -10,10 +10,12 @@ export async function quickOpen(page: Page, url: string): Promise<void> {
 
   await debugPrint(page, `Filtering files by "${chalk.bold(url)}"`, "quickOpen");
   await page.keyboard.type(url);
-  await page.waitForSelector(`[data-test-id="QuickOpenResultsList"]:has-text("${url}")`);
+  const sourceRow = await page.waitForSelector(
+    `[data-test-id="QuickOpenResultsList"]:has-text("${url}")`
+  );
 
   await debugPrint(page, `Opening file "${chalk.bold(url)}"`, "quickOpen");
-  await page.keyboard.press("Enter");
+  sourceRow.click();
   await page.waitForSelector(`[data-test-name="Source-${url}"]`);
   await page.waitForSelector(`[data-test-name="Source"]`);
 }


### PR DESCRIPTION
This is kind of a guess, because it's hard to reproduce outside of a backend E2E test, it's based on this replay:
https://app.replay.io/recording/breakpoints-07-rewind-and-seek-using-command-bar-and-console-messages--e7d1f71a-7d16-4f41-9c1d-73444e6e8dda?point=7788445288999393628005161043493003&time=2835.3146997929607&focusRegion=eyJiZWdpbiI6eyJwb2ludCI6IjAiLCJ0aW1lIjowfSwiZW5kIjp7InBvaW50IjoiNTY0NjYyMjgzNDA5NDM2NTcwNjQzNTI5MDExNDQ1MTA0NjQiLCJ0aW1lIjoxNzgzM319

In that replay we properly wait for the `bundle_input` row to be shown, and then we hit `enter`. But just because the bundle input row is *visible* does not mean that it's the first result yet, so hitting enter selects the top source, and then when `bundle_input` fails to open the test fails.

I've opted for actually clicking the selector, which I suspect will be more robust than just adding an additional wait, but maybe there's an even better solution that I missed.