### PR TITLE
Improved testsuites hierarchy

### DIFF
--- a/src/ui/components/TestSuite/views/TestItem/TestSteps/NetworkTestStepRow.module.css
+++ b/src/ui/components/TestSuite/views/TestItem/TestSteps/NetworkTestStepRow.module.css
@@ -1,5 +1,5 @@
 .Indented {
-  padding-left: 2rem;
+  padding-left: 1rem;
 }
 
 .Token {

--- a/src/ui/components/TestSuite/views/TestMetadata/Panel.module.css
+++ b/src/ui/components/TestSuite/views/TestMetadata/Panel.module.css
@@ -18,7 +18,6 @@
   flex: 1 1 auto;
   font-size: var(--font-size-large);
   color: var(--body-color);
-  overflow: hidden;
   text-overflow: ellipsis;
   word-break: break-all;
   white-space: nowrap;

--- a/src/ui/components/TestSuite/views/TestMetadata/Panel.module.css
+++ b/src/ui/components/TestSuite/views/TestMetadata/Panel.module.css
@@ -18,9 +18,11 @@
   flex: 1 1 auto;
   font-size: var(--font-size-large);
   color: var(--body-color);
+  overflow: hidden;
   text-overflow: ellipsis;
   word-break: break-all;
   white-space: nowrap;
+  line-height: 120%;
 }
 
 .ResultIconAndLabel {

--- a/src/ui/components/TestSuite/views/TestMetadata/TestItemTree.module.css
+++ b/src/ui/components/TestSuite/views/TestMetadata/TestItemTree.module.css
@@ -9,27 +9,13 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  margin-bottom: 30px;
 }
 
 .Scope {
-}
-
-/* Hierarchy styles */
-
-.Tree > .Tree {
-  font-size: 16px;
-}
-
-.Tree > .Tree > .Tree {
-  color: var(--body-color);
-  font-size: 13px;
-}
-
-.Tree > .Tree > .Tree > DIV {
-  font-size: var(--font-size-small);
+  font-size: var(--font-size-medium);
   color: var(--theme-base-60);
   text-transform: uppercase;
   font-weight: bold;
   line-height: 2rem;
-  margin-top: 0.75rem;
 }

--- a/src/ui/components/TestSuite/views/TestMetadata/TestItemTree.module.css
+++ b/src/ui/components/TestSuite/views/TestMetadata/TestItemTree.module.css
@@ -17,5 +17,5 @@
   color: var(--theme-base-60);
   text-transform: uppercase;
   font-weight: bold;
-  line-height: 2rem;
+  margin-bottom: 0.5rem;
 }

