### PR TITLE
Improve loading screen states

### DIFF
--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -217,7 +217,7 @@ function _DevTools({
     }
   }, [loadingFinished, trackLoadingIdleTime, sessionId]);
 
-  if (1 == 1) {
+  if (!loadingFinished) {
     return <LoadingScreen fallbackMessage="Loading..." />;
   }
 

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -217,7 +217,7 @@ function _DevTools({
     }
   }, [loadingFinished, trackLoadingIdleTime, sessionId]);
 
-  if (!loadingFinished) {
+  if (1 == 1) {
     return <LoadingScreen fallbackMessage="Loading..." />;
   }
 

--- a/src/ui/components/shared/LoadingScreen.module.css
+++ b/src/ui/components/shared/LoadingScreen.module.css
@@ -24,7 +24,7 @@
 }
 
 .messageWrapper a:hover {
-  color: rgb(80, 202, 255);
+  color: var(--primary-accent);
 }
 
 .viewportWrapper {

--- a/src/ui/components/shared/LoadingScreen.module.css
+++ b/src/ui/components/shared/LoadingScreen.module.css
@@ -1,0 +1,38 @@
+.loadingScreenWrapper {
+  position: relative;
+  display: flex;
+  width: 24rem;
+  flex-direction: column;
+  align-items: center;
+  padding: 1rem 1rem 3rem;
+  margin: 0.25rem;
+}
+
+.hoverboardWrapper {
+  height: 8rem;
+  width: 8rem;
+  cursor: pointer;
+}
+
+.messageWrapper {
+  font-size: 0.875rem;
+  text-align: center;
+}
+
+.messageWrapper a {
+  text-decoration: underline;
+}
+
+.messageWrapper a:hover {
+  color: rgb(80, 202, 255);
+}
+
+.viewportWrapper {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 1rem;
+  margin: 0.5rem;
+  border-radius: 0.5rem;
+}

--- a/src/ui/components/shared/LoadingScreen.module.css
+++ b/src/ui/components/shared/LoadingScreen.module.css
@@ -3,9 +3,6 @@
   display: flex;
   width: 24rem;
   flex-direction: column;
-  align-items: center;
-  padding: 1rem 1rem 3rem;
-  margin: 0.25rem;
 }
 
 .hoverboardWrapper {

--- a/src/ui/components/shared/LoadingScreen.tsx
+++ b/src/ui/components/shared/LoadingScreen.tsx
@@ -69,16 +69,9 @@ function LoadingScreen({
       const randomIndex = Math.floor(Math.random() * phrases.length);
       setMessage(phrases[randomIndex]);
     };
-
     const phraseTimeout = setTimeout(changeMessage, 5000);
-
     return () => clearTimeout(phraseTimeout);
   }, []);
