### PR TITLE
Test Suites: Library: Collapse tests by directory

### DIFF
--- a/packages/replay-next/components/Icon.tsx
+++ b/packages/replay-next/components/Icon.tsx
@@ -33,6 +33,8 @@ export type IconType =
   | "fast-forward"
   | "file"
   | "folder"
+  | "folder-closed"
+  | "folder-open"
   | "inspect"
   | "invisible"
   | "invoke-getter"
@@ -230,8 +232,13 @@ export default function Icon({
         "M6 22q-.825 0-1.412-.587Q4 20.825 4 20V4q0-.825.588-1.413Q5.175 2 6 2h8l6 6v12q0 .825-.587 1.413Q18.825 22 18 22Zm7-13V4H6v16h12V9ZM6 4v5-5 16V4Z";
       break;
     case "folder":
+    case "folder-closed":
       path =
-        "M20 6h-8l-2-2H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm0 12H4V8h16v10z";
+        "M20,18H4V8H20M20,6H12L10,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V8C22,6.89 21.1,6 20,6Z";
+      break;
+    case "folder-open":
+      path =
+        "M6.1,10L4,18V8H21A2,2 0 0,0 19,6H12L10,4H4A2,2 0 0,0 2,6V18A2,2 0 0,0 4,20H19C19.9,20 20.7,19.4 20.9,18.5L23.2,10H6.1M19,18H6L7.6,12H20.6L19,18Z";
       break;
     case "inspect":
       path =

--- a/src/ui/components/Library/Team/View/TestRuns/Overview/RunResults.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/Overview/RunResults.tsx
@@ -76,7 +76,7 @@ function TestStatusGroupExpanded({
 }) {
   const tree = useFileNameTree(recordingGroup);
 
-  return <PathNodeRenderer depth={0} label={label} pathNode={tree} />;
+  return <PathNodeRenderer depth={1} label={label} pathNode={tree} />;
 }
 
 function FileNodeRenderer({
@@ -148,6 +148,9 @@ function PathNodeRenderer({
         >
           <Icon className="h-5 w-5" type={expanded ? "folder-open" : "folder-closed"} />
           {pathName}
+          {!expanded && (
+            <div className="text-xs text-bodySubColor">({pathNode.nestedRecordingCount} tests)</div>
+          )}
         </div>
       )}
       {expanded &&

--- a/src/ui/components/Library/Team/View/TestRuns/Overview/RunResults.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/Overview/RunResults.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useContext, useMemo, useState } from "react";
+import { unstable_Offscreen as Offscreen, ReactNode, useContext, useMemo, useState } from "react";
 
 import Icon from "replay-next/components/Icon";
 import {
@@ -107,8 +107,8 @@ function FileNodeRenderer({
         <div className="truncate">{name}</div>
         {!expanded && <div className="text-xs text-bodySubColor">({recordings.length} tests)</div>}
       </div>
-      {expanded &&
-        recordings.map(recording => (
+      <Offscreen mode={expanded ? "visible" : "hidden"}>
+        {recordings.map(recording => (
           <TestResultListItem
             depth={depth + 1}
             key={recording.id}
@@ -117,6 +117,7 @@ function FileNodeRenderer({
             secondaryBadgeCount={/* index > 0 ? index + 1 : null */ null}
           />
         ))}
+      </Offscreen>
     </>
   );
 }
@@ -166,8 +167,8 @@ function PathNodeRenderer({
           )}
         </div>
       )}
-      {expanded &&
-        children.map((childNode, index) => {
+      <Offscreen mode={expanded ? "visible" : "hidden"}>
+        {children.map((childNode, index) => {
           if (isPathNode(childNode)) {
             return (
               <PathNodeRenderer depth={depth + 1} key={index} label={label} pathNode={childNode} />
@@ -178,6 +179,7 @@ function PathNodeRenderer({
             );
           }
         })}
+      </Offscreen>
     </>
   );
 }

--- a/src/ui/components/Library/Team/View/TestRuns/Overview/RunResults.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/Overview/RunResults.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo, useState } from "react";
+import { ReactNode, useContext, useMemo, useState } from "react";
 
 import Icon from "replay-next/components/Icon";
 import {
@@ -88,7 +88,7 @@ function FileNodeRenderer({
   label: string;
   fileNode: FileNode;
 }) {
-  const { fileName, recordings } = fileNode;
+  const { name, recordings } = fileNode;
 
   const [expanded, setExpanded] = useState(true);
 
@@ -97,14 +97,14 @@ function FileNodeRenderer({
   return (
     <>
       <div
-        className={`flex cursor-pointer items-center gap-2 py-2 ${styles.libraryRow}`}
+        className={`flex cursor-pointer items-center gap-2 truncate py-2 pr-4 ${styles.libraryRow}`}
         onClick={onClick}
         style={{
           paddingLeft: `${depth * 1}rem`,
         }}
       >
-        <Icon className="h-5 w-5" type="file" />
-        <div>{fileName}</div>
+        <Icon className="h-5 w-5 shrink-0" type="file" />
+        <div className="truncate">{name}</div>
         {!expanded && <div className="text-xs text-bodySubColor">({recordings.length} tests)</div>}
       </div>
       {expanded &&
@@ -130,31 +130,44 @@ function PathNodeRenderer({
   label: string;
   pathNode: PathNode;
 }) {
-  const { children, pathName } = pathNode;
+  const { children, name, pathNames } = pathNode;
 
   const [expanded, setExpanded] = useState(true);
 
   const onClick = () => setExpanded(!expanded);
 
+  const formattedNames: ReactNode[] = [];
+  pathNames.forEach((pathName, index) => {
+    if (index > 0) {
+      formattedNames.push(
+        <div key={`${index}-separator`} className="text-xs text-bodySubColor">
+          /
+        </div>
+      );
+    }
+
+    formattedNames.push(<div key={index}>{pathName}</div>);
+  });
+
   return (
     <>
-      {pathName && (
+      {name && (
         <div
-          className={`flex cursor-pointer items-center gap-2 py-2 ${styles.libraryRow}`}
+          className={`flex cursor-pointer items-center gap-2 truncate py-2 pr-4 ${styles.libraryRow}`}
           onClick={onClick}
           style={{
             paddingLeft: `${depth * 1}rem`,
           }}
         >
-          <Icon className="h-5 w-5" type={expanded ? "folder-open" : "folder-closed"} />
-          {pathName}
+          <Icon className="h-5 w-5 shrink-0" type={expanded ? "folder-open" : "folder-closed"} />
+          <div className="flex items-center gap-1 truncate">{formattedNames}</div>
           {!expanded && (
             <div className="text-xs text-bodySubColor">({pathNode.nestedRecordingCount} tests)</div>
           )}
         </div>
       )}
       {expanded &&
-        Array.from(Object.values(children)).map((childNode, index) => {
+        children.map((childNode, index) => {
           if (isPathNode(childNode)) {
             return (
               <PathNodeRenderer depth={depth + 1} key={index} label={label} pathNode={childNode} />

--- a/src/ui/components/Library/Team/View/TestRuns/Overview/TestResultListItem.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/Overview/TestResultListItem.tsx
@@ -12,10 +12,12 @@ import MaterialIcon from "ui/components/shared/MaterialIcon";
 import styles from "../../../../Library.module.css";
 
 export function TestResultListItem({
+  depth,
   label,
   recording,
   secondaryBadgeCount,
 }: {
+  depth: number;
   label: string;
   recording: Recording;
   secondaryBadgeCount: number | null;
@@ -24,19 +26,15 @@ export function TestResultListItem({
 
   const numComments = comments?.length ?? 0;
 
-  let filePath;
   let title;
 
   const testMetadata = metadata?.test;
   if (testMetadata != null) {
     if (isGroupedTestCasesV1(testMetadata)) {
-      filePath = testMetadata.file;
       title = testMetadata.title;
     } else if (isGroupedTestCasesV2(testMetadata)) {
-      filePath = testMetadata.source.path;
       title = testMetadata.source.title;
     } else {
-      filePath = testMetadata.source.filePath;
       title = testMetadata.source.title;
     }
   }
@@ -63,6 +61,9 @@ export function TestResultListItem({
       className={`flex w-full flex-grow cursor-pointer flex-row items-center justify-center gap-2 truncate px-4 py-2 transition duration-150 ${styles.libraryRow}`}
       target="_blank"
       rel="noopener noreferrer"
+      style={{
+        paddingLeft: `${depth * 1}rem`,
+      }}
     >
       <div className="flex flex-row items-center gap-1">
         {secondaryBadgeCount != null && <Icon className="ml-2 h-4 w-4" type="arrow-nested" />}
@@ -81,7 +82,6 @@ export function TestResultListItem({
       </div>
       <div className="flex shrink grow flex-col truncate">
         <div className="block truncate">{title || "Test"}</div>
-        <div className="truncate text-xs text-bodySubColor">{filePath}</div>
       </div>
       {numComments > 0 && (
         <div className="align-items-center flex shrink-0 flex-row space-x-1 text-gray-600">

--- a/src/ui/components/Library/Team/View/TestRuns/Overview/useFileNameTree.ts
+++ b/src/ui/components/Library/Team/View/TestRuns/Overview/useFileNameTree.ts
@@ -1,0 +1,90 @@
+import assert from "assert";
+import { useMemo } from "react";
+
+import { insertString } from "replay-next/src/utils/array";
+import { Recording } from "shared/graphql/types";
+import { RecordingGroup } from "ui/utils/testRuns";
+
+export function useFileNameTree(recordingGroup: RecordingGroup) {
+  const { fileNameToRecordings } = recordingGroup;
+
+  const sortedFileNames = useMemo(() => {
+    const fileNames: string[] = [];
+    for (let fileName in fileNameToRecordings) {
+      insertString(fileNames, fileName);
+    }
+    return fileNames;
+  }, [fileNameToRecordings]);
+
+  const tree = useMemo<Tree>(() => {
+    const root: Tree = {
+      children: {},
+      pathName: null,
+      type: "path",
+    };
+
+    for (let fileName of sortedFileNames) {
+      const recordings = fileNameToRecordings[fileName];
+
+      const parts = fileName.split("/");
+
+      let currentNode: PathNode = root;
+      for (let index = 0; index < parts.length - 1; index++) {
+        const part = parts[index];
+        const existingNode = currentNode.children[part];
+        if (existingNode) {
+          assert(isPathNode(existingNode));
+          currentNode = existingNode;
+        } else {
+          currentNode = currentNode.children[part] = {
+            children: {},
+            pathName: part,
+            type: "path",
+          };
+        }
+      }
+
+      const part = parts[parts.length - 1];
+      let node = currentNode.children[part];
+      if (node) {
+        assert(isFileNode(node));
+      } else {
+        node = currentNode.children[part] = {
+          fileName: part,
+          recordings: [],
+          type: "file",
+        };
+      }
+      node.recordings.push(...recordings);
+    }
+
+    return root;
+  }, [fileNameToRecordings, sortedFileNames]);
+
+  return tree;
+}
+
+export type Tree = PathNode;
+export type TreeNode = FileNode | PathNode;
+
+export type PathNode = {
+  children: {
+    [name: string]: TreeNode;
+  };
+  pathName: string | null;
+  type: "path";
+};
+
+export type FileNode = {
+  fileName: string;
+  recordings: Recording[];
+  type: "file";
+};
+
+export function isFileNode(node: FileNode | PathNode): node is FileNode {
+  return node.type === "file";
+}
+
+export function isPathNode(node: FileNode | PathNode): node is PathNode {
+  return node.type === "path";
+}

--- a/src/ui/components/Library/Team/View/TestRuns/Overview/useFileNameTree.ts
+++ b/src/ui/components/Library/Team/View/TestRuns/Overview/useFileNameTree.ts
@@ -19,6 +19,7 @@ export function useFileNameTree(recordingGroup: RecordingGroup) {
   const tree = useMemo<Tree>(() => {
     const root: Tree = {
       children: {},
+      nestedRecordingCount: 0,
       pathName: null,
       type: "path",
     };
@@ -27,6 +28,8 @@ export function useFileNameTree(recordingGroup: RecordingGroup) {
       const recordings = fileNameToRecordings[fileName];
 
       const parts = fileName.split("/");
+
+      const ancestors: PathNode[] = [root];
 
       let currentNode: PathNode = root;
       for (let index = 0; index < parts.length - 1; index++) {
@@ -38,10 +41,13 @@ export function useFileNameTree(recordingGroup: RecordingGroup) {
         } else {
           currentNode = currentNode.children[part] = {
             children: {},
+            nestedRecordingCount: 0,
             pathName: part,
             type: "path",
           };
         }
+
+        ancestors.push(currentNode);
       }
 
       const part = parts[parts.length - 1];
@@ -56,6 +62,10 @@ export function useFileNameTree(recordingGroup: RecordingGroup) {
         };
       }
       node.recordings.push(...recordings);
+
+      ancestors.forEach(ancestor => {
+        ancestor.nestedRecordingCount += recordings.length;
+      });
     }
 
     return root;
@@ -71,6 +81,7 @@ export type PathNode = {
   children: {
     [name: string]: TreeNode;
   };
+  nestedRecordingCount: number;
   pathName: string | null;
   type: "path";
 };


### PR DESCRIPTION
### [Loom overview](https://www.loom.com/share/7818fc10b4ea44fe98c26099ef3225ea)

### Before

<img width="732" alt="Screen Shot 2023-06-14 at 12 48 47 PM" src="https://github.com/replayio/devtools/assets/29597/9c399a67-3804-4ff2-9660-96a352f0cf96">

### After

<img width="633" alt="Screen Shot 2023-06-14 at 12 47 23 PM" src="https://github.com/replayio/devtools/assets/29597/ca633300-5931-449a-a8ed-e984800d361a">

