### PR TITLE
Test Suites: Library: Styling tweaks

### DIFF
--- a/src/ui/components/Library/Team/View/TestRuns/Overview/RunResults.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/Overview/RunResults.tsx
@@ -21,12 +21,9 @@ import { TestResultListItem } from "./TestResultListItem";
 import { TestRunOverviewContext } from "./TestRunOverviewContainerContextType";
 import styles from "../../../../Library.module.css";
 
-// TODO [FE-1583] Memoize things better
-
 export function RunResults() {
   const testSuite = useContext(TestRunOverviewContext).testSuite!;
 
-  // TODO [FE-1583] Debounce and useTransition ?
   const [filterByText, setFilterByText] = useState("");
   const filterByTextDeferred = useDeferredValue(filterByText);
 
@@ -38,13 +35,18 @@ export function RunResults() {
 
   return (
     <>
-      <div className="mb-2 border-b border-themeBorder">
+      <div className="relative mb-2 border-b border-themeBorder bg-bodyBgcolor p-2">
         <input
-          className="w-full appearance-none border-none bg-bodyBgcolor py-2 px-4 text-sm focus:bg-chrome focus:outline-none focus:ring-0"
+          className="w-full appearance-none rounded border-none bg-gray-900 text-xs focus:outline-none focus:ring"
           onChange={event => setFilterByText(event.currentTarget.value)}
           placeholder="Filter tests"
           type="text"
           value={filterByText}
+        />
+
+        <Icon
+          className="absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 opacity-50"
+          type="search"
         />
       </div>
       <div className="no-scrollbar flex flex-col overflow-y-auto">

--- a/src/ui/components/Library/Team/View/TestRuns/Overview/RunSummary.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/Overview/RunSummary.tsx
@@ -12,19 +12,6 @@ import { AttributeContainer } from "../AttributeContainer";
 import { RunStats } from "../RunStats";
 import { getDuration } from "../utils";
 
-function Title({ testSuite }: { testSuite: TestSuite }) {
-  return (
-    <div className="flex flex-col overflow-hidden">
-      <div className="overflow-hidden overflow-ellipsis whitespace-nowrap text-xl font-medium">
-        {testSuite.primaryTitle}
-      </div>
-      <div className="text overflow-hidden overflow-ellipsis whitespace-nowrap font-medium text-bodySubColor">
-        {testSuite.secondaryTitle}
-      </div>
-    </div>
-  );
-}
-
 function getModeIcon(mode: TestSuiteMode): string[] {
   switch (mode) {
     case "diagnostics":
@@ -58,7 +45,7 @@ export function Attributes({ testSuite }: { testSuite: TestSuite }) {
     const { branchName, isPrimaryBranch, user } = source;
 
     return (
-      <div className="flex flex-row flex-wrap items-center gap-4 pl-1">
+      <div className="flex flex-row flex-wrap items-center gap-4">
         <AttributeContainer icon="schedule">{getTruncatedRelativeDate(date)}</AttributeContainer>
         {user ? <AttributeContainer icon="person">{user}</AttributeContainer> : null}
         <BranchIcon branchName={branchName} isPrimaryBranch={isPrimaryBranch} title={title} />
@@ -119,12 +106,17 @@ function RunnerLink({ testSuite }: { testSuite: TestSuite }) {
 
 export function RunSummary({ testSuite }: { testSuite: TestSuite }) {
   return (
-    <div className="flex flex-col space-y-2 border-b border-themeBorder p-4">
-      <div className="flex flex-row justify-between">
-        <Title testSuite={testSuite} />
+    <div className="flex flex-col gap-1 border-b border-themeBorder p-4">
+      <div className="flex flex-row items-center justify-between gap-1">
+        <div className="overflow-hidden overflow-ellipsis whitespace-nowrap text-xl font-medium">
+          {testSuite.primaryTitle}
+        </div>
         <RunStats testSuite={testSuite} />
       </div>
-      <div className="flex w-full flex-row items-center gap-4 text-xs">
+      <div className="text overflow-hidden overflow-ellipsis whitespace-nowrap font-medium text-bodySubColor">
+        {testSuite.secondaryTitle}
+      </div>
+      <div className="mt-1 flex w-full flex-row items-center gap-4 text-xs">
         <Attributes testSuite={testSuite} />
         <div className="grow" />
         <PullRequestLink testSuite={testSuite} />


### PR DESCRIPTION
## Style filter input in a more recognizable way:

<img width="643" alt="Screen Shot 2023-06-15 at 11 30 16 AM" src="https://github.com/replayio/devtools/assets/29597/e732158a-dada-492b-9291-da7fb62a1c10">

<img width="641" alt="Screen Shot 2023-06-15 at 11 30 23 AM" src="https://github.com/replayio/devtools/assets/29597/cf09df7b-7e66-4766-877b-e667e5a1c7e8">

## Fixed run summary alignment and gaps/padding

* Fixed vertical alignment of run title and count badges
* Fixed gap between run title and count badges
* Removed extra padding left on attributes row (that was messing up the left alignment)

### Before
<img width="643" alt="Screen Shot 2023-06-15 at 11 59 25 AM" src="https://github.com/replayio/devtools/assets/29597/b9439f56-68a6-4589-9afd-45ea204f7ce8">

### After
<img width="639" alt="Screen Shot 2023-06-15 at 12 03 22 PM" src="https://github.com/replayio/devtools/assets/29597/d3c8f3b5-c34f-4233-bcaa-e7ec34b7903a">
