### PR TITLE
Test Suites: Library view: Hide empty filter header; tweak filter input bg color

### DIFF
--- a/src/ui/components/Library/Team/View/FilterBarContainer.tsx
+++ b/src/ui/components/Library/Team/View/FilterBarContainer.tsx
@@ -1,9 +1,18 @@
+import { useContext } from "react";
+
+import { ViewContext } from "ui/components/Library/Team/View/ViewContextRoot";
 import LaunchButton from "ui/components/shared/LaunchButton";
 
 import { FilterBar } from "./FilterBar";
 import styles from "../../Library.module.css";
 
 export function FilterBarContainer() {
+  const { view } = useContext(ViewContext);
+
+  if (view !== "recordings") {
+    return null;
+  }
+
   return (
     <div className={`flex h-16 flex-row items-center space-x-3 p-4 ${styles.libraryHeader}`}>
       <FilterBar />

--- a/src/ui/components/Library/Team/View/TestRuns/Overview/RunResults.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/Overview/RunResults.tsx
@@ -39,7 +39,7 @@ export function RunResults() {
     <>
       <div className="relative mb-2 border-b border-themeBorder bg-bodyBgcolor p-2">
         <input
-          className="w-full appearance-none rounded border-none bg-gray-900 text-xs focus:outline-none focus:ring"
+          className="w-full appearance-none rounded border-none bg-black bg-opacity-10 text-xs focus:outline-none focus:ring focus:ring-primaryAccent"
           onChange={event => setFilterByText(event.currentTarget.value)}
           placeholder="Filter tests"
           type="text"


### PR DESCRIPTION
<img width="801" alt="Screen Shot 2023-06-15 at 2 22 57 PM" src="https://github.com/replayio/devtools/assets/29597/ee645f14-c7f2-4af7-a838-a135442bb4ba">

<img width="803" alt="Screen Shot 2023-06-15 at 2 23 01 PM" src="https://github.com/replayio/devtools/assets/29597/ffbe0266-9740-4db6-97f8-d24df9d0be23">

<img width="805" alt="Screen Shot 2023-06-15 at 2 23 10 PM" src="https://github.com/replayio/devtools/assets/29597/dd07fdb2-9cf5-4d36-ad37-075397206385">

<img width="804" alt="Screen Shot 2023-06-15 at 2 23 13 PM" src="https://github.com/replayio/devtools/assets/29597/d01b41a2-f1df-47fa-bba4-96a642ffbc3e">
