### PR TITLE
Improve UX for Console source locations with unknown file names

### DIFF
--- a/packages/replay-next/components/console/Source.module.css
+++ b/packages/replay-next/components/console/Source.module.css
@@ -5,3 +5,8 @@
   text-align: right;
   color: var(--color-default);
 }
+
+.UnknownSourceLabel {
+  text-decoration: underline;
+  color: var(--color-dim);
+}

--- a/packages/replay-next/components/console/Source.tsx
+++ b/packages/replay-next/components/console/Source.tsx
@@ -51,16 +51,14 @@ export default function Source({
     }
   };
 
-  const sourceString = `${fileName}:${location.line}`;
-
   return (
     <span
       className={`${styles.Source} ${className}`}
       data-test-name="Console-Source"
       onClick={openSource}
-      title={sourceString}
+      title={`${fileName ?? "unknown"}:${location.line}`}
     >
-      {sourceString}
+      {fileName ?? <span className={styles.UnknownSourceLabel}>unknown</span>}:{location.line}
     </span>
   );
 }

--- a/src/devtools/client/debugger/src/components/shared/InspectorContextReduxAdapter.tsx
+++ b/src/devtools/client/debugger/src/components/shared/InspectorContextReduxAdapter.tsx
@@ -4,7 +4,7 @@ import {
   PauseId,
   Value as ProtocolValue,
 } from "@replayio/protocol";
-import React, { ReactNode, useCallback, useMemo } from "react";
+import { ReactNode, useCallback, useMemo } from "react";
 
 import { selectNode } from "devtools/client/inspector/markup/actions/markup";
 import { onViewSourceInDebugger } from "devtools/client/webconsole/actions";
@@ -13,12 +13,10 @@ import { InspectorContext } from "replay-next/src/contexts/InspectorContext";
 import useLocalStorage from "replay-next/src/hooks/useLocalStorage";
 import { setSelectedPanel, setSelectedPrimaryPanel } from "ui/actions/layout";
 import { sidePanelStorageKey } from "ui/components/DevTools";
-import { getSourceDetailsEntities } from "ui/reducers/sources";
-import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
+import { useAppDispatch } from "ui/setup/hooks";
 
 // Adapter that connects inspect-function and inspect-html-element actions with Redux.
 export default function InspectorContextReduxAdapter({ children }: { children: ReactNode }) {
-  const sourcesById = useAppSelector(getSourceDetailsEntities);
   const dispatch = useAppDispatch();
   const [, setSidePanelCollapsed] = useLocalStorage(sidePanelStorageKey, false);
 
@@ -26,20 +24,18 @@ export default function InspectorContextReduxAdapter({ children }: { children: R
     (mappedLocation: MappedLocation) => {
       const location = mappedLocation.length > 0 ? mappedLocation[mappedLocation.length - 1] : null;
       if (location) {
-        const url = sourcesById[location.sourceId]?.url;
-        if (url) {
-          dispatch(
-            onViewSourceInDebugger({
-              url,
-              sourceId: location.sourceId,
-              line: location.line,
-              column: location.column,
-            })
-          );
-        }
+        const sourceId = location.sourceId;
+        dispatch(
+          onViewSourceInDebugger({
+            column: location.column,
+            line: location.line,
+            openSource: true,
+            sourceId,
+          })
+        );
       }
     },
-    [sourcesById, dispatch]
+    [dispatch]
   );
 
   const showCommentsPanel = useCallback(() => {

--- a/src/devtools/client/inspector/event-listeners/EventListenersApp.tsx
+++ b/src/devtools/client/inspector/event-listeners/EventListenersApp.tsx
@@ -103,13 +103,12 @@ export const EventListenersApp = () => {
                                   title="Open in Debugger"
                                   onClick={() => {
                                     dispatch(
-                                      onViewSourceInDebugger(
-                                        {
-                                          ...location,
-                                          url: locationUrl,
-                                        },
-                                        true
-                                      )
+                                      onViewSourceInDebugger({
+                                        column: location.column,
+                                        line: location.line,
+                                        openSource: true,
+                                        sourceId: location.sourceId,
+                                      })
                                     );
                                   }}
                                 >

--- a/src/devtools/client/webconsole/actions/toolbox.ts
+++ b/src/devtools/client/webconsole/actions/toolbox.ts
@@ -8,27 +8,23 @@ import { selectSource } from "devtools/client/debugger/src/actions/sources";
 import { showSource } from "devtools/client/debugger/src/actions/ui";
 import { getContext } from "devtools/client/debugger/src/selectors";
 import type { UIThunkAction } from "ui/actions";
-import { getSourceDetails, getSourceToDisplayForUrl } from "ui/reducers/sources";
 
-export function onViewSourceInDebugger(
-  frame: { sourceId?: string; url: string; line?: number; column: number },
-  openSource = true
-): UIThunkAction {
+export function onViewSourceInDebugger({
+  column,
+  line,
+  openSource,
+  sourceId,
+}: {
+  column?: number;
+  line?: number;
+  openSource: boolean;
+  sourceId: string;
+}): UIThunkAction {
   return async (dispatch, getState) => {
-    const cx = getContext(getState());
-    const source = frame.sourceId
-      ? getSourceDetails(getState(), frame.sourceId)
-      : getSourceToDisplayForUrl(getState(), frame.url!);
-    if (source) {
-      dispatch(showSource(cx, source.id, openSource));
-      await dispatch(
-        selectSource(
-          cx,
-          source.id,
-          { sourceId: source.id, line: frame.line, column: frame.column },
-          openSource
-        )
-      );
-    }
+    const state = getContext(getState());
+
+    dispatch(showSource(state, sourceId, openSource));
+
+    await dispatch(selectSource(state, sourceId, { column, line, sourceId }, openSource));
   };
 }

--- a/src/ui/components/SearchFilesReduxAdapter.tsx
+++ b/src/ui/components/SearchFilesReduxAdapter.tsx
@@ -18,17 +18,14 @@ export default function SearchFilesReduxAdapter() {
     if (focusedSource != null) {
       const { mode, startLineIndex, sourceId } = focusedSource;
       if (mode === "search-result") {
-        const url = sourcesById[sourceId]?.url;
-        if (url) {
-          dispatch(
-            onViewSourceInDebugger({
-              url,
-              sourceId,
-              line: startLineIndex !== null ? startLineIndex + 1 : undefined,
-              column: 0,
-            })
-          );
-        }
+        dispatch(
+          onViewSourceInDebugger({
+            column: 0,
+            line: startLineIndex !== null ? startLineIndex + 1 : undefined,
+            openSource: true,
+            sourceId,
+          })
+        );
       }
     }
   }, [dispatch, focusedSource, sourcesById]);


### PR DESCRIPTION
### [Loom overview](https://www.loom.com/share/028ea85736064b6b882afd7cfb351cb7)

- [x] Improve display name for these locations
- [x] Fix clicking on these location to actually open the source file

I'm not sure why the code was written this way, but historically we accepted an _optional_ source ID and a _required_ URL (so that we could find the source ID):
https://github.com/replayio/devtools/blob/fbbdf543143d690e2b56766d40ec0acca3cd2ba2/src/devtools/client/webconsole/actions/toolbox.ts#L13C17-L23

In practice, every place that called this method had a source ID, and was having to do a separate lookup to find the URL. (And in the case of an unnamed source, no URL meant that we didn't call this method at all.)

This PR fixes that.