### PR TITLE
Tighten our Tour conditionals

### DIFF
--- a/src/ui/components/Tour/Tour.tsx
+++ b/src/ui/components/Tour/Tour.tsx
@@ -56,8 +56,7 @@ const Tour: React.FC = () => {
 
   const isNewUser =
     showDevtoolsNag && showConsoleNavigate && showBreakpointAdd && showBreakpointEdit;
-  const hasCompletedTour =
-    !showDevtoolsNag && !showConsoleNavigate && !showBreakpointAdd && !showBreakpointEdit;
+  const hasCompletedTour = !showBreakpointEdit;
 
   const recordingId = useGetRecordingId();
   const { recording } = useGetRecording(recordingId);
@@ -203,9 +202,16 @@ const Tour: React.FC = () => {
                   helloAgain
                 ) : (
                   <>
-                    {showConsoleNavigate && timeTravel}
-                    {!showConsoleNavigate && showBreakpointAdd && oneClickLogs}
-                    {!showConsoleNavigate && !showBreakpointAdd && showBreakpointEdit && editLogs}
+                    {!hasCompletedTour && (
+                      <>
+                        {showConsoleNavigate && timeTravel}
+                        {!showConsoleNavigate && showBreakpointAdd && oneClickLogs}
+                        {!showConsoleNavigate &&
+                          !showBreakpointAdd &&
+                          showBreakpointEdit &&
+                          editLogs}
+                      </>
+                    )}
                     {hasCompletedTour && (
                       <CompletedTour
                         setShowPassport={setShowPassport}
@@ -227,12 +233,15 @@ const Tour: React.FC = () => {
         )}
         {!isNewUser && viewMode !== "non-dev" && (
           <>
-            {showConsoleNavigate && showBreakpointAdd && showBreakpointEdit && <TimeTravelGif />}
-
-            {!showConsoleNavigate && !showBreakpointAdd && showBreakpointEdit && <EditLogsGif />}
-
-            {!showConsoleNavigate && showBreakpointAdd && <OneClickLogsGif />}
-
+            {!hasCompletedTour && ( // some people jump to the final step of the tour, so this lets them
+              <>
+                {showConsoleNavigate && <TimeTravelGif />}
+                {!showConsoleNavigate && !showBreakpointAdd && showBreakpointEdit && (
+                  <EditLogsGif />
+                )}
+                {!showConsoleNavigate && showBreakpointAdd && <OneClickLogsGif />}
+              </>
+            )}
             {hasCompletedTour && <CompletedTourGif />}
           </>
         )}


### PR DESCRIPTION
Addresses https://linear.app/replay/issue/DES-680/investigate-tour-bug-tour-disappearing-before-completion

It's possible to set a print statement without following the Tour steps, which was triggering the end of the tour. This was causing a few different issues (images disappearing, the tab disappearing, etc).

This ticket:

* Makes it easier to complete the Tour (all you need to to is edit a print statement)
* Makes "is the tour complete" a higher-level bit of logic

This is good because:

* It stops punishing/confusing people who jump straight to their ah-ha moment
* But the standard Tour is still solid and easy to follow

Addresses https://linear.app/replay/issue/DES-680/investigate-tour-bug-tour-disappearing-before-completion