### PR TITLE
Truncating testsuite urls at 250 characters

### DIFF
--- a/src/ui/components/TestSuite/views/TestItem/TestSteps/NavigationTestStepRow.tsx
+++ b/src/ui/components/TestSuite/views/TestItem/TestSteps/NavigationTestStepRow.tsx
@@ -9,10 +9,15 @@ export default memo(function NavigationTestStepRow({
 }: {
   navigationTestStep: NavigationTestStep;
 }) {
+  let url = navigationTestStep.data.url;
+  let displayUrl = url.length > 250 ? url.slice(0, 250) + "..." : url;
+
   return (
     <div className={styles.Indented}>
       <div className={styles.Text}>
-        <span className={styles.Name}>{navigationTestStep.data.url}</span>
+        <span className={styles.Name} title={url}>
+          {displayUrl}
+        </span>
       </div>
     </div>
   );


### PR DESCRIPTION
**Summary**

In testsuites, it's possible for URLs to be extremely long, which makes the UX look funny. This change truncates things at 250 characters and adds a little tooltip if you need to see the whole thing.

<img width="297" alt="image" src="https://github.com/replayio/devtools/assets/9154902/3f60a23b-ed7f-40d0-b857-6ab31ca5f0bc">

Addresses https://linear.app/replay/issue/DES-690/we-should-truncate-long-urls-in-the-cy-panel