### PR TITLE
Wait for the focus range instead of loaded regions

### DIFF
--- a/packages/shared/client/ReplayClient.ts
+++ b/packages/shared/client/ReplayClient.ts
@@ -58,10 +58,9 @@ import uniqueId from "lodash/uniqueId";
 import { addEventListener, client, initSocket, removeEventListener } from "protocol/socket";
 import { compareNumericStrings, defer, waitForTime } from "protocol/utils";
 import { initProtocolMessagesStore } from "replay-next/components/protocol/ProtocolMessagesStore";
-import { areRangesEqual } from "replay-next/src/utils/time";
 import { TOO_MANY_POINTS_TO_FIND } from "shared/constants";
 import { ProtocolError, commandError } from "shared/utils/error";
-import { isPointInRegions, isRangeInRegions, isTimeInRegions } from "shared/utils/time";
+import { isPointInRegion, isRangeInRegions } from "shared/utils/time";
 
 import { ReplayClientEvents, ReplayClientInterface, SourceLocationRange } from "./types";
 
@@ -82,6 +81,8 @@ export class ReplayClient implements ReplayClientInterface {
   private _sessionId: SessionId | null = null;
 
   private sessionWaiter = defer<SessionId>();
+
+  private focusRange: TimeStampedPointRange | null = null;
 
   private nextFindPointsId = 1;
   private nextRunEvaluationId = 1;
@@ -109,6 +110,7 @@ export class ReplayClient implements ReplayClientInterface {
   configure(sessionId: string): void {
     this._sessionId = sessionId;
     this.sessionWaiter.resolve(sessionId);
+    this.getFocusWindow();
   }
 
   waitForSession() {
@@ -156,7 +158,7 @@ export class ReplayClient implements ReplayClientInterface {
   async createPause(executionPoint: ExecutionPoint): Promise<createPauseResult> {
     const sessionId = this.getSessionIdThrows();
 
-    await this._waitForPointToBeLoaded(executionPoint);
+    await this.waitForPointToBeInFocusRange(executionPoint);
 
     const response = await client.Session.createPause({ point: executionPoint }, sessionId);
 
@@ -221,6 +223,7 @@ export class ReplayClient implements ReplayClientInterface {
 
     this._sessionId = sessionId;
     this.sessionWaiter.resolve(sessionId);
+    this.getFocusWindow();
 
     return sessionId;
   }
@@ -290,7 +293,7 @@ export class ReplayClient implements ReplayClientInterface {
     // but right now it will just silently return a subset of messages.
     // Given that we are extra careful here not to to fetch messages in unloaded regions
     // because the result might be invalid (and may get cached by a Suspense caller).
-    await this._waitForRangeToBeLoaded(pointRange);
+    await this.waitForRangeToBeInFocusRange(pointRange);
 
     const response = await client.Console.findMessagesInRange({ range: pointRange }, sessionId);
 
@@ -339,7 +342,7 @@ export class ReplayClient implements ReplayClientInterface {
       pointLimits.maxCount = MAX_POINTS_TO_FIND;
     }
 
-    await this._waitForRangeToBeLoaded(
+    await this.waitForRangeToBeInFocusRange(
       pointLimits.begin && pointLimits.end
         ? { begin: pointLimits.begin, end: pointLimits.end }
         : null
@@ -479,6 +482,8 @@ export class ReplayClient implements ReplayClientInterface {
   async getFocusWindow(): Promise<TimeStampedPointRange> {
     const sessionId = this.getSessionIdThrows();
     const { window } = await client.Session.getFocusWindow({}, sessionId);
+    this.focusRange = window;
+    this._dispatchEvent("focusRangeChange", window);
     return window;
   }
 
@@ -583,7 +588,7 @@ export class ReplayClient implements ReplayClientInterface {
     focusRange: PointRange | null
   ) {
     const sessionId = this.getSessionIdThrows();
-    await this._waitForRangeToBeLoaded(focusRange);
+    await this.waitForRangeToBeInFocusRange(focusRange);
     const { hits } = await client.Debugger.getHitCounts(
       { sourceId, locations, maxHits: TOO_MANY_POINTS_TO_FIND, range: focusRange || undefined },
       sessionId
@@ -623,7 +628,8 @@ export class ReplayClient implements ReplayClientInterface {
   async requestFocusRange(range: FocusWindowRequest): Promise<TimeStampedPointRange> {
     const sessionId = this.getSessionIdThrows();
     const { window } = await client.Session.requestFocusRange({ range }, sessionId);
-
+    this.focusRange = window;
+    this._dispatchEvent("focusRangeChange", window);
     return window;
   }
 
@@ -780,7 +786,7 @@ export class ReplayClient implements ReplayClientInterface {
       pointLimits.maxCount = MAX_POINTS_TO_RUN_EVALUATION;
     }
 
-    await this._waitForRangeToBeLoaded(
+    await this.waitForRangeToBeInFocusRange(
       pointLimits.begin && pointLimits.end
         ? { begin: pointLimits.begin, end: pointLimits.end }
         : null
@@ -877,75 +883,51 @@ export class ReplayClient implements ReplayClientInterface {
     }
   }
 
-  async _waitForPointToBeLoaded(point: ExecutionPoint): Promise<void> {
+  async waitForPointToBeInFocusRange(point: ExecutionPoint): Promise<void> {
     return new Promise(resolve => {
-      const checkLoaded = () => {
-        const loadedRegions = this.loadedRegions;
-        let isLoaded = false;
-        if (loadedRegions !== null) {
-          isLoaded = isPointInRegions(point, loadedRegions.loaded);
+      const checkFocusRange = () => {
+        let isInFocusRange = false;
+        if (this.focusRange !== null) {
+          isInFocusRange = isPointInRegion(point, this.focusRange);
         }
 
-        if (isLoaded) {
+        if (isInFocusRange) {
           resolve();
 
-          this.removeEventListener("loadedRegionsChange", checkLoaded);
+          this.removeEventListener("focusRangeChange", checkFocusRange);
         }
       };
 
-      this.addEventListener("loadedRegionsChange", checkLoaded);
+      this.addEventListener("focusRangeChange", checkFocusRange);
 
-      checkLoaded();
+      checkFocusRange();
     });
   }
 
-  async _waitForRangeToBeLoaded(
-    focusRange: TimeStampedPointRange | PointRange | null
+  async waitForRangeToBeInFocusRange(
+    range: TimeStampedPointRange | PointRange | null
   ): Promise<void> {
+    if (range === null) {
+      return Promise.resolve();
+    }
+
     return new Promise(resolve => {
-      const checkLoaded = () => {
-        const loadedRegions = this.loadedRegions;
-        let isLoaded = false;
-        if (loadedRegions !== null && loadedRegions.loading.length > 0) {
-          if (focusRange !== null) {
-            isLoaded = isRangeInRegions(focusRange, loadedRegions.indexed);
-          } else {
-            isLoaded = areRangesEqual(loadedRegions.indexed, loadedRegions.loading);
-          }
+      const checkFocusRange = () => {
+        let isInFocusRange = false;
+        if (this.focusRange !== null) {
+          isInFocusRange = isRangeInRegions(range, [this.focusRange]);
         }
 
-        if (isLoaded) {
+        if (isInFocusRange) {
           resolve();
 
-          this.removeEventListener("loadedRegionsChange", checkLoaded);
+          this.removeEventListener("focusRangeChange", checkFocusRange);
         }
       };
 
-      this.addEventListener("loadedRegionsChange", checkLoaded);
+      this.addEventListener("focusRangeChange", checkFocusRange);
 
-      checkLoaded();
-    });
-  }
-
-  async waitForTimeToBeLoaded(time: number): Promise<void> {
-    return new Promise(resolve => {
-      const checkLoaded = () => {
-        const loadedRegions = this.loadedRegions;
-        let isLoaded = false;
-        if (loadedRegions !== null) {
-          isLoaded = isTimeInRegions(time, loadedRegions.loaded);
-        }
-
-        if (isLoaded) {
-          resolve();
-
-          this.removeEventListener("loadedRegionsChange", checkLoaded);
-        }
-      };
-
-      this.addEventListener("loadedRegionsChange", checkLoaded);
-
-      checkLoaded();
+      checkFocusRange();
     });
   }
 

--- a/packages/shared/client/types.ts
+++ b/packages/shared/client/types.ts
@@ -129,7 +129,7 @@ export type PointBehavior = {
   shouldLog: POINT_BEHAVIOR;
 };
 
-export type ReplayClientEvents = "loadedRegionsChange";
+export type ReplayClientEvents = "focusRangeChange" | "loadedRegionsChange";
 
 export type HitPointStatus =
   | "complete"
@@ -261,5 +261,4 @@ export interface ReplayClientInterface {
     }) => void,
     onSourceContentsChunk: ({ chunk, sourceId }: { chunk: string; sourceId: SourceId }) => void
   ): Promise<void>;
-  waitForTimeToBeLoaded(time: number): Promise<void>;
 }


### PR DESCRIPTION
Replaces #9272, addressing the concern described at the end of https://github.com/replayio/devtools/pull/9272#discussion_r1221696470