### PR TITLE
Show loading state for J2C buttons

### DIFF
--- a/src/ui/components/Events/Event.tsx
+++ b/src/ui/components/Events/Event.tsx
@@ -24,6 +24,7 @@ type EventProps = {
   event: ReplayEvent;
   executionPoint: string;
   jumpToCodeAnnotation?: ParsedJumpToCodeAnnotation;
+  jumpToCodeLoadingStatus: "loading" | "complete";
   onSeek: (point: string, time: number) => void;
 };
 
@@ -49,6 +50,7 @@ export default React.memo(function Event({
   event,
   onSeek,
   jumpToCodeAnnotation,
+  jumpToCodeLoadingStatus,
 }: EventProps) {
   const dispatch = useAppDispatch();
   const { kind, point, time } = event;
@@ -94,7 +96,13 @@ export default React.memo(function Event({
   if (event.kind === "mousedown" || event.kind === "keypress") {
     // The backend routine only saves annotations for actual hits.
     // If there's no annotation, we know there's no hits.
-    const jumpToCodeStatus: JumpToCodeStatus = !!jumpToCodeAnnotation ? "found" : "no_hits";
+    const annotationsLoading = jumpToCodeLoadingStatus === "loading";
+    const hasJumpToCodeAnnotation = !!jumpToCodeAnnotation;
+    const jumpToCodeStatus: JumpToCodeStatus = annotationsLoading
+      ? "loading"
+      : hasJumpToCodeAnnotation
+      ? "found"
+      : "no_hits";
 
     renderedJumpToCodeButton = (
       <JumpToCodeButton

--- a/src/ui/components/Events/Events.tsx
+++ b/src/ui/components/Events/Events.tsx
@@ -1,7 +1,7 @@
 import classNames from "classnames";
 import sortedLastIndex from "lodash/sortedLastIndex";
 import { memo, useContext, useMemo } from "react";
-import { useImperativeCacheValue } from "suspense";
+import { STATUS_PENDING, STATUS_RESOLVED, useImperativeCacheValue } from "suspense";
 
 import { getExecutionPoint } from "devtools/client/debugger/src/reducers/pause";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
@@ -61,7 +61,7 @@ function Events() {
   );
 
   const jumpToCodeAnnotations: ParsedJumpToCodeAnnotation[] =
-    annotationsStatus === "resolved" ? parsedAnnotations : NO_ANNOTATIONS;
+    annotationsStatus === STATUS_RESOLVED ? parsedAnnotations : NO_ANNOTATIONS;
 
   const jumpToCodeEntriesPerEvent = useMemo(() => {
     const jumpToCodeEntriesByPoint: Record<string, ParsedJumpToCodeAnnotation> = {};
@@ -97,6 +97,9 @@ function Events() {
                   currentTime={currentTime}
                   executionPoint={executionPoint!}
                   jumpToCodeAnnotation={jumpToCodeEntriesPerEvent[event.point]}
+                  jumpToCodeLoadingStatus={
+                    annotationsStatus === STATUS_PENDING ? "loading" : "complete"
+                  }
                 />
               </div>
             </div>

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
@@ -1,7 +1,7 @@
 import assert from "assert";
 import { TimeStampedPoint } from "@replayio/protocol";
 import { Suspense, memo, useContext, useMemo, useState } from "react";
-import { useImperativeCacheValue } from "suspense";
+import { STATUS_PENDING, STATUS_RESOLVED, useImperativeCacheValue } from "suspense";
 
 import { getExecutionPoint } from "devtools/client/debugger/src/selectors";
 import Loader from "replay-next/components/Loader";
@@ -80,7 +80,7 @@ export default memo(function UserActionEventRow({
   });
 
   const jumpToCodeAnnotations: ParsedJumpToCodeAnnotation[] =
-    annotationsStatus === "resolved" ? parsedAnnotations : NO_ANNOTATIONS;
+    annotationsStatus === STATUS_RESOLVED ? parsedAnnotations : NO_ANNOTATIONS;
 
   const [canShowJumpToCode, jumpToCodeAnnotation] = findJumpToCodeDetailsIfAvailable(
     groupedTestCases,
@@ -100,7 +100,10 @@ export default memo(function UserActionEventRow({
   const showBadge = isCurrent && command.name === "get" && result != null;
   const showJumpToCode = (isHovered || isCurrent) && canShowJumpToCode;
 
-  const jumpToCodeStatus: JumpToCodeStatus = !!jumpToCodeAnnotation ? "found" : "no_hits";
+  let jumpToCodeStatus: JumpToCodeStatus = "loading";
+  if (annotationsStatus !== STATUS_PENDING) {
+    jumpToCodeStatus = !!jumpToCodeAnnotation ? "found" : "no_hits";
+  }
 
   const eventNumber = useMemo(() => {
     if (parentId !== null) {


### PR DESCRIPTION
This PR:

- Updates the Events sidebar and Cypress Panel to try to show a loading state for J2C buttons if we haven't received annotations yet

Honestly I don't think this is going to end up showing up most of the time, because of the timing of when we receive annotations for Cypress and mouse/keyboard events for Events anyway.  But I already had that loading state in the button component, just needed to pass in the right status flag.