### PR TITLE
First authenticated e2e tests (comments)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -13,5 +13,5 @@ FRONTEND_API_SECRET=
 # API Key to source icons from Figma
 FIGMA_TOKEN=
 # Authenticated e2e tests
-E2E_FE_TEST_USER_1_API_KEY=
-E2E_FE_TEST_USER_2_API_KEY=
+E2E_USER_1_API_KEY=
+E2E_USER_2_API_KEY=

--- a/.github/workflows/delta.yml
+++ b/.github/workflows/delta.yml
@@ -69,6 +69,8 @@ jobs:
         run: yarn test:ci --reporter @replayio/playwright/reporter,line
         working-directory: packages/replay-next/playwright
         env:
+          API_KEY_1: ${{ secrets.E2E_USER_1_API_KEY }}
+          API_KEY_2: ${{ secrets.E2E_USER_2_API_KEY }}
           SHARD: ${{ matrix.shard }}
           SHARDS: 10
       - name: Upload results

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,7 +88,7 @@ jobs:
         run: npx @replayio/playwright install
       - uses: replayio/action-playwright@main
         with:
-          command: npx playwright test --shard ${{ matrix.shard }}/10 --reporter=@replayio/playwright/reporter,line tests/*.ts
+          command: E2E_USER_1_API_KEY=${{ secrets.E2E_USER_1_API_KEY }} E2E_USER_2_API_KEY=${{ secrets.E2E_USER_2_API_KEY }} npx playwright test --shard ${{ matrix.shard }}/10 --reporter=@replayio/playwright/reporter,line tests/*.ts
           working-directory: ./packages/e2e-tests
           api-key: ${{ env.RECORD_REPLAY_API_KEY }}
           public: true

--- a/packages/e2e-tests/examples.json
+++ b/packages/e2e-tests/examples.json
@@ -1,4 +1,6 @@
 {
+  "authenticated_comments_1.html": "10f1cf17-2a29-4cde-b54e-dcf77f738fbd",
+  "authenticated_comments_2.html": "80e2ad7d-7b13-42d8-af3b-9c761d8528f2",
   "cra/dist/index.html": "19fe1893-b9ea-41a5-a90a-90a209064c0b",
   "doc_async.html": "8c2257d9-6857-4640-8755-b219f286061c",
   "doc_control_flow.html": "8b024e1a-1e84-4424-97bd-3c2c528642fd",

--- a/packages/e2e-tests/helpers/comments.ts
+++ b/packages/e2e-tests/helpers/comments.ts
@@ -1,0 +1,210 @@
+import { Locator, Page, expect } from "@playwright/test";
+import chalk from "chalk";
+
+import { selectContextMenuItem } from "./context-menu";
+import { confirmDialog } from "./dialog";
+import { clearText, focus, isEditable, type as typeText } from "./lexical";
+import { openSource } from "./source-explorer-panel";
+import { getSourceLine } from "./source-panel";
+import { debugPrint, waitFor } from "./utils";
+
+// Keep in sync with shared/graphq/types
+type CommentType =
+  | "network-request"
+  | "source-code"
+  | "visual"
+  // This is a special type that is used to indicate that the comment is a reply to another comment
+  | "reply";
+
+export async function addSourceComment(
+  page: Page,
+  options: {
+    lineNumber: number;
+    text: string;
+    url: string;
+  }
+) {
+  const { lineNumber, url, text } = options;
+
+  await debugPrint(
+    page,
+    `Adding Source comment to ${chalk.bold(`${url}:${lineNumber}`)} with text "${chalk.bold(
+      text
+    )}"`,
+    "addSourceComment"
+  );
+
+  await openSource(page, url);
+
+  const lineLocator = await getSourceLine(page, lineNumber);
+  await lineLocator.click({ button: "right" });
+
+  const idsBefore = await getCommentIds(page, { type: "source-code" });
+
+  await selectContextMenuItem(page, {
+    contextMenuItemTestName: "ContextMenuItem-AddComment",
+    contextMenuTestId: `ContextMenu-Source-${lineNumber}`,
+  });
+
+  // Wait for new comment to be added
+  const commentsLocator = await getComments(page, { type: "source-code" });
+  await waitFor(async () => await expect(await commentsLocator.count()).toBe(idsBefore.size + 1));
+
+  // Find ID of new comment
+  const idsAfter = await getCommentIds(page, { type: "source-code" });
+  idsBefore.forEach(id => idsAfter.delete(id));
+  expect(idsAfter.size).toBe(1);
+
+  const id = Array.from(idsAfter.values())[0];
+  const lexicalSelector = `[data-test-id="CommentInput-${id}"]`;
+  await focus(page, lexicalSelector);
+  await typeText(page, lexicalSelector, text, true);
+
+  await expect(await isEditable(page, lexicalSelector)).toBe(false);
+
+  const commentLocator = await getComments(page, { text, type: "source-code" });
+  await expect(await commentLocator.count()).toBe(1);
+
+  return commentLocator;
+}
+
+export async function deleteAllComments(page: Page) {
+  await showCommentsPanel(page);
+
+  const comments = await getComments(page, { type: "source-code" });
+  const count = await comments.count();
+
+  await debugPrint(page, `Deleting all ${chalk.bold(count)} comments`, "deleteAllComments");
+
+  for (let index = count - 1; index >= 0; index--) {
+    const commentLocator = comments.nth(index);
+    await deleteComment(page, commentLocator);
+  }
+}
+
+export async function deleteComment(page: Page, commentLocator: Locator) {
+  await showCommentsPanel(page);
+
+  const button = commentLocator.locator('[data-test-name="ContextMenuButton"]').first();
+  await button.click();
+
+  await debugPrint(page, `Deleting comment`, "deleteComment");
+
+  await selectContextMenuItem(page, {
+    contextMenuItemTestName: "ContextMenuItem-DeleteComment",
+    contextMenuTestName: "ContextMenu-Comment",
+  });
+
+  await confirmDialog(page, { dialogTestName: "ConfirmDialog-DeleteComment" });
+}
+
+export async function editComment(page: Page, commentLocator: Locator, options: { text: string }) {
+  const { text } = options;
+
+  await debugPrint(page, `Edit comment to contain text "${chalk.bold(text)}"`, "editComment");
+
+  await showCommentsPanel(page);
+
+  const button = commentLocator.locator('[data-test-name="ContextMenuButton"]');
+  await button.click();
+
+  await selectContextMenuItem(page, {
+    contextMenuItemTestName: "ContextMenuItem-EditComment",
+    contextMenuTestName: "ContextMenu-Comment",
+  });
+
+  const id = (await commentLocator.getAttribute("data-test-comment-id")) as string;
+  const lexicalSelector = `[data-test-id="CommentInput-${id}"]`;
+
+  await focus(page, lexicalSelector);
+  await clearText(page, lexicalSelector);
+  await typeText(page, lexicalSelector, text, true);
+
+  commentLocator = await getComment(page, id);
+
+  await expect(await isEditable(page, lexicalSelector)).toBe(false);
+  await expect(await commentLocator.textContent()).toContain(text);
+
+  return commentLocator;
+}
+
+async function getCommentIds(page: Page, options?: { type?: CommentType }): Promise<Set<string>> {
+  const ids: Set<string> = new Set();
+
+  const commentsLocator = await getComments(page, options);
+  const count = await commentsLocator.count();
+  for (let index = count - 1; index >= 0; index--) {
+    const commentLocator = commentsLocator.nth(index);
+    const id = (await commentLocator.getAttribute("data-test-comment-id")) as string;
+    ids.add(id);
+  }
+
+  return ids;
+}
+getComment;
+
+export async function getComment(page: Page, id: string) {
+  return page.locator(`[data-test-comment-id="${id}"]`);
+}
+
+export async function getComments(
+  page: Page,
+  options?: {
+    text?: string;
+    type?: CommentType;
+  }
+) {
+  const { text, type } = options ?? {};
+
+  await debugPrint(
+    page,
+    text
+      ? `Finding "${chalk.bold(type)}" comment with text "${chalk.bold(text)}"`
+      : `Finding "${chalk.bold(type)}" comment`,
+    "getComments"
+  );
+
+  const textSelector = text ? `:has-text("${text}")` : "";
+  const typeSelector = type ? `[data-test-comment-type="${type}"]` : "[data-test-comment-type]";
+
+  return page.locator(`${typeSelector}${textSelector}`);
+}
+
+export async function replyToComment(
+  page: Page,
+  commentLocator: Locator,
+  options: { text: string; url: string }
+) {
+  const { text, url } = options;
+
+  await debugPrint(page, `Replying to comment with text "${chalk.bold(text)}"`, "replyToComment");
+
+  await openSource(page, url);
+
+  const replyButton = commentLocator.locator(`[data-test-name="CommentReplyButton"]`);
+  await replyButton.click();
+
+  const replyId = await commentLocator
+    .locator('[data-test-comment-type="reply"]')
+    .last()
+    .getAttribute("data-test-comment-id");
+
+  const lexicalSelector = `[data-test-id="CommentInput-${replyId}"]`;
+  await focus(page, lexicalSelector);
+  await typeText(page, lexicalSelector, text, true);
+
+  await expect(await isEditable(page, lexicalSelector)).toBe(false);
+
+  const replyLocator = await getComments(page, { text, type: "reply" });
+  await expect(await replyLocator.count()).toBe(1);
+
+  return replyLocator;
+}
+
+export async function showCommentsPanel(page: Page): Promise<void> {
+  const commentsPanelLocator = page.locator('[data-test-name="CommentCardList"]');
+  let isVisible = await commentsPanelLocator.isVisible();
+  if (!isVisible) {
+    await page.locator('[data-test-name="ToolbarButton-Comments"]').click();
+  }
+}

--- a/packages/e2e-tests/helpers/context-menu.ts
+++ b/packages/e2e-tests/helpers/context-menu.ts
@@ -1,0 +1,52 @@
+import { Locator, Page } from "@playwright/test";
+
+export async function selectContextMenuItem(
+  page: Page,
+  options: {
+    contextMenuItemTestId?: string;
+    contextMenuItemTestName?: string;
+    contextMenuItemText?: string;
+    contextMenuTestId?: string;
+    contextMenuTestName?: string;
+  }
+) {
+  const {
+    contextMenuItemTestId,
+    contextMenuItemTestName,
+    contextMenuItemText,
+    contextMenuTestId,
+    contextMenuTestName,
+  } = options;
+
+  let contextMenuLocator: Locator;
+  if (contextMenuTestId) {
+    contextMenuLocator = page.locator(`[data-test-id="${contextMenuTestId}"]`);
+  } else if (contextMenuTestName) {
+    contextMenuLocator = page.locator(`[data-test-name="${contextMenuTestName}"]`);
+  } else if (contextMenuItemText) {
+    contextMenuLocator = page.locator(
+      `[data-test-name="ContextMenu"]:has-text("${contextMenuItemText}")`
+    );
+  } else {
+    contextMenuLocator = page.locator('[data-test-name="ContextMenu"]');
+  }
+
+  let contextMenuItemLocator: Locator;
+  if (contextMenuItemTestId) {
+    contextMenuItemLocator = contextMenuLocator.locator(
+      `[data-test-id="${contextMenuItemTestId}"]`
+    );
+  } else if (contextMenuItemTestName) {
+    contextMenuItemLocator = contextMenuLocator.locator(
+      `[data-test-name="${contextMenuItemTestName}"]`
+    );
+  } else if (contextMenuItemText) {
+    contextMenuItemLocator = contextMenuLocator.locator(
+      `[data-test-name="ContextMenuItem"]:has-text("${contextMenuItemText}")`
+    );
+  } else {
+    throw Error("Insufficient options provided to identify a context menu item");
+  }
+
+  await contextMenuItemLocator.click();
+}

--- a/packages/e2e-tests/helpers/dialog.ts
+++ b/packages/e2e-tests/helpers/dialog.ts
@@ -1,0 +1,61 @@
+import { Locator, Page, expect } from "@playwright/test";
+
+import { debugPrint } from "./utils";
+
+export async function confirmDialog(
+  page: Page,
+  options: {
+    dialogTestId?: string;
+    dialogTestName?: string;
+    dialogText?: string;
+  }
+) {
+  const { dialogTestId, dialogTestName, dialogText } = options;
+
+  await debugPrint(page, `Confirming active dialog`, "confirmDialog");
+
+  let buttonLocator: Locator;
+  if (dialogTestId) {
+    buttonLocator = page.locator(`[data-test-id="${dialogTestId}-ConfirmButton"]`);
+  } else if (dialogTestName) {
+    buttonLocator = page.locator(`[data-test-name="${dialogTestName}-ConfirmButton"]`);
+  } else if (dialogText) {
+    buttonLocator = page.locator(
+      `[data-test-name="ConfirmDialog"]:has-text("${dialogText}") [data-test-name="ConfirmDialog-ConfirmButton"]`
+    );
+  } else {
+    buttonLocator = page.locator('[data-test-name="ConfirmDialog-ConfirmButton"]');
+  }
+
+  await buttonLocator.click();
+  await expect(await buttonLocator.isVisible()).toBe(false);
+}
+
+export async function declineDialog(
+  page: Page,
+  options: {
+    dialogTestId?: string;
+    dialogTestName?: string;
+    dialogText?: string;
+  }
+) {
+  const { dialogTestId, dialogTestName, dialogText } = options;
+
+  await debugPrint(page, `Declining active dialog`, "declineDialog");
+
+  let buttonLocator: Locator;
+  if (dialogTestId) {
+    buttonLocator = page.locator(`[data-test-id="${dialogTestId}-DeclineButton"]`);
+  } else if (dialogTestName) {
+    buttonLocator = page.locator(`[data-test-name="${dialogTestName}-DeclineButton"]`);
+  } else if (dialogText) {
+    buttonLocator = page.locator(
+      `[data-test-name="DeclineDialog"]:has-text("${dialogText}") [data-test-name="DeclineDialog-DeclineButton"]`
+    );
+  } else {
+    buttonLocator = page.locator('[data-test-name="DeclineDialog-DeclineButton"]');
+  }
+
+  await buttonLocator.click();
+  await expect(await buttonLocator.isVisible()).toBe(false);
+}

--- a/packages/e2e-tests/helpers/index.ts
+++ b/packages/e2e-tests/helpers/index.ts
@@ -1,9 +1,12 @@
 import { Page } from "@playwright/test";
 import chalk from "chalk";
+import dotenv from "dotenv";
 
 import { RecordingTarget } from "replay-next/src/suspense/BuildIdCache";
 
 import { debugPrint } from "./utils";
+
+dotenv.config({ path: "../../.env" });
 
 const exampleRecordings = require("../examples.json");
 
@@ -34,10 +37,14 @@ export async function openViewerTab(page: Page) {
   await tab.click();
 }
 
-export async function startTest(page: Page, example: string) {
+export async function startTest(page: Page, example: string, apiKey?: string) {
   const recordingId = exampleRecordings[example];
   const base = process.env.PLAYWRIGHT_TEST_BASE_URL || "http://localhost:8080";
-  const url = `${base}/recording/${recordingId}?e2e=1`;
+
+  let url = `${base}/recording/${recordingId}?e2e=1`;
+  if (apiKey) {
+    url += `&apiKey=${apiKey}`;
+  }
 
   await debugPrint(page, `Navigating to ${chalk.bold(url)}`, "startTest");
 

--- a/packages/e2e-tests/helpers/lexical.ts
+++ b/packages/e2e-tests/helpers/lexical.ts
@@ -32,16 +32,10 @@ export async function hideTypeAheadSuggestions(page: Page, selector: string) {
   }
 }
 
-export async function type(page: Page, selector: string, text: string, shouldSubmit: boolean) {
-  await clearText(page, selector);
-
+export async function isEditable(page: Page, selector: string): Promise<boolean> {
   const input = page.locator(selector);
-  await input.type(text);
-
-  if (shouldSubmit) {
-    await delay(200);
-    await submitCurrentText(page, selector);
-  }
+  const editable = await input.getAttribute("contenteditable");
+  return editable === "true";
 }
 
 export async function submitCurrentText(page: Page, selector: string) {
@@ -64,5 +58,17 @@ export async function submitCurrentText(page: Page, selector: string) {
       // This likely indicates something unexpected.
       break;
     }
+  }
+}
+
+export async function type(page: Page, selector: string, text: string, shouldSubmit: boolean) {
+  await clearText(page, selector);
+
+  const input = page.locator(selector);
+  await input.type(text);
+
+  if (shouldSubmit) {
+    await delay(200);
+    await submitCurrentText(page, selector);
   }
 }

--- a/packages/e2e-tests/tests/comments-01.test.ts
+++ b/packages/e2e-tests/tests/comments-01.test.ts
@@ -1,0 +1,36 @@
+import test from "@playwright/test";
+
+import { openDevToolsTab, startTest } from "../helpers";
+import {
+  addSourceComment,
+  deleteAllComments,
+  deleteComment,
+  editComment,
+} from "../helpers/comments";
+import { openSource } from "../helpers/source-explorer-panel";
+
+// Each authenticated e2e test must use a unique recording id;
+// else shared state from one test could impact another test running in parallel.
+// TODO [SCS-1066] Share recordings between other tests
+const url = "authenticated_comments_1.html";
+
+test(`comments-01: Test add, edit, and delete comment functionality`, async ({ page }) => {
+  await startTest(page, url, process.env.E2E_USER_1_API_KEY);
+  await openDevToolsTab(page);
+
+  await openSource(page, url);
+
+  // Clean up from previous tests
+  // TODO [SCS-1066] Ideally we would create a fresh recording for each test run
+  await deleteAllComments(page);
+
+  let commentLocator = await addSourceComment(page, {
+    text: "This is a test comment",
+    lineNumber: 3,
+    url,
+  });
+
+  commentLocator = await editComment(page, commentLocator, { text: "This is an updated comment" });
+
+  await deleteComment(page, commentLocator);
+});

--- a/packages/e2e-tests/tests/comments-02.test.ts
+++ b/packages/e2e-tests/tests/comments-02.test.ts
@@ -1,0 +1,59 @@
+import test from "@playwright/test";
+
+import { openDevToolsTab, startTest } from "../helpers";
+import {
+  addSourceComment,
+  deleteAllComments,
+  getComments,
+  replyToComment,
+} from "../helpers/comments";
+import { openSource } from "../helpers/source-explorer-panel";
+
+// Each authenticated e2e test must use a unique recording id;
+// else shared state from one test could impact another test running in parallel.
+// TODO [SCS-1066] Share recordings between other tests
+const url = "authenticated_comments_2.html";
+
+test(`comments-02: Test shared comments and replies`, async ({ page }) => {
+  await startTest(page, url, process.env.E2E_USER_1_API_KEY);
+  await openDevToolsTab(page);
+  await openSource(page, url);
+
+  // Clean up from previous tests
+  // TODO [SCS-1066] Ideally we would create a fresh recording for each test run
+  await deleteAllComments(page);
+
+  await addSourceComment(page, {
+    text: "This is a test comment from user 1",
+    lineNumber: 3,
+    url,
+  });
+
+  // Switch to user 2
+  await startTest(page, url, process.env.E2E_USER_2_API_KEY);
+  await openDevToolsTab(page);
+  await openSource(page, url);
+
+  const commentLocator = await getComments(page, {
+    text: "This is a test comment from user 1",
+    type: "source-code",
+  });
+
+  await replyToComment(page, commentLocator, {
+    text: "This is a reply from user 2",
+    url,
+  });
+
+  // Switch back to user 1
+  await startTest(page, url, process.env.E2E_USER_1_API_KEY);
+  await openDevToolsTab(page);
+  await openSource(page, url);
+
+  // Verify reply is visible
+  const replyLocator = await getComments(page, {
+    text: "This is a reply from user 2",
+    type: "source-code",
+  });
+
+  await deleteAllComments(page);
+});

--- a/packages/replay-next/components/lexical/CommentEditor.tsx
+++ b/packages/replay-next/components/lexical/CommentEditor.tsx
@@ -237,6 +237,26 @@ export default function CommentEditor({
     }
   }, [onFormSubmit]);
 
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (editor) {
+      const element = editor.getRootElement();
+      if (element) {
+        if (dataTestId) {
+          element.setAttribute("data-test-id", dataTestId);
+        } else {
+          element.removeAttribute("data-test-id");
+        }
+
+        if (dataTestName) {
+          element.setAttribute("data-test-name", dataTestName);
+        } else {
+          element.removeAttribute("data-test-name");
+        }
+      }
+    }
+  }, [editorRef, dataTestId, dataTestName]);
+
   return (
     <div className={styles.Editor}>
       <LexicalComposer initialConfig={createInitialConfig(markdown, editable)}>

--- a/packages/replay-next/components/sources/useSourceContextMenu.tsx
+++ b/packages/replay-next/components/sources/useSourceContextMenu.tsx
@@ -69,7 +69,11 @@ export default function useSourceContextMenu({
     <>
       {accessToken !== null && (
         <>
-          <ContextMenuItem disabled={isPending} onSelect={addComment}>
+          <ContextMenuItem
+            dataTestName="ContextMenuItem-AddComment"
+            disabled={isPending}
+            onSelect={addComment}
+          >
             Add comment to line {lineNumber}
           </ContextMenuItem>
           <ContextMenuDivider />
@@ -82,6 +86,10 @@ export default function useSourceContextMenu({
         {showHitCounts ? "Hide" : "Show"} hit counts
       </ContextMenuItem>
     </>,
-    { requireClickToShow: true }
+    {
+      requireClickToShow: true,
+      dataTestId: `ContextMenu-Source-${lineNumber}`,
+      dataTestName: "ContextMenu-Source",
+    }
   );
 }

--- a/packages/replay-next/playwright/package.json
+++ b/packages/replay-next/playwright/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "playwright:install": "playwright install chromium",
     "test": "playwright test tests",
-    "test:ci": "WRITE_SNAPSHOT_IMAGE_FILES=true playwright test tests --shard=$SHARD/$SHARDS",
+    "test:ci": "E2E_USER_1_API_KEY=$API_KEY_1 E2E_USER_2_API_KEY=$API_KEY_2 WRITE_SNAPSHOT_IMAGE_FILES=true playwright test tests --shard=$SHARD/$SHARDS",
     "test:debug": "PWDEBUG=console VISUAL_DEBUG=true yarn test"
   }
 }

--- a/packages/shared/graphql/types.ts
+++ b/packages/shared/graphql/types.ts
@@ -63,6 +63,7 @@ export interface CommentSourceLocation {
   sourceId: string;
 }
 
+// TODO Keep in sync with e2e-tests/helpers/comments
 export type CommentType = "source-code" | "network-request" | "visual";
 
 interface Remark {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -53,7 +53,7 @@ function handleAuthError() {
 
 function AppUtilities({ children }: { children: ReactNode }) {
   const router = useRouter();
-  const { isAuthenticated, getAccessTokenSilently, error } = useAuth0();
+  const { getAccessTokenSilently, isAuthenticated } = useAuth0();
 
   _handleAuthError = async () => {
     // This handler attempts to handle the scenario in which the frontend and

--- a/public/test/examples/authenticated_comments_1.html
+++ b/public/test/examples/authenticated_comments_1.html
@@ -1,0 +1,28 @@
+<div>Hello World!</div>
+<script>
+const object = {
+  obj: { value: 0, subobj: { subvalue: 0 } },
+  value: 0,
+};
+
+function recordingFinished() {
+  console.log("ExampleFinished");
+}
+let iteration = 0;
+function f() {
+  iteration++;
+  updateObject();
+  console.log(`Iteration ${iteration}`, object);
+  if (iteration >= 10) {
+    window.setTimeout(recordingFinished);
+    return;
+  }
+  window.setTimeout(f, 100);
+}
+function updateObject() {
+  object.value = iteration;
+  object.obj.value = iteration * 2;
+  object.obj.subobj.subvalue = iteration * 3;
+}
+window.setTimeout(f, 100);
+</script>

--- a/public/test/examples/authenticated_comments_2.html
+++ b/public/test/examples/authenticated_comments_2.html
@@ -1,0 +1,28 @@
+<div>Hello World!</div>
+<script>
+const object = {
+  obj: { value: 0, subobj: { subvalue: 0 } },
+  value: 0,
+};
+
+function recordingFinished() {
+  console.log("ExampleFinished");
+}
+let iteration = 0;
+function f() {
+  iteration++;
+  updateObject();
+  console.log(`Iteration ${iteration}`, object);
+  if (iteration >= 10) {
+    window.setTimeout(recordingFinished);
+    return;
+  }
+  window.setTimeout(f, 100);
+}
+function updateObject() {
+  object.value = iteration;
+  object.obj.value = iteration * 2;
+  object.obj.subobj.subvalue = iteration * 3;
+}
+window.setTimeout(f, 100);
+</script>

--- a/src/ui/components/Comments/CommentCard.tsx
+++ b/src/ui/components/Comments/CommentCard.tsx
@@ -84,8 +84,10 @@ function CommentCard({
         !comment.isPublished && styles.Unpublished,
         isFocused || styles.UnfocusedDimmed
       )}
+      data-test-comment-id={comment.id}
+      data-test-comment-type={comment.type}
+      data-test-id={`CommentCard-${comment.id}`}
       data-test-name="CommentCard"
-      data-test-comment-time={comment.time}
       onClick={onClick}
     >
       {pauseOverlayPosition !== null && (
@@ -107,7 +109,3 @@ function CommentCard({
 
 const MemoizedCommentCard = memo(CommentCard);
 export default MemoizedCommentCard;
-
-export function getCommentTimeFromElement(element: Element) {
-  return parseInt(element.getAttribute("data-test-comment-time") ?? "", 10);
-}

--- a/src/ui/components/Comments/CommentCardsList.tsx
+++ b/src/ui/components/Comments/CommentCardsList.tsx
@@ -122,7 +122,7 @@ export default function CommentCardsList() {
   }
 
   return (
-    <div className={styles.Sidebar}>
+    <div className={styles.Sidebar} data-test-name="CommentCardList">
       <div className={styles.Toolbar}>
         <div className={styles.ToolbarHeader}>Comments</div>
         <CommentDropDownMenu />

--- a/src/ui/components/Comments/CommentReplyButton.tsx
+++ b/src/ui/components/Comments/CommentReplyButton.tsx
@@ -48,7 +48,12 @@ export default function CommentReplyButton({ comment }: { comment: Comment }) {
 
   return (
     <div className={styles.Row}>
-      <button className={styles.Button} disabled={isPending} onClick={addReply}>
+      <button
+        className={styles.Button}
+        data-test-name="CommentReplyButton"
+        disabled={isPending}
+        onClick={addReply}
+      >
         Reply
       </button>
 

--- a/src/ui/components/Comments/EditableRemark.module.css
+++ b/src/ui/components/Comments/EditableRemark.module.css
@@ -68,3 +68,10 @@
 .Icon {
   color: rgb(156 163 175 / var(--tw-text-opacity));
 }
+
+.ContextMenuButton {
+  padding: 0;
+  border: none;
+  background: none;
+  outline: none;
+}

--- a/src/ui/components/Comments/EditableRemark.tsx
+++ b/src/ui/components/Comments/EditableRemark.tsx
@@ -120,20 +120,23 @@ export default function EditableRemark({
         </div>
         <div className={styles.Time}>{formatRelativeTime(new Date(remark.createdAt))}</div>
 
-        <MaterialIcon
-          className={styles.Icon}
-          disabled={isPending}
-          outlined
+        <button
+          className={styles.ContextMenuButton}
+          data-test-name="ContextMenuButton"
           onClick={onContextMenuClick}
         >
-          more_vert
-        </MaterialIcon>
+          <MaterialIcon className={styles.Icon} disabled={isPending} outlined>
+            more_vert
+          </MaterialIcon>
+        </button>
       </div>
 
       <div className={classNames.join(" ")} onDoubleClick={onDoubleClick}>
         <CommentEditor
           autoFocus={isEditing}
           collaborators={collaborators}
+          dataTestId={remark.id ? `CommentInput-${remark.id}` : undefined}
+          dataTestName="CommentInput"
           editable={isEditing && !isPending}
           initialValue={content}
           onCancel={discardPendingChanges}

--- a/src/ui/components/Comments/ReplyCard.tsx
+++ b/src/ui/components/Comments/ReplyCard.tsx
@@ -1,14 +1,24 @@
 import classNames from "classnames";
+import { memo } from "react";
 
 import { Reply } from "ui/state/comments";
 
 import EditableRemark from "./EditableRemark";
 import styles from "./ReplyCard.module.css";
 
-export default function ReplyCard({ reply }: { reply: Reply }) {
+function ReplyCard({ reply }: { reply: Reply }) {
   return (
-    <div className={classNames(styles.ReplyCard, !reply.isPublished && styles.Unpublished)}>
+    <div
+      className={classNames(styles.ReplyCard, !reply.isPublished && styles.Unpublished)}
+      data-test-comment-id={reply.id}
+      data-test-comment-type="reply"
+      data-test-id={`CommentCard-${reply.id}`}
+      data-test-name="CommentCard"
+    >
       <EditableRemark remark={reply} type="reply" />
     </div>
   );
 }
+
+const MemoizedReplyCard = memo(ReplyCard);
+export default MemoizedReplyCard;

--- a/src/ui/components/Comments/useCommentContextMenu.tsx
+++ b/src/ui/components/Comments/useCommentContextMenu.tsx
@@ -43,6 +43,7 @@ export default function useCommentContextMenu({
 
     confirmDestructive({
       acceptLabel: "Delete comment",
+      dataTestName: "ConfirmDialog-DeleteComment",
       description: `${deleteDescription}`,
       message: "Are you sure?",
     }).then(async confirmed => {
@@ -67,12 +68,16 @@ export default function useCommentContextMenu({
   const contextMenuItems: ReactNode[] = [];
   if (isCurrentUserAuthor) {
     contextMenuItems.push(
-      <ContextMenuItem key="edit" onSelect={editRemark}>
+      <ContextMenuItem dataTestName="ContextMenuItem-EditComment" key="edit" onSelect={editRemark}>
         Edit comment
       </ContextMenuItem>
     );
     contextMenuItems.push(
-      <ContextMenuItem key="delete" onSelect={confirmDelete}>
+      <ContextMenuItem
+        dataTestName="ContextMenuItem-DeleteComment"
+        key="delete"
+        onSelect={confirmDelete}
+      >
         {type === "comment" ? "Delete comment and replies" : "Delete comment"}
       </ContextMenuItem>
     );
@@ -106,5 +111,7 @@ export default function useCommentContextMenu({
     </ContextMenuItem>
   );
 
-  return useContextMenu(contextMenuItems);
+  return useContextMenu(contextMenuItems, {
+    dataTestName: "ContextMenu-Comment",
+  });
 }

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -184,7 +184,7 @@ function _DevTools({
 
   useEffect(() => {
     let token: Promise<TokenState | void> = Promise.resolve();
-    if (isAuthenticated && !isTest()) {
+    if (isAuthenticated) {
       token = tokenManager.getToken();
     }
 

--- a/src/ui/components/shared/Button.tsx
+++ b/src/ui/components/shared/Button.tsx
@@ -85,28 +85,35 @@ export const Button = forwardRef<
     size: ButtonSizes;
     style: ButtonStyles;
   }
->(({ size, children, dataTestId, style, color, className, onClick = () => {}, type }, ref) => {
-  const buttonClasses = getButtonClasses(color, style, size);
+>(
+  (
+    { size, children, dataTestId, dataTestName, style, color, className, onClick = () => {}, type },
+    ref
+  ) => {
+    const buttonClasses = getButtonClasses(color, style, size);
 
-  return (
-    <button
-      onClick={onClick}
-      data-test-id={dataTestId}
-      disabled={style === "disabled"}
-      className={classNames(buttonClasses, className)}
-      ref={ref}
-      type={type}
-    >
-      {children}
-    </button>
-  );
-});
+    return (
+      <button
+        onClick={onClick}
+        data-test-id={dataTestId}
+        data-test-name={dataTestName}
+        disabled={style === "disabled"}
+        className={classNames(buttonClasses, className)}
+        ref={ref}
+        type={type}
+      >
+        {children}
+      </button>
+    );
+  }
+);
 Button.displayName = "Button";
 
 interface ButtonProps {
   children?: React.ReactNode;
   className?: string;
   dataTestId?: string;
+  dataTestName?: string;
   onClick?: () => void;
   type?: "button" | "submit";
 }

--- a/src/ui/components/shared/Confirm/ConfirmDialog.tsx
+++ b/src/ui/components/shared/Confirm/ConfirmDialog.tsx
@@ -13,6 +13,8 @@ import {
 
 export type ConfirmOptions = {
   acceptLabel: string;
+  dataTestId?: string;
+  dataTestName?: string;
   declineLabel?: string;
   description?: string;
   isDestructive?: boolean;
@@ -26,6 +28,8 @@ type PropTypes = ConfirmOptions & DialogPropTypes;
 export const ConfirmDialog = ({
   acceptLabel,
   className,
+  dataTestId,
+  dataTestName,
   declineLabel = "Cancel",
   description,
   message,
@@ -50,6 +54,8 @@ export const ConfirmDialog = ({
     <Dialog
       {...props}
       className={className}
+      dataTestId={dataTestId}
+      dataTestName={dataTestName}
       onKeyUp={evt => {
         if (evt.key === "Escape") {
           evt.stopPropagation();
@@ -61,11 +67,19 @@ export const ConfirmDialog = ({
       <DialogTitle>{message}</DialogTitle>
       {description && <DialogDescription>{description}</DialogDescription>}
       <DialogActions>
-        <SecondaryButton color="blue" className="mx-3 flex-1 justify-center" onClick={onDecline}>
+        <SecondaryButton
+          color="blue"
+          className="mx-3 flex-1 justify-center"
+          dataTestId={dataTestId ? `${dataTestId}-DeclineButton` : undefined}
+          dataTestName={dataTestName ? `${dataTestName}-DeclineButton` : undefined}
+          onClick={onDecline}
+        >
           {declineLabel}
         </SecondaryButton>
         <Button
           className="mx-2 flex-1 justify-center"
+          dataTestId={dataTestId ? `${dataTestId}-ConfirmButton` : undefined}
+          dataTestName={dataTestName ? `${dataTestName}-ConfirmButton` : undefined}
           color={isDestructive ? "pink" : "blue"}
           onClick={onAccept}
           ref={primaryButtonRef}

--- a/src/ui/components/shared/Confirm/ConfirmHook.tsx
+++ b/src/ui/components/shared/Confirm/ConfirmHook.tsx
@@ -32,6 +32,7 @@ export const useConfirm = () => {
     (options: Omit<ConfirmOptions, "onAccept" | "onDecline">): Promise<boolean> => {
       return new Promise(resolve => {
         showConfirmation({
+          dataTestName: "ConfirmDialog",
           ...options,
           onAccept: () => resolve(true),
           onDecline: () => resolve(false),

--- a/src/ui/components/shared/Dialog.tsx
+++ b/src/ui/components/shared/Dialog.tsx
@@ -4,12 +4,16 @@ import React, { HTMLProps } from "react";
 import ReplayLogo from "./ReplayLogo";
 
 export type DialogPropTypes = HTMLProps<HTMLDivElement> & { showFooterLinks?: boolean } & {
+  dataTestId?: string;
+  dataTestName?: string;
   showIllustration?: boolean;
 };
 
 export function Dialog({
   children,
   className,
+  dataTestId,
+  dataTestName,
   showFooterLinks,
   showIllustration,
   ...props
@@ -19,6 +23,8 @@ export function Dialog({
       <div
         {...props}
         className={classNames("dialog flex flex-col items-center", className)}
+        data-test-id={dataTestId}
+        data-test-name={dataTestName}
         role="dialog"
         style={{ animation: "linearFadeIn ease 200ms", width: 400 }}
       >

--- a/src/ui/utils/tokenManager.tsx
+++ b/src/ui/utils/tokenManager.tsx
@@ -3,6 +3,7 @@ import jwt_decode from "jwt-decode";
 import React, { ReactNode } from "react";
 
 import { Deferred, assert, defer } from "protocol/utils";
+import { isTest } from "ui/utils/environment";
 
 import { getAuthClientId, getAuthHost } from "./auth";
 import { listenForAccessToken } from "./browser";
@@ -49,13 +50,17 @@ class TokenManager {
   private listeners: TokenListener[] = [];
 
   constructor() {
-    // if (isTest()) {
-    //   this.currentState = {
-    //     loading: false,
-    //     token: "E2E-TEST-TOKEN",
-    //   };
-    //   this.deferredState.resolve(this.currentState);
-    // }
+    if (isTest()) {
+      const url = new URL(window.location.href);
+      const apiKey = url.searchParams.get("apiKey");
+      if (apiKey) {
+        this.currentState = {
+          loading: false,
+          token: apiKey,
+        };
+        this.deferredState.resolve(this.currentState);
+      }
+    }
 
     if (typeof window !== "undefined") {
       listenForAccessToken(token => {


### PR DESCRIPTION
Adds our first authenticated e2e tests for comments:
- [x] Adding, editing, and deleting a source code comment
- [x] Comments and replies between multiple users

The bulk of this PR is adding new e2e helper methods for interacting with context menus and comment cards.

Note there are a couple of _TODO_ comments in this PR, blocked by SCS-1066:
* Tests must begin by cleaning up after previously failed or timed out tests (since we have to re-use recordings)
* Each authenticated test must have its own, unique recording id (else parallel tests might interfere with each other)