### PR TITLE
Sort test run test items by filename for readability

### DIFF
--- a/src/ui/components/Library/Team/View/TestRuns/Overview/RunResults.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/Overview/RunResults.tsx
@@ -70,8 +70,14 @@ function TestStatusGroupExpanded({
   label: string;
   recordingGroup: RecordingGroup;
 }) {
-  const entries = Array.from(Object.entries(recordingGroup.fileNameToRecordings));
-  return entries.map(([fileName, recordings]) => (
+  const sortedEntries = useMemo(() => {
+    const entries = Array.from(Object.entries(recordingGroup.fileNameToRecordings));
+    // Sort by filename ascending
+    entries.sort((a, b) => a[0].localeCompare(b[0]));
+    return entries;
+  }, [recordingGroup.fileNameToRecordings]);
+
+  return sortedEntries.map(([fileName, recordings]) => (
     <TestFileGroup key={fileName} fileName={fileName} label={label} recordings={recordings} />
   )) as any;
 }


### PR DESCRIPTION
This PR:

- Sorts the per-filename groups in the library test run list alphabetically, because WOW was it annoying to try to find the right test otherwise :(

(also we should totally add a search filter input)

Before:

![image](https://github.com/replayio/devtools/assets/1128784/1694ebcc-18bb-427a-a77f-50632c81d901)


After:

![image](https://github.com/replayio/devtools/assets/1128784/90ca7bd7-ad19-4fa5-909d-cbb79f737895)
