### PR TITLE
releases: fetch from API instead of directly from S3

### DIFF
--- a/pages/api/releases.ts
+++ b/pages/api/releases.ts
@@ -1,7 +1,7 @@
 import { NextApiRequest, NextApiResponse } from "next";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const releases = await fetch("https://static.replay.io/downloads/releases.json");
+  const releases = await fetch("https://api.replay.io/v1/releases");
   const json = await releases.json();
   res.status(200).json(json);
 }


### PR DESCRIPTION
Resolves RUN-1944

Can't be merged until the backend work is merged + deployed, but I figured I'd queue this up in the meantime.