### PR TITLE
Improve test step list item click->jump behavior

### DIFF
--- a/src/ui/components/TestSuite/hooks/useJumpToSource.ts
+++ b/src/ui/components/TestSuite/hooks/useJumpToSource.ts
@@ -16,9 +16,11 @@ import { AwaitTimeout, awaitWithTimeout } from "ui/utils/awaitWithTimeout";
 export function useJumpToSource({
   testMetadata,
   testStep,
+  openSourceAutomatically = false,
 }: {
   testMetadata: ProcessedTestMetadata;
   testStep: ProcessedTestStep;
+  openSourceAutomatically: boolean;
 }) {
   const replayClient = useContext(ReplayClientContext);
 
@@ -42,7 +44,9 @@ export function useJumpToSource({
   }
 
   const onClick = async () => {
-    dispatch(setViewMode("dev"));
+    if (openSourceAutomatically) {
+      dispatch(setViewMode("dev"));
+    }
 
     if (testMetadata && testStep.type === "step") {
       const locationPromise = TestStepSourceLocationCache.readAsync(
@@ -65,7 +69,7 @@ export function useJumpToSource({
       }
 
       if (location) {
-        dispatch(selectLocation(context, location));
+        dispatch(selectLocation(context, location, openSourceAutomatically));
       }
 
       if (testStep.metadata.range.beginPoint && testStep.metadata.range.beginTime) {

--- a/src/ui/components/TestSuite/views/TestItem/DropDownMenu.tsx
+++ b/src/ui/components/TestSuite/views/TestItem/DropDownMenu.tsx
@@ -54,12 +54,16 @@ function JumpToSourceMenuItem({
   testMetadata: ProcessedTestMetadata;
   testStep: ProcessedTestStep;
 }) {
-  const { disabled, onClick } = useJumpToSource({ testMetadata, testStep });
+  const { disabled, onClick } = useJumpToSource({
+    testMetadata,
+    testStep,
+    openSourceAutomatically: true,
+  });
 
   return (
     <ContextMenuItem disabled={disabled} onSelect={onClick}>
       <MaterialIcon>code</MaterialIcon>
-      Jump to source
+      Jump to test source
     </ContextMenuItem>
   );
 }

--- a/src/ui/components/TestSuite/views/TestItem/TestCaseSectionRow.tsx
+++ b/src/ui/components/TestSuite/views/TestItem/TestCaseSectionRow.tsx
@@ -80,7 +80,9 @@ export function TestCaseSectionRow({
       data-type={testStep.type}
       data-test-name="TestCaseSectionRow"
       onClick={() => {
-        selectTestStep(testStep);
+        startTransition(() => {
+          selectTestStep(testStep);
+        });
       }}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}

--- a/src/ui/components/TestSuite/views/TestItem/TestSteps/AnnotatedTestStepRow.tsx
+++ b/src/ui/components/TestSuite/views/TestItem/TestSteps/AnnotatedTestStepRow.tsx
@@ -14,6 +14,7 @@ import { useJumpToSource } from "ui/components/TestSuite/hooks/useJumpToSource";
 import { getConsolePropsCountSuspense } from "ui/components/TestSuite/suspense/consoleProps";
 import { AnnotatedTestStep, ProcessedTestMetadata } from "ui/components/TestSuite/types";
 import { Position } from "ui/components/TestSuite/views/TestItem/types";
+import { getViewMode } from "ui/reducers/layout";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { ParsedJumpToCodeAnnotation } from "ui/suspense/annotationsCaches";
 import { eventListenersJumpLocationsCache } from "ui/suspense/annotationsCaches";
@@ -77,6 +78,7 @@ export default memo(function AnnotatedTestStepRow({
 
   const dispatch = useAppDispatch();
   const executionPoint = useAppSelector(getExecutionPoint);
+  const viewMode = useAppSelector(getViewMode);
   const { status: annotationsStatus, value: parsedAnnotations } = useImperativeCacheValue(
     eventListenersJumpLocationsCache
   );
@@ -93,6 +95,7 @@ export default memo(function AnnotatedTestStepRow({
   const { disabled: jumpToTestSourceDisabled, onClick: onClickJumpToTestSource } = useJumpToSource({
     testMetadata,
     testStep,
+    openSourceAutomatically: viewMode === "dev",
   });
 
   const jumpToCodeAnnotations: ParsedJumpToCodeAnnotation[] =

--- a/src/ui/components/TestSuite/views/TestItem/TestSteps/AnnotatedTestStepRow.tsx
+++ b/src/ui/components/TestSuite/views/TestItem/TestSteps/AnnotatedTestStepRow.tsx
@@ -6,6 +6,7 @@ import Loader from "replay-next/components/Loader";
 import useSuspendAfterMount from "replay-next/src/hooks/useSuspendAfterMount";
 import { isExecutionPointsWithinRange } from "replay-next/src/utils/time";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
+import { Annotations } from "shared/graphql/types";
 import { jumpToKnownEventListenerHit } from "ui/actions/eventListeners/jumpToCode";
 import { seek } from "ui/actions/timeline";
 import { JumpToCodeButton, JumpToCodeStatus } from "ui/components/shared/JumpToCodeButton";
@@ -25,6 +26,43 @@ const cypressStepTypesToEventTypes = {
   click: "mousedown",
   type: "keypress",
 } as const;
+
+function findJumpToCodeDetailsIfAvailable(
+  testMetadata: ProcessedTestMetadata,
+  testStep: AnnotatedTestStep,
+  testStepAnnotations: Annotations,
+  jumpToCodeAnnotations: ParsedJumpToCodeAnnotation[]
+) {
+  let canShowJumpToCode = false;
+  let jumpToCodeAnnotation: ParsedJumpToCodeAnnotation | undefined = undefined;
+
+  if (testMetadata.runner?.name === "cypress" && "category" in testStep.data) {
+    // TODO This is very Cypress-specific. Playwright steps have a `name` like `locator.click("blah")`.
+    // We only care about click events and keyboard events. Keyboard events appear to be a "type" command,
+    // as in "type this text into the input".
+    canShowJumpToCode =
+      "category" in testStep.data &&
+      testStep.data.category === "command" &&
+      (testStep.data.name === "click" || testStep.data.name === "type");
+
+    if (canShowJumpToCode) {
+      const eventKind =
+        cypressStepTypesToEventTypes[
+          testStep.data.name as keyof typeof cypressStepTypesToEventTypes
+        ];
+
+      const { start, end } = testStepAnnotations;
+
+      if (eventKind && start && end) {
+        jumpToCodeAnnotation = jumpToCodeAnnotations.find(a =>
+          isExecutionPointsWithinRange(a.point, start.point, end.point)
+        );
+      }
+    }
+  }
+
+  return [canShowJumpToCode, jumpToCodeAnnotation] as const;
+}
 
 export default memo(function AnnotatedTestStepRow({
   position,
@@ -60,47 +98,14 @@ export default memo(function AnnotatedTestStepRow({
   const jumpToCodeAnnotations: ParsedJumpToCodeAnnotation[] =
     annotationsStatus === "resolved" ? parsedAnnotations : NO_ANNOTATIONS;
 
-  const jumpToCodeEntriesPerEvent = useMemo(() => {
-    const jumpToCodeEntriesByPoint: Record<string, ParsedJumpToCodeAnnotation> = {};
-
-    for (const jumpToCodeAnnotation of jumpToCodeAnnotations) {
-      jumpToCodeEntriesByPoint[jumpToCodeAnnotation.point] = jumpToCodeAnnotation;
-    }
-
-    return jumpToCodeEntriesByPoint;
-  }, [jumpToCodeAnnotations]);
-
   const [canShowJumpToCode, jumpToCodeAnnotation] = useMemo(() => {
-    let canShowJumpToCode = false;
-    let jumpToCodeAnnotation: ParsedJumpToCodeAnnotation | undefined = undefined;
-
-    if ("category" in testStep.data) {
-      // TODO This is very Cypress-specific. Playwright steps have a `name` like `locator.click("blah")`.
-      // We only care about click events and keyboard events. Keyboard events appear to be a "type" command,
-      // as in "type this text into the input".
-      canShowJumpToCode =
-        "category" in testStep.data &&
-        testStep.data.category === "command" &&
-        (testStep.data.name === "click" || testStep.data.name === "type");
-
-      if (canShowJumpToCode) {
-        const eventKind =
-          cypressStepTypesToEventTypes[
-            testStep.data.name as keyof typeof cypressStepTypesToEventTypes
-          ];
-
-        const { start, end } = annotations;
-
-        if (eventKind && start && end) {
-          jumpToCodeAnnotation = jumpToCodeAnnotations.find(a =>
-            isExecutionPointsWithinRange(a.point, start.point, end.point)
-          );
-        }
-      }
-    }
-
-    return [canShowJumpToCode, jumpToCodeAnnotation] as const;
-  }, [jumpToCodeAnnotations, testStep.data, annotations]);
+    return findJumpToCodeDetailsIfAvailable(
+      testMetadata,
+      testStep,
+      annotations,
+      jumpToCodeAnnotations
+    );
+  }, [jumpToCodeAnnotations, testStep, annotations, testMetadata]);
 
   const onJumpToClickEvent = async () => {
     const onSeek = (point: string, time: number) => dispatch(seek(point, time, true));


### PR DESCRIPTION
This PR:

- Extracts the logic for determining _if_ we can do "Jump to Code" for a test step list item into a separate function, for readability
- Updates the `useJumpToSource` hook to allow skipping the "open source file" part, while still always seeking to the timestamp
- Updates `<AnnotatedTestStepRow>` to only try to open the test source file on list item click if we're already in DevTools mode, so that users can click around to see the app UI at different timestamps in Viewer mode
- Restores the `startTransition()` call in `<TestCaseSectionRow>`