### PR TITLE
Cancel RDT and DOM node pickers on click outside the video preview

### DIFF
--- a/packages/e2e-tests/helpers/react-devtools-panel.ts
+++ b/packages/e2e-tests/helpers/react-devtools-panel.ts
@@ -1,15 +1,32 @@
 import { Locator, Page, expect } from "@playwright/test";
 
-import { waitFor } from "./utils";
+import { getElementClasses, waitFor } from "./utils";
 
 export async function checkInspectedItemValue(item: Locator, expectedValue: string) {
   const value = await getInspectedItemValue(item);
   expect(value).toBe(expectedValue);
 }
 
+export function getComponentPickerButton(page: Page) {
+  return page.locator(
+    "[data-react-devtools-portal-root] div[class^=SearchInput] button[class^=Toggle]"
+  );
+}
+
+export async function isComponentPickerEnabled(componentPicker: Locator) {
+  const classes = await getElementClasses(componentPicker);
+  return classes.some(c => c.startsWith("ToggleOn"));
+}
+
 export async function enableComponentPicker(page: Page) {
-  await page.locator("[data-react-devtools-portal-root] [class^=ToggleOff]").click();
-  await page.locator("[data-react-devtools-portal-root] [class^=ToggleOn]").waitFor();
+  const componentPicker = getComponentPickerButton(page);
+  if (await isComponentPickerEnabled(componentPicker)) {
+    await componentPicker.click();
+  }
+  await componentPicker.click();
+  await waitFor(async () => expect(await isComponentPickerEnabled(componentPicker)).toBe(true));
+
+  return componentPicker;
 }
 
 export function getInspectedItem(page: Page, kind: "Props" | "Hooks", name: string) {

--- a/packages/e2e-tests/helpers/utils.ts
+++ b/packages/e2e-tests/helpers/utils.ts
@@ -136,3 +136,5 @@ export async function waitFor(
     }
   }
 }
