### PR TITLE
Fix React DEV warnings about HTML attribute casing

### DIFF
--- a/packages/replay-next/components/console/MessagesList.tsx
+++ b/packages/replay-next/components/console/MessagesList.tsx
@@ -195,11 +195,11 @@ function MessagesList({ forwardedRef }: { forwardedRef: ForwardedRef<HTMLElement
         className={styles.Container}
         data-test-state-errors={showErrors ? true : undefined}
         data-test-state-exceptions={showExceptions ? true : undefined}
-        data-test-state-filterByText={filterByText}
+        data-test-state-filter-by-text={filterByText}
         data-test-state-logs={showLogs ? true : undefined}
-        data-test-state-nodeModules={showNodeModules ? true : undefined}
-        data-test-state-searchByText={searchState.query}
-        data-test-state-cacheStreamingStatus={streamingStatus}
+        data-test-state-node-modules={showNodeModules ? true : undefined}
+        data-test-state-search-by-text={searchState.query}
+        data-test-state-cache-streaming-status={streamingStatus}
         data-test-state-timestamps={showTimestamps ? true : undefined}
         data-test-state-warnings={showWarnings ? true : undefined}
         data-test-name="Messages"

--- a/packages/replay-next/playwright/tests/utils/console.ts
+++ b/packages/replay-next/playwright/tests/utils/console.ts
@@ -27,7 +27,7 @@ export async function filterByText(page: Page, text: string) {
   // Wait for Console to apply new filter text
   await waitFor(async () => {
     const messageList = page.locator('[data-test-name="Messages"]');
-    const value = await messageList.getAttribute(`data-test-state-filterByText`);
+    const value = await messageList.getAttribute(`data-test-state-filter-by-text`);
     expect(value).toBe(text);
   });
 }
@@ -158,7 +158,7 @@ export async function searchByText(page: Page, text: string) {
   // Wait for Console to apply new filter text
   await waitFor(async () => {
     const messageList = page.locator('[data-test-name="Messages"]');
-    const value = await messageList.getAttribute(`data-test-state-searchByText`);
+    const value = await messageList.getAttribute(`data-test-state-search-by-text`);
     expect(value).toBe(text);
   });
 }
@@ -308,7 +308,7 @@ export async function verifyTypeAheadContainsSuggestions(page: Page, ...suggesti
 export async function waitForMessageStatus(page: Page, status: Status = "resolved") {
   await waitFor(async () => {
     const messageList = page.locator('[data-test-name="Messages"]');
-    const value = await messageList.getAttribute(`data-test-state-cacheStreamingStatus`);
+    const value = await messageList.getAttribute(`data-test-state-cache-streaming-status`);
     expect(value).toBe(status);
   });
 }


### PR DESCRIPTION
These clutter the console and potentially mask other, important warnings.