### PR TITLE
Test Suite UI tweaks

### DIFF
--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -522,6 +522,7 @@
   --testsuites-steps-toggle-bgcolor: #191f2a;
   --testsuites-success-color: #30e60b;
   --testsuites-skipped-color: var(--theme-base-70);
+  --testsuites-unresolved-color: var(--background-color-contrast-1);
 
   --circular-progress-bar-trail-color: var(--testsuites-steps-bgcolor);
 
@@ -1038,6 +1039,8 @@
   --testsuites-steps-bgcolor: #fff;
   --testsuites-steps-toggle-bgcolor: #fff;
   --testsuites-success-color: #058b00;
+  --testsuites-skipped-color: var(--theme-base-70);
+  --testsuites-unresolved-color: var(--background-color-contrast-1);
 
   --circular-progress-bar-trail-color: var(--testsuites-steps-bgcolor);
 

--- a/packages/replay-next/src/utils/string.test.ts
+++ b/packages/replay-next/src/utils/string.test.ts
@@ -1,0 +1,21 @@
+import { truncateMiddle } from "replay-next/src/utils/string";
+
+describe("string util", () => {
+  describe("truncateMiddle", () => {
+    it("should handle empty strings", () => {
+      expect(truncateMiddle("", 10)).toEqual("");
+    });
+
+    it("should not truncate strings that are <= the specified maximum length", () => {
+      expect(truncateMiddle("one", 5)).toEqual("one");
+      expect(truncateMiddle("three", 5)).toEqual("three");
+    });
+
+    it("should truncate strings that are > than the specified length", () => {
+      expect(truncateMiddle("1234567890123456", 10)).toEqual("1234...3456");
+      expect(truncateMiddle("123456789012345", 10)).toEqual("1234...2345");
+      expect(truncateMiddle("1234567890123456", 9)).toEqual("123...456");
+      expect(truncateMiddle("123456789012345", 9)).toEqual("123...345");
+    });
+  });
+});

--- a/packages/replay-next/src/utils/string.ts
+++ b/packages/replay-next/src/utils/string.ts
@@ -24,3 +24,12 @@ export function stringify(value: any, space?: string | number): string {
     space
   );
 }
+
+export function truncateMiddle(value: string, maxLength = 250, separator = "...") {
+  if (value.length > maxLength) {
+    const charIndex = (maxLength - separator.length) / 2;
+    return value.slice(0, Math.ceil(charIndex)) + separator + value.slice(0 - Math.ceil(charIndex));
+  }
+
+  return value;
+}

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/NavigationEventRow.module.css
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/NavigationEventRow.module.css
@@ -10,6 +10,6 @@
   flex: 0 1 auto;
   overflow: hidden;
   text-overflow: ellipsis;
-  word-break: break-word;
+  word-break: break-all;
   color: var(--color-link);
 }

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/NavigationEventRow.module.css
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/NavigationEventRow.module.css
@@ -3,6 +3,7 @@
 }
 .Text {
   flex: 1;
+  color: var(--color-dim);
 }
 
 .Name {
@@ -10,4 +11,5 @@
   overflow: hidden;
   text-overflow: ellipsis;
   word-break: break-word;
+  color: var(--color-link);
 }

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/NavigationEventRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/NavigationEventRow.tsx
@@ -1,5 +1,6 @@
 import { memo } from "react";
 
+import { truncateMiddle } from "replay-next/src/utils/string";
 import { NavigationEvent } from "shared/test-suites/RecordingTestMetadata";
 
 import styles from "./NavigationEventRow.module.css";
