### PR TITLE
Bailout suspending for eager evaluation if expression is empty

### DIFF
--- a/packages/replay-next/components/console/EagerEvaluationResult.tsx
+++ b/packages/replay-next/components/console/EagerEvaluationResult.tsx
@@ -19,6 +19,10 @@ export default function EagerEvaluationResult({
 }) {
   const { selectedPauseAndFrameId } = useContext(SelectedFrameContext);
 
+  if (expression == "") {
+    return null;
+  }
+
   let pauseId: PauseId | null = null;
   let frameId: FrameId | null = null;
   if (selectedPauseAndFrameId) {


### PR DESCRIPTION
This won't fix the issue reported in FE-1552, but it is silly for us not to do this.