### PR TITLE
Use `hasAnnotationKind` to check for individual annotation types faster

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@lexical/react": "^0.6.5",
     "@reduxjs/toolkit": "^1.8.4",
     "@replayio/overboard": "^0.4.1",
-    "@replayio/protocol": "^0.50.0",
+    "@replayio/protocol": "^0.53.0",
     "@sentry/react": "^7.9.0",
     "@sentry/tracing": "^7.9.0",
     "@stripe/react-stripe-js": "^1.7.0",

--- a/packages/replay-next/package.json
+++ b/packages/replay-next/package.json
@@ -11,7 +11,7 @@
     "@codemirror/state_replay_next": "npm:@codemirror/state@6.1.2",
     "@lezer/common_replay_next": "npm:@lezer/common@1.0.1",
     "@lezer/highlight_replay_next": "npm:@lezer/highlight@1.1.1",
-    "@replayio/protocol": "^0.50.0",
+    "@replayio/protocol": "^0.53.0",
     "date-fns": "^2.28.0",
     "design": "workspace:*",
     "escape-html": "^1.0.3",

--- a/packages/replay-next/src/suspense/PauseCache.ts
+++ b/packages/replay-next/src/suspense/PauseCache.ts
@@ -31,15 +31,9 @@ export const pauseIdCache: Cache<
   debugLabel: "PauseIdForExecutionPoint",
   getKey: ([replayClient, executionPoint, time]) => `${executionPoint}:${time}`,
   load: async ([replayClient, executionPoint, time]) => {
-    const { data, pauseId, stack } = await replayClient.createPause(executionPoint);
+    const { pauseId } = await replayClient.createPause(executionPoint);
 
     pauseIdToPointAndTimeMap.set(pauseId, [executionPoint, time]);
-
-    const sources = await sourcesByIdCache.readAsync(replayClient);
-
-    if (data) {
-      cachePauseData(replayClient, sources, pauseId, data, stack);
-    }
 
     return pauseId;
   },

--- a/packages/shared/client/ReplayClient.ts
+++ b/packages/shared/client/ReplayClient.ts
@@ -437,6 +437,12 @@ export class ReplayClient implements ReplayClientInterface {
     return result;
   }
 
+  async hasAnnotationKind(kind: string): Promise<boolean> {
+    const sessionId = this.getSessionIdThrows();
+    const { hasKind } = await client.Session.hasAnnotationKind({ kind }, sessionId);
+    return hasKind;
+  }
+
   async getAnnotationKinds(): Promise<string[]> {
     const sessionId = this.getSessionIdThrows();
     const { kinds } = await client.Session.getAnnotationKinds({}, sessionId);

--- a/packages/shared/client/types.ts
+++ b/packages/shared/client/types.ts
@@ -215,6 +215,7 @@ export interface ReplayClientInterface {
   ): Promise<HitCount[]>;
   getSourceOutline(sourceId: SourceId): Promise<getSourceOutlineResult>;
   getTopFrame(pauseId: PauseId): Promise<getTopFrameResult>;
+  hasAnnotationKind(kind: string): Promise<boolean>;
   initialize(recordingId: string, accessToken: string | null): Promise<SessionId>;
   mapExpressionToGeneratedScope(expression: string, location: Location): Promise<string>;
   requestFocusRange(range: FocusWindowRequest): Promise<TimeStampedPointRange>;

--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -52,6 +52,8 @@ import timeline, {
 import { UIState } from "ui/state";
 import { UnexpectedError } from "ui/state/app";
 import {
+  REACT_ANNOTATIONS_KIND,
+  REDUX_ANNOTATIONS_KIND,
   annotationKindsCache,
   eventListenersJumpLocationsCache,
   reactDevToolsAnnotationsCache,
@@ -219,7 +221,8 @@ export default async function setupDevtools(store: AppStore, replayClient: Repla
 
   ThreadFront.waitForSession().then(() => {
     // Precache annotations
-    annotationKindsCache.prefetch(replayClient);
+    annotationKindsCache.prefetch(replayClient, REACT_ANNOTATIONS_KIND);
+    annotationKindsCache.prefetch(replayClient, REDUX_ANNOTATIONS_KIND);
     reactDevToolsAnnotationsCache.prefetch();
     eventListenersJumpLocationsCache.prefetch();
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3994,10 +3994,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@replayio/protocol@npm:^0.50.0":
-  version: 0.50.0
-  resolution: "@replayio/protocol@npm:0.50.0"
-  checksum: 04144053427aca9e119787f28fb384ddbc8ed42338b311313ca2b9a9aff5cd2627cb3ed091e03a409daad3186633e9f77c86f57539c295d40f9e7745ab0968bb
+"@replayio/protocol@npm:^0.53.0":
+  version: 0.53.0
+  resolution: "@replayio/protocol@npm:0.53.0"
+  checksum: 37f4532b4d27f59b71bfd51b4005383db8a590ede5d8501d0b656fb66f2396ab4108065d8b6ac8e2bea0fe50d3d2a15a21e6237d57dbbd3095bc3ca11414b38a
   languageName: node
   linkType: hard
 
@@ -20476,7 +20476,7 @@ __metadata:
     "@recordreplay/sourcemap-upload-cli": ^0.1.1
     "@reduxjs/toolkit": ^1.8.4
     "@replayio/overboard": ^0.4.1
-    "@replayio/protocol": ^0.50.0
+    "@replayio/protocol": ^0.53.0
     "@replayio/replay": ^0.12.4
     "@sentry/react": ^7.9.0
     "@sentry/tracing": ^7.9.0
@@ -20955,7 +20955,7 @@ __metadata:
     "@lezer/common_replay_next": "npm:@lezer/common@1.0.1"
     "@lezer/highlight_replay_next": "npm:@lezer/highlight@1.1.1"
     "@playwright/test": ^1.23.1
-    "@replayio/protocol": ^0.50.0
+    "@replayio/protocol": ^0.53.0
     "@testing-library/jest-dom": ^5.16.3
     "@testing-library/react": ^13.2.0
     "@types/uuid": ^7.0.3


### PR DESCRIPTION
This PR:

- Bumps the protocol package
- Adds `hasAnnotationKind()` to `ReplayClient`
- Swaps the annotation kinds cache to use that instead, so that we don't block on a check for _all_ annotations returning before we get _any_ of them back