-
-  useEffect(() => {
-    const phraseTimeout = setTimeout(changeMessage, 5000);
-    return () => clearTimeout(phraseTimeout);
-  }, [changeMessage]);
 
   useEffect(() => {
     const stalledTimeoutId = setTimeout(() => {

--- a/src/ui/components/shared/LoadingScreen.tsx
+++ b/src/ui/components/shared/LoadingScreen.tsx
@@ -64,9 +64,15 @@ function LoadingScreen({
 
   const [message, setMessage] = useState(fallbackMessage);
 
-  const changeMessage = useCallback(() => {
-    const randomIndex = Math.floor(Math.random() * phrases.length);
-    setMessage(phrases[randomIndex]);
+  useEffect(() => {
+    const changeMessage = () => {
+      const randomIndex = Math.floor(Math.random() * phrases.length);
+      setMessage(phrases[randomIndex]);
+    };
+
+    const phraseTimeout = setTimeout(changeMessage, 5000);
+
+    return () => clearTimeout(phraseTimeout);
   }, []);
 
   useEffect(() => {

--- a/src/ui/components/shared/LoadingScreen.tsx
+++ b/src/ui/components/shared/LoadingScreen.tsx
@@ -18,15 +18,15 @@ const Hoverboard = dynamic(() => import("./Hoverboard"), {
 export function LoadingScreenTemplate({ children }: { children?: ReactNode }) {
   const [hoverboardColor, setHoverboardColor] = useState(colorOptions[2]);
 
-  const changeHoverboardColor = () => {
+  const changeHoverboardColor = useCallback(() => {
     const randomIndex = Math.floor(Math.random() * colorOptions.length);
     setHoverboardColor(colorOptions[randomIndex]);
-  };
+  }, []);
 
   useEffect(() => {
-    const interval = setInterval(changeHoverboardColor, 5_000);
-    return () => clearInterval(interval);
-  }, [hoverboardColor]);
+    const timeoutId = setTimeout(changeHoverboardColor, 5000);
+    return () => clearTimeout(timeoutId);
+  }, [changeHoverboardColor]);
 
   return (
     <div className={styles.loadingScreenWrapper}>

--- a/src/ui/components/shared/LoadingScreen.tsx
+++ b/src/ui/components/shared/LoadingScreen.tsx
@@ -6,6 +6,7 @@ import { getAwaitingSourcemaps, getUploading } from "ui/reducers/app";
 import { UIState } from "ui/state";
 
 import { BubbleViewportWrapper } from "./Viewport";
+import styles from "./LoadingScreen.module.css";
 
 const colorOptions: Array<"blue" | "green" | "red"> = ["blue", "green", "red"];
 
@@ -28,10 +29,10 @@ export function LoadingScreenTemplate({ children }: { children?: ReactNode }) {
   }, [hoverboardColor]);
 
   return (
-    <BubbleViewportWrapper>
-      <div className="relative flex w-96 flex-col items-center space-y-1 rounded-lg bg-loadingBoxes p-4 py-12 shadow-sm">
+    <BubbleViewportWrapper className={styles.viewportWrapper}>
+      <div className={styles.loadingScreenWrapper}>
         <div className="flex flex-col items-center space-y-2">
-          <div className="h-32 w-32" onClick={changeHoverboardColor}>
+          <div className={styles.hoverboardWrapper} onClick={changeHoverboardColor}>
             <Hoverboard color={hoverboardColor} />
           </div>
           {children}
@@ -45,32 +46,48 @@ function LoadingScreen({
   uploading,
   awaitingSourcemaps,
   fallbackMessage,
-  stalledTimeout = 9000,
+  stalledTimeout = 15000,
 }: PropsFromRedux & { fallbackMessage: string; stalledTimeout?: number }) {
-  // The backend send events in this order: uploading replay -> uploading sourcemaps.
-  let waitingForMessage = <span>{fallbackMessage}</span>;
-  if (awaitingSourcemaps) {
-    waitingForMessage = <span>Uploading sourcemaps...</span>;
-    stalledTimeout = Infinity;
-  } else if (uploading) {
-    waitingForMessage = <span>Uploading {Math.round(+uploading.amount)}Mb</span>;
-    stalledTimeout = Infinity;
-  }
+  const phrases = [
+    "Tuning the flux capacitor...",
+    "Prepping DeLorean for time travel...",
+    "Revving up to 88 miles per hour...",
+    "Gathering 1.21 gigawatts of power...",
+    "Ensuring temporal paradox safeguards...",
+    "Being careful not to mess up your timeline...",
+  ];
+  const longWaitMessage =
+    "<div><p>This is taking longer than expected.</p><p><a href='http://replay.io/discord' target='discord'>Contact us on Discord</a></p>";
 
-  let [stalled, setStalled] = useState<boolean>(false);
+  const [message, setMessage] = useState(fallbackMessage);
+
+  const changeMessage = () => {
+    const randomIndex = Math.floor(Math.random() * phrases.length);
+    setMessage(phrases[randomIndex]);
+  };
+
   useEffect(() => {
-    if (stalledTimeout === Infinity) {
-      return;
-    }
+    const phraseTimeout = setTimeout(changeMessage, 5000);
+    return () => clearTimeout(phraseTimeout);
+  }, []);
 
-    const timeout = setTimeout(() => setStalled(true), stalledTimeout);
+  useEffect(() => {
+    const stalledTimeoutId = setTimeout(() => {
+      setMessage(longWaitMessage);
+    }, stalledTimeout);
+    return () => clearTimeout(stalledTimeoutId);
+  }, []);
 
-    return () => clearTimeout(timeout);
-  }, [fallbackMessage, stalledTimeout]);
+  const waitingForMessage =
+    awaitingSourcemaps || uploading ? (
+      <span>Uploading {Math.round(uploading?.amount || 0)}Mb</span>
+    ) : (
+      <span dangerouslySetInnerHTML={{ __html: message }}></span>
+    );
 
   return (
     <LoadingScreenTemplate>
-      <span className="text-sm">{stalled ? "Reticulating splines..." : waitingForMessage}</span>
+      <span className={styles.messageWrapper} dangerouslySetInnerHTML={{ __html: message }}></span>
     </LoadingScreenTemplate>
   );
 }

--- a/src/ui/components/shared/LoadingScreen.tsx
+++ b/src/ui/components/shared/LoadingScreen.tsx
@@ -29,16 +29,18 @@ export function LoadingScreenTemplate({ children }: { children?: ReactNode }) {
   }, [hoverboardColor]);
 
   return (
-    <BubbleViewportWrapper className={styles.viewportWrapper}>
-      <div className={styles.loadingScreenWrapper}>
-        <div className="flex flex-col items-center space-y-2">
-          <div className={styles.hoverboardWrapper} onClick={changeHoverboardColor}>
-            <Hoverboard color={hoverboardColor} />
+    <div className={styles.loadingScreenWrapper}>
+      <BubbleViewportWrapper>
+        <div className={styles.loadingScreenWrapper}>
+          <div className="flex flex-col items-center space-y-2">
+            <div className={styles.hoverboardWrapper} onClick={changeHoverboardColor}>
+              <Hoverboard color={hoverboardColor} />
+            </div>
+            {children}
           </div>
-          {children}
         </div>
-      </div>
-    </BubbleViewportWrapper>
+      </BubbleViewportWrapper>
+    </div>
   );
 }
 

--- a/src/ui/components/shared/LoadingScreen.tsx
+++ b/src/ui/components/shared/LoadingScreen.tsx
@@ -61,22 +61,22 @@ function LoadingScreen({
 
   const [message, setMessage] = useState(fallbackMessage);
 
-  const changeMessage = () => {
+  const changeMessage = useCallback(() => {
     const randomIndex = Math.floor(Math.random() * phrases.length);
     setMessage(phrases[randomIndex]);
-  };
+  }, [phrases]);
 
   useEffect(() => {
     const phraseTimeout = setTimeout(changeMessage, 5000);
     return () => clearTimeout(phraseTimeout);
-  }, []);
+  }, [changeMessage]);
 
   useEffect(() => {
     const stalledTimeoutId = setTimeout(() => {
       setMessage(longWaitMessage);
     }, stalledTimeout);
     return () => clearTimeout(stalledTimeoutId);
-  }, []);
+  }, [stalledTimeout]);
 
   const waitingForMessage =
     awaitingSourcemaps || uploading ? (

--- a/src/ui/components/shared/LoadingScreen.tsx
+++ b/src/ui/components/shared/LoadingScreen.tsx
@@ -1,5 +1,5 @@
 import dynamic from "next/dynamic";
-import React, { ReactNode, useEffect, useState } from "react";
+import React, { ReactNode, useCallback, useEffect, useState } from "react";
 import { ConnectedProps, connect } from "react-redux";
 
 import { getAwaitingSourcemaps, getUploading } from "ui/reducers/app";
@@ -66,7 +66,7 @@ function LoadingScreen({
   const changeMessage = useCallback(() => {
     const randomIndex = Math.floor(Math.random() * phrases.length);
     setMessage(phrases[randomIndex]);
-  }, [phrases]);
+  }, []);
 
   useEffect(() => {
     const phraseTimeout = setTimeout(changeMessage, 5000);

--- a/src/ui/components/shared/LoadingScreen.tsx
+++ b/src/ui/components/shared/LoadingScreen.tsx
@@ -44,20 +44,21 @@ export function LoadingScreenTemplate({ children }: { children?: ReactNode }) {
   );
 }
 
+const phrases = [
+  "Tuning the flux capacitor...",
+  "Prepping DeLorean for time travel...",
+  "Revving up to 88 miles per hour...",
+  "Gathering 1.21 gigawatts of power...",
+  "Ensuring temporal paradox safeguards...",
+  "Being careful not to mess up your timeline...",
+];
+
 function LoadingScreen({
   uploading,
   awaitingSourcemaps,
   fallbackMessage,
   stalledTimeout = 15000,
 }: PropsFromRedux & { fallbackMessage: string; stalledTimeout?: number }) {
-  const phrases = [
-    "Tuning the flux capacitor...",
-    "Prepping DeLorean for time travel...",
-    "Revving up to 88 miles per hour...",
-    "Gathering 1.21 gigawatts of power...",
-    "Ensuring temporal paradox safeguards...",
-    "Being careful not to mess up your timeline...",
-  ];
   const longWaitMessage =
     "<div><p>This is taking longer than expected.</p><p><a href='http://replay.io/discord' target='discord'>Contact us on Discord</a></p>";
 
@@ -82,11 +83,10 @@ function LoadingScreen({
 
   const waitingForMessage =
     awaitingSourcemaps || uploading ? (
-      <span>Uploading {Math.round(uploading?.amount || 0)}Mb</span>
+      <span>Uploading {Math.round(uploading?.amount ? Number(uploading.amount) : 0)}Mb</span>
     ) : (
       <span dangerouslySetInnerHTML={{ __html: message }}></span>
     );
-
   return (
     <LoadingScreenTemplate>
       <span className={styles.messageWrapper} dangerouslySetInnerHTML={{ __html: message }}></span>

--- a/src/ui/components/shared/LoadingScreen.tsx
+++ b/src/ui/components/shared/LoadingScreen.tsx
@@ -24,8 +24,8 @@ export function LoadingScreenTemplate({ children }: { children?: ReactNode }) {
   }, []);
 
   useEffect(() => {
-    const timeoutId = setTimeout(changeHoverboardColor, 5000);
-    return () => clearTimeout(timeoutId);
+    const timeoutId = setInterval(changeHoverboardColor, 5000);
+    return () => clearInterval(timeoutId);
   }, [changeHoverboardColor]);
 
   return (
@@ -70,11 +70,14 @@ function LoadingScreen({
       setMessage(phrases[randomIndex]);
     };
     const phraseTimeout = setTimeout(changeMessage, 5000);
+    // swap to cutesy phrase after 5 seconds
+    // note: this should only be called a single time
     return () => clearTimeout(phraseTimeout);
   }, []);
 
   useEffect(() => {
     const stalledTimeoutId = setTimeout(() => {
+      // after 15 seconds, switch to stalled message
       setMessage(longWaitMessage);
     }, stalledTimeout);
     return () => clearTimeout(stalledTimeoutId);


### PR DESCRIPTION
**Problem we're trying to solve**

* Right now our loading screen can stall out silently, so this PR makes it more clear
* There's no option to contact us, so this PR adds one
* This is a good place to add some tone, so this PR adds some

Loom demonstration: https://www.loom.com/share/d397fe24860b4c4a8e16dd5c49796843

Addresses https://linear.app/replay/issue/DES-635/our-loading-screen-needs-to-provide-help-when-things-stall-out