### PR TITLE
Make e2e and screenshot tests more resilient to timeouts

### DIFF
--- a/packages/e2e-tests/helpers/index.ts
+++ b/packages/e2e-tests/helpers/index.ts
@@ -66,6 +66,14 @@ export async function startTest(page: Page, example: string, apiKey?: string) {
 
   await page.goto(url);
 
+  // When Replay is under heavy load, the backend may need to scale up AWS resources.
+  // This should not cause e2e tests to fail, even though it takes longer than the default 15s timeout.
+  // Relaxing only the initial check allows more time for the backend to scale up
+  // without compromising the integrity of the tests overall.
+  await page.locator('[data-panel-id="Panel-SidePanel"]').waitFor({
+    timeout: 60_000,
+  });
+
   // Wait for the recording basic information to load such that the primary tabs are visible.
   if (example.startsWith("node")) {
     await page.locator('[data-panel-id="Panel-SecondaryToolbox"]').waitFor();
@@ -74,5 +82,4 @@ export async function startTest(page: Page, example: string, apiKey?: string) {
     await page.locator('[data-test-id="ViewToggle-Viewer"]').waitFor();
     await page.locator('[data-test-id="ViewToggle-DevTools"]').waitFor();
   }
-  await page.locator('[data-panel-id="Panel-SidePanel"]').waitFor();
 }

--- a/packages/replay-next/components/Initializer.tsx
+++ b/packages/replay-next/components/Initializer.tsx
@@ -78,6 +78,8 @@ export default function Initializer({
           trackEvent: () => {},
           trackEventOnce: () => {},
         });
+
+        document.body.setAttribute("data-initialized", "true");
       };
 
       asyncInitialize();

