### PR TITLE
Improved logged out experience (NGX)

### DIFF
--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -41,14 +41,16 @@ function useInitialPrimaryPanel() {
 
   const { comments } = hooks.useGetComments(recordingId);
 
-  const initialPrimaryPanel =
-    recording && isTestSuiteReplay(recording)
-      ? "cypress"
-      : showTour
-      ? "tour"
-      : !isAuthenticated && comments.length > 0
-      ? "comments"
-      : "events";
+  let initialPrimaryPanel;
+  if (recording && isTestSuiteReplay(recording)) {
+    initialPrimaryPanel = "cypress";
+  } else if (showTour) {
+    initialPrimaryPanel = "tour";
+  } else if (!isAuthenticated && comments.length > 0) {
+    initialPrimaryPanel = "comments";
+  } else {
+    initialPrimaryPanel = "events";
+  }
 
   useEffect(() => {
     if (selectedPrimaryPanel == null) {

--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import PrimaryPanes from "devtools/client/debugger/src/components/PrimaryPanes";
 import SecondaryPanes from "devtools/client/debugger/src/components/SecondaryPanes";
@@ -37,8 +37,18 @@ function useInitialPrimaryPanel() {
 
   const { nags } = hooks.useGetUserInfo();
   const showTour = shouldShowTour(nags);
+  const { isAuthenticated } = useAuth0();
+
+  const { comments } = hooks.useGetComments(recordingId);
+
   const initialPrimaryPanel =
-    recording && isTestSuiteReplay(recording) ? "cypress" : showTour ? "tour" : "events";
+    recording && isTestSuiteReplay(recording)
+      ? "cypress"
+      : showTour
+      ? "tour"
+      : !isAuthenticated && comments.length > 0
+      ? "comments"
+      : "events";
 
   useEffect(() => {
     if (selectedPrimaryPanel == null) {
@@ -92,25 +102,44 @@ export default function SidePanel() {
   const { recording } = useGetRecording(recordingId);
   const testSuite = recording && isTestSuiteReplay(recording);
 
+  const { comments, loading } = hooks.useGetComments(recordingId);
+
+  const [isNGXHeaderVisible, setIsNGXHeaderVisible] = useState(
+    localStorage.getItem("NGXHeaderVisibility") !== "hidden"
+  );
+
+  const initialPanelRef = useRef(selectedPrimaryPanel);
+
+  useEffect(() => {
+    if (selectedPrimaryPanel !== initialPanelRef.current) {
+      setIsNGXHeaderVisible(false);
+      localStorage.setItem("NGXHeaderVisibility", "hidden");
+    }
+  }, [selectedPrimaryPanel]);
+
   return (
     <div className="flex w-full flex-col gap-2">
-      {!isAuthenticated && !testSuite && (
+      {!isAuthenticated && !testSuite && isNGXHeaderVisible && (
         <div className={styles.TourBox}>
           <h2>Welcome to Replay!</h2>
-          <p>Just getting started with time travel debugging? Check out our docs!</p>
-
-          <button
-            type="button"
-            onClick={() => launchQuickstart("https://docs.replay.io/debugging")}
-            style={{ padding: "4px 8px" }}
-          >
-            <div className="mr-1">Documentation</div>
-            <MaterialIcon style={{ fontSize: "16px" }}>arrow_forward</MaterialIcon>
-          </button>
+          {comments.length > 0 ? (
+            <p>Check out the comments below to get started:</p>
+          ) : (
+            <>
+              <p>Just getting started with time travel debugging? Check out our docs!</p>
+              <button
+                type="button"
+                onClick={() => launchQuickstart("https://docs.replay.io/debugging")}
+                style={{ padding: "4px 8px" }}
+              >
+                <div className="mr-1">Documentation</div>
+                <MaterialIcon style={{ fontSize: "16px" }}>arrow_forward</MaterialIcon>
+              </button>
+            </>
+          )}
         </div>
       )}
-
-      {!isAuthenticated && testSuite && (
+      {!isAuthenticated && testSuite && isNGXHeaderVisible && (
         <div className={styles.TourBox}>
           <h2>Welcome! 👋</h2>
           <p>We've written some docs to get the most out of Replay test suites. Check them out!</p>


### PR DESCRIPTION
**Old version**

1. We'd put a documentation link up in all situations
2. The documentation link (aka "fuchsia hat") wasn't dismissible

![image](https://github.com/replayio/devtools/assets/9154902/a9619ebe-bf6c-4988-b40b-2252c4a4d273)

**New version**

1. If there are comments, we default to that tab with special copy
2. ... and when you click onto any other tab, the "fuchsia hat" goes away (localStorage is used for this)
3. If there are no comments, we show the standard documentation link
4. ... but when you click into any other tab, the "fuchsia hat" goes away

![image](https://github.com/replayio/devtools/assets/9154902/960120ff-2325-447e-b16c-ca5cb77d4d4e)


Here's a little demo:
https://www.loom.com/share/445b9aab2f7144ef9a481c7f470c8220