### PR TITLE
Remove duration from test run list

### DIFF
--- a/src/ui/components/Library/Team/View/TestRuns/TestRunListItem.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunListItem.tsx
@@ -3,14 +3,10 @@ import { useContext } from "react";
 
 import { TestSuite } from "shared/test-suites/TestRun";
 import { BranchIcon } from "ui/components/Library/Team/View/TestRuns/BranchIcon";
-import { getDuration } from "ui/components/Library/Team/View/TestRuns/utils";
 import Icon from "ui/components/shared/Icon";
 
 import { TeamContext } from "../../TeamContextRoot";
-import {
-  getDurationString,
-  getTruncatedRelativeDate,
-} from "../Recordings/RecordingListItem/RecordingListItem";
+import { getTruncatedRelativeDate } from "../Recordings/RecordingListItem/RecordingListItem";
 import { AttributeContainer } from "./AttributeContainer";
 import { ModeAttribute } from "./Overview/RunSummary";
 import { RunStats } from "./RunStats";
@@ -31,14 +27,10 @@ function Title({ testSuite }: { testSuite: TestSuite }) {
 }
 
 function Attributes({ testSuite }: { testSuite: TestSuite }) {
-  const { date, results, source, primaryTitle } = testSuite;
-  const { recordings } = results;
+  const { date, source, primaryTitle } = testSuite;
 
   if (source) {
     const { branchName, isPrimaryBranch, user } = source;
-
-    const duration = getDuration(recordings);
-    const durationString = getDurationString(duration);
 
     return (
       <div className="flex flex-row items-center gap-4 text-xs font-light">
@@ -49,7 +41,6 @@ function Attributes({ testSuite }: { testSuite: TestSuite }) {
           isPrimaryBranch={isPrimaryBranch}
           title={primaryTitle}
         />
-        <AttributeContainer icon="timer">{durationString}</AttributeContainer>
         <ModeAttribute testSuite={testSuite} />
       </div>
     );


### PR DESCRIPTION
## Issue

The duration of a test run is always showing as `0 sec` because we're calculating off the duration of each recording and we're not returning the recordings with the test runs. We could but it slows the query and isn't adding much value.

## Resolution

Removes the duration from the list item but kept it in the detail view (which does have the recordings already).

## Additional Considerations

We could consider calculating the duration as replays are added to the test run like we do for result counts and that would avoid fetching the recordings just to get the duration. But, I'm not sure the duration is adding much value anyway so I'd suggest deferring that for now.