### PR TITLE
Authenticated e2e tests (comment previews)

### DIFF
--- a/packages/e2e-tests/authenticated/comments-01.test.ts
+++ b/packages/e2e-tests/authenticated/comments-01.test.ts
@@ -2,7 +2,7 @@ import test from "@playwright/test";
 
 import { openDevToolsTab, startTest } from "../helpers";
 import {
-  addSourceComment,
+  addSourceCodeComment,
   deleteAllComments,
   deleteComment,
   editComment,
@@ -14,19 +14,18 @@ import { openSource } from "../helpers/source-explorer-panel";
 // TODO [SCS-1066] Share recordings between other tests
 const url = "authenticated_comments_1.html";
 
-test(`authenticated-comments-01: Test add, edit, and delete comment functionality`, async ({
+test(`authenticated/comments-01: Test add, edit, and delete comment functionality`, async ({
   page,
 }) => {
   await startTest(page, url, process.env.E2E_USER_1_API_KEY);
   await openDevToolsTab(page);
-
   await openSource(page, url);
 
   // Clean up from previous tests
   // TODO [SCS-1066] Ideally we would create a fresh recording for each test run
   await deleteAllComments(page);
 
-  let commentLocator = await addSourceComment(page, {
+  let commentLocator = await addSourceCodeComment(page, {
     text: "This is a test comment",
     lineNumber: 3,
     url,

--- a/packages/e2e-tests/authenticated/comments-02.test.ts
+++ b/packages/e2e-tests/authenticated/comments-02.test.ts
@@ -2,7 +2,7 @@ import test, { Page } from "@playwright/test";
 
 import { openDevToolsTab, startTest } from "../helpers";
 import {
-  addSourceComment,
+  addSourceCodeComment,
   deleteAllComments,
   getComments,
   replyToComment,
@@ -21,7 +21,7 @@ async function load(page: Page, apiKey: string) {
   await openSource(page, url);
 }
 
-test(`authenticated-comments-02: Test shared comments and replies`, async ({ browser }) => {
+test(`authenticated/comments-02: Test shared comments and replies`, async ({ browser }) => {
   let pageOne: Page;
   let pageTwo: Page;
 
@@ -37,7 +37,7 @@ test(`authenticated-comments-02: Test shared comments and replies`, async ({ bro
     // TODO [SCS-1066] Ideally we would create a fresh recording for each test run
     await deleteAllComments(page);
 
-    await addSourceComment(page, {
+    await addSourceCodeComment(page, {
       text: "This is a test comment from user 1",
       lineNumber: 3,
       url,

--- a/packages/e2e-tests/authenticated/comments-03.test.ts
+++ b/packages/e2e-tests/authenticated/comments-03.test.ts
@@ -1,0 +1,61 @@
+import test, { expect } from "@playwright/test";
+
+import { openDevToolsTab, startTest } from "../helpers";
+import {
+  addNetworkRequestComment,
+  addSourceCodeComment,
+  addVisualComment,
+  deleteAllComments,
+  toggleCommentPreview,
+} from "../helpers/comments";
+import { openNetworkPanel } from "../helpers/network-panel";
+import { openSource } from "../helpers/source-explorer-panel";
+
+// Each authenticated e2e test must use a unique recording id;
+// else shared state from one test could impact another test running in parallel.
+// TODO [SCS-1066] Share recordings between other tests
+const url = "authenticated_comments_3.html";
+
+test(`authenticated/comments-03: Comment previews`, async ({ page }) => {
+  await startTest(page, url, process.env.E2E_USER_1_API_KEY);
+  await openDevToolsTab(page);
+
+  // Clean up from previous tests
+  // TODO [SCS-1066] Ideally we would create a fresh recording for each test run
+  await deleteAllComments(page);
+
+  // Add and verify source code comment previews
+  await openSource(page, url);
+  const sourceCodeComment = await addSourceCodeComment(page, {
+    lineNumber: 23,
+    text: "source code",
+    url,
+  });
+  const sourceCodePreviewText =
+    (await sourceCodeComment.locator('[data-test-name="CommentPreview"]').textContent()) ?? "";
+  await expect(sourceCodePreviewText.trim()).toBe("iteration++;");
+
+  // Add and verify network comment
+  await openNetworkPanel(page);
+  const networkRequestComment = await addNetworkRequestComment(page, {
+    method: "GET",
+    name: "1",
+    status: 200,
+    text: "network request",
+  });
+  const networkRequestCommentPreviewText =
+    (await networkRequestComment.locator('[data-test-name="CommentPreview"]').textContent()) ?? "";
+  await expect(networkRequestCommentPreviewText.trim()).toBe("[GET] 1");
+
+  // Add and verify visual comment
+  const visualComment = await addVisualComment(page, {
+    text: "visual",
+    x: 100,
+    y: 50,
+  });
+  await toggleCommentPreview(page, visualComment, true);
+  await toggleCommentPreview(page, visualComment, false);
+
+  // Clean up
+  await deleteAllComments(page);
+});

--- a/packages/e2e-tests/authenticated/logpoints-01.test.ts
+++ b/packages/e2e-tests/authenticated/logpoints-01.test.ts
@@ -27,7 +27,7 @@ async function load(page: Page, apiKey: string) {
   await disableAllConsoleMessageTypes(page);
 }
 
-test(`authenticated-logpoints-01: Shared logpoints functionality`, async ({ browser }) => {
+test(`authenticated/logpoints-01: Shared logpoints functionality`, async ({ browser }) => {
   let pageOne: Page;
   let pageTwo: Page;
 

--- a/packages/e2e-tests/examples.json
+++ b/packages/e2e-tests/examples.json
@@ -1,6 +1,7 @@
 {
   "authenticated_comments_1.html": "10f1cf17-2a29-4cde-b54e-dcf77f738fbd",
   "authenticated_comments_2.html": "80e2ad7d-7b13-42d8-af3b-9c761d8528f2",
+  "authenticated_comments_3.html": "0cd75bf9-78a8-4c1b-9982-7290e7743c03",
   "authenticated_logpoints_1.html": "f7e69589-ddb8-4a0e-b517-f393d225991e",
   "cra/dist/index.html": "19fe1893-b9ea-41a5-a90a-90a209064c0b",
   "doc_async.html": "8c2257d9-6857-4640-8755-b219f286061c",

--- a/packages/e2e-tests/helpers/context-menu.ts
+++ b/packages/e2e-tests/helpers/context-menu.ts
@@ -1,7 +1,7 @@
 import { Locator, Page } from "@playwright/test";
 
 export async function selectContextMenuItem(
-  page: Page,
+  scope: Page | Locator,
   options: {
     contextMenuItemTestId?: string;
     contextMenuItemTestName?: string;
@@ -20,15 +20,15 @@ export async function selectContextMenuItem(
 
   let contextMenuLocator: Locator;
   if (contextMenuTestId) {
-    contextMenuLocator = page.locator(`[data-test-id="${contextMenuTestId}"]`);
+    contextMenuLocator = scope.locator(`[data-test-id="${contextMenuTestId}"]`);
   } else if (contextMenuTestName) {
-    contextMenuLocator = page.locator(`[data-test-name="${contextMenuTestName}"]`);
+    contextMenuLocator = scope.locator(`[data-test-name="${contextMenuTestName}"]`);
   } else if (contextMenuItemText) {
-    contextMenuLocator = page.locator(
+    contextMenuLocator = scope.locator(
       `[data-test-name="ContextMenu"]:has-text("${contextMenuItemText}")`
     );
   } else {
-    contextMenuLocator = page.locator('[data-test-name="ContextMenu"]');
+    contextMenuLocator = scope.locator('[data-test-name="ContextMenu"]');
   }
 
   let contextMenuItemLocator: Locator;

--- a/packages/e2e-tests/helpers/network-panel.ts
+++ b/packages/e2e-tests/helpers/network-panel.ts
@@ -1,0 +1,36 @@
+import { Locator, Page, expect } from "@playwright/test";
+import chalk from "chalk";
+
+import { debugPrint } from "./utils";
+
+export async function openNetworkPanel(page: Page): Promise<void> {
+  await page.locator('[data-test-id="PanelButton-network"]').click();
+}
+
+export async function findNetworkRequestRow(
+  page: Page,
+  options: {
+    domain?: string;
+    method?: string;
+    name?: string;
+    status?: number;
+    type?: string;
+  }
+): Promise<Locator> {
+  const { domain, name, method, status, type } = options;
+
+  await debugPrint(page, `Finding network request row`, "findNetworkRequestRow");
+
+  let selector = '[data-testid="NetworkMonitor-RequestTable-RequestRow"]';
+  [domain, name, method, status, type].forEach(value => {
+    if (value !== undefined) {
+      selector += `:has-text("${value}")`;
+    }
+  });
+
+  const locator = page.locator(selector);
+
+  await expect(await locator.count()).toBe(1);
+
+  return locator;
+}

--- a/packages/e2e-tests/helpers/utils.ts
+++ b/packages/e2e-tests/helpers/utils.ts
@@ -34,8 +34,6 @@ export async function debugPrint(page: Page | null, message: string, scope?: str
 // This helper can be useful when debugging tests but should not be used in committed tests.
 // (In other words, don't commit code that relies on this in order to work.)
 export function delay(timeout: number) {
-  debugPrint(null, `Delaying for ${chalk.bold(timeout)}ms`, "delay");
-
   return new Promise(resolve => setTimeout(resolve, timeout));
 }
 

--- a/packages/replay-next/components/Icon.tsx
+++ b/packages/replay-next/components/Icon.tsx
@@ -39,6 +39,7 @@ export default function Icon({
     | "fast-forward"
     | "file"
     | "folder"
+    | "inspect"
     | "invisible"
     | "invoke-getter"
     | "menu-closed"
@@ -222,6 +223,10 @@ export default function Icon({
     case "folder":
       path =
         "M20 6h-8l-2-2H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm0 12H4V8h16v10z";
+      break;
+    case "inspect":
+      path =
+        "M8.5,22H3.7l-1.4-1.5V3.8l1.3-1.5h17.2l1,1.5v4.9h-1.3V4.3l-0.4-0.6H4.2L3.6,4.3V20l0.7,0.7h4.2V22z M23,13.9l-4.6,3.6l4.6,4.6l-1.1,1.1l-4.7-4.4l-3.3,4.4l-3.2-12.3L23,13.9z";
       break;
     case "invisible":
       path =

--- a/packages/replay-next/components/comments/CommentPreview.tsx
+++ b/packages/replay-next/components/comments/CommentPreview.tsx
@@ -157,6 +157,8 @@ function VisualPreview({
   return (
     <div
       className={styles.OuterImageContainer}
+      data-test-name="CommentPreview-TogglePreviewButton"
+      data-test-preview-state={showPreview ? "visible" : "hidden"}
       onClick={onClick}
       title={showPreview ? "Hide preview" : "Show preview"}
     >

--- a/public/test/examples/authenticated_comments_3.html
+++ b/public/test/examples/authenticated_comments_3.html
@@ -1,0 +1,38 @@
+<div>Hello World!</div>
+<script>
+const object = {
+  obj: { value: 0, subobj: { subvalue: 0 } },
+  value: 0,
+};
+
+fetch('https://jsonplaceholder.typicode.com/todos/1')
+      .then(response => response.json())
+      .then(json => console.log(json));
+fetch('https://jsonplaceholder.typicode.com/todos/2')
+      .then(response => response.json())
+      .then(json => console.log(json));
+fetch('https://jsonplaceholder.typicode.com/todos/3')
+      .then(response => response.json())
+      .then(json => console.log(json));
+
+function recordingFinished() {
+  console.log("ExampleFinished");
+}
+let iteration = 0;
+function f() {
+  iteration++;
+  updateObject();
+  console.log(`Iteration ${iteration}`, object);
+  if (iteration >= 10) {
+    window.setTimeout(recordingFinished);
+    return;
+  }
+  window.setTimeout(f, 100);
+}
+function updateObject() {
+  object.value = iteration;
+  object.obj.value = iteration * 2;
+  object.obj.subobj.subvalue = iteration * 3;
+}
+window.setTimeout(f, 100);
+</script>

--- a/src/ui/components/Comments/CommentPreview.tsx
+++ b/src/ui/components/Comments/CommentPreview.tsx
@@ -21,7 +21,7 @@ export default function CommentPreview({
 }) {
   if (comment.sourceLocation || isSourceCodeCommentTypeData(comment.type, comment.typeData)) {
     return (
-      <div className={styles.Preview} onClick={onClick}>
+      <div className={styles.Preview} data-test-name="CommentPreview" onClick={onClick}>
         <SourceCodePreview comment={comment} />
       </div>
     );
@@ -30,7 +30,7 @@ export default function CommentPreview({
     isNetworkRequestCommentTypeData(comment.type, comment.typeData)
   ) {
     return (
-      <div className={styles.Preview} onClick={onClick}>
+      <div className={styles.Preview} data-test-name="CommentPreview" onClick={onClick}>
         <NetworkRequestPreview comment={comment} />
       </div>
     );
@@ -40,7 +40,7 @@ export default function CommentPreview({
     isVisualCommentTypeData(comment.type, comment.typeData)
   ) {
     return (
-      <div className={styles.Preview}>
+      <div className={styles.Preview} data-test-name="CommentPreview">
         <VisualPreview comment={comment} />
       </div>
     );

--- a/src/ui/components/Comments/TranscriptComments/VisualPreview.tsx
+++ b/src/ui/components/Comments/TranscriptComments/VisualPreview.tsx
@@ -94,6 +94,8 @@ function ModernVisualPreview({
   return (
     <div
       className={styles.OuterImageContainer}
+      data-test-name="CommentPreview-TogglePreviewButton"
+      data-test-preview-state={showPreview ? "visible" : "hidden"}
       onClick={onClick}
       title={showPreview ? "Hide preview" : "Show preview"}
     >

--- a/src/ui/components/Comments/useCommentContextMenu.tsx
+++ b/src/ui/components/Comments/useCommentContextMenu.tsx
@@ -112,6 +112,7 @@ export default function useCommentContextMenu({
   );
 
   return useContextMenu(contextMenuItems, {
+    dataTestId: `ContextMenu-Comment-${remark.id}`,
     dataTestName: "ContextMenu-Comment",
   });
 }

--- a/src/ui/components/NetworkMonitor/NetworkContextMenu.module.css
+++ b/src/ui/components/NetworkMonitor/NetworkContextMenu.module.css
@@ -1,0 +1,4 @@
+.CommentIcon {
+  width: 1.5rem;
+  height: 1rem;
+}

--- a/src/ui/components/VideoContextMenu.module.css
+++ b/src/ui/components/VideoContextMenu.module.css
@@ -1,0 +1,4 @@
+.Icon {
+  width: 1.5rem;
+  height: 1rem;
+}

--- a/src/ui/components/useVideoContextMenu.tsx
+++ b/src/ui/components/useVideoContextMenu.tsx
@@ -7,6 +7,7 @@ import {
   unhighlightNode,
 } from "devtools/client/inspector/markup/actions/markup";
 import { assert } from "protocol/utils";
+import Icon from "replay-next/components/Icon";
 import { createTypeDataForVisualComment } from "replay-next/components/sources/utils/comments";
 import { InspectorContext } from "replay-next/src/contexts/InspectorContext";
 import { SessionContext } from "replay-next/src/contexts/SessionContext";
@@ -20,6 +21,8 @@ import { isPlaying as isPlayingSelector } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { getMouseTarget } from "ui/suspense/nodeCaches";
 import { mouseEventCanvasPosition as getPositionForInspectingElement } from "ui/utils/nodePicker";
+
+import styles from "./VideoContextMenu.module.css";
 
 export default function useVideoContextMenu({
   canvasRef,
@@ -115,10 +118,24 @@ export default function useVideoContextMenu({
 
   return useContextMenu(
     <>
-      <ContextMenuItem onSelect={inspectElement}>Inspect element</ContextMenuItem>
-      {accessToken !== null && <ContextMenuItem onSelect={addComment}>Add comment</ContextMenuItem>}
+      <ContextMenuItem onSelect={inspectElement}>
+        <>
+          <Icon className={styles.Icon} type="inspect" />
+          Inspect element
+        </>
+      </ContextMenuItem>
+      {accessToken !== null && (
+        <ContextMenuItem dataTestName="ContextMenuItem-AddComment" onSelect={addComment}>
+          <>
+            <Icon className={styles.Icon} type="comment" />
+            Add comment
+          </>
+        </ContextMenuItem>
+      )}
     </>,
     {
+      dataTestName: "ContextMenu-Video",
+      dataTestId: "ContextMenu-Video",
       onHide,
       onShow,
       requireClickToShow: true,

--- a/src/ui/utils/apolloClient.tsx
+++ b/src/ui/utils/apolloClient.tsx
@@ -19,7 +19,7 @@ import { createClient } from "graphql-ws";
 
 import { memoizeLast } from "devtools/client/debugger/src/utils/memoizeLast";
 import { defer } from "protocol/utils";
-import { isE2ETest } from "ui/utils/environment";
+import { hasApiKey, isE2ETest } from "ui/utils/environment";
 
 export let clientWaiter = defer<ApolloClient<NormalizedCacheObject>>();
 
@@ -33,7 +33,9 @@ export async function query<TData = any, TVariables = OperationVariables>(
 export async function mutate<TData = any, TVariables = OperationVariables>(
   options: MutationOptions<TData, TVariables>
 ) {
-  if (isE2ETest()) {
+  if (isE2ETest() && !hasApiKey()) {
+    // Recordings of failed e2e tests may show the Next.js error popup triggered by a failed graphql mutation,
+    // making them hard to work with, so disable mutations unless the user is authenticated.
     return;
   }
   const apolloClient = await clientWaiter.promise;

--- a/src/ui/utils/environment.ts
+++ b/src/ui/utils/environment.ts
@@ -42,6 +42,10 @@ export function getTest() {
   return getURL().searchParams.get("test");
 }
 
+export function hasApiKey() {
+  return !!getURL().searchParams.get("apiKey");
+}
+
 // Return whether we are running one of the tests in our e2e test suite.
 // We will be connected to a live backend and testing debugging features.
 export function isE2ETest() {


### PR DESCRIPTION
### [Loom demo](https://www.loom.com/share/2790208ac1a24d099e706c31288a9b2c)

Adds a new authenticated e2e test for comment preview rendering. This test verifies that comments can be added to source code, network requests, and the video/canvas, and that our comment card UI will render the appropriate preview type for each of these comment types.

This PR also tidies up some context menu stuff that I noticed while testing:
* New "add comment" context menu option added to the network request context menu
* Icons added to the video/canvas context menu
* The `apolloClient` has been updated to not prevent e2e tests form making GraphQL mutations _if the URL has an API key query param_ (RE: #6727)