### PR TITLE
Update more components to use focus window instead of loaded regions

### DIFF
--- a/packages/replay-next/components/console/ConsoleInput.tsx
+++ b/packages/replay-next/components/console/ConsoleInput.tsx
@@ -16,11 +16,10 @@ import { SelectedFrameContext } from "replay-next/src/contexts/SelectedFrameCont
 import { SessionContext } from "replay-next/src/contexts/SessionContext";
 import { NewTerminalExpression, TerminalContext } from "replay-next/src/contexts/TerminalContext";
 import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
-import { useCurrentFocusWindow } from "replay-next/src/hooks/useCurrentFocusWindow";
+import { useIsPointWithinFocusWindow } from "replay-next/src/hooks/useIsPointWithinFocusWindow";
 import useLoadedRegions from "replay-next/src/hooks/useRegions";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { ReplayClientInterface } from "shared/client/types";
-import { isPointInRegion } from "shared/utils/time";
 
 import { ConsoleSearchContext } from "./ConsoleSearchContext";
 import EagerEvaluationResult from "./EagerEvaluationResult";
@@ -28,14 +27,14 @@ import useTerminalHistory from "./hooks/useTerminalHistory";
 import styles from "./ConsoleInput.module.css";
 
 export default function ConsoleInput({ inputRef }: { inputRef?: RefObject<ImperativeHandle> }) {
-  const focusWindow = useCurrentFocusWindow();
-
   const { executionPoint } = useContext(TimelineContext);
   const { enterFocusMode } = useContext(FocusContext);
 
+  const isPointWithinFocusWindow = useIsPointWithinFocusWindow(executionPoint);
+
   let disabledMessage = null;
   let disabledReason = undefined;
-  if (!focusWindow || !isPointInRegion(executionPoint, focusWindow)) {
+  if (!isPointWithinFocusWindow) {
     disabledReason = "not-focused";
     disabledMessage = (
       <>

--- a/packages/replay-next/src/hooks/useIsPointWithinFocusWindow.ts
+++ b/packages/replay-next/src/hooks/useIsPointWithinFocusWindow.ts
@@ -1,0 +1,12 @@
+import { ExecutionPoint } from "@replayio/protocol";
+
+import { useCurrentFocusWindow } from "replay-next/src/hooks/useCurrentFocusWindow";
+import { isPointInRegion } from "shared/utils/time";
+
+export function useIsPointWithinFocusWindow(executionPoint: ExecutionPoint | null): boolean {
+  const focusWindow = useCurrentFocusWindow();
+
+  return (
+    executionPoint !== null && focusWindow !== null && isPointInRegion(executionPoint, focusWindow)
+  );
+}

--- a/src/devtools/client/inspector/components/App.tsx
+++ b/src/devtools/client/inspector/components/App.tsx
@@ -7,9 +7,9 @@ import LayoutApp from "devtools/client/inspector/layout/components/LayoutApp";
 import MarkupApp from "devtools/client/inspector/markup/components/MarkupApp";
 import { RulesApp } from "devtools/client/inspector/rules/components/RulesApp";
 import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
-import { isPointInRegions } from "shared/utils/time";
+import { useCurrentFocusWindow } from "replay-next/src/hooks/useCurrentFocusWindow";
+import { isPointInRegion } from "shared/utils/time";
 import { enterFocusMode } from "ui/actions/timeline";
-import { getLoadedRegions } from "ui/reducers/app";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 
 import { ResponsiveTabs, Tab } from "../../shared/components/ResponsiveTabs";
@@ -35,9 +35,10 @@ export default function InspectorApp() {
   const dispatch = useAppDispatch();
   const activeTab = useAppSelector(state => state.inspector.activeTab);
   const { executionPoint } = useContext(TimelineContext);
-  const loadedRegions = useAppSelector(getLoadedRegions);
 
-  if (!isPointInRegions(executionPoint, loadedRegions?.loaded ?? [])) {
+  const focusWindow = useCurrentFocusWindow();
+
+  if (focusWindow && !isPointInRegion(executionPoint, focusWindow)) {
     return (
       <div className="inspector-responsive-container bg-bodyBgcolor p-2">
         Elements are unavailable because you're paused at a point outside{" "}

--- a/src/devtools/client/inspector/components/App.tsx
+++ b/src/devtools/client/inspector/components/App.tsx
@@ -7,8 +7,7 @@ import LayoutApp from "devtools/client/inspector/layout/components/LayoutApp";
 import MarkupApp from "devtools/client/inspector/markup/components/MarkupApp";
 import { RulesApp } from "devtools/client/inspector/rules/components/RulesApp";
 import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
-import { useCurrentFocusWindow } from "replay-next/src/hooks/useCurrentFocusWindow";
-import { isPointInRegion } from "shared/utils/time";
+import { useIsPointWithinFocusWindow } from "replay-next/src/hooks/useIsPointWithinFocusWindow";
 import { enterFocusMode } from "ui/actions/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 
@@ -36,9 +35,8 @@ export default function InspectorApp() {
   const activeTab = useAppSelector(state => state.inspector.activeTab);
   const { executionPoint } = useContext(TimelineContext);
 
-  const focusWindow = useCurrentFocusWindow();
-
-  if (focusWindow && !isPointInRegion(executionPoint, focusWindow)) {
+  const isPointWithinFocusWindow = useIsPointWithinFocusWindow(executionPoint);
+  if (!isPointWithinFocusWindow) {
     return (
       <div className="inspector-responsive-container bg-bodyBgcolor p-2">
         Elements are unavailable because you're paused at a point outside{" "}

--- a/src/ui/actions/network.ts
+++ b/src/ui/actions/network.ts
@@ -9,6 +9,7 @@ import {
   networkResponseBodyCache,
 } from "replay-next/src/suspense/NetworkRequestsCache";
 import { pauseIdCache } from "replay-next/src/suspense/PauseCache";
+import { isPointInRegion } from "shared/utils/time";
 import { RequestSummary } from "ui/components/NetworkMonitor/utils";
 import { getLoadedRegions } from "ui/reducers/app";
 import { isPointInRegions } from "ui/utils/timeline";
@@ -49,14 +50,10 @@ export function selectNetworkRequest(requestId: RequestId): UIThunkAction {
 
     const record = records[requestId];
 
-    const loadedRegions = getLoadedRegions(state);
+    const focusWindow = replayClient.getCurrentFocusWindow();
 
-    // Don't select a request that's not within a loaded region.
-    if (
-      !record ||
-      !loadedRegions ||
-      !isPointInRegions(loadedRegions.loaded, record.timeStampedPoint.point)
-    ) {
+    // Don't select a request that's not within the focus window
+    if (!record || (focusWindow && !isPointInRegion(record.timeStampedPoint.point, focusWindow))) {
       return;
     }
 

--- a/src/ui/actions/network.ts
+++ b/src/ui/actions/network.ts
@@ -53,7 +53,7 @@ export function selectNetworkRequest(requestId: RequestId): UIThunkAction {
     const focusWindow = replayClient.getCurrentFocusWindow();
 
     // Don't select a request that's not within the focus window
-    if (!record || (focusWindow && !isPointInRegion(record.timeStampedPoint.point, focusWindow))) {
+    if (!record || !focusWindow || !isPointInRegion(record.timeStampedPoint.point, focusWindow)) {
       return;
     }
 

--- a/src/ui/components/NetworkMonitor/RequestDetails.tsx
+++ b/src/ui/components/NetworkMonitor/RequestDetails.tsx
@@ -4,10 +4,10 @@ import React, { ReactNode, useEffect, useMemo, useState } from "react";
 
 import CloseButton from "devtools/client/debugger/src/components/shared/Button/CloseButton";
 import PanelTabs from "devtools/client/shared/components/PanelTabs";
+import { useCurrentFocusWindow } from "replay-next/src/hooks/useCurrentFocusWindow";
+import { isPointInRegion } from "shared/utils/time";
 import { hideRequestDetails, selectNetworkRequest } from "ui/actions/network";
-import { getLoadedRegions } from "ui/reducers/app";
-import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
-import { isPointInRegions } from "ui/utils/timeline";
+import { useAppDispatch } from "ui/setup/hooks";
 
 import AddNetworkRequestCommentButton from "./AddNetworkRequestCommentButton";
 import RequestBody from "./RequestBody";
@@ -279,7 +279,8 @@ const RequestDetails = ({
 }) => {
   const dispatch = useAppDispatch();
   const [activeTab, setActiveTab] = useState<NetworkTab>(DEFAULT_TAB);
-  const loadedRegions = useAppSelector(getLoadedRegions)?.loaded;
+
+  const focusWindow = useCurrentFocusWindow();
 
   // Keyboard shortcuts handler.
   useEffect(() => {
@@ -330,7 +331,7 @@ const RequestDetails = ({
     }
   }, [activeTab, activeTabs]);
 
-  if (!(loadedRegions && request && isPointInRegions(loadedRegions, request.point.point))) {
+  if (focusWindow && request && !isPointInRegion(request.point.point, focusWindow)) {
     return <RequestDetailsUnavailable />;
   }
 

--- a/src/ui/components/NetworkMonitor/RequestDetails.tsx
+++ b/src/ui/components/NetworkMonitor/RequestDetails.tsx
@@ -4,8 +4,7 @@ import React, { ReactNode, useEffect, useMemo, useState } from "react";
 
 import CloseButton from "devtools/client/debugger/src/components/shared/Button/CloseButton";
 import PanelTabs from "devtools/client/shared/components/PanelTabs";
-import { useCurrentFocusWindow } from "replay-next/src/hooks/useCurrentFocusWindow";
-import { isPointInRegion } from "shared/utils/time";
+import { useIsPointWithinFocusWindow } from "replay-next/src/hooks/useIsPointWithinFocusWindow";
 import { hideRequestDetails, selectNetworkRequest } from "ui/actions/network";
 import { useAppDispatch } from "ui/setup/hooks";
 
@@ -280,7 +279,7 @@ const RequestDetails = ({
   const dispatch = useAppDispatch();
   const [activeTab, setActiveTab] = useState<NetworkTab>(DEFAULT_TAB);
 
-  const focusWindow = useCurrentFocusWindow();
+  const isRequestWithinFocusWindow = useIsPointWithinFocusWindow(request.point.point);
 
   // Keyboard shortcuts handler.
   useEffect(() => {
@@ -331,7 +330,7 @@ const RequestDetails = ({
     }
   }, [activeTab, activeTabs]);
 
-  if (focusWindow && request && !isPointInRegion(request.point.point, focusWindow)) {
+  if (!request || !isRequestWithinFocusWindow) {
     return <RequestDetailsUnavailable />;
   }
 

--- a/src/ui/components/NetworkMonitor/RequestRow.tsx
+++ b/src/ui/components/NetworkMonitor/RequestRow.tsx
@@ -2,6 +2,7 @@ import classNames from "classnames";
 import React, { useLayoutEffect, useRef } from "react";
 import { Row } from "react-table";
 
+import { useIsPointWithinFocusWindow } from "replay-next/src/hooks/useIsPointWithinFocusWindow";
 import useNetworkContextMenu from "ui/components/NetworkMonitor/useNetworkContextMenu";
 
 import { RequestSummary } from "./utils";
@@ -10,7 +11,6 @@ import styles from "./RequestTable.module.css";
 export const RequestRow = ({
   currentTime,
   isFirstInFuture,
-  isInLoadedRegion,
   isInPast,
   isSelected,
   onClick,
@@ -19,7 +19,6 @@ export const RequestRow = ({
 }: {
   currentTime: number;
   isFirstInFuture: boolean;
-  isInLoadedRegion: boolean;
   isInPast: boolean;
   isSelected: boolean;
   onClick: (row: RequestSummary) => void;
@@ -28,6 +27,8 @@ export const RequestRow = ({
 }) => {
   const prevIsSelectedRef = useRef<boolean>(false);
   const ref = useRef<HTMLDivElement>(null);
+
+  const isInLoadedRegion = useIsPointWithinFocusWindow(row.original.point.point);
 
   // Make sure newly selected Network requests have been scrolled into view.
   useLayoutEffect(() => {

--- a/src/ui/components/NetworkMonitor/RequestTable.tsx
+++ b/src/ui/components/NetworkMonitor/RequestTable.tsx
@@ -69,7 +69,7 @@ const RequestTable = ({
             }
 
             const isInLoadedRegion =
-              !focusWindow || isPointInRegion(row.original.point.point, focusWindow);
+              focusWindow !== null && isPointInRegion(row.original.point.point, focusWindow);
 
             prepareRow(row);
 

--- a/src/ui/components/NetworkMonitor/RequestTable.tsx
+++ b/src/ui/components/NetworkMonitor/RequestTable.tsx
@@ -1,12 +1,11 @@
 import classNames from "classnames";
 import { Row, TableInstance } from "react-table";
 
+import { useCurrentFocusWindow } from "replay-next/src/hooks/useCurrentFocusWindow";
 import { useNag } from "replay-next/src/hooks/useNag";
 import { Nag } from "shared/graphql/types";
-import { getLoadedRegions } from "ui/reducers/app";
-import { useAppSelector } from "ui/setup/hooks";
+import { isPointInRegion } from "shared/utils/time";
 import { trackEvent } from "ui/utils/telemetry";
-import { isTimeInRegions } from "ui/utils/timeline";
 
 import { HeaderGroups } from "./HeaderGroups";
 import { RequestRow } from "./RequestRow";
@@ -36,7 +35,7 @@ const RequestTable = ({
 }) => {
   const { columns, getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } = table;
 
-  const loadedRegions = useAppSelector(getLoadedRegions);
+  const focusWindow = useCurrentFocusWindow();
 
   const onSeek = (request: RequestSummary) => {
     trackEvent("net_monitor.seek_to_request");
@@ -69,9 +68,8 @@ const RequestTable = ({
               firstInFuture = true;
             }
 
-            const isInLoadedRegion = loadedRegions
-              ? isTimeInRegions(row.original.point.time, loadedRegions.loaded)
-              : false;
+            const isInLoadedRegion =
+              !focusWindow || isPointInRegion(row.original.point.point, focusWindow);
 
             prepareRow(row);
 

--- a/src/ui/components/NetworkMonitor/RequestTable.tsx
+++ b/src/ui/components/NetworkMonitor/RequestTable.tsx
@@ -1,10 +1,8 @@
 import classNames from "classnames";
 import { Row, TableInstance } from "react-table";
 
-import { useCurrentFocusWindow } from "replay-next/src/hooks/useCurrentFocusWindow";
 import { useNag } from "replay-next/src/hooks/useNag";
 import { Nag } from "shared/graphql/types";
-import { isPointInRegion } from "shared/utils/time";
 import { trackEvent } from "ui/utils/telemetry";
 
 import { HeaderGroups } from "./HeaderGroups";
@@ -34,8 +32,6 @@ const RequestTable = ({
   table: TableInstance<RequestSummary>;
 }) => {
   const { columns, getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } = table;
-
-  const focusWindow = useCurrentFocusWindow();
 
   const onSeek = (request: RequestSummary) => {
     trackEvent("net_monitor.seek_to_request");
@@ -68,16 +64,12 @@ const RequestTable = ({
               firstInFuture = true;
             }
 
-            const isInLoadedRegion =
-              focusWindow !== null && isPointInRegion(row.original.point.point, focusWindow);
-
             prepareRow(row);
 
             return (
               <RequestRow
                 currentTime={currentTime}
                 isFirstInFuture={firstInFuture}
-                isInLoadedRegion={isInLoadedRegion}
                 isInPast={inPast}
                 isSelected={selectedRequest?.id === row.original.id}
                 key={row.getRowProps().key}

--- a/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
+++ b/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
@@ -8,14 +8,13 @@ import { getThreadContext } from "devtools/client/debugger/src/reducers/pause";
 import { highlightNode, unhighlightNode } from "devtools/client/inspector/markup/actions/markup";
 import { ThreadFront } from "protocol/thread";
 import { compareNumericStrings } from "protocol/utils";
-import { useCurrentFocusWindow } from "replay-next/src/hooks/useCurrentFocusWindow";
+import { useIsPointWithinFocusWindow } from "replay-next/src/hooks/useIsPointWithinFocusWindow";
 import { useNag } from "replay-next/src/hooks/useNag";
 import { RecordingTarget, recordingTargetCache } from "replay-next/src/suspense/BuildIdCache";
 import { objectCache } from "replay-next/src/suspense/ObjectPreviews";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { ReplayClientInterface } from "shared/client/types";
 import { Nag } from "shared/graphql/types";
-import { isPointInRegion } from "shared/utils/time";
 import { UIThunkAction } from "ui/actions";
 import { fetchMouseTargetsForPause } from "ui/actions/app";
 import { enterFocusMode } from "ui/actions/timeline";
@@ -438,7 +437,7 @@ const nodePickerInstance = new NodePickerClass();
 export default function ReactDevtoolsPanel() {
   const client = useContext(ReplayClientContext);
   const currentPoint = useAppSelector(getCurrentPoint);
-  const focusWindow = useCurrentFocusWindow();
+  const isPointWithinFocusWindow = useIsPointWithinFocusWindow(currentPoint);
   const pauseId = useAppSelector(state => state.pause.id);
   const [, dismissInspectComponentNag] = useNag(Nag.INSPECT_COMPONENT);
   const [protocolCheckFailed, setProtocolCheckFailed] = useState(false);
@@ -528,7 +527,7 @@ export default function ReactDevtoolsPanel() {
     return null;
   }
 
-  if (focusWindow && !isPointInRegion(currentPoint, focusWindow)) {
+  if (!isPointWithinFocusWindow) {
     return (
       <div className="h-full bg-bodyBgcolor p-2">
         React components are unavailable because you're paused at a point outside{" "}

--- a/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
+++ b/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
@@ -1,6 +1,5 @@
 import { ExecutionPoint, NodeBounds, ObjectId, Object as ProtocolObject } from "@replayio/protocol";
-import React, { useContext, useMemo } from "react";
-import { useEffect, useState } from "react";
+import React, { useContext, useEffect, useMemo, useState } from "react";
 import type { SerializedElement, Store, Wall } from "react-devtools-inline/frontend";
 import { useImperativeCacheValue } from "suspense";
 
@@ -9,15 +8,16 @@ import { getThreadContext } from "devtools/client/debugger/src/reducers/pause";
 import { highlightNode, unhighlightNode } from "devtools/client/inspector/markup/actions/markup";
 import { ThreadFront } from "protocol/thread";
 import { compareNumericStrings } from "protocol/utils";
+import { useCurrentFocusWindow } from "replay-next/src/hooks/useCurrentFocusWindow";
 import { useNag } from "replay-next/src/hooks/useNag";
 import { RecordingTarget, recordingTargetCache } from "replay-next/src/suspense/BuildIdCache";
 import { objectCache } from "replay-next/src/suspense/ObjectPreviews";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { ReplayClientInterface } from "shared/client/types";
 import { Nag } from "shared/graphql/types";
-import { isPointInRegions } from "shared/utils/time";
+import { isPointInRegion } from "shared/utils/time";
 import { UIThunkAction } from "ui/actions";
-import { fetchMouseTargetsForPause, getLoadedRegions } from "ui/actions/app";
+import { fetchMouseTargetsForPause } from "ui/actions/app";
 import { enterFocusMode } from "ui/actions/timeline";
 import {
   getCurrentPoint,
@@ -28,12 +28,14 @@ import {
 } from "ui/reducers/app";
 import { getPreferredLocation } from "ui/reducers/sources";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
-import { ParsedReactDevToolsAnnotation } from "ui/suspense/annotationsCaches";
-import { reactDevToolsAnnotationsCache } from "ui/suspense/annotationsCaches";
+import {
+  ParsedReactDevToolsAnnotation,
+  reactDevToolsAnnotationsCache,
+} from "ui/suspense/annotationsCaches";
 import { getMouseTarget } from "ui/suspense/nodeCaches";
 import { NodePicker as NodePickerClass, NodePickerOpts } from "ui/utils/nodePicker";
 import { getJSON } from "ui/utils/objectFetching";
-import { sendTelemetryEvent, trackEvent } from "ui/utils/telemetry";
+import { trackEvent } from "ui/utils/telemetry";
 
 import { injectReactDevtoolsBackend } from "./react-devtools/injectReactDevtoolsBackend";
 
@@ -436,7 +438,7 @@ const nodePickerInstance = new NodePickerClass();
 export default function ReactDevtoolsPanel() {
   const client = useContext(ReplayClientContext);
   const currentPoint = useAppSelector(getCurrentPoint);
-  const loadedRegions = useAppSelector(getLoadedRegions);
+  const focusWindow = useCurrentFocusWindow();
   const pauseId = useAppSelector(state => state.pause.id);
   const [, dismissInspectComponentNag] = useNag(Nag.INSPECT_COMPONENT);
   const [protocolCheckFailed, setProtocolCheckFailed] = useState(false);
@@ -526,7 +528,7 @@ export default function ReactDevtoolsPanel() {
     return null;
   }
 
-  if (!isPointInRegions(currentPoint, loadedRegions?.loaded ?? [])) {
+  if (focusWindow && !isPointInRegion(currentPoint, focusWindow)) {
     return (
       <div className="h-full bg-bodyBgcolor p-2">
         React components are unavailable because you're paused at a point outside{" "}


### PR DESCRIPTION
Open question: Which of these is the better pattern to check with?
```js
// Pattern 1: Only passes if there is a focus region and an execution point and the point falls within the range
const condition = !focusWindow || !isPointInRegion(executionPoint, focusWindow);

// Pattern 2: Passes if there is no focus region or if the point falls within the focus range
const condition = focusWindow && !isPointInRegion(executionPoint, focusWindow);
```

I could see arguments for either. Maybe it's not that important, as `focusWindow` will only _briefly_ be `null` before the Replay Client is initialized/configured (during which it syncs the remote region). For now, I've decided to go with the _stricter_ option (1).

## Elements panel

### Before

https://github.com/replayio/devtools/assets/29597/21f652c8-8af9-45df-8480-049bff90ec7e

### After

https://github.com/replayio/devtools/assets/29597/a7e284b6-e14a-4304-906a-4b6ec9401109

## Network panel

### Before

https://github.com/replayio/devtools/assets/29597/992f7915-c22e-410f-aee0-7165a4ccdbb6

### After

https://github.com/replayio/devtools/assets/29597/829bc42e-eb97-4820-89fe-14c0c1b62742

## React DevTools

### Before

https://github.com/replayio/devtools/assets/29597/49600422-0e60-43f1-bc4f-1a125b310a94

### After

https://github.com/replayio/devtools/assets/29597/483ce0a0-6bae-489c-aa06-d279be493bfb

