### PR TITLE
Cleanup focus window references

### DIFF
--- a/packages/protocol/socket.ts
+++ b/packages/protocol/socket.ts
@@ -6,7 +6,6 @@ import {
   EventParams,
   FocusWindowRequest as FocusWindow,
   PauseId,
-  PointDescription,
   ProtocolClient,
   SessionId,
 } from "@replayio/protocol";

--- a/packages/replay-next/components/console/Focuser.module.css
+++ b/packages/replay-next/components/console/Focuser.module.css
@@ -1,5 +1,5 @@
-.FocusRegionRowOff,
-.FocusRegionRowOn {
+.FocusWindowRowOff,
+.FocusWindowRowOn {
   padding: 0.25rem;
   display: flex;
   flex-direction: row;
@@ -9,7 +9,7 @@
   border-radius: 0.5rem;
   margin-left: 0.5rem;
 }
-.FocusRegionRowOn {
+.FocusWindowRowOn {
   background-color: var(--focus-mode-active-background-color);
 }
 

--- a/packages/replay-next/components/console/Focuser.tsx
+++ b/packages/replay-next/components/console/Focuser.tsx
@@ -29,7 +29,7 @@ export default function Focuser() {
   };
 
   return (
-    <div className={rangeForDisplay === null ? styles.FocusRegionRowOff : styles.FocusRegionRowOn}>
+    <div className={rangeForDisplay === null ? styles.FocusWindowRowOff : styles.FocusWindowRowOn}>
       <button className={styles.FocusToggleButton} onClick={toggleFocus}>
         Focus {rangeForDisplay === null ? "off" : "on"}
       </button>

--- a/packages/replay-next/src/contexts/FocusContext.tsx
+++ b/packages/replay-next/src/contexts/FocusContext.tsx
@@ -89,7 +89,7 @@ export function FocusContextRoot({ children }: PropsWithChildren<{}>) {
     }
 
     const timeoutId = setTimeout(() => {
-      client.requestFocusRange({ begin: range.begin.time, end: range.end.time });
+      client.requestFocusWindow({ begin: range.begin.time, end: range.end.time });
     }, FOCUS_DEBOUNCE_DURATION);
 
     return () => {

--- a/packages/shared/client/types.ts
+++ b/packages/shared/client/types.ts
@@ -133,7 +133,7 @@ export type PointBehavior = {
   shouldLog: POINT_BEHAVIOR;
 };
 
-export type ReplayClientEvents = "focusRangeChange" | "loadedRegionsChange";
+export type ReplayClientEvents = "focusWindowChange" | "loadedRegionsChange";
 
 export type HitPointStatus =
   | "complete"
@@ -199,7 +199,6 @@ export interface ReplayClientInterface {
     focusRange: PointRange | null
   ): Promise<Record<string, number>>;
   getExceptionValue(pauseId: PauseId): Promise<getExceptionValueResult>;
-  getFocusWindow(): Promise<TimeStampedPointRange>;
   getFrameSteps(pauseId: PauseId, frameId: FrameId): Promise<PointDescription[]>;
   getMappedLocation(location: Location): Promise<MappedLocation>;
   getObjectWithPreview(
@@ -234,7 +233,8 @@ export interface ReplayClientInterface {
   hasAnnotationKind(kind: string): Promise<boolean>;
   initialize(recordingId: string, accessToken: string | null): Promise<SessionId>;
   mapExpressionToGeneratedScope(expression: string, location: Location): Promise<string>;
-  requestFocusRange(range: FocusWindowRequest): Promise<TimeStampedPointRange>;
+  requestFocusWindow(range: FocusWindowRequest): Promise<TimeStampedPointRange>;
+  getCurrentFocusWindow(): TimeStampedPointRange | null;
   removeEventListener(type: ReplayClientEvents, handler: Function): void;
   repaintGraphics(pauseId: PauseId): Promise<repaintGraphicsResult>;
   runEvaluation(

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/useStackFrameContextMenu.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/useStackFrameContextMenu.tsx
@@ -6,7 +6,7 @@ import Icon from "replay-next/components/Icon";
 import { copyToClipboard } from "replay-next/components/sources/utils/clipboard";
 import { getFrameStepForFrameLocation } from "replay-next/src/suspense/FrameStepsCache";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
-import { seek, setFocusRegionBeginTime, setFocusRegionEndTime } from "ui/actions/timeline";
+import { seek, setFocusWindowBeginTime, setFocusWindowEndTime } from "ui/actions/timeline";
 import { useAppDispatch } from "ui/setup/hooks";
 
 interface StackFrameContextMenuOptions {
@@ -43,7 +43,7 @@ export function useStackFrameContextMenu({
       const matchingFrameStep = await getMatchingFramestep();
 
       if (matchingFrameStep) {
-        dispatch(setFocusRegionBeginTime(matchingFrameStep.time, true));
+        dispatch(setFocusWindowBeginTime(matchingFrameStep.time, true));
       }
     };
 
@@ -51,7 +51,7 @@ export function useStackFrameContextMenu({
       const matchingFrameStep = await getMatchingFramestep();
 
       if (matchingFrameStep) {
-        dispatch(setFocusRegionEndTime(matchingFrameStep.time, true));
+        dispatch(setFocusWindowEndTime(matchingFrameStep.time, true));
       }
     };
 

--- a/src/ui/actions/timeline.test.ts
+++ b/src/ui/actions/timeline.test.ts
@@ -1,22 +1,22 @@
 import { encodeObjectToURL, getPausePointParams } from "ui/utils/environment";
 
 describe("getPauseParams", () => {
-  const urlWithFocusRegion = (focusRegion: string) => {
-    return `https://app.replay.io/recording/12345?point=23456&time=2&focusRegion=${focusRegion}`;
+  const urlWithFocusWindow = (focusWindow: string) => {
+    return `https://app.replay.io/recording/12345?point=23456&time=2&focusWindow=${focusWindow}`;
   };
 
-  const focusRegionParams: string = encodeObjectToURL({
+  const focusWindowParams: string = encodeObjectToURL({
     begin: { point: "12345", time: 1 },
     end: { point: "67890", time: 2 },
   })!;
-  const malformedParams = focusRegionParams.slice(0, focusRegionParams.length - 2);
+  const malformedParams = focusWindowParams.slice(0, focusWindowParams.length - 2);
   it("can parse correctly formed parameters", () => {
     const original = window.location.href;
-    window.location.href = urlWithFocusRegion(focusRegionParams);
+    window.location.href = urlWithFocusWindow(focusWindowParams);
 
     expect(getPausePointParams()).toMatchInlineSnapshot(`
       Object {
-        "focusRegion": Object {
+        "focusWindow": Object {
           "begin": Object {
             "point": "12345",
             "time": 1,
@@ -36,28 +36,28 @@ describe("getPauseParams", () => {
 
   it("does not blow up on malformed parameters", () => {
     const original = window.location.href;
-    window.location.href = urlWithFocusRegion(malformedParams);
+    window.location.href = urlWithFocusWindow(malformedParams);
 
-    expect(getPausePointParams()?.focusRegion).toBeUndefined();
+    expect(getPausePointParams()?.focusWindow).toBeUndefined();
 
     window.location.href = original;
   });
 });
 
 describe("encodeObjectToUrl", () => {
-  const focusRegion = {
+  const focusWindow = {
     begin: { point: "12345", time: 1 },
     end: { point: "67890", time: 10 },
   };
 
   it("base64 encodes the JSON value", () => {
-    expect(encodeObjectToURL(focusRegion)).toMatchInlineSnapshot(
+    expect(encodeObjectToURL(focusWindow)).toMatchInlineSnapshot(
       `"eyJiZWdpbiI6eyJwb2ludCI6IjEyMzQ1IiwidGltZSI6MX0sImVuZCI6eyJwb2ludCI6IjY3ODkwIiwidGltZSI6MTB9fQ%3D%3D"`
     );
   });
 
   it("has to be URL decoded before it can be parsed as base64", () => {
-    const encoded: string = encodeObjectToURL(focusRegion)!;
+    const encoded: string = encodeObjectToURL(focusWindow)!;
 
     expect(() => {
       atob(encoded);
@@ -65,8 +65,8 @@ describe("encodeObjectToUrl", () => {
   });
 
   it("can be decoded to the JSON representation of the original", () => {
-    const encoded: string = encodeObjectToURL(focusRegion)!;
+    const encoded: string = encodeObjectToURL(focusWindow)!;
 
-    expect(atob(decodeURIComponent(encoded))).toEqual(JSON.stringify(focusRegion));
+    expect(atob(decodeURIComponent(encoded))).toEqual(JSON.stringify(focusWindow));
   });
 });

--- a/src/ui/components/Comments/TranscriptComments/NetworkRequestPreview.tsx
+++ b/src/ui/components/Comments/TranscriptComments/NetworkRequestPreview.tsx
@@ -7,7 +7,7 @@ import { networkRequestsCache } from "replay-next/src/suspense/NetworkRequestsCa
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { setSelectedPanel } from "ui/actions/layout";
 import { selectNetworkRequest } from "ui/actions/network";
-import { getFocusRegion } from "ui/reducers/timeline";
+import { getFocusWindow } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { Comment } from "ui/state/comments";
 import { trackEvent } from "ui/utils/telemetry";
@@ -79,7 +79,7 @@ function ModernNetworkRequestPreview({
   time: number;
 }) {
   const dispatch = useAppDispatch();
-  const focusRegion = useAppSelector(getFocusRegion);
+  const focusWindow = useAppSelector(getFocusWindow);
 
   const onClick = () => {
     trackEvent("comments.select_request");
@@ -87,7 +87,7 @@ function ModernNetworkRequestPreview({
     dispatch(selectNetworkRequest(id));
   };
 
-  const isSeekEnabled = focusRegion == null || isInFocusSpan(time, focusRegion);
+  const isSeekEnabled = focusWindow == null || isInFocusSpan(time, focusWindow);
 
   return (
     <div

--- a/src/ui/components/Comments/useCommentContextMenu.tsx
+++ b/src/ui/components/Comments/useCommentContextMenu.tsx
@@ -4,7 +4,7 @@ import { ContextMenuDivider, ContextMenuItem, useContextMenu } from "use-context
 
 import Icon from "replay-next/components/Icon";
 import { SessionContext } from "replay-next/src/contexts/SessionContext";
-import { setFocusRegionBeginTime, setFocusRegionEndTime } from "ui/actions/timeline";
+import { setFocusWindowBeginTime, setFocusWindowEndTime } from "ui/actions/timeline";
 import { useAppDispatch } from "ui/setup/hooks";
 import type { Remark } from "ui/state/comments";
 import { trackEvent } from "ui/utils/telemetry";
@@ -58,11 +58,11 @@ export default function useCommentContextMenu({
   };
 
   const setFocusEnd = () => {
-    dispatch(setFocusRegionEndTime(remark.time, true));
+    dispatch(setFocusWindowEndTime(remark.time, true));
   };
 
   const setFocusStart = () => {
-    dispatch(setFocusRegionBeginTime(remark.time!, true));
+    dispatch(setFocusWindowBeginTime(remark.time!, true));
   };
 
   const contextMenuItems: ReactNode[] = [];

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -138,7 +138,6 @@ function _DevTools({
   apiKey,
   clearTrialExpired,
   createSocket,
-  loadedRegions,
   loadingFinished,
   sessionId,
   showCommandPalette,
@@ -263,7 +262,6 @@ function _DevTools({
 const connector = connect(
   (state: UIState) => ({
     loadingFinished: selectors.getLoadingFinished(state),
-    loadedRegions: selectors.getLoadedRegions(state),
     sessionId: selectors.getSessionId(state),
     showCommandPalette: selectors.getShowCommandPalette(state),
   }),

--- a/src/ui/components/Events/Events.tsx
+++ b/src/ui/components/Events/Events.tsx
@@ -5,7 +5,7 @@ import { STATUS_PENDING, STATUS_RESOLVED, useImperativeCacheValue } from "suspen
 
 import { getExecutionPoint } from "devtools/client/debugger/src/reducers/pause";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
-import { getFilteredEventsForFocusRegion } from "ui/actions/app";
+import { getFilteredEventsForFocusWindow } from "ui/actions/app";
 import { seek } from "ui/actions/timeline";
 import useEventsPreferences from "ui/components/Events/useEventsPreferences";
 import { getCurrentTime } from "ui/reducers/timeline";
@@ -32,7 +32,7 @@ function Events() {
   const dispatch = useAppDispatch();
   const currentTime = useAppSelector(getCurrentTime);
   const executionPoint = useAppSelector(getExecutionPoint);
-  const events = useAppSelector(getFilteredEventsForFocusRegion);
+  const events = useAppSelector(getFilteredEventsForFocusWindow);
 
   const { status: annotationsStatus, value: parsedAnnotations } = useImperativeCacheValue(
     eventListenersJumpLocationsCache,

--- a/src/ui/components/Events/EventsDropDownMenu.tsx
+++ b/src/ui/components/Events/EventsDropDownMenu.tsx
@@ -3,7 +3,7 @@ import { ContextMenuCategory, ContextMenuItem, useContextMenu } from "use-contex
 
 import { Badge, Checkbox } from "design";
 import Icon from "replay-next/components/Icon";
-import { getFilteredEventsForFocusRegion } from "ui/reducers/app";
+import { getFilteredEventsForFocusWindow } from "ui/reducers/app";
 import { useAppSelector } from "ui/setup/hooks";
 
 import useEventsPreferences, { FiltersKey } from "./useEventsPreferences";
@@ -19,7 +19,7 @@ function createSelectHandler(callback: () => void): (event: UIEvent) => void {
 }
 
 export default function EventsDropDownMenu() {
-  const events = useAppSelector(getFilteredEventsForFocusRegion);
+  const events = useAppSelector(getFilteredEventsForFocusWindow);
   const eventCounts = useMemo<{ [key in FiltersKey]: number }>(
     () =>
       events.reduce(

--- a/src/ui/components/Events/useEventContextMenu.tsx
+++ b/src/ui/components/Events/useEventContextMenu.tsx
@@ -2,7 +2,7 @@ import { ContextMenuDivider, ContextMenuItem, useContextMenu } from "use-context
 
 import Icon from "replay-next/components/Icon";
 import { copyToClipboard as copyTextToClipboard } from "replay-next/components/sources/utils/clipboard";
-import { setFocusRegionBeginTime, setFocusRegionEndTime } from "ui/actions/timeline";
+import { setFocusWindowBeginTime, setFocusWindowEndTime } from "ui/actions/timeline";
 import { useAppDispatch } from "ui/setup/hooks";
 import { ReplayEvent } from "ui/state/app";
 
@@ -10,11 +10,11 @@ export default function useEventContextMenu(event: ReplayEvent) {
   const dispatch = useAppDispatch();
 
   const setFocusEnd = () => {
-    dispatch(setFocusRegionEndTime(event.time, true));
+    dispatch(setFocusWindowEndTime(event.time, true));
   };
 
   const setFocusStart = () => {
-    dispatch(setFocusRegionBeginTime(event.time!, true));
+    dispatch(setFocusWindowBeginTime(event.time!, true));
   };
 
   const onCopyUrl = () => {

--- a/src/ui/components/FocusContextReduxAdapter.tsx
+++ b/src/ui/components/FocusContextReduxAdapter.tsx
@@ -5,28 +5,28 @@ import { FocusContext, UpdateOptions } from "replay-next/src/contexts/FocusConte
 import { TimeRange } from "replay-next/src/types";
 import {
   enterFocusMode,
-  setFocusRegionFromTimeRange,
+  setFocusWindowFromTimeRange,
   syncFocusedRegion,
-  updateFocusRegionParam,
+  updateFocusWindowParam,
 } from "ui/actions/timeline";
-import { getFocusRegion } from "ui/reducers/timeline";
+import { getFocusWindow } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
-import { rangeForFocusRegion } from "ui/utils/timeline";
+import { rangeForFocusWindow } from "ui/utils/timeline";
 
 // Adapter that reads focus region (from Redux) and passes it to the FocusContext.
 export default function FocusContextReduxAdapter({ children }: PropsWithChildren) {
   const dispatch = useAppDispatch();
-  const focusRegion = useAppSelector(getFocusRegion);
+  const focusWindow = useAppSelector(getFocusWindow);
 
-  const deferredFocusRegion = useDeferredValue(focusRegion);
-  const isPending = deferredFocusRegion !== focusRegion;
+  const deferredFocusWindow = useDeferredValue(focusWindow);
+  const isPending = deferredFocusWindow !== focusWindow;
 
   const update = useCallback(
     async (value: TimeStampedPointRange | null, options: UpdateOptions) => {
       const { sync } = options;
 
       await dispatch(
-        setFocusRegionFromTimeRange(
+        setFocusWindowFromTimeRange(
           value !== null
             ? {
                 begin: value.begin.time,
@@ -38,7 +38,7 @@ export default function FocusContextReduxAdapter({ children }: PropsWithChildren
 
       if (sync) {
         await dispatch(syncFocusedRegion());
-        dispatch(updateFocusRegionParam());
+        dispatch(updateFocusWindowParam());
       }
     },
     [dispatch]
@@ -49,7 +49,7 @@ export default function FocusContextReduxAdapter({ children }: PropsWithChildren
       const { sync } = options;
 
       await dispatch(
-        setFocusRegionFromTimeRange(
+        setFocusWindowFromTimeRange(
           value !== null
             ? {
                 begin: value[0],
@@ -61,7 +61,7 @@ export default function FocusContextReduxAdapter({ children }: PropsWithChildren
 
       if (sync) {
         await dispatch(syncFocusedRegion());
-        dispatch(updateFocusRegionParam());
+        dispatch(updateFocusWindowParam());
       }
     },
     [dispatch]
@@ -73,12 +73,12 @@ export default function FocusContextReduxAdapter({ children }: PropsWithChildren
         dispatch(enterFocusMode());
       },
       isTransitionPending: isPending,
-      range: deferredFocusRegion ? rangeForFocusRegion(deferredFocusRegion) : null,
-      rangeForDisplay: focusRegion ? rangeForFocusRegion(focusRegion) : null,
+      range: deferredFocusWindow ? rangeForFocusWindow(deferredFocusWindow) : null,
+      rangeForDisplay: focusWindow ? rangeForFocusWindow(focusWindow) : null,
       update,
       updateForTimelineImprecise,
     };
-  }, [deferredFocusRegion, dispatch, isPending, focusRegion, update, updateForTimelineImprecise]);
+  }, [deferredFocusWindow, dispatch, isPending, focusWindow, update, updateForTimelineImprecise]);
 
   return <FocusContext.Provider value={context}>{children}</FocusContext.Provider>;
 }

--- a/src/ui/components/NetworkMonitor/index.tsx
+++ b/src/ui/components/NetworkMonitor/index.tsx
@@ -18,7 +18,7 @@ import RequestDetails from "ui/components/NetworkMonitor/RequestDetails";
 import RequestTable from "ui/components/NetworkMonitor/RequestTable";
 import Table from "ui/components/NetworkMonitor/Table";
 import { getSelectedRequestId } from "ui/reducers/network";
-import { getCurrentTime, getFocusRegion } from "ui/reducers/timeline";
+import { getCurrentTime, getFocusWindow } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { timeMixpanelEvent } from "ui/utils/mixpanel";
 import { trackEvent } from "ui/utils/telemetry";
@@ -30,7 +30,7 @@ export default function NetworkMonitor() {
 
   const currentTime = useAppSelector(getCurrentTime);
   const context = useAppSelector(getThreadContext);
-  const focusRegion = useAppSelector(getFocusRegion);
+  const focusWindow = useAppSelector(getFocusWindow);
 
   const selectedRequestId = useAppSelector(getSelectedRequestId);
   const [types, setTypes] = useState<Set<CanonicalRequestType>>(new Set([]));
@@ -41,7 +41,7 @@ export default function NetworkMonitor() {
   const { complete, data: records = {}, value: ids = [] } = useStreamingValue(stream);
 
   const { countAfter, countBefore, filteredIds } = useMemo(() => {
-    if (focusRegion === null) {
+    if (focusWindow === null) {
       return {
         countAfter: 0,
         countBefore: 0,
@@ -59,9 +59,9 @@ export default function NetworkMonitor() {
         const record = records[id];
         const point = record.timeStampedPoint.point;
 
-        if (isExecutionPointsLessThan(point, focusRegion.begin.point)) {
+        if (isExecutionPointsLessThan(point, focusWindow.begin.point)) {
           countBefore++;
-        } else if (isExecutionPointsGreaterThan(point, focusRegion.end.point)) {
+        } else if (isExecutionPointsGreaterThan(point, focusWindow.end.point)) {
           countAfter++;
         } else {
           filteredIds.push(id);
@@ -74,7 +74,7 @@ export default function NetworkMonitor() {
       countBefore,
       filteredIds,
     };
-  }, [focusRegion, ids, records]);
+  }, [focusWindow, ids, records]);
 
   const toggleType = (type: CanonicalRequestType) => {
     dispatch(hideRequestDetails());

--- a/src/ui/components/NetworkMonitor/useNetworkContextMenu.tsx
+++ b/src/ui/components/NetworkMonitor/useNetworkContextMenu.tsx
@@ -11,7 +11,7 @@ import { GraphQLClientContext } from "replay-next/src/contexts/GraphQLClientCont
 import { InspectorContext } from "replay-next/src/contexts/InspectorContext";
 import { SessionContext } from "replay-next/src/contexts/SessionContext";
 import { addComment as addCommentGraphQL } from "shared/graphql/Comments";
-import { setFocusRegionBeginTime, setFocusRegionEndTime } from "ui/actions/timeline";
+import { setFocusWindowBeginTime, setFocusWindowEndTime } from "ui/actions/timeline";
 import useCopyAsCURL from "ui/components/NetworkMonitor/useCopyAsCURL";
 import { useAppDispatch } from "ui/setup/hooks";
 
@@ -37,11 +37,11 @@ export default function useNetworkContextMenu({ row }: { row: Row<RequestSummary
   const endTime = requestSummary.end;
 
   const setFocusEnd = () => {
-    dispatch(setFocusRegionEndTime(endTime!, true));
+    dispatch(setFocusWindowEndTime(endTime!, true));
   };
 
   const setFocusStart = () => {
-    dispatch(setFocusRegionBeginTime(beginTime!, true));
+    dispatch(setFocusWindowBeginTime(beginTime!, true));
   };
 
   const addComment = () => {

--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -13,7 +13,7 @@ import { isTestSuiteReplay } from "ui/components/TestSuite/utils/isTestSuiteRepl
 import hooks from "ui/hooks";
 import { useGetRecording, useGetRecordingId } from "ui/hooks/recordings";
 import { useFeature } from "ui/hooks/settings";
-import { getFilteredEventsForFocusRegion } from "ui/reducers/app";
+import { getFilteredEventsForFocusWindow } from "ui/reducers/app";
 import { getSelectedPrimaryPanel } from "ui/reducers/layout";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { PrimaryPanelName } from "ui/state/layout";
@@ -67,7 +67,7 @@ export default function SidePanel() {
   const selectedPrimaryPanel = useInitialPrimaryPanel();
   const [replayInfoCollapsed, setReplayInfoCollapsed] = useState(false);
   const [eventsCollapsed, setEventsCollapsed] = useState(false);
-  const events = useAppSelector(getFilteredEventsForFocusRegion);
+  const events = useAppSelector(getFilteredEventsForFocusWindow);
   const { isAuthenticated } = useAuth0();
 
   const launchQuickstart = (url: string) => {

--- a/src/ui/components/Timeline/CurrentTimeIndicator.tsx
+++ b/src/ui/components/Timeline/CurrentTimeIndicator.tsx
@@ -15,13 +15,13 @@ export default function CurrentTimeIndicator({ editMode }: { editMode: EditMode 
   // When the focus region is being resized, the video preview updates to track its drag handle.
   // During this time, the currentTime indicator should be de-emphasized.
   // Same for when the region is being dragged.
-  const isResizingFocusRegion = editMode !== null;
+  const isResizingFocusWindow = editMode !== null;
 
   return (
     <div
       className={classNames({
-        "progress-line-paused-edit-mode-inactive": !isResizingFocusRegion,
-        "progress-line-paused-edit-mode-active": isResizingFocusRegion,
+        "progress-line-paused-edit-mode-inactive": !isResizingFocusWindow,
+        "progress-line-paused-edit-mode-active": isResizingFocusWindow,
       })}
       style={{ left: `${percent}%` }}
     />

--- a/src/ui/components/Timeline/FocusInputs.tsx
+++ b/src/ui/components/Timeline/FocusInputs.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { getFormattedTime } from "shared/utils/time";
-import { updateFocusRegion } from "ui/actions/timeline";
+import { updateFocusWindow } from "ui/actions/timeline";
 import { selectors } from "ui/reducers";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { getSecondsFromFormattedTime } from "ui/utils/timeline";
@@ -12,7 +12,7 @@ import styles from "./FocusInputs.module.css";
 export default function FocusInputs() {
   const dispatch = useAppDispatch();
   const currentTime = useAppSelector(selectors.getCurrentTime);
-  const focusRegion = useAppSelector(selectors.getFocusRegion);
+  const focusWindow = useAppSelector(selectors.getFocusWindow);
   const showFocusModeControls = useAppSelector(selectors.getShowFocusModeControls);
   const recordingDuration = useAppSelector(selectors.getRecordingDuration);
 
@@ -22,9 +22,9 @@ export default function FocusInputs() {
   // Avoid layout shift; keep input size consistent when focus mode toggles.
   const inputSize = formattedDuration.length;
 
-  if (showFocusModeControls && focusRegion !== null) {
-    const formattedEndTime = getFormattedTime(focusRegion.end.time);
-    const formattedBeginTime = getFormattedTime(focusRegion.begin.time);
+  if (showFocusModeControls && focusWindow !== null) {
+    const formattedEndTime = getFormattedTime(focusWindow.end.time);
+    const formattedBeginTime = getFormattedTime(focusWindow.begin.time);
 
     const validateAndSaveBeginTime = async (pending: string) => {
       try {
@@ -33,10 +33,10 @@ export default function FocusInputs() {
           // If the new end time is less than the current start time, the user is probably trying to move the whole range.
           // We can simplify this operation by resetting both the start and end time to the same value.
           const newEndTime =
-            newBeginTime <= focusRegion.end.time ? focusRegion.end.time : newBeginTime;
+            newBeginTime <= focusWindow.end.time ? focusWindow.end.time : newBeginTime;
 
           await dispatch(
-            updateFocusRegion({
+            updateFocusWindow({
               begin: newBeginTime,
               end: newEndTime,
             })
@@ -53,10 +53,10 @@ export default function FocusInputs() {
           // If the new start time is greater than the current end time, the user is probably trying to move the whole range.
           // We can simplify this operation by resetting both the start and end time to the same value.
           const newBeginTime =
-            newEndTime >= focusRegion.begin.time ? focusRegion.begin.time : newEndTime;
+            newEndTime >= focusWindow.begin.time ? focusWindow.begin.time : newEndTime;
 
           await dispatch(
-            updateFocusRegion({
+            updateFocusWindow({
               begin: newBeginTime,
               end: newEndTime,
             })

--- a/src/ui/components/Timeline/FocusModePopout.tsx
+++ b/src/ui/components/Timeline/FocusModePopout.tsx
@@ -3,12 +3,12 @@ import React, { useEffect } from "react";
 import { useNag } from "replay-next/src/hooks/useNag";
 import { Nag } from "shared/graphql/types";
 import { DebouncedOrThrottledFunction } from "shared/utils/function";
-import { exitFocusMode, syncFocusedRegion, updateFocusRegionParam } from "ui/actions/timeline";
+import { exitFocusMode, syncFocusedRegion, updateFocusWindowParam } from "ui/actions/timeline";
 import {
-  getFocusRegionBackup,
+  getFocusWindowBackup,
   getShowFocusModeControls,
-  isMaximumFocusRegion,
-  setFocusRegion,
+  isMaximumFocusWindow,
+  setFocusWindow,
 } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { AppDispatch } from "ui/setup/store";
@@ -19,9 +19,9 @@ import Icon from "../shared/Icon";
 import styles from "./FocusModePopout.module.css";
 
 export default function FocusModePopout({
-  updateFocusRegionThrottled,
+  updateFocusWindowThrottled,
 }: {
-  updateFocusRegionThrottled: DebouncedOrThrottledFunction<
+  updateFocusWindowThrottled: DebouncedOrThrottledFunction<
     (dispatch: AppDispatch, begin: number, end: number) => void
   >;
 }) {
@@ -29,17 +29,17 @@ export default function FocusModePopout({
   const showFocusModeControls = useAppSelector(getShowFocusModeControls);
 
   const dispatch = useAppDispatch();
-  const focusRegionBackup = useAppSelector(getFocusRegionBackup);
-  const showMaxFocusRegionMessage = useAppSelector(isMaximumFocusRegion);
+  const focusWindowBackup = useAppSelector(getFocusWindowBackup);
+  const showMaxFocusWindowMessage = useAppSelector(isMaximumFocusWindow);
 
   const hideModal = () => dispatch(exitFocusMode());
 
   const discardPendingChanges = (isImplicit: boolean) => {
-    if (updateFocusRegionThrottled.hasPending()) {
-      updateFocusRegionThrottled.cancel();
+    if (updateFocusWindowThrottled.hasPending()) {
+      updateFocusWindowThrottled.cancel();
     }
 
-    dispatch(setFocusRegion(focusRegionBackup));
+    dispatch(setFocusWindow(focusWindowBackup));
     dispatch(syncFocusedRegion());
 
     if (isImplicit) {
@@ -51,12 +51,12 @@ export default function FocusModePopout({
     hideModal();
   };
   const savePendingChanges = async () => {
-    if (updateFocusRegionThrottled.hasPending()) {
-      await updateFocusRegionThrottled.flush();
+    if (updateFocusWindowThrottled.hasPending()) {
+      await updateFocusWindowThrottled.flush();
     }
 
     dispatch(syncFocusedRegion());
-    dispatch(updateFocusRegionParam());
+    dispatch(updateFocusWindowParam());
     trackEvent("timeline.save_focus");
 
     hideModal();
@@ -97,7 +97,7 @@ export default function FocusModePopout({
   const timelineNode = document.querySelector(".timeline");
   const timelineHeight = timelineNode!.getBoundingClientRect().height;
 
-  const message = showMaxFocusRegionMessage ? (
+  const message = showMaxFocusWindowMessage ? (
     "Maximum window reached."
   ) : (
     <>

--- a/src/ui/components/Timeline/Focuser.tsx
+++ b/src/ui/components/Timeline/Focuser.tsx
@@ -16,18 +16,18 @@ function stopEvent(event: MouseEvent) {
 type Props = {
   editMode: EditMode | null;
   setEditMode: React.Dispatch<React.SetStateAction<EditMode | null>>;
-  updateFocusRegionThrottled: (dispatch: AppDispatch, begin: number, end: number) => void;
+  updateFocusWindowThrottled: (dispatch: AppDispatch, begin: number, end: number) => void;
 };
 
 export default function ConditionalFocuser({
   editMode,
   setEditMode,
-  updateFocusRegionThrottled,
+  updateFocusWindowThrottled,
 }: Props) {
-  const focusRegion = useAppSelector(selectors.getFocusRegion);
+  const focusWindow = useAppSelector(selectors.getFocusWindow);
   const showFocusModeControls = useAppSelector(selectors.getShowFocusModeControls);
 
-  if (!focusRegion || !showFocusModeControls) {
+  if (!focusWindow || !showFocusModeControls) {
     return null;
   }
 
@@ -35,20 +35,20 @@ export default function ConditionalFocuser({
     <Focuser
       editMode={editMode}
       setEditMode={setEditMode}
-      updateFocusRegionThrottled={updateFocusRegionThrottled}
+      updateFocusWindowThrottled={updateFocusWindowThrottled}
     />
   );
 }
 
-function Focuser({ editMode, setEditMode, updateFocusRegionThrottled }: Props) {
+function Focuser({ editMode, setEditMode, updateFocusWindowThrottled }: Props) {
   const dispatch = useAppDispatch();
-  const focusRegion = useAppSelector(selectors.getFocusRegion)!;
+  const focusWindow = useAppSelector(selectors.getFocusWindow)!;
   const zoomRegion = useAppSelector(selectors.getZoomRegion);
 
   // Mirror focus state so we can re-render immediately and dispatch throttled Redux updates
-  const [displayedFocusRegion, setDisplayedFocusRegion] = useState({
-    beginTime: focusRegion?.begin.time ?? zoomRegion.beginTime,
-    endTime: focusRegion?.end.time ?? zoomRegion.endTime,
+  const [displayedFocusWindow, setDisplayedFocusWindow] = useState({
+    beginTime: focusWindow?.begin.time ?? zoomRegion.beginTime,
+    endTime: focusWindow?.end.time ?? zoomRegion.endTime,
   });
 
   const containerRef = useRef<HTMLDivElement>(null);
@@ -57,7 +57,7 @@ function Focuser({ editMode, setEditMode, updateFocusRegionThrottled }: Props) {
 
   useEffect(() => {
     const container = containerRef.current;
-    if (!container || !focusRegion || !editMode) {
+    if (!container || !focusWindow || !editMode) {
       return;
     }
 
@@ -95,15 +95,15 @@ function Focuser({ editMode, setEditMode, updateFocusRegionThrottled }: Props) {
           container.getBoundingClientRect(),
           zoomRegion
         );
-        const beginTime = focusRegion.begin.time;
-        const endTime = focusRegion.end.time;
+        const beginTime = focusWindow.begin.time;
+        const endTime = focusWindow.end.time;
 
         switch (editMode.type) {
           case "drag": {
             // Re-center the focus region around the mouse cursor.
-            const focusRegionDuration = endTime - beginTime;
-            let newEndTime = mouseTime + focusRegionDuration / 2;
-            let newBeginTime = mouseTime - focusRegionDuration / 2;
+            const focusWindowDuration = endTime - beginTime;
+            let newEndTime = mouseTime + focusWindowDuration / 2;
+            let newBeginTime = mouseTime - focusWindowDuration / 2;
 
             // Make sure the new focus region is still within our zoom bounds.
             if (newBeginTime < zoomRegion.beginTime) {
@@ -114,15 +114,15 @@ function Focuser({ editMode, setEditMode, updateFocusRegionThrottled }: Props) {
               newEndTime = zoomRegion.endTime;
             }
 
-            updateDisplayedFocusRegion(newBeginTime, newEndTime);
+            updateDisplayedFocusWindow(newBeginTime, newEndTime);
             break;
           }
           case "resize-end": {
-            updateDisplayedFocusRegion(beginTime, mouseTime);
+            updateDisplayedFocusWindow(beginTime, mouseTime);
             break;
           }
           case "resize-start": {
-            updateDisplayedFocusRegion(mouseTime, endTime);
+            updateDisplayedFocusWindow(mouseTime, endTime);
             break;
           }
         }
@@ -170,9 +170,9 @@ function Focuser({ editMode, setEditMode, updateFocusRegionThrottled }: Props) {
       }
     };
 
-    const updateDisplayedFocusRegion = (beginTime: number, endTime: number) => {
-      setDisplayedFocusRegion({ beginTime, endTime });
-      updateFocusRegionThrottled(dispatch, beginTime, endTime);
+    const updateDisplayedFocusWindow = (beginTime: number, endTime: number) => {
+      setDisplayedFocusWindow({ beginTime, endTime });
+      updateFocusWindowThrottled(dispatch, beginTime, endTime);
     };
 
     document.addEventListener("click", onDocumentClick, true);
@@ -188,7 +188,7 @@ function Focuser({ editMode, setEditMode, updateFocusRegionThrottled }: Props) {
     };
   });
 
-  if (!focusRegion) {
+  if (!focusWindow) {
     return null;
   }
 
@@ -202,8 +202,8 @@ function Focuser({ editMode, setEditMode, updateFocusRegionThrottled }: Props) {
   const setEditModeToResizeEnd = () => setEditMode({ type: "resize-end" });
   const setEditModeToResizeStart = () => setEditMode({ type: "resize-start" });
 
-  const left = getPositionFromTime(displayedFocusRegion.beginTime, zoomRegion);
-  const right = getPositionFromTime(displayedFocusRegion.endTime, zoomRegion);
+  const left = getPositionFromTime(displayedFocusWindow.beginTime, zoomRegion);
+  const right = getPositionFromTime(displayedFocusWindow.endTime, zoomRegion);
 
   return (
     <div className="relative top-0 left-0 h-full w-full" ref={containerRef}>

--- a/src/ui/components/Timeline/PlaybackControls.tsx
+++ b/src/ui/components/Timeline/PlaybackControls.tsx
@@ -8,12 +8,12 @@ import { trackEvent } from "ui/utils/telemetry";
 export default function PlayPauseButton() {
   const dispatch = useAppDispatch();
   const currentTime = useAppSelector(selectors.getCurrentTime);
-  const focusRegion = useAppSelector(selectors.getFocusRegion);
+  const focusWindow = useAppSelector(selectors.getFocusWindow);
   const playback = useAppSelector(selectors.getPlayback);
   const recordingDuration = useAppSelector(selectors.getRecordingDuration);
 
-  const isAtEnd = focusRegion
-    ? currentTime === focusRegion.end.time
+  const isAtEnd = focusWindow
+    ? currentTime === focusWindow.end.time
     : currentTime == recordingDuration;
 
   let onClick;

--- a/src/ui/components/Timeline/Timeline.tsx
+++ b/src/ui/components/Timeline/Timeline.tsx
@@ -5,7 +5,7 @@ import {
   seekToTime,
   setTimelineToTime,
   stopPlayback,
-  updateFocusRegion,
+  updateFocusWindow,
 } from "ui/actions/timeline";
 import useTimelineContextMenu from "ui/components/Timeline/useTimelineContextMenu";
 import { selectors } from "ui/reducers";
@@ -128,7 +128,7 @@ export default function Timeline() {
 
   return (
     <>
-      <FocusModePopout updateFocusRegionThrottled={updateFocusRegionThrottled} />
+      <FocusModePopout updateFocusWindowThrottled={updateFocusWindowThrottled} />
       <div className="timeline">
         <div className="commands">
           <PlayPauseButton />
@@ -157,7 +157,7 @@ export default function Timeline() {
               <Focuser
                 editMode={editMode}
                 setEditMode={setEditMode}
-                updateFocusRegionThrottled={updateFocusRegionThrottled}
+                updateFocusWindowThrottled={updateFocusWindowThrottled}
               />
             </div>
           </div>
@@ -172,6 +172,6 @@ export default function Timeline() {
   );
 }
 
-const updateFocusRegionThrottled = throttle((dispatch: AppDispatch, begin: number, end: number) => {
-  return dispatch(updateFocusRegion({ begin, end }));
+const updateFocusWindowThrottled = throttle((dispatch: AppDispatch, begin: number, end: number) => {
+  return dispatch(updateFocusWindow({ begin, end }));
 }, 250);

--- a/src/ui/components/Timeline/Tooltip.tsx
+++ b/src/ui/components/Timeline/Tooltip.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { getFormattedTime } from "shared/utils/time";
 import { getNonLoadingTimeRanges } from "ui/reducers/app";
 import {
-  getFocusRegion,
+  getFocusWindow,
   getHoverTime,
   getShowFocusModeControls,
   getZoomRegion,
@@ -16,7 +16,7 @@ export default function Tooltip({ timelineWidth }: { timelineWidth: number }) {
   const zoomRegion = useAppSelector(getZoomRegion);
   const showFocusModeControls = useAppSelector(getShowFocusModeControls);
   const nonLoadingRegion = useAppSelector(getNonLoadingTimeRanges);
-  const focusRegion = useAppSelector(getFocusRegion);
+  const focusWindow = useAppSelector(getFocusWindow);
 
   if (!hoverTime || showFocusModeControls) {
     return null;
@@ -29,7 +29,7 @@ export default function Tooltip({ timelineWidth }: { timelineWidth: number }) {
   );
 
   const isHoveredOnUnFocusedRegion =
-    focusRegion && (focusRegion.begin.time > hoverTime || focusRegion.end.time < hoverTime);
+    focusWindow && (focusWindow.begin.time > hoverTime || focusWindow.end.time < hoverTime);
 
   const timestamp = getFormattedTime(hoverTime);
   const message =

--- a/src/ui/components/Timeline/UnfocusedRegion.tsx
+++ b/src/ui/components/Timeline/UnfocusedRegion.tsx
@@ -5,15 +5,15 @@ import { useAppSelector } from "ui/setup/hooks";
 import { getVisiblePosition } from "ui/utils/timeline";
 
 export default function UnfocusedRegion() {
-  const focusRegion = useAppSelector(selectors.getFocusRegion);
+  const focusWindow = useAppSelector(selectors.getFocusWindow);
   const zoomRegion = useAppSelector(selectors.getZoomRegion);
 
-  if (!focusRegion) {
+  if (!focusWindow) {
     return null;
   }
 
-  const beginTime = focusRegion!.begin.time;
-  const endTime = focusRegion!.end.time;
+  const beginTime = focusWindow!.begin.time;
+  const endTime = focusWindow!.end.time;
   const duration = zoomRegion.endTime - zoomRegion.beginTime;
 
   const start = getVisiblePosition({ time: beginTime, zoom: zoomRegion }) * 100;

--- a/src/ui/components/Timeline/UnloadedRegions.tsx
+++ b/src/ui/components/Timeline/UnloadedRegions.tsx
@@ -3,14 +3,14 @@ import clamp from "lodash/clamp";
 import { FC } from "react";
 
 import { getLoadedRegions } from "ui/reducers/app";
-import { getFocusRegion, getZoomRegion } from "ui/reducers/timeline";
+import { getFocusWindow, getZoomRegion } from "ui/reducers/timeline";
 import { useAppSelector } from "ui/setup/hooks";
 import { getVisiblePosition, overlap } from "ui/utils/timeline";
 
 export const UnloadedRegions: FC = () => {
   const loadedRegions = useAppSelector(getLoadedRegions);
   const zoomRegion = useAppSelector(getZoomRegion);
-  const focusRegion = useAppSelector(getFocusRegion);
+  const focusWindow = useAppSelector(getFocusWindow);
 
   // Check loadedRegions to keep typescript happy.
   if (!loadedRegions) {
@@ -26,8 +26,8 @@ export const UnloadedRegions: FC = () => {
   const { begin, end } = loadedRegions.loaded[0];
   let beginTime = begin.time;
   let endTime = end.time;
-  if (focusRegion) {
-    const overlappingRegions = overlap([focusRegion], loadedRegions.loading);
+  if (focusWindow) {
+    const overlappingRegions = overlap([focusWindow], loadedRegions.loading);
     if (overlappingRegions.length > 0) {
       const focusedAndLoaded = overlappingRegions[0];
       beginTime = focusedAndLoaded.begin.time;

--- a/src/ui/components/Timeline/useTimelineContextMenu.tsx
+++ b/src/ui/components/Timeline/useTimelineContextMenu.tsx
@@ -19,7 +19,7 @@ import {
   getUrlParams,
   seekToTime,
   syncFocusedRegion,
-  updateFocusRegion,
+  updateFocusWindow,
 } from "ui/actions/timeline";
 import { useAppDispatch } from "ui/setup/hooks";
 import { getUrlString } from "ui/utils/environment";
@@ -27,7 +27,7 @@ import { getUrlString } from "ui/utils/environment";
 import styles from "./ContextMenu.module.css";
 
 export default function useTimelineContextMenu() {
-  const { rangeForDisplay: focusRegion } = useContext(FocusContext);
+  const { rangeForDisplay: focusWindow } = useContext(FocusContext);
   const { showCommentsPanel } = useContext(InspectorContext);
   const replayClient = useContext(ReplayClientContext);
   const { accessToken, duration, recordingId } = useContext(SessionContext);
@@ -36,8 +36,8 @@ export default function useTimelineContextMenu() {
 
   const [relativePosition, setRelativePosition] = useState(0);
 
-  const focusBeginTime = focusRegion?.begin.time;
-  const focusEndTime = focusRegion?.end.time;
+  const focusBeginTime = focusWindow?.begin.time;
+  const focusEndTime = focusWindow?.end.time;
   const currentTime = relativePosition * duration;
 
   const onShow = (event: UIEvent) => {
@@ -67,7 +67,7 @@ export default function useTimelineContextMenu() {
     let end = focusEndTime ?? duration;
     end = Math.min(end, currentTime + MAX_FOCUS_REGION_DURATION);
 
-    await dispatch(updateFocusRegion({ begin: currentTime, end }));
+    await dispatch(updateFocusWindow({ begin: currentTime, end }));
     dispatch(syncFocusedRegion());
   };
 
@@ -75,14 +75,14 @@ export default function useTimelineContextMenu() {
     let begin = focusBeginTime ?? 0;
     begin = Math.max(begin, currentTime - MAX_FOCUS_REGION_DURATION);
 
-    await dispatch(updateFocusRegion({ begin, end: currentTime }));
+    await dispatch(updateFocusWindow({ begin, end: currentTime }));
     dispatch(syncFocusedRegion());
   };
 
   const shareReplay = async () => {
     const { point, time } = await replayClient.getPointNearTime(currentTime);
 
-    const params = getUrlParams({ focusRegion, point, time });
+    const params = getUrlParams({ focusWindow, point, time });
     const urlString = getUrlString(params);
 
     copyToClipboard(urlString);

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -3,7 +3,7 @@ import { PayloadAction, createSelector, createSlice } from "@reduxjs/toolkit";
 import { RecordingTarget } from "replay-next/src/suspense/BuildIdCache";
 import { compareExecutionPoints, isExecutionPointsWithinRange } from "replay-next/src/utils/time";
 import { Workspace } from "shared/graphql/types";
-import { getCurrentTime, getFocusRegion, getZoomRegion } from "ui/reducers/timeline";
+import { getCurrentTime, getFocusWindow, getZoomRegion } from "ui/reducers/timeline";
 import { UIState } from "ui/state";
 import {
   AppMode,
@@ -302,16 +302,16 @@ export const getSortedEventsForDisplay = createSelector(
   }
 );
 
-export const getFilteredEventsForFocusRegion = createSelector(
-  getFocusRegion,
+export const getFilteredEventsForFocusWindow = createSelector(
+  getFocusWindow,
   getSortedEventsForDisplay,
-  (focusRegion, sortedEvents) => {
-    if (!focusRegion) {
+  (focusWindow, sortedEvents) => {
+    if (!focusWindow) {
       return sortedEvents;
     }
 
     const filteredEvents = sortedEvents.filter(e => {
-      return isExecutionPointsWithinRange(e.point, focusRegion.begin.point, focusRegion.end.point);
+      return isExecutionPointsWithinRange(e.point, focusWindow.begin.point, focusWindow.end.point);
     });
     return filteredEvents;
   }

--- a/src/ui/reducers/timeline.test.ts
+++ b/src/ui/reducers/timeline.test.ts
@@ -5,8 +5,8 @@ import { UIStore } from "ui/actions";
 import * as actions from "../actions/timeline";
 import {
   getCurrentTime,
-  getFocusRegion,
-  getFocusRegionBackup,
+  getFocusWindow,
+  getFocusWindowBackup,
   getHoverTime,
   getPlayback,
   setTimelineState,
@@ -34,11 +34,11 @@ describe("Redux timeline state", () => {
   });
 
   describe("focus region", () => {
-    it("should assign a default focusRegion around the current time when toggled on", async () => {
-      expect(getFocusRegionBackup(store.getState())).toBeNull();
+    it("should assign a default focusWindow around the current time when toggled on", async () => {
+      expect(getFocusWindowBackup(store.getState())).toBeNull();
       await dispatch(actions.toggleFocusMode());
-      expect(getFocusRegionBackup(store.getState())).toBeNull();
-      expect(getFocusRegion(store.getState())).toMatchInlineSnapshot(`
+      expect(getFocusWindowBackup(store.getState())).toBeNull();
+      expect(getFocusWindow(store.getState())).toMatchInlineSnapshot(`
         Object {
           "begin": Object {
             "point": "67.5",
@@ -52,9 +52,9 @@ describe("Redux timeline state", () => {
       `);
     });
 
-    it("should not force the currentTime to be within the focusRegion as it moves around", async () => {
+    it("should not force the currentTime to be within the focusWindow as it moves around", async () => {
       await dispatch(
-        actions.updateFocusRegion({
+        actions.updateFocusWindow({
           begin: 50,
           end: 60,
         })
@@ -62,7 +62,7 @@ describe("Redux timeline state", () => {
       expect(getCurrentTime(store.getState())).toBe(75);
 
       await dispatch(
-        actions.updateFocusRegion({
+        actions.updateFocusWindow({
           begin: 75,
           end: 85,
         })
@@ -70,7 +70,7 @@ describe("Redux timeline state", () => {
       expect(getCurrentTime(store.getState())).toBe(75);
 
       await dispatch(
-        actions.updateFocusRegion({
+        actions.updateFocusWindow({
           begin: 25,
           end: 30,
         })
@@ -81,7 +81,7 @@ describe("Redux timeline state", () => {
     it("should update the hoverTime (and the time displayed in the video player) to match the handle being dragged", async () => {
       // If we are moving the whole focus region, seek to the current time.
       await dispatch(
-        actions.updateFocusRegion({
+        actions.updateFocusWindow({
           begin: 60,
           end: 80,
         })
@@ -90,7 +90,7 @@ describe("Redux timeline state", () => {
 
       // If we are moving the beginTime, seek to that point
       await dispatch(
-        actions.updateFocusRegion({
+        actions.updateFocusWindow({
           begin: 65,
           end: 80,
         })
@@ -99,7 +99,7 @@ describe("Redux timeline state", () => {
 
       // If we are moving the endTime, seek to that point
       await dispatch(
-        actions.updateFocusRegion({
+        actions.updateFocusWindow({
           begin: 65,
           end: 75,
         })
@@ -109,14 +109,14 @@ describe("Redux timeline state", () => {
       // Moving the entire range should not move the hover time,
       // unless the time would otherwise be out of the new focused region.
       await dispatch(
-        actions.updateFocusRegion({
+        actions.updateFocusWindow({
           begin: 68,
           end: 78,
         })
       );
       expect(getHoverTime(store.getState())).toBe(75);
       await dispatch(
-        actions.updateFocusRegion({
+        actions.updateFocusWindow({
           begin: 80,
           end: 90,
         })
@@ -124,15 +124,15 @@ describe("Redux timeline state", () => {
       expect(getHoverTime(store.getState())).toBe(80);
     });
 
-    it("should not allow an invalid focusRegion to be set", async () => {
+    it("should not allow an invalid focusWindow to be set", async () => {
       // Before the start of the zoom region
       await dispatch(
-        actions.updateFocusRegion({
+        actions.updateFocusWindow({
           begin: 30,
           end: 40,
         })
       );
-      expect(getFocusRegion(store.getState())).toMatchInlineSnapshot(`
+      expect(getFocusWindow(store.getState())).toMatchInlineSnapshot(`
         Object {
           "begin": Object {
             "point": "50",
@@ -147,12 +147,12 @@ describe("Redux timeline state", () => {
 
       // After the end of the zoom region
       await dispatch(
-        actions.updateFocusRegion({
+        actions.updateFocusWindow({
           begin: 110,
           end: 125,
         })
       );
-      expect(getFocusRegion(store.getState())).toMatchInlineSnapshot(`
+      expect(getFocusWindow(store.getState())).toMatchInlineSnapshot(`
         Object {
           "begin": Object {
             "point": "100",
@@ -167,18 +167,18 @@ describe("Redux timeline state", () => {
 
       // Overlapping
       await dispatch(
-        actions.updateFocusRegion({
+        actions.updateFocusWindow({
           begin: 60,
           end: 80,
         })
       );
       await dispatch(
-        actions.updateFocusRegion({
+        actions.updateFocusWindow({
           begin: 90,
           end: 80,
         })
       );
-      expect(getFocusRegion(store.getState())).toMatchInlineSnapshot(`
+      expect(getFocusWindow(store.getState())).toMatchInlineSnapshot(`
         Object {
           "begin": Object {
             "point": "80",
@@ -193,18 +193,18 @@ describe("Redux timeline state", () => {
 
       // Overlapping alternate
       await dispatch(
-        actions.updateFocusRegion({
+        actions.updateFocusWindow({
           begin: 60,
           end: 80,
         })
       );
       await dispatch(
-        actions.updateFocusRegion({
+        actions.updateFocusWindow({
           begin: 60,
           end: 50,
         })
       );
-      expect(getFocusRegion(store.getState())).toMatchInlineSnapshot(`
+      expect(getFocusWindow(store.getState())).toMatchInlineSnapshot(`
         Object {
           "begin": Object {
             "point": "60",
@@ -218,12 +218,12 @@ describe("Redux timeline state", () => {
       `);
     });
 
-    it("should stop playback before resizing focusRegion", async () => {
+    it("should stop playback before resizing focusWindow", async () => {
       dispatch(actions.startPlayback());
       expect(getPlayback(store.getState())).not.toBeNull();
 
       await dispatch(
-        actions.updateFocusRegion({
+        actions.updateFocusWindow({
           begin: 50,
           end: 60,
         })
@@ -233,8 +233,8 @@ describe("Redux timeline state", () => {
 
     describe("set start time", () => {
       it("should focus from the start time to the end of the zoom region if no focus region has been set", async () => {
-        await dispatch(actions.setFocusRegionBeginTime(65, false));
-        expect(getFocusRegion(store.getState())).toMatchInlineSnapshot(`
+        await dispatch(actions.setFocusWindowBeginTime(65, false));
+        expect(getFocusWindow(store.getState())).toMatchInlineSnapshot(`
           Object {
             "begin": Object {
               "point": "65",
@@ -250,13 +250,13 @@ describe("Redux timeline state", () => {
 
       it("should only update the start time when a region is set", async () => {
         await dispatch(
-          actions.updateFocusRegion({
+          actions.updateFocusWindow({
             begin: 50,
             end: 70,
           })
         );
-        await dispatch(actions.setFocusRegionBeginTime(65, false));
-        expect(getFocusRegion(store.getState())).toMatchInlineSnapshot(`
+        await dispatch(actions.setFocusWindowBeginTime(65, false));
+        expect(getFocusWindow(store.getState())).toMatchInlineSnapshot(`
           Object {
             "begin": Object {
               "point": "65",
@@ -273,8 +273,8 @@ describe("Redux timeline state", () => {
 
     describe("set end time", () => {
       it("should focus from the beginning of the zoom region to the specified end time if no focus region has been set", async () => {
-        await dispatch(actions.setFocusRegionEndTime(65, false));
-        expect(getFocusRegion(store.getState())).toMatchInlineSnapshot(`
+        await dispatch(actions.setFocusWindowEndTime(65, false));
+        expect(getFocusWindow(store.getState())).toMatchInlineSnapshot(`
           Object {
             "begin": Object {
               "point": "50",
@@ -290,13 +290,13 @@ describe("Redux timeline state", () => {
 
       it("should only update the end time when a region is set", async () => {
         await dispatch(
-          actions.updateFocusRegion({
+          actions.updateFocusWindow({
             begin: 50,
             end: 70,
           })
         );
-        await dispatch(actions.setFocusRegionEndTime(65, false));
-        expect(getFocusRegion(store.getState())).toMatchInlineSnapshot(`
+        await dispatch(actions.setFocusWindowEndTime(65, false));
+        expect(getFocusWindow(store.getState())).toMatchInlineSnapshot(`
           Object {
             "begin": Object {
               "point": "50",

--- a/src/ui/reducers/timeline.ts
+++ b/src/ui/reducers/timeline.ts
@@ -4,7 +4,7 @@ import sortBy from "lodash/sortBy";
 
 import { MAX_FOCUS_REGION_DURATION } from "ui/actions/timeline";
 import { UIState } from "ui/state";
-import { FocusRegion, HoveredItem, TimeRange, TimelineState } from "ui/state/timeline";
+import { FocusWindow, HoveredItem, TimeRange, TimelineState } from "ui/state/timeline";
 import { getPausePointParams } from "ui/utils/environment";
 import { mergeSortedPointLists } from "ui/utils/timeline";
 
@@ -12,13 +12,13 @@ function initialTimelineState(): TimelineState {
   return {
     allPaintsReceived: false,
     currentTime: 0,
-    focusRegion: getPausePointParams().focusRegion,
-    focusRegionBackup: null,
+    focusWindow: getPausePointParams().focusWindow,
+    focusWindowBackup: null,
     hoveredItem: null,
     markTimeStampedPoint: null,
     hoverTime: null,
     playback: null,
-    playbackFocusRegion: false,
+    playbackFocusWindow: false,
     playbackPrecachedTime: 0,
     paints: [{ time: 0, point: "0" }],
     points: [{ time: 0, point: "0" }],
@@ -56,11 +56,11 @@ const timelineSlice = createSlice({
     setPlaybackPrecachedTime(state, action: PayloadAction<number>) {
       state.playbackPrecachedTime = action.payload;
     },
-    setPlaybackFocusRegion(state, action: PayloadAction<boolean>) {
-      state.playbackFocusRegion = action.payload;
+    setPlaybackFocusWindow(state, action: PayloadAction<boolean>) {
+      state.playbackFocusWindow = action.payload;
     },
-    setFocusRegion(state, action: PayloadAction<FocusRegion | null>) {
-      state.focusRegion = action.payload;
+    setFocusWindow(state, action: PayloadAction<FocusWindow | null>) {
+      state.focusWindow = action.payload;
     },
     pointsReceived(state, action: PayloadAction<TimeStampedPoint[]>) {
       const mutablePoints = [...state.points];
@@ -94,9 +94,9 @@ export const {
   setHoveredItem,
   setMarkTimeStampPoint,
   setPlaybackPrecachedTime,
-  setPlaybackFocusRegion,
+  setPlaybackFocusWindow,
   setPlaybackStalled,
-  setFocusRegion,
+  setFocusWindow: setFocusWindow,
   setTimelineState,
   pointsReceived,
   paintsReceived,
@@ -130,12 +130,12 @@ export const getBasicProcessingProgress = (state: UIState) => {
   return (1.0 * (maxPaint?.time || 0)) / maxPoint.time;
 };
 export const getPlaybackPrecachedTime = (state: UIState) => state.timeline.playbackPrecachedTime;
-export const getPlaybackFocusRegion = (state: UIState) => state.timeline.playbackFocusRegion;
-export const getFocusRegion = (state: UIState) => state.timeline.focusRegion;
-export const isMaximumFocusRegion = (state: UIState) => {
-  const focusRegion = getFocusRegion(state);
-  if (focusRegion) {
-    const duration = focusRegion.end.time - focusRegion.begin.time;
+export const getPlaybackFocusWindow = (state: UIState) => state.timeline.playbackFocusWindow;
+export const getFocusWindow = (state: UIState) => state.timeline.focusWindow;
+export const isMaximumFocusWindow = (state: UIState) => {
+  const focusWindow = getFocusWindow(state);
+  if (focusWindow) {
+    const duration = focusWindow.end.time - focusWindow.begin.time;
     // JavaScript floating point numbers are not precise enough,
     // so in order to avoid occasional flickers from rounding errors, fuzz it a bit.
     return duration + 0.1 >= MAX_FOCUS_REGION_DURATION;
@@ -143,4 +143,4 @@ export const isMaximumFocusRegion = (state: UIState) => {
     return false;
   }
 };
-export const getFocusRegionBackup = (state: UIState) => state.timeline.focusRegionBackup;
+export const getFocusWindowBackup = (state: UIState) => state.timeline.focusWindowBackup;

--- a/src/ui/state/timeline.ts
+++ b/src/ui/state/timeline.ts
@@ -11,7 +11,7 @@ export interface ZoomRegion {
   scale: number;
 }
 
-export interface FocusRegion {
+export interface FocusWindow {
   end: TimeStampedPoint;
   begin: TimeStampedPoint;
 }
@@ -20,8 +20,8 @@ export interface TimelineState {
   allPaintsReceived: boolean;
   currentTime: number;
   dragging: boolean;
-  focusRegion: FocusRegion | null;
-  focusRegionBackup: FocusRegion | null;
+  focusWindow: FocusWindow | null;
+  focusWindowBackup: FocusWindow | null;
   hoveredItem: HoveredItem | null;
   hoverTime: number | null;
   markTimeStampedPoint: TimeStampedPoint | null;
@@ -31,7 +31,7 @@ export interface TimelineState {
     beginDate: number;
     time: number;
   } | null;
-  playbackFocusRegion: boolean;
+  playbackFocusWindow: boolean;
   playbackPrecachedTime: number;
   points: TimeStampedPoint[];
   recordingDuration: number | null;

--- a/src/ui/utils/environment.ts
+++ b/src/ui/utils/environment.ts
@@ -102,14 +102,14 @@ export function hasLoadingParam() {
   return getURL().searchParams.get("loading") != null;
 }
 
-export function getFocusRegion() {
+export function getFocusWindow() {
   const url = getURL();
-  const focusRegionParam = url.searchParams.get("focusRegion");
-  return focusRegionParam ? (decodeBase64FromURL(focusRegionParam) as TimeStampedPointRange) : null;
+  const focusWindowParam = url.searchParams.get("focusWindow");
+  return focusWindowParam ? (decodeBase64FromURL(focusWindowParam) as TimeStampedPointRange) : null;
 }
 
 export function getPausePointParams(): {
-  focusRegion: TimeStampedPointRange | null;
+  focusWindow: TimeStampedPointRange | null;
   point: ExecutionPoint | null;
   time: number | null;
 } {
@@ -127,12 +127,12 @@ export function getPausePointParams(): {
     }
   }
 
-  const focusRegion = getFocusRegion();
+  const focusWindow = getFocusWindow();
 
   if (time != null && point != null) {
-    return { focusRegion, point, time };
+    return { focusWindow, point, time };
   } else {
-    return { focusRegion, point: null, time: null };
+    return { focusWindow, point: null, time: null };
   }
 }
 

--- a/src/ui/utils/timeline.test.ts
+++ b/src/ui/utils/timeline.test.ts
@@ -1,17 +1,17 @@
-import { FocusRegion, ZoomRegion } from "ui/state/timeline";
+import { FocusWindow, ZoomRegion } from "ui/state/timeline";
 
 import {
-  filterToFocusRegion,
+  filterToFocusWindow,
   getSecondsFromFormattedTime,
   getTimeFromPosition,
-  isFocusRegionSubset,
+  isFocusWindowSubset,
   isValidTimeString,
   mergeSortedPointLists,
   overlap,
 } from "./timeline";
 
 const point = (time: number) => ({ time, point: `${time}` });
-const focusRegion = (from: number, to: number): FocusRegion => ({
+const focusWindow = (from: number, to: number): FocusWindow => ({
   begin: point(from),
   end: point(to),
 });
@@ -100,28 +100,28 @@ describe("getTimeFromPosition", () => {
   });
 });
 
-describe("isFocusRegionSubset", () => {
+describe("isFocusWindowSubset", () => {
   it("should always be true when previous focus region was null", () => {
-    expect(isFocusRegionSubset(null, null)).toBe(true);
-    expect(isFocusRegionSubset(null, focusRegion(0, 0))).toBe(true);
-    expect(isFocusRegionSubset(null, focusRegion(0, 1000))).toBe(true);
-    expect(isFocusRegionSubset(null, focusRegion(1000, 1000))).toBe(true);
+    expect(isFocusWindowSubset(null, null)).toBe(true);
+    expect(isFocusWindowSubset(null, focusWindow(0, 0))).toBe(true);
+    expect(isFocusWindowSubset(null, focusWindow(0, 1000))).toBe(true);
+    expect(isFocusWindowSubset(null, focusWindow(1000, 1000))).toBe(true);
   });
 
   it("should never be true when new focus region was null (unless previous one was also)", () => {
-    expect(isFocusRegionSubset(focusRegion(0, 0), null)).toBe(false);
-    expect(isFocusRegionSubset(focusRegion(0, 1000), null)).toBe(false);
-    expect(isFocusRegionSubset(focusRegion(1000, 1000), null)).toBe(false);
+    expect(isFocusWindowSubset(focusWindow(0, 0), null)).toBe(false);
+    expect(isFocusWindowSubset(focusWindow(0, 1000), null)).toBe(false);
+    expect(isFocusWindowSubset(focusWindow(1000, 1000), null)).toBe(false);
   });
 
   it("should correctly differentiate between overlapping and non-overlapping focus regions", () => {
-    expect(isFocusRegionSubset(focusRegion(0, 0), focusRegion(0, 0))).toBe(true);
-    expect(isFocusRegionSubset(focusRegion(100, 200), focusRegion(0, 50))).toBe(false);
-    expect(isFocusRegionSubset(focusRegion(100, 200), focusRegion(50, 150))).toBe(false);
-    expect(isFocusRegionSubset(focusRegion(100, 200), focusRegion(100, 200))).toBe(true);
-    expect(isFocusRegionSubset(focusRegion(100, 200), focusRegion(125, 175))).toBe(true);
-    expect(isFocusRegionSubset(focusRegion(100, 200), focusRegion(150, 250))).toBe(false);
-    expect(isFocusRegionSubset(focusRegion(100, 200), focusRegion(200, 300))).toBe(false);
+    expect(isFocusWindowSubset(focusWindow(0, 0), focusWindow(0, 0))).toBe(true);
+    expect(isFocusWindowSubset(focusWindow(100, 200), focusWindow(0, 50))).toBe(false);
+    expect(isFocusWindowSubset(focusWindow(100, 200), focusWindow(50, 150))).toBe(false);
+    expect(isFocusWindowSubset(focusWindow(100, 200), focusWindow(100, 200))).toBe(true);
+    expect(isFocusWindowSubset(focusWindow(100, 200), focusWindow(125, 175))).toBe(true);
+    expect(isFocusWindowSubset(focusWindow(100, 200), focusWindow(150, 250))).toBe(false);
+    expect(isFocusWindowSubset(focusWindow(100, 200), focusWindow(200, 300))).toBe(false);
   });
 });
 describe("isValidTimeString", () => {
@@ -184,22 +184,22 @@ describe("overlap", () => {
   });
 });
 
-describe("filterToFocusRegion", () => {
+describe("filterToFocusWindow", () => {
   it("will not include points before the region", () => {
-    expect(filterToFocusRegion([point(5)], focusRegion(10, 20))).toEqual([[], 1, 0]);
+    expect(filterToFocusWindow([point(5)], focusWindow(10, 20))).toEqual([[], 1, 0]);
   });
   it("will not include points after the region", () => {
-    expect(filterToFocusRegion([point(25)], focusRegion(10, 20))).toEqual([[], 0, 1]);
+    expect(filterToFocusWindow([point(25)], focusWindow(10, 20))).toEqual([[], 0, 1]);
   });
   it("will include points inside the region", () => {
-    expect(filterToFocusRegion([point(5), point(15), point(25)], focusRegion(10, 20))).toEqual([
+    expect(filterToFocusWindow([point(5), point(15), point(25)], focusWindow(10, 20))).toEqual([
       [point(15)],
       1,
       1,
     ]);
   });
   it("will include points on the boundaries the region", () => {
-    expect(filterToFocusRegion([point(10), point(15), point(20)], focusRegion(10, 20))).toEqual([
+    expect(filterToFocusWindow([point(10), point(15), point(20)], focusWindow(10, 20))).toEqual([
       [point(10), point(15), point(20)],
       0,
       0,

--- a/src/ui/utils/timeline.ts
+++ b/src/ui/utils/timeline.ts
@@ -4,7 +4,7 @@ import sortedIndexBy from "lodash/sortedIndexBy";
 import sortedLastIndexBy from "lodash/sortedLastIndexBy";
 
 import { assert } from "protocol/utils";
-import { FocusRegion, ZoomRegion } from "ui/state/timeline";
+import { FocusWindow, ZoomRegion } from "ui/state/timeline";
 
 import { timelineMarkerWidth } from "../constants";
 
@@ -184,8 +184,8 @@ export function isSameTimeStampedPointRange(
   return sameBegin && sameEnd;
 }
 
-export function isInFocusSpan(time: number, focusRegion: FocusRegion) {
-  return time >= focusRegion.begin.time && time <= focusRegion.end.time;
+export function isInFocusSpan(time: number, focusWindow: FocusWindow) {
+  return time >= focusWindow.begin.time && time <= focusWindow.end.time;
 }
 
 export function isPointInRegions(regions: TimeStampedPointRange[], point: string) {
@@ -198,8 +198,8 @@ export function isTimeInRegions(time: number, regions?: TimeStampedPointRange[])
   return !!regions?.some(region => time >= region.begin.time && time <= region.end.time);
 }
 
-export function rangeForFocusRegion(focusRegion: FocusRegion): TimeStampedPointRange {
-  return { begin: focusRegion.begin || { time: 0, point: "0" }, end: focusRegion.end };
+export function rangeForFocusWindow(focusWindow: FocusWindow): TimeStampedPointRange {
+  return { begin: focusWindow.begin || { time: 0, point: "0" }, end: focusWindow.end };
 }
 
 export const overlap = (a: TimeStampedPointRange[], b: TimeStampedPointRange[]) => {
@@ -235,35 +235,35 @@ export function getTimeFromPosition(
   return time;
 }
 
-export function isFocusRegionSubset(
-  prevFocusRegion: FocusRegion | null,
-  nextFocusRegion: FocusRegion | null
+export function isFocusWindowSubset(
+  prevFocusWindow: FocusWindow | null,
+  nextFocusWindow: FocusWindow | null
 ): boolean {
-  if (prevFocusRegion === null) {
+  if (prevFocusWindow === null) {
     // Previously the entire timeline was selected.
     // No matter what the new focus region is, it will be a subset.
     return true;
-  } else if (nextFocusRegion === null) {
+  } else if (nextFocusWindow === null) {
     // The new selection includes the entire timeline.
     // No matter what the previous focus region is, the new one is not a subset.
     return false;
   } else {
     return (
-      nextFocusRegion.begin.time >= prevFocusRegion.begin.time &&
-      nextFocusRegion.end.time <= prevFocusRegion.end.time
+      nextFocusWindow.begin.time >= prevFocusWindow.begin.time &&
+      nextFocusWindow.end.time <= prevFocusWindow.end.time
     );
   }
 }
 
-export function filterToFocusRegion<T extends TimeStampedPoint>(
+export function filterToFocusWindow<T extends TimeStampedPoint>(
   sortedPoints: T[],
-  focusRegion: FocusRegion | null
+  focusWindow: FocusWindow | null
 ): [filtered: T[], filteredBeforeCount: number, filteredAfterCount: number] {
-  if (!focusRegion) {
+  if (!focusWindow) {
     return [sortedPoints, 0, 0];
   }
 
-  const { begin: beginPoint, end: endPoint } = rangeForFocusRegion(focusRegion);
+  const { begin: beginPoint, end: endPoint } = rangeForFocusWindow(focusWindow);
 
   const beginIndex = sortedIndexBy(sortedPoints, beginPoint, ({ point }) => BigInt(point));
   const endIndex = sortedLastIndexBy(sortedPoints, endPoint, ({ point }) => BigInt(point));


### PR DESCRIPTION
Preparation for FE-1546:
- [x] Renamed various focus range/region/window references to use "focus window"
- [x] Rename `ReplayClient` methods:
   * `getFocusWindow` to `syncFocusWindow` (since this is a remote operation)
   * `requestFocusRange` to `requestFocusWindow`
- [x] Remove redundant call to `syncFocusWindow` from Redux action `createSocket`
   * Made this method "private" since `initialize` and `configure` already call it
- [x] Add `ReplayClient.getCurrentFocusWindow`
   * Components to switch over to using this rather than the loaded region (not part of this PR)