@@ -9,10 +10,12 @@ export default memo(function NavigationEventRow({
 }: {
   navigationEvent: NavigationEvent;
 }) {
+  const formattedUrl = truncateMiddle(navigationEvent.data.url, 150);
+
   return (
     <div className={styles.Indented}>
       <div className={styles.Text}>
-        Opened <span className={styles.Name}>{navigationEvent.data.url}</span>
+        Opened <span className={styles.Name}>{formattedUrl}</span>
       </div>
     </div>
   );

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/NavigationEventRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/NavigationEventRow.tsx
@@ -12,7 +12,7 @@ export default memo(function NavigationEventRow({
   return (
     <div className={styles.Indented}>
       <div className={styles.Text}>
-        <span className={styles.Name}>{navigationEvent.data.url}</span>
+        Opened <span className={styles.Name}>{navigationEvent.data.url}</span>
       </div>
     </div>
   );

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/NetworkRequestEventRow.module.css
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/NetworkRequestEventRow.module.css
@@ -25,4 +25,5 @@
 
 .Text {
   flex: 1;
+  word-break: break-all;
 }

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/NetworkRequestEventRow.module.css
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/NetworkRequestEventRow.module.css
@@ -19,6 +19,9 @@
 .StatusBadge[data-status-badge="success"] {
   background-color: var(--testsuites-success-color);
 }
+.StatusBadge[data-status-badge="unresolved"] {
+  background-color: var(--testsuites-unresolved-color);
+}
 
 .Text {
   flex: 1;

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/NetworkRequestEventRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/NetworkRequestEventRow.tsx
@@ -1,5 +1,6 @@
 import { memo } from "react";
 
+import { truncateMiddle } from "replay-next/src/utils/string";
 import { NetworkRequestEvent } from "shared/test-suites/RecordingTestMetadata";
 import { setSelectedPanel } from "ui/actions/layout";
 import { selectAndFetchRequest } from "ui/actions/network";
@@ -33,6 +34,8 @@ export default memo(function NetworkRequestEventRow({
     dispatch(selectAndFetchRequest(id));
   };
 
+  const formattedPathname = truncateMiddle(pathname, 150);
+
   return (
     <div className={styles.Indented} onClick={showNetworkPanel}>
       <div className={styles.Text}>
@@ -43,7 +46,7 @@ export default memo(function NetworkRequestEventRow({
             <span className={styles.Token}>{response.status}</span>{" "}
           </>
         )}
-        <span className={styles.Token}>{pathname}</span>
+        <span className={styles.Token}>{formattedPathname}</span>
       </div>
     </div>
   );

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/NetworkRequestEventRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/NetworkRequestEventRow.tsx
@@ -17,7 +17,7 @@ export default memo(function NetworkRequestEventRow({
 
   const dispatch = useAppDispatch();
 
-  let statusBadge: string | null = null;
+  let statusBadge: string = "unresolved";
   if (response != null) {
     if (response.status >= 400) {
       statusBadge = "error";
@@ -36,11 +36,7 @@ export default memo(function NetworkRequestEventRow({
   return (
     <div className={styles.Indented} onClick={showNetworkPanel}>
       <div className={styles.Text}>
-        {statusBadge !== null && (
-          <>
-            <span className={styles.StatusBadge} data-status-badge={statusBadge} />{" "}
-          </>
-        )}
+        <span className={styles.StatusBadge} data-status-badge={statusBadge} />{" "}
         <span className={styles.Token}>{method}</span>{" "}
         {response && (
           <>


### PR DESCRIPTION
## Network requests

Improved styling for unresolved requests (e.g. Replay stopped before a response was recorded):

| Before | After |
| --- | --- |
| <img width="226" alt="Screen Shot 2023-06-12 at 8 53 57 AM" src="https://github.com/replayio/devtools/assets/29597/1be5ac7b-2ae2-4902-a4b2-077d2a29ba26"> | <img width="221" alt="Screen Shot 2023-06-12 at 9 00 01 AM" src="https://github.com/replayio/devtools/assets/29597/f0dd743d-51fe-44ec-b9eb-e54bbecda11a"> |

Also improve formatting for longer URLs (word-break, middle truncation):

| Before | After |
| --- | --- |
| <img width="395" alt="Screen Shot 2023-06-12 at 10 11 21 AM" src="https://github.com/replayio/devtools/assets/29597/15ffc42d-3195-41d5-948a-c5e6ef805fcc"> | <img width="389" alt="Screen Shot 2023-06-12 at 10 14 03 AM" src="https://github.com/replayio/devtools/assets/29597/36075d15-f1c2-47cb-b379-8fd330939110"> |

## Navigation

Improved styling for navigation events so they didn't just float:

| Before | After |
| --- | --- |
| <img width="350" alt="Screen Shot 2023-06-12 at 8 55 58 AM" src="https://github.com/replayio/devtools/assets/29597/9f4dd2a9-4411-4135-8dce-50d877d68726"> | <img width="358" alt="Screen Shot 2023-06-12 at 8 58 07 AM" src="https://github.com/replayio/devtools/assets/29597/422efae6-01f8-492f-a88b-e77b6caa86e4"> |

Also improve formatting and display for longer URLs (word-break, middle truncation):

| Before | After |
| --- | --- |
| <img width="378" alt="Screen Shot 2023-06-12 at 10 18 53 AM" src="https://github.com/replayio/devtools/assets/29597/f8c12a5a-2db4-4f23-a74e-9d900d62b54e"> | <img width="377" alt="Screen Shot 2023-06-12 at 10 13 25 AM" src="https://github.com/replayio/devtools/assets/29597/d258167f-be27-45d2-ae33-2173d1c31305"> |
