### PR TITLE
[Ignore]

### DIFF
--- a/src/ui/components/shared/Onboarding/BubbleBackground.module.css
+++ b/src/ui/components/shared/Onboarding/BubbleBackground.module.css
@@ -8,3 +8,5 @@
   background: #081120;
   color: #d7d7db;
 }
+
+/* Testing PR */

--- a/src/ui/components/shared/Onboarding/BubbleBackground.module.css
+++ b/src/ui/components/shared/Onboarding/BubbleBackground.module.css
@@ -5,7 +5,6 @@
   width: 100%;
   margin: 0;
   padding: 0;
-  background: linear-gradient(to bottom, #081120 0%, #152746 50%, black 100%);
-
+  background: #081120;
   color: #d7d7db;
 }


### PR DESCRIPTION
**Summary**

Last week I committed [this PR](https://github.com/replayio/devtools/commit/e8b1caecb15bbe9f4e1960b86e090824cbb71203#diff-08ba8b007c17174535e61a7422566fb3b70c9bada21eb0b464273fef58b78295) to align our onboarding with the rest of our onboarding experience. Unfortunately, it also affecting our loading screen.

What I'd like to do with this PR is keep the onboarding goodness but re-architect our default modals (which includes our loading screen) so they can have different visuals. More specifically, I'm going for this architecture:

* Onboarding should be forced to dark theme (and in some cases, maybe we special-case early screens with their own illustrations)
*  Everything else (for example our loading screen) should respect user theme