### PR TITLE
Test Suite data hardening

### DIFF
--- a/packages/shared/test-suites/RecordingTestMetadata.ts
+++ b/packages/shared/test-suites/RecordingTestMetadata.ts
@@ -587,6 +587,16 @@ export async function processGroupedTestCases(
         const annotationsByTest: Annotation[][] = annotations.reduce(
           (accumulated: Annotation[][], annotation: Annotation) => {
             eventSwitch: switch (annotation.message.event) {
+              case "step:enqueue":
+              case "step:start": {
+                if (currentTestHasEnded) {
+                  // TODO [SCS-1186]
+                  // Ignore steps that start outside of a test boundary;
+                  // These likely correspond to beforeAll or afterAll hooks which we filter for now
+                  return accumulated;
+                }
+                break;
+              }
               case "test:start": {
                 // Tests that were skipped won't have annotations.
                 // Add empty annotations arrays for these.
@@ -613,6 +623,8 @@ export async function processGroupedTestCases(
               }
             }
 
+            // Ignore annotations that happen before the first test
+            // (These are probably beforeAll annotations, which we don't fully support yet)
             if (currentTestAnnotations) {
               currentTestAnnotations.push(annotation);
             }

--- a/packages/shared/test-suites/RecordingTestMetadata.ts
+++ b/packages/shared/test-suites/RecordingTestMetadata.ts
@@ -314,6 +314,9 @@ export async function processCypressTestRecording(
       main: [],
     };
 
+    let beginPoint: TimeStampedPoint | null = null;
+    let endPoint: TimeStampedPoint | null = null;
+
     const navigationEvents: RecordingTestMetadataV3.NavigationEvent[] = [];
 
     // Note that event annotations may be interleaved,
@@ -355,14 +358,28 @@ export async function processCypressTestRecording(
           }
           break;
         }
+        case "test:start": {
+          beginPoint = {
+            point: annotation.point,
+            time: annotation.time,
+          };
+          break;
+        }
+        case "test:end": {
+          endPoint = {
+            point: annotation.point,
+            time: annotation.time,
+          };
+          break;
+        }
         default: {
           console.warn(`Unexpected annotation type: ${annotation.message.event}`);
         }
       }
     }
 
-    let testBeginPoint: TimeStampedPoint | null = null;
-    let testEndPoint: TimeStampedPoint | null = null;
+    assert(beginPoint !== null, "Test must have a begin point");
+    assert(endPoint !== null, "Test must have a end point");
 
     for (let sectionName in partialEvents) {
       const testEvents = events[sectionName as RecordingTestMetadataV3.TestSectionName];
@@ -409,9 +426,6 @@ export async function processCypressTestRecording(
         annotations.forEach(annotation => {
           switch (annotation.message.event) {
             case "step:end": {
-              if (!testEndPoint || comparePoints(testEndPoint.point, annotation.point) < 0) {
-                testEndPoint = { point: annotation.point, time: annotation.time };
-              }
               endPoint = {
                 point: annotation.point,
                 time: annotation.time,
@@ -425,9 +439,6 @@ export async function processCypressTestRecording(
               break;
             }
             case "step:enqueue": {
-              if (!testBeginPoint || comparePoints(testBeginPoint.point, annotation.point) > 0) {
-                testBeginPoint = { point: annotation.point, time: annotation.time };
-              }
               if (!isChaiAssertion) {
                 viewSourceTimeStampedPoint = {
                   point: annotation.point,
@@ -491,8 +502,6 @@ export async function processCypressTestRecording(
       });
     }
 
-    assert(testBeginPoint && testEndPoint, "No steps for test");
-
     // Finds the section that contains a given point
     // defaults to the main (test body) section if no matches found
     const findSection = (point: ExecutionPoint) => {
@@ -507,11 +516,7 @@ export async function processCypressTestRecording(
       return events.main;
     };
 
-    const networkRequestEvents = await processNetworkData(
-      replayClient,
-      testBeginPoint,
-      testEndPoint
-    );
+    const networkRequestEvents = await processNetworkData(replayClient, beginPoint, endPoint);
     // Now that section boundaries have been defined by user-actions,
     // merge in navigation and network events.
     navigationEvents.forEach(navigationEvent => {
@@ -533,8 +538,8 @@ export async function processCypressTestRecording(
       result,
       source,
       timeStampedPointRange: {
-        begin: testBeginPoint,
-        end: testEndPoint,
+        begin: beginPoint,
+        end: endPoint,
       },
     };
   } else if (isTestRecordingV3(testRecording)) {
@@ -559,11 +564,30 @@ export async function processGroupedTestCases(
       case "cypress": {
         const annotations = await AnnotationsCache.readAsync(replayClient);
 
+        // Annotations for the entire recording (which may include more than one test)
+        // we need to splice only the appropriate subset for each test.
+        const annotationsByTest: Annotation[][] = annotations.reduce(
+          (accumulated: Annotation[][], annotation: Annotation) => {
+            if (annotation.message.event === "test:start") {
+              // Start a new annotations array for each test
+              accumulated.push([annotation]);
+            } else if (accumulated.length > 0) {
+              // Else add new annotations to the current test
+              // (Note some recordings have annotations data before the first "test:start")
+              accumulated[accumulated.length - 1].push(annotation);
+            }
+
+            return accumulated;
+          },
+          []
+        );
+
         // GroupedTestCasesV2 and GroupedTestCases types are the same,
         // except for annotation data inside of their recorded tests
         let testRecordings: RecordingTestMetadataV3.TestRecording[] = [];
         for (let index = 0; index < partialTestRecordings.length; index++) {
           const legacyTest = partialTestRecordings[index];
+          const annotations = annotationsByTest[index];
           const test = await processCypressTestRecording(legacyTest, annotations, replayClient);
 
           testRecordings.push(test);

--- a/packages/shared/test-suites/RecordingTestMetadata.ts
+++ b/packages/shared/test-suites/RecordingTestMetadata.ts
@@ -233,7 +233,7 @@ export namespace RecordingTestMetadataV3 {
 
     // Precisely defines the start/stop execution points (and times) for the action
     // This value comes from annotations and so is only avaiable for Cypress tests (for now)
-    timeStampedPointRange: TimeStampedPointRange | null;
+    timeStampedPointRange: TimeStampedPointRange;
 
     type: "user-action";
   }
@@ -319,228 +319,241 @@ export async function processCypressTestRecording(
 
     const navigationEvents: RecordingTestMetadataV3.NavigationEvent[] = [];
 
-    // Note that event annotations may be interleaved,
-    // meaning that we can't step through both arrays in one pass.
-    // Instead we have to loop over the annotations array once to group data by event id–
-    // (and also find the navigation and test start/end annotations)–
-    // then we can iterate over the user-action events.
-    const userActionEventIdToAnnotations: Record<string, Annotation[]> = {};
+    // Skipped tests won't contain any annotations (include begin/end point)
+    if (result !== "skipped") {
+      // Note that event annotations may be interleaved,
+      // meaning that we can't step through both arrays in one pass.
+      // Instead we have to loop over the annotations array once to group data by event id–
+      // (and also find the navigation and test start/end annotations)–
+      // then we can iterate over the user-action events.
+      const userActionEventIdToAnnotations: Record<string, Annotation[]> = {};
 
-    for (let index = 0; index < annotations.length; index++) {
-      const annotation = annotations[index];
-      switch (annotation.message.event) {
-        case "event:navigation": {
-          assert(annotation.message.url, "Navigation annotation must have a URL");
+      for (let index = 0; index < annotations.length; index++) {
+        const annotation = annotations[index];
+        switch (annotation.message.event) {
+          case "event:navigation": {
+            assert(annotation.message.url, "Navigation annotation must have a URL");
 
-          const navigationEvent: RecordingTestMetadataV3.NavigationEvent = {
-            data: {
-              url: annotation.message.url,
-            },
-            timeStampedPoint: {
+            const navigationEvent: RecordingTestMetadataV3.NavigationEvent = {
+              data: {
+                url: annotation.message.url,
+              },
+              timeStampedPoint: {
+                point: annotation.point,
+                time: annotation.time,
+              },
+              type: "navigation",
+            };
+
+            navigationEvents.push(navigationEvent);
+            break;
+          }
+          case "step:end":
+          case "step:enqueue":
+          case "step:start": {
+            const id = annotation.message.id;
+            assert(id != null, "Annotation event must have an id");
+            if (userActionEventIdToAnnotations[id] == null) {
+              userActionEventIdToAnnotations[id] = [annotation];
+            } else {
+              userActionEventIdToAnnotations[id].push(annotation);
+            }
+            break;
+          }
+          case "test:start": {
+            beginPoint = {
               point: annotation.point,
               time: annotation.time,
-            },
-            type: "navigation",
-          };
-
-          navigationEvents.push(navigationEvent);
-          break;
-        }
-        case "step:end":
-        case "step:enqueue":
-        case "step:start": {
-          const id = annotation.message.id;
-          assert(id != null, "Annotation event must have an id");
-          if (userActionEventIdToAnnotations[id] == null) {
-            userActionEventIdToAnnotations[id] = [annotation];
-          } else {
-            userActionEventIdToAnnotations[id].push(annotation);
+            };
+            break;
           }
-          break;
-        }
-        case "test:start": {
-          beginPoint = {
-            point: annotation.point,
-            time: annotation.time,
-          };
-          break;
-        }
-        case "test:end": {
-          endPoint = {
-            point: annotation.point,
-            time: annotation.time,
-          };
-          break;
-        }
-        default: {
-          console.warn(`Unexpected annotation type: ${annotation.message.event}`);
+          case "test:end": {
+            endPoint = {
+              point: annotation.point,
+              time: annotation.time,
+            };
+            break;
+          }
+          default: {
+            console.warn(`Unexpected annotation type: ${annotation.message.event}`);
+          }
         }
       }
-    }
 
-    assert(beginPoint !== null, "Test must have a begin point");
-    assert(endPoint !== null, "Test must have a end point");
+      assert(beginPoint !== null, "Test must have a begin point");
+      assert(endPoint !== null, "Test must have a end point");
 
-    for (let sectionName in partialEvents) {
-      const testEvents = events[sectionName as RecordingTestMetadataV3.TestSectionName];
-
-      const partialTestEvents =
-        partialEvents[sectionName as RecordingTestMetadataV3.TestSectionName];
-      partialTestEvents.forEach(partialTestEvent => {
-        const {
-          category,
-          command,
-          error = null,
-          id,
-          parentId = null,
-          scope = null,
-        } = partialTestEvent.data;
-
-        assert(category, `Test event must have "category" property`);
-        assert(command, `Test event must have "command" property`);
-        assert(id, `Test event must have "id" property`);
-
-        // The client does not show certain types of chained events in the list
-        // they clutter without adding much value
-        if (parentId !== null) {
-          switch (command.name) {
-            case "as":
-            case "then":
-              return null;
-          }
+      for (let sectionName in partialEvents) {
+        // TODO [SCS-1186] Ignore beforeAll/afterAll sections for now;
+        // We'll need to make some changes to both Devtools UI and the Replay plug-in to handle these
+        switch (sectionName) {
+          case "afterAll":
+          case "beforeAll":
+            continue;
         }
 
-        const annotations = userActionEventIdToAnnotations[id];
+        const testEvents = events[sectionName as RecordingTestMetadataV3.TestSectionName];
 
-        assert(annotations != null, `Missing annotations for test event (${command.name})`);
+        const partialTestEvents =
+          partialEvents[sectionName as RecordingTestMetadataV3.TestSectionName];
+        partialTestEvents.forEach(partialTestEvent => {
+          const {
+            category,
+            command,
+            error = null,
+            id,
+            parentId = null,
+            scope = null,
+          } = partialTestEvent.data;
 
-        let beginPoint: TimeStampedPoint | null = null;
-        let endPoint: TimeStampedPoint | null = null;
-        let resultPoint: TimeStampedPoint | null = null;
-        let resultVariable: string | null = null;
-        let viewSourceTimeStampedPoint: TimeStampedPoint | null = null;
+          assert(category, `Test event must have "category" property`);
+          assert(command, `Test event must have "command" property`);
+          assert(id, `Test event must have "id" property`);
 
-        const isChaiAssertion = command.name === "assert";
-        // TODO [FE-1419] name === "assert" && !annotations.enqueue;
-
-        annotations.forEach(annotation => {
-          switch (annotation.message.event) {
-            case "step:end": {
-              endPoint = {
-                point: annotation.point,
-                time: annotation.time,
-              };
-
-              resultPoint = {
-                point: annotation.point,
-                time: annotation.time,
-              };
-              resultVariable = annotation.message.logVariable ?? null;
-              break;
-            }
-            case "step:enqueue": {
-              if (!isChaiAssertion) {
-                viewSourceTimeStampedPoint = {
-                  point: annotation.point,
-                  time: annotation.time,
-                };
-              }
-              break;
-            }
-            case "step:start": {
-              beginPoint = {
-                point: annotation.point,
-                time: annotation.time,
-              };
-
-              if (isChaiAssertion) {
-                viewSourceTimeStampedPoint = {
-                  point: annotation.point,
-                  time: annotation.time,
-                };
-              }
-              break;
+          // The client does not show certain types of chained events in the list
+          // they clutter without adding much value
+          if (parentId !== null) {
+            switch (command.name) {
+              case "as":
+              case "then":
+                return null;
             }
           }
-        });
 
-        assert(beginPoint !== null, `Missing "step:start" annotation for test event ${id}`);
-        assert(endPoint !== null, `Missing "step:end" annotation for test event ${id}`);
-        assert(resultPoint !== null, `Missing "step:end" annotation for test event ${id}`);
-        assert(
-          viewSourceTimeStampedPoint !== null,
-          `Missing ${
-            isChaiAssertion ? "step:start" : "step:enqueue"
-          } annotation for test event ${id}`
-        );
+          const annotations = userActionEventIdToAnnotations[id];
 
-        testEvents.push({
-          data: {
-            category: category,
-            command: {
-              arguments: command.arguments,
-              name: command.name,
-            },
-            error,
-            id,
-            parentId,
-            result: resultVariable
-              ? {
-                  timeStampedPoint: resultPoint,
-                  variable: resultVariable,
+          assert(annotations != null, `Missing annotations for test event (${command.name})`);
+
+          let beginPoint: TimeStampedPoint | null = null;
+          let endPoint: TimeStampedPoint | null = null;
+          let resultPoint: TimeStampedPoint | null = null;
+          let resultVariable: string | null = null;
+          let viewSourceTimeStampedPoint: TimeStampedPoint | null = null;
+
+          const isChaiAssertion = command.name === "assert";
+          // TODO [FE-1419] name === "assert" && !annotations.enqueue;
+
+          annotations.forEach(annotation => {
+            switch (annotation.message.event) {
+              case "step:end": {
+                endPoint = {
+                  point: annotation.point,
+                  time: annotation.time,
+                };
+
+                resultPoint = {
+                  point: annotation.point,
+                  time: annotation.time,
+                };
+                resultVariable = annotation.message.logVariable ?? null;
+                break;
+              }
+              case "step:enqueue": {
+                if (!isChaiAssertion) {
+                  viewSourceTimeStampedPoint = {
+                    point: annotation.point,
+                    time: annotation.time,
+                  };
                 }
-              : null,
-            scope,
-            viewSourceTimeStampedPoint,
-          },
-          timeStampedPointRange: {
-            begin: beginPoint,
-            end: endPoint,
-          },
-          type: "user-action",
+                break;
+              }
+              case "step:start": {
+                beginPoint = {
+                  point: annotation.point,
+                  time: annotation.time,
+                };
+
+                if (isChaiAssertion) {
+                  viewSourceTimeStampedPoint = {
+                    point: annotation.point,
+                    time: annotation.time,
+                  };
+                }
+                break;
+              }
+            }
+          });
+
+          assert(beginPoint !== null, `Missing "step:start" annotation for test event ${id}`);
+          assert(
+            viewSourceTimeStampedPoint !== null,
+            `Missing ${
+              isChaiAssertion ? "step:start" : "step:enqueue"
+            } annotation for test event ${id}`
+          );
+
+          testEvents.push({
+            data: {
+              category: category,
+              command: {
+                arguments: command.arguments,
+                name: command.name,
+              },
+              error,
+              id,
+              parentId,
+              result:
+                resultVariable && resultPoint
+                  ? {
+                      timeStampedPoint: resultPoint,
+                      variable: resultVariable,
+                    }
+                  : null,
+              scope,
+              viewSourceTimeStampedPoint,
+            },
+            timeStampedPointRange: {
+              begin: beginPoint,
+              end: endPoint || beginPoint,
+            },
+            type: "user-action",
+          });
         });
+      }
+
+      // Finds the section that contains a given point
+      // defaults to the main (test body) section if no matches found
+      const findSection = (point: ExecutionPoint) => {
+        const sections = Object.values(events);
+        for (let index = sections.length - 1; index >= 0; index--) {
+          const events = sections[index];
+          const firstEvent = events[0];
+          if (firstEvent && comparePoints(getTestEventExecutionPoint(firstEvent)!, point) <= 0) {
+            return events;
+          }
+        }
+        return events.main;
+      };
+
+      const networkRequestEvents = await processNetworkData(replayClient, beginPoint, endPoint);
+      // Now that section boundaries have been defined by user-actions,
+      // merge in navigation and network events.
+      navigationEvents.forEach(navigationEvent => {
+        const events = findSection(navigationEvent.timeStampedPoint.point);
+        insert(events, navigationEvent, (a, b) =>
+          comparePoints(getTestEventExecutionPoint(a), getTestEventExecutionPoint(b))
+        );
+      });
+      networkRequestEvents.forEach(networkRequestEvent => {
+        const events = findSection(networkRequestEvent.timeStampedPoint.point);
+        insert(events, networkRequestEvent, (a, b) =>
+          comparePoints(getTestEventExecutionPoint(a), getTestEventExecutionPoint(b))
+        );
       });
     }
-
-    // Finds the section that contains a given point
-    // defaults to the main (test body) section if no matches found
-    const findSection = (point: ExecutionPoint) => {
-      const sections = Object.values(events);
-      for (let index = sections.length - 1; index >= 0; index--) {
-        const events = sections[index];
-        const firstEvent = events[0];
-        if (firstEvent && comparePoints(getTestEventExecutionPoint(firstEvent)!, point) <= 0) {
-          return events;
-        }
-      }
-      return events.main;
-    };
-
-    const networkRequestEvents = await processNetworkData(replayClient, beginPoint, endPoint);
-    // Now that section boundaries have been defined by user-actions,
-    // merge in navigation and network events.
-    navigationEvents.forEach(navigationEvent => {
-      const events = findSection(navigationEvent.timeStampedPoint.point);
-      insert(events, navigationEvent, (a, b) =>
-        comparePoints(getTestEventExecutionPoint(a)!, getTestEventExecutionPoint(b)!)
-      );
-    });
-    networkRequestEvents.forEach(networkRequestEvent => {
-      const events = findSection(networkRequestEvent.timeStampedPoint.point);
-      insert(events, networkRequestEvent, (a, b) =>
-        comparePoints(getTestEventExecutionPoint(a)!, getTestEventExecutionPoint(b)!)
-      );
-    });
 
     return {
       error,
       events,
       result,
       source,
-      timeStampedPointRange: {
-        begin: beginPoint,
-        end: endPoint,
-      },
+      timeStampedPointRange:
+        beginPoint && endPoint
+          ? {
+              begin: beginPoint,
+              end: endPoint,
+            }
+          : null,
     };
   } else if (isTestRecordingV3(testRecording)) {
     return testRecording;
@@ -564,17 +577,44 @@ export async function processGroupedTestCases(
       case "cypress": {
         const annotations = await AnnotationsCache.readAsync(replayClient);
 
+        let currentTestAnnotations: Annotation[] | null = null;
+        let currentTestRecording: AnyTestRecording | null = null;
+        let currentTestRecordingIndex = -1;
+        let currentTestHasEnded = true;
+
         // Annotations for the entire recording (which may include more than one test)
         // we need to splice only the appropriate subset for each test.
         const annotationsByTest: Annotation[][] = annotations.reduce(
           (accumulated: Annotation[][], annotation: Annotation) => {
-            if (annotation.message.event === "test:start") {
-              // Start a new annotations array for each test
-              accumulated.push([annotation]);
-            } else if (accumulated.length > 0) {
-              // Else add new annotations to the current test
-              // (Note some recordings have annotations data before the first "test:start")
-              accumulated[accumulated.length - 1].push(annotation);
+            eventSwitch: switch (annotation.message.event) {
+              case "test:start": {
+                // Tests that were skipped won't have annotations.
+                // Add empty annotations arrays for these.
+                if (currentTestHasEnded) {
+                  while (currentTestRecordingIndex < partialTestRecordings.length - 1) {
+                    currentTestRecordingIndex++;
+                    currentTestRecording = partialTestRecordings[currentTestRecordingIndex];
+
+                    currentTestAnnotations = [];
+                    currentTestHasEnded = false;
+
+                    accumulated.push(currentTestAnnotations);
+
+                    if (currentTestRecording.result !== "skipped") {
+                      break eventSwitch;
+                    }
+                  }
+                }
+                break;
+              }
+              case "test:end": {
+                currentTestHasEnded = true;
+                break;
+              }
+            }
+
+            if (currentTestAnnotations) {
+              currentTestAnnotations.push(annotation);
             }
 
             return accumulated;
@@ -647,6 +687,14 @@ export async function processPlaywrightTestRecording(
     };
 
     for (let sectionName in partialEvents) {
+      // TODO [SCS-1186] Ignore beforeAll/afterAll sections for now;
+      // We'll need to make some changes to both Devtools UI and the Replay plug-in to handle these
+      switch (sectionName) {
+        case "afterAll":
+        case "beforeAll":
+          continue;
+      }
+
       const testEvents = events[sectionName as RecordingTestMetadataV3.TestSectionName];
 
       const partialTestEvents =
@@ -689,7 +737,10 @@ export async function processPlaywrightTestRecording(
             scope,
             viewSourceTimeStampedPoint: null,
           },
-          timeStampedPointRange: null,
+          // HACK
+          // This will be filled in below;
+          // There are asserts to ensure it
+          timeStampedPointRange: null as any,
           type: "user-action",
         });
       });
@@ -767,11 +818,11 @@ export function getGroupedTestCasesFilePath(groupedTestCases: AnyGroupedTestCase
 
 export function getTestEventExecutionPoint(
   testEvent: RecordingTestMetadataV3.TestEvent
-): ExecutionPoint | null {
+): ExecutionPoint {
   if (isNavigationTestEvent(testEvent) || isNetworkRequestTestEvent(testEvent)) {
     return testEvent.timeStampedPoint.point;
   } else {
-    return testEvent.timeStampedPointRange ? testEvent.timeStampedPointRange.begin.point : null;
+    return testEvent.timeStampedPointRange.begin.point;
   }
 }
 

--- a/src/ui/components/TestSuite/views/GroupedTestCases/Panel.tsx
+++ b/src/ui/components/TestSuite/views/GroupedTestCases/Panel.tsx
@@ -2,23 +2,26 @@ import assert from "assert";
 import { useContext, useEffect, useMemo } from "react";
 
 import { SessionContext } from "replay-next/src/contexts/SessionContext";
-import { GroupedTestCases, TestEnvironmentError } from "shared/test-suites/RecordingTestMetadata";
+import { ReplayClientContext } from "shared/client/ReplayClientContext";
+import { TestEnvironmentError } from "shared/test-suites/RecordingTestMetadata";
 import { getFormattedTime } from "shared/utils/time";
 import { getTruncatedRelativeDate } from "ui/components/Library/Team/View/Recordings/RecordingListItem/RecordingListItem";
 import LabeledIcon from "ui/components/TestSuite/components/LabeledIcon";
 import { TestResultIcon } from "ui/components/TestSuite/components/TestResultIcon";
 import { RecordingCache } from "ui/components/TestSuite/suspense/RecordingCache";
+import { TestSuiteCache } from "ui/components/TestSuite/suspense/TestSuiteCache";
 import { formatTitle } from "ui/components/TestSuite/utils/formatTitle";
 import { createTestTree } from "ui/components/TestSuite/views/GroupedTestCases/createTestTree";
 import { TestRecordingTree } from "ui/components/TestSuite/views/GroupedTestCases/TestRecordingTree";
-import { TestSuiteContext } from "ui/components/TestSuite/views/TestSuiteContext";
 import { sendTelemetryEvent } from "ui/utils/telemetry";
 
 import styles from "./Panel.module.css";
 
 export default function Panel() {
+  const replayClient = useContext(ReplayClientContext);
   const { recordingId } = useContext(SessionContext);
-  const { groupedTestCases } = useContext(TestSuiteContext);
+
+  const groupedTestCases = TestSuiteCache.read(replayClient, recordingId);
   assert(groupedTestCases != null);
 
   const { approximateDuration, environment, resultCounts, source, testRecordings } =

--- a/src/ui/components/TestSuite/views/GroupedTestCases/TestRecordingTreeRow.module.css
+++ b/src/ui/components/TestSuite/views/GroupedTestCases/TestRecordingTreeRow.module.css
@@ -1,10 +1,16 @@
-.Row {
+.Row,
+.SkippedRow {
   display: flex;
   gap: 1ch;
-  cursor: pointer;
   transition: opacity 0.18s ease-out;
   overflow-x: hidden;
   overflow-wrap: anywhere;
+}
+.Row {
+  cursor: pointer;
+}
+.SkippedRow {
+  color: var(--color-dim);
 }
 
 .Row[data-is-pending] {

--- a/src/ui/components/TestSuite/views/GroupedTestCases/TestRecordingTreeRow.tsx
+++ b/src/ui/components/TestSuite/views/GroupedTestCases/TestRecordingTreeRow.tsx
@@ -22,7 +22,7 @@ export default function TestRecordingTreeRow({
 
   return (
     <li
-      className={styles.Row}
+      className={result === "skipped" ? styles.SkippedRow : styles.Row}
       data-is-pending={isPending || undefined}
       data-test-name="TestRecordingTreeRow"
       onClick={onClick}

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
@@ -9,6 +9,7 @@ import { isExecutionPointsWithinRange } from "replay-next/src/utils/time";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import {
   GroupedTestCases,
+  RecordingTestMetadataV3,
   TestSectionName,
   UserActionEvent,
   isUserActionTestEvent,
@@ -39,10 +40,12 @@ const cypressStepTypesToEventTypes = {
 } as const;
 
 export default memo(function UserActionEventRow({
+  groupedTestCases,
   position,
   testSectionName,
   userActionEvent,
 }: {
+  groupedTestCases: RecordingTestMetadataV3.GroupedTestCases;
   position: Position;
   testSectionName: TestSectionName;
   userActionEvent: UserActionEvent;
@@ -50,9 +53,9 @@ export default memo(function UserActionEventRow({
   const { data, timeStampedPointRange } = userActionEvent;
   const { command, error, parentId, result } = data;
 
-  const client = useContext(ReplayClientContext);
-  const { groupedTestCases, testRecording } = useContext(TestSuiteContext);
-  assert(groupedTestCases != null);
+  const replayClient = useContext(ReplayClientContext);
+
+  const { testRecording } = useContext(TestSuiteContext);
   assert(testRecording != null);
 
   const dispatch = useAppDispatch();
@@ -60,7 +63,7 @@ export default memo(function UserActionEventRow({
   const viewMode = useAppSelector(getViewMode);
   const { status: annotationsStatus, value: parsedAnnotations } = useImperativeCacheValue(
     eventListenersJumpLocationsCache,
-    client
+    replayClient
   );
 
   const [isHovered, setIsHovered] = useState(false);

--- a/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
@@ -1,7 +1,10 @@
+import assert from "assert";
 import { ReactNode, useContext, useMemo, useTransition } from "react";
 
 import { comparePoints } from "protocol/execution-point-utils";
 import Icon from "replay-next/components/Icon";
+import { SessionContext } from "replay-next/src/contexts/SessionContext";
+import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import {
   TestEvent,
   TestSectionName,
@@ -9,6 +12,7 @@ import {
   getTestEventTime,
 } from "shared/test-suites/RecordingTestMetadata";
 import { setTimelineToTime } from "ui/actions/timeline";
+import { TestSuiteCache } from "ui/components/TestSuite/suspense/TestSuiteCache";
 import { useTestEventContextMenu } from "ui/components/TestSuite/views/TestRecording/useTestEventContextMenu";
 import { TestSuiteContext } from "ui/components/TestSuite/views/TestSuiteContext";
 import { useAppDispatch } from "ui/setup/hooks";
@@ -26,6 +30,8 @@ export function TestSectionRow({
   testEvent: TestEvent;
   testSectionName: TestSectionName;
 }) {
+  const replayClient = useContext(ReplayClientContext);
+  const { recordingId } = useContext(SessionContext);
   const {
     setTestEvent,
     testEvent: selectedTestEvent,
@@ -55,6 +61,9 @@ export function TestSectionRow({
     return position;
   }, [selectedTestEvent, testEvent, testRecording, testSectionName]);
 
+  const groupedTestCases = TestSuiteCache.read(replayClient, recordingId);
+  assert(groupedTestCases !== null);
+
   let child: ReactNode;
   let status;
   switch (testEvent.type) {
@@ -67,6 +76,7 @@ export function TestSectionRow({
     case "user-action":
       child = (
         <UserActionEventRow
+          groupedTestCases={groupedTestCases}
           position={position}
           testSectionName={testSectionName}
           userActionEvent={testEvent}

--- a/src/ui/components/TestSuite/views/TestRecording/useTestEventContextMenu.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/useTestEventContextMenu.tsx
@@ -2,6 +2,8 @@ import { useContext } from "react";
 import { ContextMenuItem, useContextMenu } from "use-context-menu";
 
 import { assert } from "protocol/utils";
+import { SessionContext } from "replay-next/src/contexts/SessionContext";
+import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import {
   TestEvent,
   UserActionEvent,
@@ -13,6 +15,7 @@ import { startPlayback } from "ui/actions/timeline";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
 import { useJumpToSource } from "ui/components/TestSuite/hooks/useJumpToSource";
 import { useShowUserActionEventBoundary } from "ui/components/TestSuite/hooks/useShowUserActionEventBoundary";
+import { TestSuiteCache } from "ui/components/TestSuite/suspense/TestSuiteCache";
 import { TestSuiteContext } from "ui/components/TestSuite/views/TestSuiteContext";
 import { useAppDispatch } from "ui/setup/hooks";
 
@@ -31,9 +34,13 @@ export function useTestEventContextMenu(testEvent: TestEvent) {
 }
 
 function JumpToSourceMenuItem({ userActionEvent }: { userActionEvent: UserActionEvent }) {
-  const { groupedTestCases, setTestEvent, testRecording } = useContext(TestSuiteContext);
-  assert(groupedTestCases != null);
+  const replayClient = useContext(ReplayClientContext);
+  const { recordingId } = useContext(SessionContext);
+  const { setTestEvent, testRecording } = useContext(TestSuiteContext);
   assert(testRecording != null);
+
+  const groupedTestCases = TestSuiteCache.read(replayClient, recordingId);
+  assert(groupedTestCases != null);
 
   const { disabled, onClick } = useJumpToSource({
     groupedTestCases,

--- a/src/ui/components/TestSuite/views/TestSuiteContext.tsx
+++ b/src/ui/components/TestSuite/views/TestSuiteContext.tsx
@@ -3,24 +3,15 @@ import {
   createContext,
   useCallback,
   useContext,
-  useEffect,
   useMemo,
   useState,
 } from "react";
 
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
-import { SessionContext } from "replay-next/src/contexts/SessionContext";
 import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
-import { ReplayClientContext } from "shared/client/ReplayClientContext";
-import {
-  GroupedTestCases,
-  TestEvent,
-  TestRecording,
-} from "shared/test-suites/RecordingTestMetadata";
-import { TestSuiteCache } from "ui/components/TestSuite/suspense/TestSuiteCache";
+import { TestEvent, TestRecording } from "shared/test-suites/RecordingTestMetadata";
 
 type TestSuiteContextType = {
-  groupedTestCases: GroupedTestCases | null;
   setTestRecording: (value: TestRecording | null) => Promise<void>;
   setTestEvent: (value: TestEvent | null) => void;
   testEvent: TestEvent | null;
@@ -31,24 +22,10 @@ export const TestSuiteContext = createContext<TestSuiteContextType>(null as any)
 
 export function TestSuiteContextRoot({ children }: PropsWithChildren) {
   const { updateForTimelineImprecise: zoom } = useContext(FocusContext);
-  const replayClient = useContext(ReplayClientContext);
-  const { recordingId } = useContext(SessionContext);
   const { update: seekToTime } = useContext(TimelineContext);
 
-  const [groupedTestCases, setGroupedTestCases] = useState<GroupedTestCases | null>(null);
   const [testEvent, setTestEvent] = useState<TestEvent | null>(null);
   const [testRecording, setTestRecording] = useState<TestRecording | null>(null);
-
-  useEffect(() => {
-    async function fetchGroupedTestCases() {
-      const groupedTestCases = await TestSuiteCache.readAsync(replayClient, recordingId);
-      if (groupedTestCases != null) {
-        setGroupedTestCases(groupedTestCases);
-      }
-    }
-
-    fetchGroupedTestCases();
-  }, [recordingId, replayClient]);
 
   const setTestRecordingWrapper = useCallback(
     async (testRecording: TestRecording | null) => {
@@ -73,13 +50,12 @@ export function TestSuiteContextRoot({ children }: PropsWithChildren) {
 
   const value = useMemo(
     () => ({
-      groupedTestCases,
       setTestEvent,
       setTestRecording: setTestRecordingWrapper,
       testEvent,
       testRecording,
     }),
-    [groupedTestCases, setTestRecordingWrapper, testEvent, testRecording]
+    [setTestRecordingWrapper, testEvent, testRecording]
   );
 
   return <TestSuiteContext.Provider value={value}>{children}</TestSuiteContext.Provider>;

--- a/src/ui/components/TestSuite/views/TestSuitePanel.tsx
+++ b/src/ui/components/TestSuite/views/TestSuitePanel.tsx
@@ -1,5 +1,6 @@
-import { useContext } from "react";
+import { Suspense, useContext } from "react";
 
+import ErrorBoundary from "replay-next/components/ErrorBoundary";
 import Loader from "replay-next/components/Loader";
 import { TestSuiteContext } from "ui/components/TestSuite/views/TestSuiteContext";
 
@@ -7,15 +8,25 @@ import GroupTestCasesPanel from "./GroupedTestCases";
 import TestRecordingPanel from "./TestRecording";
 import styles from "./TestSuitePanel.module.css";
 
+// TODO Show better/custom error fallback to failed test suites
 export default function TestSuitePanel() {
-  const { groupedTestCases, testRecording } = useContext(TestSuiteContext);
-  if (groupedTestCases == null) {
-    return (
-      <div className={styles.Loading} data-test-name="TestSuitePanel">
-        <Loader />
-      </div>
-    );
-  }
+  return (
+    <ErrorBoundary>
+      <Suspense
+        fallback={
+          <div className={styles.Loading} data-test-name="TestSuitePanel">
+            <Loader />
+          </div>
+        }
+      >
+        <TestSuiteSuspends />
+      </Suspense>
+    </ErrorBoundary>
+  );
+}
+
+function TestSuiteSuspends() {
+  const { testRecording } = useContext(TestSuiteContext);
 
   return (
     <div className={styles.Panel} data-test-name="TestSuitePanel">


### PR DESCRIPTION
- [x] Revert commit bb818ff (#9355)
- [x] Wrap Test Suite data loading with an error boundary so that only the Test Suites panel goes down in the event of an error; (this was happening too high up in the tree previously)
  - [ ] ~~Show non-error-looking fallback with a message to contact support?~~
- [x] Temporarily hide all beforeAll/afterAll user actions/annotations
- [x] Support skipped tests (don't throw on missing annotations, show as gray and non-interactive)
- [x] Handle missing step:end annotations
- [ ] ~~Log unexpected cases that we try to still support to Honeycomb~~

# Screenshots

Skipped tests look like this now:
<img width="273" alt="Screen Shot 2023-06-20 at 2 15 06 PM" src="https://github.com/replayio/devtools/assets/29597/7d209634-e588-4811-8974-50194ab64c2b">

Bad data that we can't recover from looks like this (for now):
<img width="1276" alt="Screen Shot 2023-06-20 at 2 17 23 PM" src="https://github.com/replayio/devtools/assets/29597/a26afe2d-8058-4e25-87a8-00380b4265b1">

# Test cases

Missing annotations:
* 443c51d0-95bf-4aab-983f-2a5809c163f9
* (most WanDB-flakes or Metabase (no asserts) tests?)

Skipped test:
* 7b188dd2-496e-46aa-8212-af4a2a02929f

Missing step:end annotations:
* ba4396b9-f58d-4d19-a0ac-fbcd076815da

Bad metadata (retries):
* 103c7ac5-66af-4ef8-92cf-448fe08a69c5
* 16fde575-777e-4734-9735-97047ba40550
* a597b3a0-4768-46ae-9ed7-17fe5f6dcdbe