### PR TITLE
Remove recording+workspace is-test check

### DIFF
--- a/pages/recording/[[...id]].tsx
+++ b/pages/recording/[[...id]].tsx
@@ -1,6 +1,6 @@
 import Head from "next/head";
 import { useRouter } from "next/router";
-import { GetServerSideProps, GetStaticProps } from "next/types";
+import { GetServerSideProps } from "next/types";
 import React, { useContext, useEffect, useState } from "react";
 import { ConnectedProps, connect } from "react-redux";
 
@@ -161,23 +161,7 @@ function RecordingPage({
       setRecording(rec);
 
       const isTestReplay = rec.metadata?.test && rec.metadata?.source;
-      const isTestWorkspace = rec.workspace?.isTest;
-
-      if (rec.private) {
-        if (isTestReplay && !isTestWorkspace) {
-          setExpectedError({
-            content: "This recording is not available.",
-            message: "The recording must belong to a test suite",
-          });
-        } else if (!isTestReplay && isTestWorkspace) {
-          setExpectedError({
-            content: "This recording is not available.",
-            message: "The recording cannot be in a test suite",
-          });
-        }
-      }
-
-      if (rec.metadata?.test) {
+      if (isTestReplay) {
         trackEvent("session_start.test");
       }
 


### PR DESCRIPTION
Replay should prevent users from abusing test workspaces for non-test recordings. For this reason, @jasonLaster and @jaril recently added a check to the frontend that verifies test recordings can only be viewed in test workspaces and vice versa (#9320, #9326)

Unfortunately that change prevented test recordings from being shared with users that aren't in the test workspace (e.g. Jason was unable to view a recording shared with him from another team).

Longer term, the backend should be responsible for this type of access control. For now, to unblock collaborators, this PR removes that check entirely.