--- a/packages/replay-next/playwright/playwright.config.ts
+++ b/packages/replay-next/playwright/playwright.config.ts
@@ -18,6 +18,8 @@ const config: FullConfig = {
   retries: RECORD_VIDEO || VISUAL_DEBUG ? 0 : 2,
   snapshotDir: "./snapshots",
   use: {
+    // Don't allow any one action to take more than 15s
+    actionTimeout: 15_000,
     browserName: "chromium",
     launchOptions: {
       slowMo,
@@ -31,7 +33,9 @@ const config: FullConfig = {
   testDir: __dirname,
   testMatch: ["tests/**/*.ts"],
   testIgnore: ["tests/**/beforeEach.ts", "tests/**/shared.ts", "tests/utils/*"],
-  timeout: 30_000,
+
+  // Give individual tests a while to complete instead of default 30s
+  timeout: 120_000,
 };
 
 if (CI) {

--- a/packages/replay-next/playwright/tests/console/beforeEach.ts
+++ b/packages/replay-next/playwright/tests/console/beforeEach.ts
@@ -5,7 +5,7 @@ import testSetup from "../utils/testSetup";
 export function beforeEach(recordingId: string = "4ccc9f9f-f0d3-4418-ac21-1b316e462a44") {
   testSetup(recordingId);
 
-  test.beforeEach(async ({ page }, testInfo) => {
+  test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(5000);
   });
 }

--- a/packages/replay-next/playwright/tests/console/shared.ts
+++ b/packages/replay-next/playwright/tests/console/shared.ts
@@ -1,10 +1,12 @@
 import { Page } from "@playwright/test";
 
 import { toggleProtocolMessage, toggleProtocolMessages } from "../utils/console";
-import { getTestUrl } from "../utils/general";
+import { getTestUrl, waitForSession } from "../utils/general";
 
 export async function setup(page: Page, toggleState: boolean | null = null) {
   await page.goto(getTestUrl("console"));
+
+  await waitForSession(page);
 
   if (typeof toggleState === "boolean") {
     await toggleProtocolMessages(page, toggleState);

--- a/packages/replay-next/playwright/tests/nested/beforeEach.ts
+++ b/packages/replay-next/playwright/tests/nested/beforeEach.ts
@@ -1,16 +1,19 @@
 import { test } from "@playwright/test";
 
 import { toggleProtocolMessages } from "../utils/console";
-import { getTestUrl } from "../utils/general";
+import { getTestUrl, waitForSession } from "../utils/general";
 import testSetup from "../utils/testSetup";
 
 export function beforeEach() {
   testSetup("4f76b342-c7a8-467f-ad08-9fa885f10477");
 
-  test.beforeEach(async ({ page }, testInfo) => {
+  test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(5000);
 
     await page.goto(getTestUrl("console"));
+
+    await waitForSession(page);
+
     await toggleProtocolMessages(page, true);
   });
 }

--- a/packages/replay-next/playwright/tests/object-inspector-context-menu/beforeEach.ts
+++ b/packages/replay-next/playwright/tests/object-inspector-context-menu/beforeEach.ts
@@ -1,7 +1,7 @@
 import { test } from "@playwright/test";
 
 import { toggleProtocolMessage, toggleProtocolMessages } from "../utils/console";
-import { getTestUrl } from "../utils/general";
+import { getTestUrl, waitForSession } from "../utils/general";
 import testSetup from "../utils/testSetup";
 
 export function beforeEach() {
@@ -13,6 +13,8 @@ export function beforeEach() {
     context.grantPermissions(["clipboard-read"]);
 
     await page.goto(getTestUrl("console"));
+
+    await waitForSession(page);
 
     await toggleProtocolMessages(page, false);
     await toggleProtocolMessage(page, "logs", true);

--- a/packages/replay-next/playwright/tests/object-inspector/beforeEach.ts
+++ b/packages/replay-next/playwright/tests/object-inspector/beforeEach.ts
@@ -1,16 +1,18 @@
 import { test } from "@playwright/test";
 
 import { toggleProtocolMessage, toggleProtocolMessages } from "../utils/console";
-import { getTestUrl } from "../utils/general";
+import { getTestUrl, waitForSession } from "../utils/general";
 import testSetup from "../utils/testSetup";
 
 export function beforeEach() {
   testSetup("bc6df6be-8305-4e1e-9eda-c1da63ef023d");
 
-  test.beforeEach(async ({ page }, testInfo) => {
+  test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(5000);
 
     await page.goto(getTestUrl("console"));
+
+    await waitForSession(page);
 
     await toggleProtocolMessages(page, false);
     await toggleProtocolMessage(page, "logs", true);

--- a/packages/replay-next/playwright/tests/scopes-inspector/beforeEach.ts
+++ b/packages/replay-next/playwright/tests/scopes-inspector/beforeEach.ts
@@ -1,14 +1,16 @@
 import { test } from "@playwright/test";
 
-import { getTestUrl } from "../utils/general";
+import { getTestUrl, waitForSession } from "../utils/general";
 import testSetup from "../utils/testSetup";
 
 export function beforeEach() {
   testSetup("b1849642-40a3-445c-96f8-4bcd2c35586e");
 
-  test.beforeEach(async ({ page }, testInfo) => {
+  test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(5000);
 
     await page.goto(getTestUrl("scopes-inspector"));
+
+    await waitForSession(page);
   });
 }

--- a/packages/replay-next/playwright/tests/source-and-console/beforeEach.ts
+++ b/packages/replay-next/playwright/tests/source-and-console/beforeEach.ts
@@ -1,6 +1,6 @@
 import { test } from "@playwright/test";
 
-import { getTestUrl } from "../utils/general";
+import { getTestUrl, waitForSession } from "../utils/general";
 import { goToLine, openSourceFile, waitForSourceContentsToStream } from "../utils/source";
 import testSetup from "../utils/testSetup";
 import { sourceId } from "./shared";
@@ -8,10 +8,13 @@ import { sourceId } from "./shared";
 export function beforeEach(recordingId = "c9fffa00-ac71-48bc-adb2-52ae81588e85") {
   testSetup(recordingId);
 
-  test.beforeEach(async ({ page }, testInfo) => {
+  test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(5000);
 
     await page.goto(getTestUrl("source-and-console"));
+
+    await waitForSession(page);
+
     await openSourceFile(page, sourceId);
 
     // Wait for source contents to finish streaming (loading and parsing)

--- a/packages/replay-next/playwright/tests/source-preview/beforeEach.ts
+++ b/packages/replay-next/playwright/tests/source-preview/beforeEach.ts
@@ -1,14 +1,16 @@
 import { test } from "@playwright/test";
 
-import { getTestUrl } from "../utils/general";
+import { getTestUrl, waitForSession } from "../utils/general";
 import testSetup from "../utils/testSetup";
 
 export function beforeEach() {
   testSetup("b1849642-40a3-445c-96f8-4bcd2c35586e");
 
-  test.beforeEach(async ({ page }, testInfo) => {
+  test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(5000);
 
     await page.goto(getTestUrl("source-preview"));
+
+    await waitForSession(page);
   });
 }

--- a/packages/replay-next/playwright/tests/source-search/beforeEach.ts
+++ b/packages/replay-next/playwright/tests/source-search/beforeEach.ts
@@ -1,14 +1,16 @@
 import { test } from "@playwright/test";
 
-import { getTestUrl } from "../utils/general";
+import { getTestUrl, waitForSession } from "../utils/general";
 import testSetup from "../utils/testSetup";
 
 export function beforeEach() {
   testSetup("c9fffa00-ac71-48bc-adb2-52ae81588e85");
 
-  test.beforeEach(async ({ page }, testInfo) => {
+  test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(5000);
 
     await page.goto(getTestUrl("source-search"));
+
+    await waitForSession(page);
   });
 }

--- a/packages/replay-next/playwright/tests/utils/general.ts
+++ b/packages/replay-next/playwright/tests/utils/general.ts
@@ -271,7 +271,7 @@ export async function waitForSession(page: Page): Promise<void> {
   await waitFor(
     async () => {
       const value = await page.locator("body").getAttribute("data-initialized");
-      expect(value).toBe("true", "Replay session not initialized");
+      expect(value).toBe("true");
     },
     {
       retryInterval: 1_000,

--- a/packages/replay-next/playwright/tests/utils/general.ts
+++ b/packages/replay-next/playwright/tests/utils/general.ts
@@ -261,3 +261,21 @@ export async function waitFor(
     }
   }
 }
+
+export async function waitForSession(page: Page): Promise<void> {
+  // When Replay is under heavy load, the backend may need to scale up AWS resources.
+  // This should not cause e2e tests to fail, even though it takes longer than the default 15s timeout.
+  // Relaxing only the initial check allows more time for the backend to scale up
+  // without compromising the integrity of the tests overall.
+
+  await waitFor(
+    async () => {
+      const value = await page.locator("body").getAttribute("data-initialized");
+      expect(value).toBe("true", "Replay session not initialized");
+    },
+    {
+      retryInterval: 1_000,
+      timeout: 60_000,
+    }
+  );
+}


### PR DESCRIPTION
When Replay is under heavy load, the backend may need to scale up AWS resources. This should not cause e2e tests to fail, even though it takes longer than the default 15s timeout. Relaxing only the initial check allows more time for the backend to scale up without compromising the integrity of the tests overall.

---

I tested this by adding a hard-coded 30 second delay to session initialization and confirming that tests failed. Then I updated both e2e and screenshot tests to add a longer delay await at the beginning (in shared setup code) to give the session long enough to finish initializing and confirmed that all tests ran and passed (though slowly). I think this should be sufficient to guard against transient timeouts while AWS usage is scaling up.