--- a/src/ui/components/TestSuite/views/TestMetadata/TestItemTree.module.css
+++ b/src/ui/components/TestSuite/views/TestMetadata/TestItemTree.module.css
@@ -9,7 +9,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  margin-bottom: 30px;
+  margin-bottom: 1rem;
 }
 
 .Scope {

--- a/src/ui/components/TestSuite/views/TestMetadata/TestItemTree.module.css
+++ b/src/ui/components/TestSuite/views/TestMetadata/TestItemTree.module.css
@@ -1,18 +1,35 @@
 .Tree {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
 }
 .Tree[data-nested] {
-  padding-left: 0.75rem;
 }
 
 .List {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  padding-left: 0.75rem;
 }
 
 .Scope {
+}
+
+/* Hierarchy styles */
+
+.Tree > .Tree {
+  font-size: 16px;
+}
+
+.Tree > .Tree > .Tree {
+  color: var(--body-color);
+  font-size: 13px;
+}
+
+.Tree > .Tree > .Tree > DIV {
+  font-size: var(--font-size-small);
+  color: var(--theme-base-60);
+  text-transform: uppercase;
+  font-weight: bold;
+  line-height: 2rem;
+  margin-top: 0.75rem;
 }

--- a/src/ui/components/TestSuite/views/TestMetadata/TestItemTree.tsx
+++ b/src/ui/components/TestSuite/views/TestMetadata/TestItemTree.tsx
@@ -57,28 +57,29 @@ function TestTree({
 }) {
   const testTree = useMemo(() => createTestTree(testItems), [testItems]);
 
-  return <TreeRenderer selectTestItem={selectTestItem} testTree={testTree} />;
+  return <TreeRenderer isTopScope={true} selectTestItem={selectTestItem} testTree={testTree} />;
 }
 
 function TreeRenderer({
-  isNested = false,
+  isTopScope = false,
   scope = null,
   selectTestItem,
   testTree,
 }: {
-  isNested?: boolean;
+  isTopScope?: boolean;
   scope?: string | null;
   selectTestItem: (testItem: ProcessedTestItem) => void;
   testTree: TestTree;
 }) {
-  const parentScope = scope;
+  const className = scope ? styles.TreeNested : styles.Tree;
+  const scopeClassName = isTopScope ? styles.TopScope : styles.Scope;
   return (
-    <div className={styles.Tree} data-nested={isNested || undefined}>
-      {scope !== null && <div className={styles.Scope}>{scope}</div>}
+    <div className={className} data-nested={!!scope}>
+      {scope !== null && <div className={scopeClassName}>{scope}</div>}
       {Object.keys(testTree.scopes).map(scope => (
         <TreeRenderer
           key={scope}
-          isNested={isNested || !!parentScope}
+          isTopScope={false}
           scope={scope}
           selectTestItem={selectTestItem}
           testTree={testTree.scopes[scope]}

--- a/src/ui/components/TestSuite/views/TestMetadata/TestItemTree.tsx
+++ b/src/ui/components/TestSuite/views/TestMetadata/TestItemTree.tsx
@@ -57,29 +57,28 @@ function TestTree({
 }) {
   const testTree = useMemo(() => createTestTree(testItems), [testItems]);
 
-  return <TreeRenderer isTopScope={true} selectTestItem={selectTestItem} testTree={testTree} />;
+  return <TreeRenderer selectTestItem={selectTestItem} testTree={testTree} />;
 }
 
 function TreeRenderer({
-  isTopScope = false,
+  isNested = false,
   scope = null,
   selectTestItem,
   testTree,
 }: {
-  isTopScope?: boolean;
+  isNested?: boolean;
   scope?: string | null;
   selectTestItem: (testItem: ProcessedTestItem) => void;
   testTree: TestTree;
 }) {
-  const className = scope ? styles.TreeNested : styles.Tree;
-  const scopeClassName = isTopScope ? styles.TopScope : styles.Scope;
+  const parentScope = scope;
   return (
-    <div className={className} data-nested={!!scope}>
-      {scope !== null && <div className={scopeClassName}>{scope}</div>}
+    <div className={styles.Tree} data-nested={isNested || undefined}>
+      {scope !== null && <div className={styles.Scope}>{scope}</div>}
       {Object.keys(testTree.scopes).map(scope => (
         <TreeRenderer
           key={scope}
-          isTopScope={false}
+          isNested={isNested || !!parentScope}
           scope={scope}
           selectTestItem={selectTestItem}
           testTree={testTree.scopes[scope]}


### PR DESCRIPTION
**Summary**

Last week I pushed [this PR](https://github.com/replayio/devtools/pull/9188) to improve visual hierarchy, but it failed in some situations. That led to [this bug](https://linear.app/replay/issue/FE-1480/test-suites-font-size-is-off) and Brian reverted [here](https://github.com/replayio/devtools/commit/67109276d27b998d81d5854bf46e350021bd2035).

This commit addresses the issue more carefully, and I've tested it on these links (all localhost):

[Link one](http://localhost:8080/recording/cypresse2eadding-spects--2510b505-2ae9-4009-baea-4a866cd2a69b?point=7463926734776456180313999007547641&time=3897&focusRegion=eyJiZWdpbiI6eyJwb2ludCI6Ijc0NjM5MjY3MzQ3NzY0NTYxODAzMTM5OTkwMDc1NDc2NDEiLCJ0aW1lIjozODk3fSwiZW5kIjp7InBvaW50IjoiMTM2Mjk3NzkyNTUxMzQ2MTk2MTMyNTkxMjY0MzU0ODAwOTgiLCJ0aW1lIjo2MDMyfX0%253D)

[Link two](http://localhost:8080/recording/cypresse2eediting-spects--246f386c-f890-42fe-aa08-ac1fd756704c?point=28557632726786868294881658399621120&time=12169)

[Link three](http://localhost:8080/recording/cypresstestsuibankaccountsspects--f7ef4ea0-5f50-474a-aa70-f89cabe5a0da?point=14603334920664384764506418295342008&time=9415&focusRegion=eyJiZWdpbiI6eyJwb2ludCI6Ijc0NjM5MjY3MzkxMzkyNzI1NjI3NTY5NTI5MjMzMDgyOTYiLCJ0aW1lIjo0ODQzfSwiZW5kIjp7InBvaW50IjoiMjMwNDA4MTczMTg0NTk3NzEzMzc0OTE5MDg2MDQ3MjYxODEiLCJ0aW1lIjoxMjUwNn19)

[Link four](http://localhost:8080/recording/cypressintegrationallsortingspecjs--229a01dd-c01f-45cc-9ad7-2c08ce6a12a0?point=2271629876170247722668778961502515&time=1267)

[Link five](http://localhost:8080/recording/cypressintegrationallfiltersspects--cefb8a85-197f-49e0-bea4-3669d383b2df?point=2596148429826941608430510891073820&time=1400)

Old:
![image](https://github.com/replayio/devtools/assets/9154902/25a65ecd-4b5c-4b62-9a28-44d83fa199e0)

New:
![image](https://github.com/replayio/devtools/assets/9154902/7a3683bf-feca-410e-aa29-d5fb8ef62e8f)
