### PR TITLE
Don't use `loaded` regions to power the loading bar

### DIFF
--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -222,11 +222,14 @@ export const getIndexedAndLoadedRegions = createSelector(getLoadedRegions, loade
   return overlap(loadedRegions.indexed, loadedRegions.loaded);
 });
 
-// Calculates the percentage of loading regions that have been loaded and indexed.
+// Returns 1 if we have loaded at least one section of the recording. This method has been changed
+// many times and this latest version is really a temporary change while the backend team decides
+// whether to pull out `indexed` and `loaded` events completely in exchange for something more
+// meaningful. We want the client to start sending requests earlier so that we can better gauge
+// how we should change our loading algorithms, and we also want users to feel free to interact
+// with the recording as long as we're somewhat close to being able to respond to their requests.
 //
-// For example:
-// If 80% of the regions have been indexed and 50% have been loaded, this method would return 0.65.
-// If 100% of the regions have been indexed and 50% have been loaded, this method would return 0.75.
+// See https://github.com/replayio/devtools/pull/9268 for more discussion.
 export const getIndexedProgress = createSelector(getLoadedRegions, regions => {
   if (!regions) {
     return 0;
@@ -245,11 +248,7 @@ export const getIndexedProgress = createSelector(getLoadedRegions, regions => {
     return 0;
   }
 
-  const totalIndexedTime = indexed.reduce((totalTime, { begin, end }) => {
-    return totalTime + end.time - begin.time;
-  }, 0);
-
-  return totalIndexedTime / totalLoadingTime;
+  return indexed.find(({ begin, end }) => end.time - begin.time > 0) ? 1 : 0;
 });
 
 export const getIsIndexed = createSelector(getIndexedProgress, progress => progress === 1);


### PR DESCRIPTION
This is a tiny change but has a pretty massive implication for the UI, so let's talk about why this might be a good idea.

Right now loading has three discrete phases from the devtools point of view:

- Creating a session (this is *usually* fast, but if we are currently scaling up it can take a while)
- Hoverboard (I think this blocks on having at least one paint?)
- Indexing/growing the process tree.

This makes no changes to the first two phases, but it almost completely gets rid of the third. I say almost completely because we will still wait for *some* region to get loaded, so that we can be sure that we have successfully downloaded snapshots. Now the user still might see a loading bar, but it will sit at 0% until we have finished RTP'ing to the beginning of the first segment.

Previously it was important to wait until things were loaded, because the backend might throw an error if the queried part of the recording was not loaded yet. Now, that should never happen as long as the request is within the load*ing* region (requests in the regions that are not even attempting to load have always errored and still will).

This *will* have a negative effect on some command times. However, the worst case scenario is that the user requests something in the region that takes the longest to load, and in that case the wait time is exactly as long as it would take us to get to 100%. This is a simple case of tail latency bias - blocking performance for *all* part of the recording gated by the *worst* parts of the recording.

This might have other implications I have not thought about (although it seems to work well locally), so I'm happy to discuss any part of this!