### PR TITLE
Fix `logpoints-02` save flakiness and clean up Playwright in-browser console logs

### DIFF
--- a/packages/e2e-tests/helpers/utils.ts
+++ b/packages/e2e-tests/helpers/utils.ts
@@ -1,5 +1,6 @@
 import { Locator, Page } from "@playwright/test";
 import chalk from "chalk";
+import stripAnsi from "strip-ansi";
 
 export function getCommandKey() {
   const macOS = process.platform === "darwin";
@@ -19,14 +20,18 @@ export async function clearTextArea(page: Page, textArea: Locator) {
 
 // Other test utils can use this to print formatted status messages that help visually monitor test progress.
 export async function debugPrint(page: Page | null, message: string, scope?: string) {
-  console.log("      ", message, scope ? chalk.dim(`(${scope})`) : "");
+  const formattedScope = scope ? `(${scope})` : "";
+  console.log("      ", message, formattedScope ? chalk.dim(formattedScope) : "");
 
   if (page !== null) {
+    // Strip out all ANSI escape codes when we log this inside the browser.
+    // Otherwise, the console messages in the recording are hard to read.
+    const plainMessage = stripAnsi(message);
     await page.evaluate(
       ({ message, scope }) => {
-        console.log(`${message} %c${scope || ""}`, "color: #999;");
+        console.log(`${message} ${scope}`);
       },
-      { message, scope }
+      { message: plainMessage, scope: formattedScope }
     );
   }
 }

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -29,6 +29,7 @@
     "yargs": "^17.6.0"
   },
   "dependencies": {
-    "chalk": "^4"
+    "chalk": "^4",
+    "strip-ansi": "^6.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13030,6 +13030,7 @@ __metadata:
     cypress: ^12.5.1
     log-update: ^4
     playwright: ^1.25.1
+    strip-ansi: ^6.0.0
     ts-node: ^10.7.0
     yargs: ^17.6.0
   languageName: unknown


### PR DESCRIPTION
This PR:

- Tweaks our Playwright `debugPrint()` util to strip out ANSI formatting when logging messages in-browser, to keep the messages plain and readable
- Ensures that the logpoint panel Lexical typeahead gets hidden if we're not trying to submit an item, to avoid it overlapping the "Save" button and making `logpoints-02` flake

Saw the flakiness locally, seems much more consistent with the hide fix in place