### PR TITLE
Port workaround for preferred locations and corresponding source IDs

### DIFF
--- a/packages/replay-next/components/console/ErrorStackRenderer.tsx
+++ b/packages/replay-next/components/console/ErrorStackRenderer.tsx
@@ -10,7 +10,7 @@ import { objectPropertyCache } from "replay-next/src/suspense/ObjectPreviews";
 import { sourceOutlineCache } from "replay-next/src/suspense/SourceOutlineCache";
 import { sourcesByIdCache, sourcesByUrlCache } from "replay-next/src/suspense/SourcesCache";
 import { findFunctionNameForLocation, isSourceMappedSource } from "replay-next/src/utils/source";
-import { getPreferredLocation } from "replay-next/src/utils/sources";
+import { getPreferredLocationWorkaround } from "replay-next/src/utils/sources";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
 import Source from "./Source";
@@ -78,7 +78,7 @@ function ErrorFrameRendererSuspends({ frame }: { frame: StackFrame }) {
       column: columnNumber,
     };
     const mappedLocation = mappedLocationCache.read(client, location);
-    const preferredLocation = getPreferredLocation(
+    const preferredLocation = getPreferredLocationWorkaround(
       sourcesById,
       preferredGeneratedSourceIds,
       mappedLocation

--- a/packages/replay-next/components/console/MessageHoverButton.tsx
+++ b/packages/replay-next/components/console/MessageHoverButton.tsx
@@ -21,7 +21,7 @@ import { SourcesContext } from "replay-next/src/contexts/SourcesContext";
 import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
 import { useNag } from "replay-next/src/hooks/useNag";
 import { sourcesByIdCache } from "replay-next/src/suspense/SourcesCache";
-import { getPreferredLocation } from "replay-next/src/utils/sources";
+import { getPreferredLocationWorkaround } from "replay-next/src/utils/sources";
 import { isExecutionPointsGreaterThan } from "replay-next/src/utils/time";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { addComment as addCommentGraphQL } from "shared/graphql/Comments";
@@ -62,7 +62,7 @@ export default function MessageHoverButton({
   const sourcesById = sourcesByIdCache.getValueIfCached(client);
   const location =
     locations && sourcesById
-      ? getPreferredLocation(sourcesById, preferredGeneratedSourceIds, locations)
+      ? getPreferredLocationWorkaround(sourcesById, preferredGeneratedSourceIds, locations)
       : null;
 
   let button = null;

--- a/packages/replay-next/components/console/Source.tsx
+++ b/packages/replay-next/components/console/Source.tsx
@@ -1,11 +1,12 @@
-import { Location as ProtocolLocation } from "@replayio/protocol";
-import { MouseEvent, useContext } from "react";
+import { MappedLocation, Location as ProtocolLocation, SourceId } from "@replayio/protocol";
+import { MouseEvent, useContext, useMemo } from "react";
 
 import { InspectorContext } from "replay-next/src/contexts/InspectorContext";
 import { SessionContext } from "replay-next/src/contexts/SessionContext";
 import { SourcesContext } from "replay-next/src/contexts/SourcesContext";
 import { getSourceSuspends, sourcesByIdCache } from "replay-next/src/suspense/SourcesCache";
-import { getPreferredLocation } from "replay-next/src/utils/sources";
+import { Source as SourceType } from "replay-next/src/suspense/SourcesCache";
+import { getPreferredLocationWorkaround } from "replay-next/src/utils/sources";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
 import styles from "./Source.module.css";
@@ -23,7 +24,11 @@ export default function Source({
   const { preferredGeneratedSourceIds } = useContext(SourcesContext);
 
   const sourcesById = sourcesByIdCache.read(client);
-  const location = getPreferredLocation(sourcesById, preferredGeneratedSourceIds, locations);
+  const location = getPreferredLocationWorkaround(
+    sourcesById,
+    preferredGeneratedSourceIds,
+    locations
+  );
   if (location == null) {
     return null;
   }

--- a/packages/replay-next/src/utils/sources.ts
+++ b/packages/replay-next/src/utils/sources.ts
@@ -111,6 +111,21 @@ export function getPreferredLocation(
   return preferredLocation;
 }
 
+export function getPreferredLocationWorkaround(
+  sourcesById: Map<SourceId, Source>,
+  preferredGeneratedSourceIds: SourceId[],
+  locations: MappedLocation
+) {
+  // TODO [FE-1508] another hack: the new console doesn't update sourceIds in locations
+  // to their first corresponding sourceId, which getPreferredLocation
+  // subsequently complains about
+  const correspondingLocations = locations.map(location => ({
+    ...location,
+    sourceId: getCorrespondingSourceIds(sourcesById, location.sourceId)[0],
+  }));
+  return getPreferredLocation(sourcesById, preferredGeneratedSourceIds, correspondingLocations);
+}
+
 export function getAlternateSourceId(
   sourcesById: Map<SourceId, Source>,
   sourceIds: SourceId[],


### PR DESCRIPTION
This PR:

- Ports a workaround for `getPreferredLocation`'s corresponding source IDs assertion that _was_ in place prior to #9204 over to the current sources handling logic.


Original hack was here:

- https://github.com/replayio/devtools/blob/4c972f026f400249b8e9e518f1c1b64e097882e4/src/ui/utils/preferredLocation.ts

I don't know why we have these corresponding source ID mismatches, but apparently we've been working around it for a long time.  Filed FE-1508 as a follow-up to review why that is and hopefully remove this hack.