### PR TITLE
Upload all Delta Replay recordings (not just failures)

### DIFF
--- a/.github/workflows/delta.yml
+++ b/.github/workflows/delta.yml
@@ -80,5 +80,5 @@ jobs:
         uses: replayio/action-upload@v0.4.7
         with:
           api-key: rwk_4mEiT150uOHyLQiQvZfPZiNjmBe4NrOXOm9yG9nS794
-          filter: ${{ 'function($v, $i, $a) { $v.metadata.test.result = "failed" and $count($a[metadata.test.file = $v.metadata.test.file and metadata.test.result = "passed"]) = 0 }' }}
+          filter: ${{ 'function() { true }' }}
           public: true


### PR DESCRIPTION
Even for tests that "pass" – it can be helpful to look at the Replay to see _why_ a screenshot changed if the change was unexpected.

I'm not sure if I'm doing this correctly :)