+
+export const getElementClasses = (loc: Locator) => loc.evaluate(el => Array.from(el.classList));

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -182,7 +182,7 @@ export function fetchMouseTargetsForPause(): UIThunkAction<Promise<NodeBounds[] 
 }
 
 export function loadMouseTargets(): UIThunkAction<Promise<NodeBounds[] | undefined>> {
-  return async (dispatch) => {
+  return async dispatch => {
     dispatch(setMouseTargetsLoading(true));
     const boundingRects = await dispatch(fetchMouseTargetsForPause());
     dispatch(setMouseTargetsLoading(false));

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -23,7 +23,6 @@ import {
   getLoadingStatusSlow,
   loadReceivedEvents,
   setCanvas as setCanvasAction,
-  setIsNodePickerActive,
   setLoadedRegions,
   setLoadingStatusSlow,
   setModal,
@@ -182,14 +181,12 @@ export function fetchMouseTargetsForPause(): UIThunkAction<Promise<NodeBounds[] 
   };
 }
 
-export function loadMouseTargets(): UIThunkAction {
-  return async (dispatch, getState, { ThreadFront, replayClient, protocolClient }) => {
+export function loadMouseTargets(): UIThunkAction<Promise<NodeBounds[] | undefined>> {
+  return async (dispatch) => {
     dispatch(setMouseTargetsLoading(true));
     const boundingRects = await dispatch(fetchMouseTargetsForPause());
     dispatch(setMouseTargetsLoading(false));
-    if (boundingRects?.length) {
-      dispatch(setIsNodePickerActive(true));
-    }
+    return boundingRects;
   };
 }
 

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -15,6 +15,7 @@ import {
   LoadedRegions,
   ModalOptionsType,
   ModalType,
+  NodePickerType,
   ReplayEvent,
   SettingsTabTitle,
   UnexpectedError,
@@ -33,8 +34,8 @@ export const initialAppState: AppState = {
   displayedLoadingProgress: null,
   events: {},
   expectedError: null,
-  isNodePickerActive: false,
-  isNodePickerInitializing: false,
+  activeNodePicker: null,
+  nodePickerStatus: "disabled",
   loadedRegions: null,
   loading: 4,
   loadingFinished: false,
@@ -131,11 +132,18 @@ const appSlice = createSlice({
       // Load multiple event types into state at once
       Object.assign(state.events, action.payload);
     },
-    setIsNodePickerActive(state, action: PayloadAction<boolean>) {
-      state.isNodePickerActive = action.payload;
+    nodePickerInitializing(state, action: PayloadAction<NodePickerType>) {
+      state.activeNodePicker = action.payload;
+      state.nodePickerStatus = "initializing";
     },
-    setIsNodePickerInitializing(state, action: PayloadAction<boolean>) {
-      state.isNodePickerInitializing = action.payload;
+    nodePickerReady(state, action: PayloadAction<NodePickerType>) {
+      if (state.activeNodePicker === action.payload && state.nodePickerStatus === "initializing") {
+        state.nodePickerStatus = "active";
+      }
+    },
+    nodePickerDisabled(state) {
+      state.activeNodePicker = null;
+      state.nodePickerStatus = "disabled";
     },
     setCanvas(state, action: PayloadAction<Canvas>) {
       state.canvas = action.payload;
@@ -171,8 +179,9 @@ export const {
   setDisplayedLoadingProgress,
   loadReceivedEvents,
   setExpectedError,
-  setIsNodePickerActive,
-  setIsNodePickerInitializing,
+  nodePickerDisabled,
+  nodePickerInitializing,
+  nodePickerReady,
   setLoadedRegions,
   setLoadingFinished,
   setLoadingStatusSlow,
@@ -309,8 +318,9 @@ export const getFilteredEventsForFocusRegion = createSelector(
   }
 );
 
-export const getIsNodePickerActive = (state: UIState) => state.app.isNodePickerActive;
-export const getIsNodePickerInitializing = (state: UIState) => state.app.isNodePickerInitializing;
+export const getIsNodePickerActive = (state: UIState) => state.app.nodePickerStatus === "active";
+export const getIsNodePickerInitializing = (state: UIState) =>
+  state.app.nodePickerStatus === "initializing";
 export const getCanvas = (state: UIState) => state.app.canvas;
 export const getVideoUrl = (state: UIState) => state.app.videoUrl;
 export const getDefaultSettingsTab = (state: UIState) => state.app.defaultSettingsTab;

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -84,6 +84,9 @@ export interface LoadedRegions {
   indexed: TimeStampedPointRange[];
 }
 
+export type NodePickerType = "reactComponent" | "domElement";
+export type NodePickerStatus = "disabled" | "initializing" | "active";
+
 export interface AppState {
   mode: AppMode;
   awaitingSourcemaps: boolean;
@@ -92,8 +95,8 @@ export interface AppState {
   displayedLoadingProgress: number | null;
   events: Events;
   expectedError: ExpectedError | null;
-  isNodePickerActive: boolean;
-  isNodePickerInitializing: boolean;
+  activeNodePicker: NodePickerType | null;
+  nodePickerStatus: NodePickerStatus;
   loadedRegions: LoadedRegions | null;
   loading: number;
   loadingFinished: boolean;

--- a/src/ui/utils/nodePicker.ts
+++ b/src/ui/utils/nodePicker.ts
@@ -3,7 +3,9 @@ import { NodeBounds } from "@replayio/protocol";
 import { getDevicePixelRatio } from "protocol/graphics";
 
 export interface NodePickerOpts {
+  name: string;
   onHovering?: (nodeId: string | null) => void;
+  onClickOutsideCanvas?: () => void;
   onPicked: (nodeId: string | null) => void;
   onHighlightNode: (nodeId: string) => void;
   onUnhighlightNode: () => void;
@@ -23,6 +25,7 @@ export class NodePicker {
     if (this.canvas) {
       this.canvas.addEventListener("mousemove", this.onMouseMove);
       this.canvas.addEventListener("click", this.onMouseClick);
+      document.addEventListener("click", this.onDocumentClicked);
     }
   }
 
@@ -30,6 +33,8 @@ export class NodePicker {
     if (this.canvas) {
       this.canvas.removeEventListener("mousemove", this.onMouseMove);
       this.canvas.removeEventListener("click", this.onMouseClick);
+      document.removeEventListener("click", this.onDocumentClicked);
+      this.opts?.onUnhighlightNode();
     }
     this.opts = undefined;
     this.hoveredNodeId = undefined;
@@ -69,6 +74,18 @@ export class NodePicker {
       }
     }
     opts?.onPicked(nodeBounds ? nodeBounds.node : null);
+  };
+
+  private onDocumentClicked = (event: MouseEvent) => {
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    if (this.canvas) {
+      if (!this.canvas.contains(event.target as Node)) {
+        this.opts?.onClickOutsideCanvas?.();
+      }
+    }
   };
 }
 


### PR DESCRIPTION
This PR:

- Rewrites chunks of the picker logic to support canceling selection on a click outside the video preview:
  - Rewrote the Redux state to be enums instead of booleans
  - Replaced back-to-back dispatches with more descriptive actions
  - Added "click outside" handler to `NodePicker` class
  - Cleared node highlighting on picker disable
  - Memoized RDT dispatch methods
  - Updated DOM and React picker setup to disable on click outside
  - Removed dead `window.gNodePicker` global
- Updates the RDT test to check this behavior