### PR TITLE
Remove the 'point' URL param usage for session creation.

### DIFF
--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -214,8 +214,6 @@ export function createSocket(
         experimentalSettings.controllerKey = String(Date.now());
       }
 
-      const loadPoint = new URL(window.location.href).searchParams.get("point") || undefined;
-
       const queuedActions: Array<Action | UIThunkAction> = [];
       let flushTimeoutId: NodeJS.Timeout | null = null;
 
@@ -246,7 +244,7 @@ export function createSocket(
 
       const sessionId = await createSession(
         recordingId,
-        loadPoint,
+        undefined,
         experimentalSettings,
         focusRange,
         {


### PR DESCRIPTION
We are currently using this 'point' query param in https://github.com/replayio/devtools/blob/3f188fbc92355d05781d2c5a698a79f1ccd88782/src/ui/utils/environment.ts#L118 but we also read it in https://github.com/replayio/devtools/blob/3f188fbc92355d05781d2c5a698a79f1ccd88782/src/ui/actions/session.ts#L217 

I think this usage is a bit confusing since it means that if you were to view a recording, select an earlier point, and then refresh the page, you'd potentially be viewing a different length of the recording.

@bhackett1024 Would you're fine with us removing this for now? I think overloading this param like this makes the app behavior confusing in a few ways, so I'm in favor of just removing this for now and adding it again when we revisit this usecase.

Fixes https://linear.app/replay/issue/FE-1568/frontend-has-two-conflicting-uses-of-the-point-query-param