### PR TITLE
Fixing broken footer error

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Footer.css
+++ b/src/devtools/client/debugger/src/components/Editor/Footer.css
@@ -56,3 +56,11 @@
   padding: 5px;
   white-space: nowrap;
 }
+
+.error {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-error);
+}

--- a/src/devtools/client/debugger/src/components/Editor/Footer.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Footer.tsx
@@ -22,7 +22,7 @@ function SourceFooter() {
   return (
     <div className="source-footer-wrapper">
       <div className="source-footer">
-        <ErrorBoundary>
+        <ErrorBoundary fallback={<div className="error">An error occurred while replaying</div>}>
           <Suspense>
             <SourcemapToggleSuspends cursorPosition={cursorPosition} />
             <SourcemapVisualizerLinkSuspends cursorPosition={cursorPosition} />


### PR DESCRIPTION
Was:
![image](https://github.com/replayio/devtools/assets/9154902/2457687a-e9bd-4dc5-9370-4aed1bc6fa5b)

Now:
![image](https://github.com/replayio/devtools/assets/9154902/b5ceb153-a5c2-46f1-b2d8-d017c8a23989)
