### PR TITLE
Add animation to menu

### DIFF
--- a/src/ui/components/shared/Dropdown.tsx
+++ b/src/ui/components/shared/Dropdown.tsx
@@ -1,3 +1,4 @@
+import { motion } from "framer-motion";
 import React, { ReactNode } from "react";
 
 export interface DropdownProps {
@@ -32,9 +33,15 @@ export default function Dropdown({
       {expanded ? (
         <div className="dropdown-container">
           <div className="mask" onClick={() => setExpanded(false)} />
-          <div className={`content ${position}`} style={orientations[orientation]}>
+          <motion.div
+            initial={{ scale: 0.8 }}
+            animate={{ scale: [0.8, 1.05, 1] }}
+            transition={{ duration: 0.17, ease: "easeInOut" }}
+            className={`content ${position}`}
+            style={orientations[orientation]}
+          >
             {children}
-          </div>
+          </motion.div>
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
Before:
![AnimatedMenu-Before](https://github.com/replayio/devtools/assets/9154902/b76bb8e2-afe2-40c2-9d7f-af509481c416)

After:
![AnimatedMenu-After](https://github.com/replayio/devtools/assets/9154902/3b8195f9-0405-441a-92dc-82f285ecd338)

We're going to be using more framer to give more life to our UX. This is a small experiment to get it rolling.