### PR TITLE
Fix e2e tests add/edit log point helpers

### DIFF
--- a/packages/e2e-tests/helpers/source-panel.ts
+++ b/packages/e2e-tests/helpers/source-panel.ts
@@ -231,8 +231,13 @@ export async function addLogpoint(
     await toggle.click({ force: true });
   }
 
+  const saveAfterEdit =
+    options.saveAfterEdit !== undefined
+      ? options.saveAfterEdit
+      : options.condition !== undefined || options.content !== undefined;
+
   await waitForLogpoint(page, options);
-  await editLogPoint(page, options);
+  await editLogPoint(page, { ...options, saveAfterEdit });
 }
 
 export async function closeSource(page: Page, url: string): Promise<void> {
@@ -254,11 +259,11 @@ export async function editLogPoint(
     content?: string;
     condition?: string;
     lineNumber: number;
-    saveAfterEdit?: boolean;
+    saveAfterEdit: boolean;
     url?: string;
   }
 ) {
-  const { badge, condition, content, lineNumber, saveAfterEdit = true, url } = options;
+  const { badge, condition, content, lineNumber, saveAfterEdit, url } = options;
 
   await debugPrint(
     page,

--- a/packages/e2e-tests/tests/logpoints-06.test.ts
+++ b/packages/e2e-tests/tests/logpoints-06.test.ts
@@ -48,7 +48,7 @@ test(`logpoints-06: should be temporarily disabled`, async ({ page }) => {
   await verifyConsoleMessage(page, MESSAGE, "log-point", 0);
 
   // Editing and saving should re-enable the log point
-  await editLogPoint(page, { content: `"${MESSAGE}"`, lineNumber, url });
+  await editLogPoint(page, { content: `"${MESSAGE}"`, lineNumber, url, saveAfterEdit: true });
   await verifyConsoleMessage(page, MESSAGE, "log-point", 1);
 
   // Now disable and re-enable the log point using the context menu


### PR DESCRIPTION
#9197 fixed most of the recent regressions. This PR should fix the rest (at last the 4 current failures on `main` pass for me locally).