### PR TITLE
Fix error message overflow in the cypress panel

### DIFF
--- a/src/ui/components/TestSuite/views/TestMetadata/TestItemTreeRow.module.css
+++ b/src/ui/components/TestSuite/views/TestMetadata/TestItemTreeRow.module.css
@@ -3,7 +3,7 @@
   gap: 1ch;
   cursor: pointer;
   transition: opacity 0.18s ease-out;
-  overflow: hidden;
+  overflow-x: hidden;
   overflow-wrap: anywhere;
 }
 

--- a/src/ui/components/TestSuite/views/TestMetadata/TestItemTreeRow.module.css
+++ b/src/ui/components/TestSuite/views/TestMetadata/TestItemTreeRow.module.css
@@ -3,7 +3,10 @@
   gap: 1ch;
   cursor: pointer;
   transition: opacity 0.18s ease-out;
+  overflow: hidden;
+  overflow-wrap: anywhere;
 }
+
 .Row[data-is-pending] {
   opacity: 0.5;
 }


### PR DESCRIPTION
Before:
<img width="1800" alt="image" src="https://github.com/replayio/devtools/assets/15959269/c9e7f3c1-8f91-4fdf-b1b4-16ac4e8a9ce1">

After:
<img width="1799" alt="image" src="https://github.com/replayio/devtools/assets/15959269/e41450ac-a12d-416c-b9b0-dc5c75ef69ea">