### PR TITLE
Separate normal workspaces from test suite workspaces

### DIFF
--- a/pages/recording/[[...id]].tsx
+++ b/pages/recording/[[...id]].tsx
@@ -160,12 +160,14 @@ function RecordingPage({
 
       setRecording(rec);
 
-      if (rec.metadata?.test && !rec.workspace?.isTest) {
+      const isTestReplay = rec.metadata?.test && rec.metadata?.source;
+
+      if (isTestReplay && !rec.workspace?.isTest) {
         setExpectedError({
           content: "This recording is not available.",
           message: "The recording must belong to a test suite",
         });
-      } else if (!rec.metadata?.test && rec.workspace?.isTest) {
+      } else if (!isTestReplay && rec.workspace?.isTest) {
         setExpectedError({
           content: "This recording is not available.",
           message: "The recording cannot be in a test suite",

--- a/pages/recording/[[...id]].tsx
+++ b/pages/recording/[[...id]].tsx
@@ -154,9 +154,25 @@ function RecordingPage({
     async function getRecording() {
       await setupDevtools(store, replayClient);
       const rec = await getAccessibleRecording(recordingId);
+      if (!rec) {
+        return;
+      }
+
       setRecording(rec);
 
-      if (rec?.metadata?.test) {
+      if (rec.metadata?.test && !rec.workspace?.isTest) {
+        setExpectedError({
+          content: "This recording is not available.",
+          message: "The recording must belong to a test suite",
+        });
+      } else if (!rec.metadata?.test && rec.workspace?.isTest) {
+        setExpectedError({
+          content: "This recording is not available.",
+          message: "The recording cannot be in a test suite",
+        });
+      }
+
+      if (rec.metadata?.test) {
         trackEvent("session_start.test");
       }
 

--- a/src/ui/graphql/recordings.ts
+++ b/src/ui/graphql/recordings.ts
@@ -76,6 +76,7 @@ export const GET_RECORDING = gql`
         id
         name
         hasPaymentMethod
+        isTest
         subscription {
           status
           trialEnds


### PR DESCRIPTION
Fixes SCS-1147

We should only let tests be viewed in test suites and only let normal replays be viewed outside of test suites.