### PR TITLE
Remove blocking on 'loaded' state of regions before sending protocol commands.

### DIFF
--- a/packages/shared/client/types.ts
+++ b/packages/shared/client/types.ts
@@ -260,5 +260,4 @@ export interface ReplayClientInterface {
     }) => void,
     onSourceContentsChunk: ({ chunk, sourceId }: { chunk: string; sourceId: SourceId }) => void
   ): Promise<void>;
-  waitForTimeToBeLoaded(time: number): Promise<void>;
 }


### PR DESCRIPTION
In the same vein as #9268.

I'm not going to land this yet, because I still need to fix the API to make sure it actually behaves properly without the DevTools doing this, but all of these checks are things that I'd consider backend bugs.