### PR TITLE
Test Suites: Library: Show failed count inline

### DIFF
--- a/src/ui/components/Library/Team/View/TestRuns/TestRunListItem.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunListItem.tsx
@@ -63,13 +63,21 @@ function Attributes({ testSuite }: { testSuite: TestSuite }) {
 }
 
 function Status({ failCount }: { failCount: number }) {
-  return (
-    <Icon
-      filename={failCount > 0 ? "testsuites-fail" : "testsuites-success"}
-      size="medium"
-      className={failCount > 0 ? "bg-[#EB5757]" : "bg-[#219653]"}
-    />
-  );
+  if (failCount > 0) {
+    return (
+      <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded-md bg-[#EB5757] text-xs font-bold text-chrome">
+        {failCount}
+      </div>
+    );
+  } else {
+    return (
+      <Icon
+        filename={failCount > 0 ? "testsuites-fail" : "testsuites-success"}
+        size="medium"
+        className={failCount > 0 ? "bg-[#EB5757]" : "bg-[#219653]"}
+      />
+    );
+  }
 }
 
 export function TestRunListItem({ testSuite }: { testSuite: TestSuite }) {


### PR DESCRIPTION
IMO a simple pass/fail isn't a strong enough signal. When there's a known broken test (like now, FE-1569) then the whole list looks the same (fail, fail, fail). Showing the _number_ of failures gives a stronger signal if a branch is status quo or an outlier.

### Before

All commits look equally broken.

<img width="665" alt="Screen Shot 2023-06-10 at 10 51 05 AM" src="https://github.com/replayio/devtools/assets/29597/111b1589-5cd6-479c-a07b-41a1d8b06232">

### After

The second commit stands out as introducing a new problem.

<img width="667" alt="Screen Shot 2023-06-10 at 10 51 01 AM" src="https://github.com/replayio/devtools/assets/29597/c71ffa49-fcd2-4666-b259-f8aab1a80afb">
