### PR TITLE
Custom Test Suite parsing error fallback UI

### DIFF
--- a/packages/shared/test-suites/RecordingTestMetadata.ts
+++ b/packages/shared/test-suites/RecordingTestMetadata.ts
@@ -828,6 +828,14 @@ export function getGroupedTestCasesFilePath(groupedTestCases: AnyGroupedTestCase
   }
 }
 
+export function getGroupedTestCasesTitle(groupedTestCases: AnyGroupedTestCases): string | null {
+  if (isGroupedTestCasesV1(groupedTestCases)) {
+    return groupedTestCases.title;
+  } else {
+    return groupedTestCases.source.title;
+  }
+}
+
 export function getTestEventExecutionPoint(
   testEvent: RecordingTestMetadataV3.TestEvent
 ): ExecutionPoint {

--- a/src/ui/components/TestSuite/views/TestSuiteErrorFallback.module.css
+++ b/src/ui/components/TestSuite/views/TestSuiteErrorFallback.module.css
@@ -1,0 +1,53 @@
+.Fallback {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  font-size: var(--font-size-regular);
+}
+
+.Header {
+  width: 100%;
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 1ch;
+  padding: 0.75rem;
+}
+
+.Title {
+  flex: 1 1 auto;
+  color: var(--body-color);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-break: break-all;
+  white-space: nowrap;
+  font-size: var(--font-size-large);
+}
+
+.ErrorIcon {
+  width: 1.25rem;
+  height: 1.25rem;
+  flex: 0 0 1.25rem;
+}
+
+.ErrorMessage {
+  display: flex;
+  flex-direction: row;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  background-color: var(--testsuites-error-bgcolor-hover);
+  color: var(--testsuites-error-color);
+  border-left: 2px solid var(--testsuites-error-border-color);
+}
+
+.ContactUsMessage {
+  padding: 0.75rem;
+}
+
+.Link {
+  color: var(--link-color);
+  text-decoration: none;
+}
+.Link:hover {
+  text-decoration: underline;
+}

--- a/src/ui/components/TestSuite/views/TestSuiteErrorFallback.tsx
+++ b/src/ui/components/TestSuite/views/TestSuiteErrorFallback.tsx
@@ -1,0 +1,40 @@
+import { useContext } from "react";
+
+import Icon from "replay-next/components/Icon";
+import { SessionContext } from "replay-next/src/contexts/SessionContext";
+import { getGroupedTestCasesTitle } from "shared/test-suites/RecordingTestMetadata";
+import { RecordingCache } from "ui/components/TestSuite/suspense/RecordingCache";
+import { formatTitle } from "ui/components/TestSuite/utils/formatTitle";
+
+import styles from "./TestSuiteErrorFallback.module.css";
+
+export default function TestSuiteErrorFallback() {
+  const { recordingId } = useContext(SessionContext);
+
+  const recording = RecordingCache.read(recordingId);
+  const rawTestMetadata = recording.metadata?.test;
+
+  const title = rawTestMetadata ? getGroupedTestCasesTitle(rawTestMetadata) : null;
+  const processedTitle = title ? formatTitle(title) : "Test";
+
+  return (
+    <div className={styles.Fallback}>
+      <div className={styles.Header}>
+        <div className={styles.Title} title={title || undefined}>
+          {processedTitle}
+        </div>
+      </div>
+      <div className={styles.ErrorMessage}>
+        <Icon className={styles.ErrorIcon} type="warning" />
+        Something went wrong processing test metadata.
+      </div>
+      <div className={styles.ContactUsMessage}>
+        Please{" "}
+        <a className={styles.Link} href="http://replay.io/discord" target="discord">
+          contact us
+        </a>{" "}
+        on Discord.
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/TestSuite/views/TestSuitePanel.tsx
+++ b/src/ui/components/TestSuite/views/TestSuitePanel.tsx
@@ -3,6 +3,7 @@ import { Suspense, useContext } from "react";
 import ErrorBoundary from "replay-next/components/ErrorBoundary";
 import Loader from "replay-next/components/Loader";
 import { TestSuiteContext } from "ui/components/TestSuite/views/TestSuiteContext";
+import TestSuiteErrorFallback from "ui/components/TestSuite/views/TestSuiteErrorFallback";
 
 import GroupTestCasesPanel from "./GroupedTestCases";
 import TestRecordingPanel from "./TestRecording";
@@ -11,7 +12,7 @@ import styles from "./TestSuitePanel.module.css";
 // TODO Show better/custom error fallback to failed test suites
 export default function TestSuitePanel() {
   return (
-    <ErrorBoundary>
+    <ErrorBoundary fallback={<TestSuiteErrorFallback />}>
       <Suspense
         fallback={
           <div className={styles.Loading} data-test-name="TestSuitePanel">


### PR DESCRIPTION
This provides a starting point to show a custom error state. @jonbell-lot23 can iterate on the UI once this lands.

## Before
<img width="1200" alt="Screen Shot 2023-06-20 at 5 15 37 PM" src="https://github.com/replayio/devtools/assets/29597/ec14d766-f077-4130-99c7-62b56370cd0b">

## After
<img width="1197" alt="Screen Shot 2023-06-20 at 5 15 53 PM" src="https://github.com/replayio/devtools/assets/29597/e6b6e53e-e05f-4698-b486-bed624e3d7de">
