### PR TITLE
Collect Cypress load times

### DIFF
--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -19,6 +19,7 @@ pref("devtools.sidePanelSize", "240px");
 pref("devtools.theme", "system");
 pref("devtools.toolbox-size", "50%");
 pref("devtools.consoleFilterDrawerExpanded", true);
+pref("devtools.logTelemetry", false);
 
 // app features
 pref("devtools.features.basicProcessingLoadingBar", false);
@@ -64,6 +65,7 @@ export const prefs = new PrefsHelper("devtools", {
   theme: ["String", "theme"],
   toolboxSize: ["String", "toolbox-size"],
   consoleFilterDrawerExpanded: ["Bool", "consoleFilterDrawerExpanded"],
+  logTelemetry: ["Bool", "logTelemetry"],
 });
 
 export const features = new PrefsHelper("devtools.features", {

--- a/src/ui/utils/replay-telemetry.ts
+++ b/src/ui/utils/replay-telemetry.ts
@@ -1,6 +1,12 @@
+import { prefs } from "./prefs";
+
 export async function pingTelemetry(event: string, tags: any = {}) {
   if (process.env.NODE_ENV === "development" && !process.env.NEXT_PUBLIC_RECORD_REPLAY_TELEMETRY) {
     return;
+  }
+
+  if (prefs.logTelemetry) {
+    console.log(`Telemetry ${event}`, tags);
   }
 
   try {


### PR DESCRIPTION
FE-1362

I think we could do better here with the right abstraction for caches. Ideally, we would start collecting loading times for several caches like the recording cache and annotation cache as well.