### PR TITLE
Add captions and clearer documentation to Passport

### DIFF
--- a/src/ui/components/Passport/Passport.module.css
+++ b/src/ui/components/Passport/Passport.module.css
@@ -74,7 +74,7 @@
 }
 
 .largeCompletedImage {
-  width: 190px;
+  width: 120px;
   height: auto;
   position: absolute;
   z-index: var(--z-index-1);
@@ -107,5 +107,18 @@
 }
 
 .checklist div.docsIcon:hover {
+  color: #2257a7;
+}
+
+.blurbContainer {
+  padding: 12px;
+  color: #4e4e4e;
+}
+
+.blurbContainer a {
+  text-decoration: underline;
+}
+
+.blurbContainer a:hover {
   color: #2257a7;
 }

--- a/src/ui/components/Passport/Passport.tsx
+++ b/src/ui/components/Passport/Passport.tsx
@@ -87,7 +87,7 @@ const Passport = () => {
       videoUrl: "https://vercel.replay.io/passport/time_travel_in_console.gif",
       imageBaseName: "time_travel_in_the_console",
       docsLink:
-        "https://www.notion.so/replayio/Navigate-in-the-console-3b732260a9254c20b43d213c4a93c9de?pvs=4",
+        "https://replayio.notion.site/Navigate-in-the-console-3b732260a9254c20b43d213c4a93c9de?pvs=4",
       blurb: "Look for the blue button in the console.",
     },
     {
@@ -96,7 +96,7 @@ const Passport = () => {
       videoUrl: "https://vercel.replay.io/passport/set_print_statement.gif",
       imageBaseName: "set_a_print_statement",
       docsLink:
-        "https://www.notion.so/replayio/Adding-print-statements-18a7d1f85b434706b46af0a8d5d298fe?pvs=4",
+        "https://replayio.notion.site/Adding-print-statements-18a7d1f85b434706b46af0a8d5d298fe?pvs=4",
       blurb: "When looking at a source, click the plus sign.",
     },
     {
@@ -104,8 +104,7 @@ const Passport = () => {
       completed: !showJumpToEvent,
       videoUrl: "https://vercel.replay.io/passport/jump_to_an_event.gif",
       imageBaseName: "jump_to_event",
-      docsLink:
-        "https://www.notion.so/replayio/Jump-to-event-199d592b0ff1458bac0f27a7c2a9f78d?pvs=4",
+      docsLink: "https://replayio.notion.site/Jump-to-event-199d592b0ff1458bac0f27a7c2a9f78d?pvs=4",
       blurb: "Click the info icon on the left nav to see all events in your replay.",
     },
   ];
@@ -117,7 +116,7 @@ const Passport = () => {
       videoUrl: "https://vercel.replay.io/passport/inspect_an_element.gif",
       imageBaseName: "inspect_element",
       docsLink:
-        "https://www.notion.so/replayio/Inspect-UI-elements-5dcab655fe7343a798f3adacbaf937fc?pvs=4",
+        "https://replayio.notion.site/Inspect-UI-elements-5dcab655fe7343a798f3adacbaf937fc?pvs=4",
       blurb: "Look for the elements tab to the right of the console.",
     },
     {
@@ -126,7 +125,7 @@ const Passport = () => {
       videoUrl: "https://vercel.replay.io/passport/inspect_a_network_request.gif",
       imageBaseName: "inspect_network_request",
       docsLink:
-        "https://www.notion.so/replayio/Inspect-network-elements-f3e47ee936324fef92fe555c9de6567d?pvs=4",
+        "https://replayio.notion.site/Inspect-network-elements-f3e47ee936324fef92fe555c9de6567d?pvs=4",
       blurb: "Network requests is to the right of the console and elements tabs.",
     },
     {
@@ -135,7 +134,7 @@ const Passport = () => {
       videoUrl: "https://vercel.replay.io/passport/inspect_a_react_component.gif",
       imageBaseName: "inspect_react_component",
       docsLink:
-        "https://www.notion.so/replayio/Inspect-React-elements-5e4ae5b2a8fb4b6bba8ca5167ce94eb0?pvs=4",
+        "https://replayio.notion.site/Inspect-React-elements-5e4ae5b2a8fb4b6bba8ca5167ce94eb0?pvs=4",
       blurb: "The React tab is in the same area as console, elements, and network events.",
     },
     {
@@ -143,8 +142,7 @@ const Passport = () => {
       completed: !showJumpToCode,
       videoUrl: "https://vercel.replay.io/passport/jump_to_code.gif",
       imageBaseName: "jump_to_code",
-      docsLink:
-        "https://www.notion.so/replayio/Jump-to-code-45026e5087014475a52dc4a8024dc850?pvs=4",
+      docsLink: "https://replayio.notion.site/Jump-to-code-45026e5087014475a52dc4a8024dc850?pvs=4",
       blurb: "Click the info icon on the left nav, then look for the blue button.",
     },
   ];
@@ -155,7 +153,7 @@ const Passport = () => {
       completed: !showAddUnicornBadge,
       videoUrl: "https://vercel.replay.io/passport/unicorn_badge.gif",
       imageBaseName: "add_a_unicorn_badge",
-      docsLink: "https://www.notion.so/replayio/Add-a-badge-c50800e3065c4c2d9ad7b16449d0a8a1?pvs=4",
+      docsLink: "https://replayio.notion.site/Add-a-badge-c50800e3065c4c2d9ad7b16449d0a8a1?pvs=4",
       blurb: "When setting a print statement, click the gray circle to the left.",
     },
     {
@@ -164,7 +162,7 @@ const Passport = () => {
       videoUrl: "https://vercel.replay.io/passport/search_source_text.gif",
       imageBaseName: "search_source_text",
       docsLink:
-        "https://www.notion.so/replayio/Search-source-text-869e0205b8b14f94b3f15020fc4bf0f9?pvs=4",
+        "https://replayio.notion.site/Search-source-text-869e0205b8b14f94b3f15020fc4bf0f9?pvs=4",
       blurb: "Click the magnifying glass icon in the left nav.",
     },
     {
@@ -173,7 +171,7 @@ const Passport = () => {
       videoUrl: "https://vercel.replay.io/passport/use_focus_mode.gif",
       imageBaseName: "use_focus_mode",
       docsLink:
-        "https://www.notion.so/replayio/Set-a-focus-window-2409a0207b2449e6baf162f27ce37b35?pvs=4",
+        "https://replayio.notion.site/Set-a-focus-window-2409a0207b2449e6baf162f27ce37b35?pvs=4",
       blurb: "Look for the focus icon in the bottom right corner.",
     },
     {
@@ -181,7 +179,7 @@ const Passport = () => {
       completed: !showFindFile,
       videoUrl: "https://vercel.replay.io/passport/find_file.gif",
       imageBaseName: "find_file",
-      docsLink: "https://www.notion.so/replayio/Go-to-file-4e867dc10f7d4db3be78e9bfc53c97f9?pvs=4",
+      docsLink: "https://replayio.notion.site/Go-to-file-4e867dc10f7d4db3be78e9bfc53c97f9?pvs=4",
       blurb: "Press command-P on your keyboard.",
     },
   ];
@@ -192,8 +190,7 @@ const Passport = () => {
       completed: !showAddComment,
       videoUrl: "https://vercel.replay.io/passport/add_a_comment.gif",
       imageBaseName: "add_a_comment",
-      docsLink:
-        "https://www.notion.so/replayio/Add-a-comment-1b042007d9874ad6880af1dea7dd1e42?pvs=4",
+      docsLink: "https://replayio.notion.site/Add-a-comment-1b042007d9874ad6880af1dea7dd1e42?pvs=4",
       blurb:
         "Click in the video region to set a comment. It's also possible to add comments to console logs, print statements, and network monitor requests.",
     },
@@ -202,7 +199,7 @@ const Passport = () => {
       completed: !showShareNag,
       videoUrl: "https://vercel.replay.io/passport/share.gif",
       imageBaseName: "share",
-      docsLink: "https://www.notion.so/replayio/Share-7ecdd5ce6c36456bb1354540656f6799?pvs=4",
+      docsLink: "https://replayio.notion.site/Share-7ecdd5ce6c36456bb1354540656f6799?pvs=4",
       blurb: "Click the blue share button at the top of the app.",
     },
   ];

--- a/src/ui/components/Passport/Passport.tsx
+++ b/src/ui/components/Passport/Passport.tsx
@@ -246,7 +246,6 @@ const Passport = () => {
     return Math.floor(Math.random() * (max - min + 1) + min);
   };
 
-  const [randomTop, setRandomTop] = useState(rand(0, 20));
   const [randomRight, setRandomRight] = useState(rand(-50, 0));
   const [randomRotation, setRandomRotation] = useState(rand(-20, 20));
 
@@ -279,7 +278,6 @@ const Passport = () => {
   };
 
   useEffect(() => {
-    setRandomTop(rand(220, 320));
     setRandomRight(rand(-50, 0));
     setRandomRotation(rand(-20, 20));
   }, [selectedItem.completed]);

--- a/src/ui/components/Passport/Passport.tsx
+++ b/src/ui/components/Passport/Passport.tsx
@@ -87,7 +87,8 @@ const Passport = () => {
       videoUrl: "https://vercel.replay.io/passport/time_travel_in_console.gif",
       imageBaseName: "time_travel_in_the_console",
       docsLink:
-        "https://www.notion.so/replayio/Debugging-1c18f02c9f1d455188e3f202ef5f5c08?pvs=4#5df63e4995a749eab6a04e266db98df0",
+        "https://www.notion.so/replayio/Navigate-in-the-console-3b732260a9254c20b43d213c4a93c9de?pvs=4",
+      blurb: "Look for the blue button in the console.",
     },
     {
       label: "Add a console log",
@@ -95,7 +96,8 @@ const Passport = () => {
       videoUrl: "https://vercel.replay.io/passport/set_print_statement.gif",
       imageBaseName: "set_a_print_statement",
       docsLink:
-        "https://www.notion.so/replayio/Debugging-1c18f02c9f1d455188e3f202ef5f5c08?pvs=4#e52695c558884780a93be039ae42867a",
+        "https://www.notion.so/replayio/Adding-print-statements-18a7d1f85b434706b46af0a8d5d298fe?pvs=4",
+      blurb: "When looking at a source, click the plus sign.",
     },
     {
       label: "Jump to event",
@@ -103,7 +105,8 @@ const Passport = () => {
       videoUrl: "https://vercel.replay.io/passport/jump_to_an_event.gif",
       imageBaseName: "jump_to_event",
       docsLink:
-        "https://www.notion.so/replayio/Debugging-1c18f02c9f1d455188e3f202ef5f5c08#c9aab3ee9d564e098b28096c9a6cda83",
+        "https://www.notion.so/replayio/Jump-to-event-199d592b0ff1458bac0f27a7c2a9f78d?pvs=4",
+      blurb: "Click the info icon on the left nav to see all events in your replay.",
     },
   ];
 
@@ -114,7 +117,8 @@ const Passport = () => {
       videoUrl: "https://vercel.replay.io/passport/inspect_an_element.gif",
       imageBaseName: "inspect_element",
       docsLink:
-        "https://www.notion.so/replayio/Debugging-1c18f02c9f1d455188e3f202ef5f5c08?pvs=4#904253ec80e542f0bb77d2c5a9bb8a4e",
+        "https://www.notion.so/replayio/Inspect-UI-elements-5dcab655fe7343a798f3adacbaf937fc?pvs=4",
+      blurb: "Look for the elements tab to the right of the console.",
     },
     {
       label: "Inspect network requests",
@@ -122,7 +126,8 @@ const Passport = () => {
       videoUrl: "https://vercel.replay.io/passport/inspect_a_network_request.gif",
       imageBaseName: "inspect_network_request",
       docsLink:
-        "https://www.notion.so/replayio/Debugging-1c18f02c9f1d455188e3f202ef5f5c08?pvs=4#f2ae6cfcef014d9fa8dce383c2a9a7fa",
+        "https://www.notion.so/replayio/Inspect-network-elements-f3e47ee936324fef92fe555c9de6567d?pvs=4",
+      blurb: "Network requests is to the right of the console and elements tabs.",
     },
     {
       label: "Inspect React components",
@@ -130,7 +135,8 @@ const Passport = () => {
       videoUrl: "https://vercel.replay.io/passport/inspect_a_react_component.gif",
       imageBaseName: "inspect_react_component",
       docsLink:
-        "https://www.notion.so/replayio/Debugging-1c18f02c9f1d455188e3f202ef5f5c08?pvs=4#a10146a9ed2c45f5bf34a59d7e1ea7b9",
+        "https://www.notion.so/replayio/Inspect-React-elements-5e4ae5b2a8fb4b6bba8ca5167ce94eb0?pvs=4",
+      blurb: "The React tab is in the same area as console, elements, and network events.",
     },
     {
       label: "Jump to code",
@@ -138,7 +144,8 @@ const Passport = () => {
       videoUrl: "https://vercel.replay.io/passport/jump_to_code.gif",
       imageBaseName: "jump_to_code",
       docsLink:
-        "https://www.notion.so/replayio/Debugging-1c18f02c9f1d455188e3f202ef5f5c08?pvs=4#5df63e4995a749eab6a04e266db98df0",
+        "https://www.notion.so/replayio/Jump-to-code-45026e5087014475a52dc4a8024dc850?pvs=4",
+      blurb: "Click the info icon on the left nav, then look for the blue button.",
     },
   ];
 
@@ -148,8 +155,8 @@ const Passport = () => {
       completed: !showAddUnicornBadge,
       videoUrl: "https://vercel.replay.io/passport/unicorn_badge.gif",
       imageBaseName: "add_a_unicorn_badge",
-      docsLink:
-        "https://www.notion.so/replayio/Print-statements-1dcf7c3a8414423aab122ea7c4a41661#d8499325adf64254b4c918bc5725129c",
+      docsLink: "https://www.notion.so/replayio/Add-a-badge-c50800e3065c4c2d9ad7b16449d0a8a1?pvs=4",
+      blurb: "When setting a print statement, click the gray circle to the left.",
     },
     {
       label: "Search source text",
@@ -157,22 +164,25 @@ const Passport = () => {
       videoUrl: "https://vercel.replay.io/passport/search_source_text.gif",
       imageBaseName: "search_source_text",
       docsLink:
-        "https://www.notion.so/replayio/Search-4bd72377ac3d498d96bb7bcb33722a75?pvs=4#e81fec2cb83d44e3be5f5bfadd39ecce",
+        "https://www.notion.so/replayio/Search-source-text-869e0205b8b14f94b3f15020fc4bf0f9?pvs=4",
+      blurb: "Click the magnifying glass icon in the left nav.",
     },
     {
       label: "Set a focus window",
       completed: !showUseFocusMode,
       videoUrl: "https://vercel.replay.io/passport/use_focus_mode.gif",
       imageBaseName: "use_focus_mode",
-      docsLink: "https://www.notion.so/replayio/Focus-Mode-bd7783ea740f40f1b25383b6aaa78471?pvs=4",
+      docsLink:
+        "https://www.notion.so/replayio/Set-a-focus-window-2409a0207b2449e6baf162f27ce37b35?pvs=4",
+      blurb: "Look for the focus icon in the bottom right corner.",
     },
     {
       label: "Go to file (cmd-p)",
       completed: !showFindFile,
       videoUrl: "https://vercel.replay.io/passport/find_file.gif",
       imageBaseName: "find_file",
-      docsLink:
-        "https://www.notion.so/replayio/Search-4bd72377ac3d498d96bb7bcb33722a75?pvs=4#167521cd6a0f44dabc257eb3fd8ca48b",
+      docsLink: "https://www.notion.so/replayio/Go-to-file-4e867dc10f7d4db3be78e9bfc53c97f9?pvs=4",
+      blurb: "Press command-P on your keyboard.",
     },
   ];
 
@@ -182,15 +192,18 @@ const Passport = () => {
       completed: !showAddComment,
       videoUrl: "https://vercel.replay.io/passport/add_a_comment.gif",
       imageBaseName: "add_a_comment",
-      docsLink: "https://www.notion.so/replayio/Comments-0a140c06524d428681cadd78acf44661?pvs=4",
+      docsLink:
+        "https://www.notion.so/replayio/Add-a-comment-1b042007d9874ad6880af1dea7dd1e42?pvs=4",
+      blurb:
+        "Click in the video region to set a comment. It's also possible to add comments to console logs, print statements, and network monitor requests.",
     },
     {
       label: "Share",
       completed: !showShareNag,
       videoUrl: "https://vercel.replay.io/passport/share.gif",
       imageBaseName: "share",
-      docsLink:
-        "https://www.notion.so/replayio/Collaboration-cf60f297c0c742f6a2345e5f8cd56ed8?pvs=4#a102e5081a6e449ab793cf63c1a99163",
+      docsLink: "https://www.notion.so/replayio/Share-7ecdd5ce6c36456bb1354540656f6799?pvs=4",
+      blurb: "Click the blue share button at the top of the app.",
     },
   ];
 
@@ -219,6 +232,7 @@ const Passport = () => {
     videoUrl: string;
     imageBaseName: string;
     docsLink?: string;
+    blurb: string;
   }
 
   interface Section {
@@ -232,7 +246,7 @@ const Passport = () => {
     return Math.floor(Math.random() * (max - min + 1) + min);
   };
 
-  const [randomBottom, setRandomBottom] = useState(rand(220, 320));
+  const [randomTop, setRandomTop] = useState(rand(0, 20));
   const [randomRight, setRandomRight] = useState(rand(-50, 0));
   const [randomRotation, setRandomRotation] = useState(rand(-20, 20));
 
@@ -257,21 +271,6 @@ const Passport = () => {
             >
               <Icon className={styles.stepIcon} type={renderCheckmarkIcon(item.completed)} />
               <span className={styles.ml2}>{item.label}</span>
-              {sectionIndex === selectedIndices.sectionIndex &&
-                itemIndex === selectedIndices.itemIndex &&
-                item.docsLink && (
-                  <div
-                    className={styles.docsIcon}
-                    onClick={e => {
-                      e.stopPropagation();
-                      handleDocsClick(item.docsLink ?? "");
-                    }}
-                  >
-                    <div className="flex items-center space-x-1">
-                      <Icon type="document" className="mr-2 w-4" />
-                    </div>
-                  </div>
-                )}
             </div>
           ))}
         </div>
@@ -280,13 +279,26 @@ const Passport = () => {
   };
 
   useEffect(() => {
-    setRandomBottom(rand(220, 320));
+    setRandomTop(rand(220, 320));
     setRandomRight(rand(-50, 0));
     setRandomRotation(rand(-20, 20));
   }, [selectedItem.completed]);
 
   return (
     <div className={`${styles.PassportBoxWrapper} flex h-screen flex-col`}>
+      {selectedItem.completed && (
+        <img
+          src={`/images/passport/${selectedItem.imageBaseName}-complete.png`}
+          className={styles.largeCompletedImage}
+          style={{
+            zIndex: 0,
+            opacity: 0.25,
+            top: `50px`,
+            right: `${randomRight}px`,
+            transform: `rotate(${randomRotation}deg)`,
+          }}
+        />
+      )}
       <div className="my-2 p-2">
         <img src={`/images/passport/passportHeader.svg`} className={`w-full px-1`} />
       </div>
@@ -301,8 +313,15 @@ const Passport = () => {
           </div>
         </div>
       </div>
-
       <div className="p-1">
+        <div className={styles.blurbContainer}>
+          <p>
+            {selectedItem.blurb}{" "}
+            <a href={selectedItem.docsLink} target="docs" rel="noreferrer">
+              Read docs
+            </a>
+          </p>
+        </div>
         <img
           src={selectedItem.videoUrl}
           className={`${styles.videoExample} w-full object-cover`}


### PR DESCRIPTION
**Summary**

* Captions added
* Links to more concise/clear docs added
* Badge regressed, so it was brought back
* This model means people can see large video versions of the small animated gifs, a big help

This work is drawn directly from user feedback and Logrocket insights that a lot of people like to drop into the docs when onboarding, and our old design was making it too hard to see.

**Next**

Getting this done moves us one step closer to [this task](https://linear.app/replay/issue/DES-598/audit-and-align-our-nux-visual-vocabulary) where we'll be working to make our visual language consistent across screens. 

Old on left, new on right:
![image](https://github.com/replayio/devtools/assets/9154902/d710386d-1514-4e71-88af-e9b124940734)

