### PR TITLE
Reduce Console screenshot test flakiness

### DIFF
--- a/packages/replay-next/components/console/MessagesList.tsx
+++ b/packages/replay-next/components/console/MessagesList.tsx
@@ -1,6 +1,7 @@
 import { ForwardedRef, MutableRefObject, ReactNode, forwardRef, useContext, useMemo } from "react";
 
 import Icon from "replay-next/components/Icon";
+import { ConsoleFiltersContext } from "replay-next/src/contexts/ConsoleFiltersContext";
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
 import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
 import { useStreamingMessages } from "replay-next/src/hooks/useStreamingMessages";
@@ -45,8 +46,9 @@ const ErrorBoundary = ({ children }: { children: ReactNode }) => (
 // 1. Using React Suspense (and Suspense caches) for just-in-time loading of Protocol data
 // 2. Using an injected ReplayClientInterface to enable easy testing/mocking
 function MessagesList({ forwardedRef }: { forwardedRef: ForwardedRef<HTMLElement> }) {
-  const { isTransitionPending: isFocusTransitionPending, range: focusRange } =
-    useContext(FocusContext);
+  const { showErrors, showExceptions, showLogs, showNodeModules, showTimestamps, showWarnings } =
+    useContext(ConsoleFiltersContext);
+  const { isTransitionPending: isFocusTransitionPending } = useContext(FocusContext);
   const loggables = useContext(LoggablesContext);
   const [searchState] = useContext(ConsoleSearchContext);
   const { executionPoint: currentExecutionPoint } = useContext(TimelineContext);
@@ -184,6 +186,12 @@ function MessagesList({ forwardedRef }: { forwardedRef: ForwardedRef<HTMLElement
       )}
       <div
         className={styles.Container}
+        data-test-state-errors={showErrors ? true : undefined}
+        data-test-state-exceptions={showExceptions ? true : undefined}
+        data-test-state-logs={showLogs ? true : undefined}
+        data-test-state-nodeModules={showNodeModules ? true : undefined}
+        data-test-state-timestamps={showTimestamps ? true : undefined}
+        data-test-state-warnings={showWarnings ? true : undefined}
         data-test-name="Messages"
         ref={forwardedRef as MutableRefObject<HTMLDivElement>}
         role="list"

--- a/packages/replay-next/playwright/tests/utils/console.ts
+++ b/packages/replay-next/playwright/tests/utils/console.ts
@@ -213,6 +213,23 @@ export async function toggleProtocolMessage(page: Page, name: ToggleName, on: bo
 
     await page.click(`[data-test-id="FilterToggle-${name}"]`);
   }
+
+  // Wait for Console to update with new filter value
+  await waitFor(async () => {
+    const messageList = page.locator('[data-test-name="Messages"]');
+    const value = await messageList.getAttribute(`data-test-state-${name}`);
+    if (on) {
+      expect(value).not.toBeNull();
+    } else {
+      expect(value).toBeNull();
+    }
+  });
+
+  // Wait for messages within the Console to fully load
+  await waitFor(async () => {
+    const messageList = page.locator('[data-test-name="Messages"]');
+    await expect(await messageList.locator('[data-test-name="Loader"]').count()).toBe(0);
+  });
 }
 
 export async function verifyConsoleMessage(


### PR DESCRIPTION
Looking at Delta's [reported flaky screenshots](https://delta.replay.io/flaky/replay?branchId=76&runId=796&snapshotId=57899&) I noticed a common pattern for Console screenshots.

For example, compare this:
![image](https://github.com/replayio/devtools/assets/29597/03d36b67-d199-473a-a2f0-81d5abe2a91f)

To this:
![image](https://github.com/replayio/devtools/assets/29597/6f704d13-ed65-4534-9d01-bae52bad19d1)

In the second image, the console "exceptions" toggle is still suspending and the "warnings" and "node modules" toggles aren't enabled yet (maybe blocked by the Suspense). In either case, it seemed we weren't waiting on the toggles to be fully applied before continuing with the test.

This PR adds two additional checks to:
1. Ensure the toggle has been applied (at the Console level)
2. Ensure all messages have finished loading data

Hopefully this will reduce one of the last major sources of flakiness in these tests.