### PR TITLE
Write Delta snapshot files to unique paths per test

### DIFF
--- a/packages/replay-next/playwright/.gitignore
+++ b/packages/replay-next/playwright/.gitignore
@@ -4,3 +4,4 @@ cache_buster
 playwright-report*
 snapshots/tests
 test-results
+visuals

--- a/packages/replay-next/playwright/tests/console/beforeEach.ts
+++ b/packages/replay-next/playwright/tests/console/beforeEach.ts
@@ -1,3 +1,4 @@
+import "../currentTestInfoWatcher";
 import { test } from "@playwright/test";
 
 import testSetup from "../utils/testSetup";

--- a/packages/replay-next/playwright/tests/currentTestInfoWatcher.ts
+++ b/packages/replay-next/playwright/tests/currentTestInfoWatcher.ts
@@ -1,0 +1,15 @@
+import { TestInfo, test } from "@playwright/test";
+
+let currentTestInfo: TestInfo | null = null;
+
+test.afterEach(async () => {
+  currentTestInfo = null;
+});
+
+test.beforeEach(async ({}, testInfo) => {
+  currentTestInfo = testInfo;
+});
+
+export function getCurrentTestInfo() {
+  return currentTestInfo;
+}

--- a/packages/replay-next/playwright/tests/nested/beforeEach.ts
+++ b/packages/replay-next/playwright/tests/nested/beforeEach.ts
@@ -1,3 +1,4 @@
+import "../currentTestInfoWatcher";
 import { test } from "@playwright/test";
 
 import { toggleProtocolMessages } from "../utils/console";

--- a/packages/replay-next/playwright/tests/object-inspector-context-menu/beforeEach.ts
+++ b/packages/replay-next/playwright/tests/object-inspector-context-menu/beforeEach.ts
@@ -1,3 +1,4 @@
+import "../currentTestInfoWatcher";
 import { test } from "@playwright/test";
 
 import { toggleProtocolMessage, toggleProtocolMessages } from "../utils/console";

--- a/packages/replay-next/playwright/tests/object-inspector/beforeEach.ts
+++ b/packages/replay-next/playwright/tests/object-inspector/beforeEach.ts
@@ -1,3 +1,4 @@
+import "../currentTestInfoWatcher";
 import { test } from "@playwright/test";
 
 import { toggleProtocolMessage, toggleProtocolMessages } from "../utils/console";

--- a/packages/replay-next/playwright/tests/scopes-inspector/beforeEach.ts
+++ b/packages/replay-next/playwright/tests/scopes-inspector/beforeEach.ts
@@ -1,3 +1,4 @@
+import "../currentTestInfoWatcher";
 import { test } from "@playwright/test";
 
 import { getTestUrl } from "../utils/general";

--- a/packages/replay-next/playwright/tests/source-and-console/beforeEach.ts
+++ b/packages/replay-next/playwright/tests/source-and-console/beforeEach.ts
@@ -1,3 +1,4 @@
+import "../currentTestInfoWatcher";
 import { test } from "@playwright/test";
 
 import { getTestUrl } from "../utils/general";

--- a/packages/replay-next/playwright/tests/source-preview/beforeEach.ts
+++ b/packages/replay-next/playwright/tests/source-preview/beforeEach.ts
@@ -1,3 +1,4 @@
+import "../currentTestInfoWatcher";
 import { test } from "@playwright/test";
 
 import { getTestUrl } from "../utils/general";

--- a/packages/replay-next/playwright/tests/source-search/beforeEach.ts
+++ b/packages/replay-next/playwright/tests/source-search/beforeEach.ts
@@ -1,3 +1,4 @@
+import "../currentTestInfoWatcher";
 import { test } from "@playwright/test";
 
 import { getTestUrl } from "../utils/general";


### PR DESCRIPTION
Initially screenshots were being saved to a directory that included the test file name and the description, e.g. `packages/replay-next/playwright/snapshots/tests/console/should-be-filterable-on-complex-content.ts-snapshots/dark/…`

As of PR #8407, screenshots for CI tests we being written to a flat directory, `packages/replay-next/playwright/visuals/dark/…`

This made a race condition for tests that happened to have screenshots with the same names. This PR restores something more like the original behavior. (Note that it will generate _a lot_ of Delta changes.)

Tagging reviewers mostly as an FYI, not for actual review.