### PR TITLE
Address lingering test flakiness around Console search/filter

### DIFF
--- a/packages/replay-next/components/console/MessagesList.tsx
+++ b/packages/replay-next/components/console/MessagesList.tsx
@@ -5,7 +5,6 @@ import { ConsoleFiltersContext } from "replay-next/src/contexts/ConsoleFiltersCo
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
 import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
 import { useStreamingMessages } from "replay-next/src/hooks/useStreamingMessages";
-import { streamingMessagesCache } from "replay-next/src/suspense/MessagesCache";
 import {
   getLoggableExecutionPoint,
   isEventLog,
@@ -57,11 +56,9 @@ function MessagesList({ forwardedRef }: { forwardedRef: ForwardedRef<HTMLElement
     showWarnings,
   } = useContext(ConsoleFiltersContext);
   const { isTransitionPending: isFocusTransitionPending } = useContext(FocusContext);
-  const loggables = useContext(LoggablesContext);
+  const { loggables, streamingStatus } = useContext(LoggablesContext);
   const [searchState] = useContext(ConsoleSearchContext);
   const { executionPoint: currentExecutionPoint } = useContext(TimelineContext);
-
-  const stream = useStreamingMessages();
 
   // The Console should render a line indicating the current execution point.
   // This point might match multiple logs– or it might be between logs, or after the last log, etc.
@@ -202,7 +199,7 @@ function MessagesList({ forwardedRef }: { forwardedRef: ForwardedRef<HTMLElement
         data-test-state-logs={showLogs ? true : undefined}
         data-test-state-nodeModules={showNodeModules ? true : undefined}
         data-test-state-searchByText={searchState.query}
-        data-test-state-cacheStreamingStatus={stream.status}
+        data-test-state-cacheStreamingStatus={streamingStatus}
         data-test-state-timestamps={showTimestamps ? true : undefined}
         data-test-state-warnings={showWarnings ? true : undefined}
         data-test-name="Messages"

--- a/packages/replay-next/components/console/MessagesList.tsx
+++ b/packages/replay-next/components/console/MessagesList.tsx
@@ -198,6 +198,7 @@ function MessagesList({ forwardedRef }: { forwardedRef: ForwardedRef<HTMLElement
         data-test-state-filterByText={filterByText}
         data-test-state-logs={showLogs ? true : undefined}
         data-test-state-nodeModules={showNodeModules ? true : undefined}
+        data-test-state-searchByText={searchState.query}
         data-test-state-timestamps={showTimestamps ? true : undefined}
         data-test-state-warnings={showWarnings ? true : undefined}
         data-test-name="Messages"

--- a/packages/replay-next/components/console/MessagesList.tsx
+++ b/packages/replay-next/components/console/MessagesList.tsx
@@ -5,6 +5,7 @@ import { ConsoleFiltersContext } from "replay-next/src/contexts/ConsoleFiltersCo
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
 import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
 import { useStreamingMessages } from "replay-next/src/hooks/useStreamingMessages";
+import { streamingMessagesCache } from "replay-next/src/suspense/MessagesCache";
 import {
   getLoggableExecutionPoint,
   isEventLog,
@@ -59,6 +60,8 @@ function MessagesList({ forwardedRef }: { forwardedRef: ForwardedRef<HTMLElement
   const loggables = useContext(LoggablesContext);
   const [searchState] = useContext(ConsoleSearchContext);
   const { executionPoint: currentExecutionPoint } = useContext(TimelineContext);
+
+  const stream = useStreamingMessages();
 
   // The Console should render a line indicating the current execution point.
   // This point might match multiple logs– or it might be between logs, or after the last log, etc.
@@ -199,6 +202,7 @@ function MessagesList({ forwardedRef }: { forwardedRef: ForwardedRef<HTMLElement
         data-test-state-logs={showLogs ? true : undefined}
         data-test-state-nodeModules={showNodeModules ? true : undefined}
         data-test-state-searchByText={searchState.query}
+        data-test-state-cacheStreamingStatus={stream.status}
         data-test-state-timestamps={showTimestamps ? true : undefined}
         data-test-state-warnings={showWarnings ? true : undefined}
         data-test-name="Messages"

--- a/packages/replay-next/components/console/hooks/useConsoleSearchDOM.ts
+++ b/packages/replay-next/components/console/hooks/useConsoleSearchDOM.ts
@@ -56,7 +56,7 @@ export default function useConsoleSearchDOM(
   searchInputRef: MutableRefObject<HTMLInputElement | null>,
   defaultVisible: boolean = true
 ): [State, Actions] {
-  const loggables = useContext(LoggablesContext);
+  const { loggables } = useContext(LoggablesContext);
 
   const [state, dispatch] = useSearchDOM<Loggable>(loggables, search, listRef);
   const [visible, setVisible] = useState<boolean>(defaultVisible);

--- a/packages/replay-next/playwright/tests/console/should-be-filterable-on-complex-content.ts
+++ b/packages/replay-next/playwright/tests/console/should-be-filterable-on-complex-content.ts
@@ -1,5 +1,7 @@
 import { test } from "@playwright/test";
 
+import { filterByText } from "replay-next/playwright/tests/utils/console";
+
 import { takeScreenshot } from "../utils/general";
 import { beforeEach } from "./beforeEach";
 import { setup } from "./shared";
@@ -9,10 +11,10 @@ beforeEach();
 test("should be filterable on complex content", async ({ page }, testInfo) => {
   await setup(page, true);
 
-  await page.fill("[data-test-id=ConsoleFilterInput]", "(3) [1, 2, 3]");
+  await filterByText(page, "(3) [1, 2, 3]");
   const consoleRoot = page.locator("[data-test-id=ConsoleRoot]");
   await takeScreenshot(page, testInfo, consoleRoot, "filtered-complex-array-preview");
 
-  await page.fill("[data-test-id=ConsoleFilterInput]", "number: 123, string:");
+  await filterByText(page, "number: 123, string:");
   await takeScreenshot(page, testInfo, consoleRoot, "filtered-complex-object-preview");
 });

--- a/packages/replay-next/playwright/tests/console/should-be-filterable.ts
+++ b/packages/replay-next/playwright/tests/console/should-be-filterable.ts
@@ -1,6 +1,6 @@
 import { test } from "@playwright/test";
 
-import { locateMessage, seekToMessage } from "../utils/console";
+import { filterByText, locateMessage, seekToMessage } from "../utils/console";
 import { delay, takeScreenshot } from "../utils/general";
 import { beforeEach } from "./beforeEach";
 import { setup } from "./shared";
@@ -10,18 +10,18 @@ beforeEach();
 test("should be filterable", async ({ page }, testInfo) => {
   await setup(page, true);
 
-  await page.fill("[data-test-id=ConsoleFilterInput]", " an ");
+  await filterByText(page, " an ");
   const consoleRoot = page.locator("[data-test-id=ConsoleRoot]");
   await takeScreenshot(page, testInfo, consoleRoot, "filtered-single-result");
 
-  await page.fill("[data-test-id=ConsoleFilterInput]", " a ");
+  await filterByText(page, " a ");
   await takeScreenshot(page, testInfo, consoleRoot, "filtered-three-results");
 
-  await page.fill("[data-test-id=ConsoleFilterInput]", "zzz");
+  await filterByText(page, "zzz");
   await takeScreenshot(page, testInfo, consoleRoot, "filtered-no-results");
 
   // Seeking to a message should not break the filter
-  await page.fill("[data-test-id=ConsoleFilterInput]", " a ");
+  await filterByText(page, " a ");
   await seekToMessage(page, await locateMessage(page, "console-log", "This is a trace"));
   await delay();
   await takeScreenshot(

--- a/packages/replay-next/playwright/tests/console/should-be-searchable-on-complex-content.ts
+++ b/packages/replay-next/playwright/tests/console/should-be-searchable-on-complex-content.ts
@@ -1,6 +1,6 @@
 import { test } from "@playwright/test";
 
-import { locateMessage, seekToMessage, showSearchInput } from "../utils/console";
+import { locateMessage, searchByText, seekToMessage, showSearchInput } from "../utils/console";
 import { takeScreenshot } from "../utils/general";
 import { beforeEach } from "./beforeEach";
 import { setup } from "./shared";
@@ -15,11 +15,11 @@ test("should be searchable on complex content", async ({ page }, testInfo) => {
 
   await showSearchInput(page);
 
-  await page.fill("[data-test-id=ConsoleSearchInput]", "(3) [1, 2, 3]");
+  await searchByText(page, "(3) [1, 2, 3]");
 
   const consoleRoot = page.locator("[data-test-id=ConsoleRoot]");
   await takeScreenshot(page, testInfo, consoleRoot, "searchable-complex-array-preview");
 
-  await page.fill("[data-test-id=ConsoleSearchInput]", "number: 123, string:");
+  await searchByText(page, "number: 123, string:");
   await takeScreenshot(page, testInfo, consoleRoot, "searchable-complex-object-preview");
 });

--- a/packages/replay-next/playwright/tests/console/should-be-searchable.ts
+++ b/packages/replay-next/playwright/tests/console/should-be-searchable.ts
@@ -1,6 +1,12 @@
 import { test } from "@playwright/test";
 
-import { filterByText, locateMessage, seekToMessage, showSearchInput } from "../utils/console";
+import {
+  filterByText,
+  locateMessage,
+  searchByText,
+  seekToMessage,
+  showSearchInput,
+} from "../utils/console";
 import { takeScreenshot } from "../utils/general";
 import { beforeEach } from "./beforeEach";
 import { setup } from "./shared";
@@ -15,14 +21,12 @@ test("should be searchable", async ({ page }, testInfo) => {
 
   await showSearchInput(page);
 
-  // TODO [FE-1478]
-  await page.fill("[data-test-id=ConsoleSearchInput]", " an ");
+  await searchByText(page, " an ");
 
   const consoleRoot = page.locator("[data-test-id=ConsoleRoot]");
   await takeScreenshot(page, testInfo, consoleRoot, "searchable-single-result");
 
-  // TODO [FE-1478]
-  await page.fill("[data-test-id=ConsoleSearchInput]", " a ");
+  await searchByText(page, " a ");
   await takeScreenshot(page, testInfo, consoleRoot, "searchable-result-1-of-3");
 
   await page.click("[data-test-id=ConsoleSearchGoToNextButton]");

--- a/packages/replay-next/playwright/tests/console/should-be-searchable.ts
+++ b/packages/replay-next/playwright/tests/console/should-be-searchable.ts
@@ -1,6 +1,6 @@
 import { test } from "@playwright/test";
 
-import { locateMessage, seekToMessage, showSearchInput } from "../utils/console";
+import { filterByText, locateMessage, seekToMessage, showSearchInput } from "../utils/console";
 import { takeScreenshot } from "../utils/general";
 import { beforeEach } from "./beforeEach";
 import { setup } from "./shared";
@@ -15,11 +15,13 @@ test("should be searchable", async ({ page }, testInfo) => {
 
   await showSearchInput(page);
 
+  // TODO [FE-1478]
   await page.fill("[data-test-id=ConsoleSearchInput]", " an ");
 
   const consoleRoot = page.locator("[data-test-id=ConsoleRoot]");
   await takeScreenshot(page, testInfo, consoleRoot, "searchable-single-result");
 
+  // TODO [FE-1478]
   await page.fill("[data-test-id=ConsoleSearchInput]", " a ");
   await takeScreenshot(page, testInfo, consoleRoot, "searchable-result-1-of-3");
 
@@ -31,7 +33,7 @@ test("should be searchable", async ({ page }, testInfo) => {
   await takeScreenshot(page, testInfo, consoleRoot, "searchable-result-2-of-3");
 
   // Changes to filters should also update search results
-  await page.fill("[data-test-id=ConsoleFilterInput]", "warning");
+  await filterByText(page, "warning");
 
   const searchResultsLabel = page.locator("[data-test-id=SearchResultsLabel]");
   await takeScreenshot(

--- a/packages/replay-next/playwright/tests/source-and-console/should-include-log-points-in-search-results.ts
+++ b/packages/replay-next/playwright/tests/source-and-console/should-include-log-points-in-search-results.ts
@@ -1,5 +1,7 @@
 import { test } from "@playwright/test";
 
+import { searchByText } from "replay-next/playwright/tests/utils/console";
+
 import { takeScreenshot } from "../utils/general";
 import { addLogPoint } from "../utils/source";
 import { beforeEach } from "./beforeEach";
@@ -10,7 +12,7 @@ beforeEach();
 test("should include log points in search results", async ({ page }, testInfo) => {
   await addLogPoint(page, { sourceId, lineNumber: 13 });
 
-  await page.fill("[data-test-id=ConsoleSearchInput]", "stack");
+  await searchByText(page, "stack");
   const messages = page.locator("[data-test-name=Messages]");
   await takeScreenshot(page, testInfo, messages, "log-point-highlighted-as-search-result");
 });

--- a/packages/replay-next/playwright/tests/source-and-console/should-include-log-points-when-filtering-data.ts
+++ b/packages/replay-next/playwright/tests/source-and-console/should-include-log-points-when-filtering-data.ts
@@ -1,5 +1,7 @@
 import { test } from "@playwright/test";
 
+import { filterByText } from "replay-next/playwright/tests/utils/console";
+
 import { takeScreenshot } from "../utils/general";
 import { addLogPoint } from "../utils/source";
 import { beforeEach } from "./beforeEach";
@@ -10,10 +12,11 @@ beforeEach();
 test("should include log points when filtering data", async ({ page }, testInfo) => {
   await addLogPoint(page, { sourceId, lineNumber: 13 });
 
-  await page.fill("[data-test-id=ConsoleFilterInput]", "stack");
   const messages = page.locator("[data-test-name=Messages]");
+
+  await filterByText(page, "stack");
   await takeScreenshot(page, testInfo, messages, "log-point-in-search-results");
 
-  await page.fill("[data-test-id=ConsoleFilterInput]", "zzz");
+  await filterByText(page, "zzz");
   await takeScreenshot(page, testInfo, messages, "log-point-not-in-search-results");
 });

--- a/packages/replay-next/playwright/tests/utils/console.ts
+++ b/packages/replay-next/playwright/tests/utils/console.ts
@@ -145,6 +145,17 @@ export function messageLocator(
   });
 }
 
+export async function searchByText(page: Page, text: string) {
+  await page.fill("[data-test-id=ConsoleSearchInput]", text);
+
+  // Wait for Console to apply new filter text
+  await waitFor(async () => {
+    const messageList = page.locator('[data-test-name="Messages"]');
+    const value = await messageList.getAttribute(`data-test-state-searchByText`);
+    expect(value).toBe(text);
+  });
+}
+
 export async function seekToMessage(page: Page, messageListItem: Locator) {
   await debugPrint(
     page,

--- a/src/ui/components/shared/Nags/Nags.tsx
+++ b/src/ui/components/shared/Nags/Nags.tsx
@@ -62,7 +62,7 @@ export function EditorNag() {
 }
 
 export function ConsoleNag() {
-  const loggables = useContext(LoggablesContext);
+  const { loggables } = useContext(LoggablesContext);
 
   // Don't show the console nag that directs the user to click on one of the console messages
   // if there aren't any console messages to begin with.


### PR DESCRIPTION
- [x] Use test helpers for Console filter and search. These have built-in checks to reduce flakiness caused by timing issues.
- [x] Update filter/search helpers to wait for all Console messages to stream in before running.