### PR TITLE
Support redirecting from /r/:id

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -50,6 +50,10 @@ const baseNextConfig = {
         destination: "/recording/:id",
         permanent: true,
       },
+      {
+        source: "/r/:id",
+        destination: "/recording/:id",
+      }
     ];
   },
 


### PR DESCRIPTION
Quality of life improvement when slinging recording ID's around. 

Eventually it's probably better to use the shortened version (`/r/` instead of `/recording/`) for copied links.