### PR TITLE
Use focus window instead of loaded regions

### DIFF
--- a/packages/replay-next/components/console/ConsoleInput.tsx
+++ b/packages/replay-next/components/console/ConsoleInput.tsx
@@ -1,9 +1,4 @@
-import {
-  ExecutionPoint,
-  FrameId,
-  loadedRegions as LoadedRegions,
-  PauseId,
-} from "@replayio/protocol";
+import { ExecutionPoint, FrameId, PauseId, TimeStampedPointRange } from "@replayio/protocol";
 import { RefObject, Suspense, useContext, useEffect, useRef, useState } from "react";
 
 import ErrorBoundary from "replay-next/components/ErrorBoundary";
@@ -16,8 +11,8 @@ import { SelectedFrameContext } from "replay-next/src/contexts/SelectedFrameCont
 import { SessionContext } from "replay-next/src/contexts/SessionContext";
 import { NewTerminalExpression, TerminalContext } from "replay-next/src/contexts/TerminalContext";
 import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
+import { useCurrentFocusWindow } from "replay-next/src/hooks/useCurrentFocusWindow";
 import { useIsPointWithinFocusWindow } from "replay-next/src/hooks/useIsPointWithinFocusWindow";
-import useLoadedRegions from "replay-next/src/hooks/useRegions";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { ReplayClientInterface } from "shared/client/types";
 
@@ -77,7 +72,7 @@ function ConsoleInputSuspends({ inputRef }: { inputRef?: RefObject<ImperativeHan
   const { addMessage } = useContext(TerminalContext);
   const { executionPoint, time } = useContext(TimelineContext);
 
-  const loadedRegions = useLoadedRegions(replayClient);
+  const focusWindow = useCurrentFocusWindow();
 
   const [historyIndex, setHistoryIndex] = useState<number | null>(null);
   const [expressionHistory, addExpression] = useTerminalHistory(recordingId);
@@ -164,7 +159,7 @@ function ConsoleInputSuspends({ inputRef }: { inputRef?: RefObject<ImperativeHan
       selectedPauseAndFrameId?.frameId ?? null,
       executionPoint,
       time,
-      loadedRegions
+      focusWindow
     );
 
     setHistoryIndex(null);
@@ -223,14 +218,14 @@ async function addMessageAsync(
   frameId: FrameId | null,
   executionPoint: ExecutionPoint,
   time: number,
-  loadedRegions: LoadedRegions | null
+  focusWindow: TimeStampedPointRange | null
 ): Promise<void> {
   if (!pauseId) {
     const pauseAndFrameId = await getPauseAndFrameIdAsync(
       replayClient,
       executionPoint,
       time,
-      loadedRegions,
+      focusWindow,
       false
     );
     if (pauseAndFrameId) {

--- a/packages/replay-next/components/lexical/plugins/code-completion/CodeCompletionPlugin.tsx
+++ b/packages/replay-next/components/lexical/plugins/code-completion/CodeCompletionPlugin.tsx
@@ -1,10 +1,10 @@
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { mergeRegister } from "@lexical/utils";
-import { ExecutionPoint, FrameId, PauseId } from "@replayio/protocol";
+import { ExecutionPoint } from "@replayio/protocol";
 import { $createTextNode, TextNode } from "lexical";
 import { useContext, useEffect } from "react";
 
-import useRegions from "replay-next/src/hooks/useRegions";
+import { useCurrentFocusWindow } from "replay-next/src/hooks/useCurrentFocusWindow";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
 import TypeAheadPlugin from "../typeahead/TypeAheadPlugin";
@@ -31,18 +31,10 @@ export default function CodeCompletionPlugin({
 
   const replayClient = useContext(ReplayClientContext);
 
-  const loadedRegions = useRegions(replayClient);
+  const focusWindow = useCurrentFocusWindow();
 
   const findMatchesWrapper = (query: string, queryScope: string | null) => {
-    return findMatches(
-      query,
-      queryScope,
-      replayClient,
-      executionPoint,
-      time,
-      loadedRegions,
-      context
-    );
+    return findMatches(query, queryScope, replayClient, executionPoint, time, focusWindow, context);
   };
 
   useEffect(() => {

--- a/packages/replay-next/components/lexical/plugins/code-completion/findMatches.ts
+++ b/packages/replay-next/components/lexical/plugins/code-completion/findMatches.ts
@@ -5,7 +5,6 @@ import {
   Property,
   Scope,
   TimeStampedPointRange,
-  loadedRegions,
 } from "@replayio/protocol";
 
 import { getPauseAndFrameIdSuspends } from "replay-next/components/sources/utils/getPauseAndFrameId";

--- a/packages/replay-next/components/lexical/plugins/code-completion/findMatches.ts
+++ b/packages/replay-next/components/lexical/plugins/code-completion/findMatches.ts
@@ -4,6 +4,7 @@ import {
   PauseId,
   Property,
   Scope,
+  TimeStampedPointRange,
   loadedRegions,
 } from "@replayio/protocol";
 
@@ -38,7 +39,7 @@ export default function findMatches(
   replayClient: ReplayClientInterface,
   executionPoint: ExecutionPoint,
   time: number,
-  loadedRegions: loadedRegions | null,
+  focusWindow: TimeStampedPointRange | null,
   context: Context
 ): Match[] {
   // Remove leading "."
@@ -53,7 +54,7 @@ export default function findMatches(
     queryScope,
     executionPoint,
     time,
-    loadedRegions,
+    focusWindow,
     context
   );
 
@@ -65,7 +66,7 @@ function fetchQueryData(
   queryScope: string | null,
   executionPoint: ExecutionPoint,
   time: number,
-  loadedRegions: loadedRegions | null,
+  focusWindow: TimeStampedPointRange | null,
   context: Context
 ): {
   properties: WeightedProperty[] | null;
@@ -77,7 +78,7 @@ function fetchQueryData(
     replayClient,
     executionPoint,
     time,
-    loadedRegions,
+    focusWindow,
     false
   );
   const frameId: FrameId | null = pauseAndFrameId?.frameId ?? null;

--- a/packages/replay-next/components/sources/PreviewPopup.tsx
+++ b/packages/replay-next/components/sources/PreviewPopup.tsx
@@ -2,14 +2,14 @@ import { Value as ProtocolValue, SourceId } from "@replayio/protocol";
 import { RefObject, Suspense, useContext, useEffect, useRef } from "react";
 
 import { SelectedFrameContext } from "replay-next/src/contexts/SelectedFrameContext";
-import useLoadedRegions from "replay-next/src/hooks/useRegions";
+import { useCurrentFocusWindow } from "replay-next/src/hooks/useCurrentFocusWindow";
 import { getFrameSuspense } from "replay-next/src/suspense/FrameCache";
 import {
   getPointAndTimeForPauseId,
   pauseEvaluationsCache,
 } from "replay-next/src/suspense/PauseCache";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
-import { isPointInRegions } from "shared/utils/time";
+import { isPointInRegion } from "shared/utils/time";
 
 import SourcePreviewInspector from "../inspector/SourcePreviewInspector";
 import Popup from "../Popup";
@@ -41,7 +41,7 @@ function SuspendingPreviewPopup({
   target,
 }: Props) {
   const client = useContext(ReplayClientContext);
-  const loadedRegions = useLoadedRegions(client);
+  const focusWindow = useCurrentFocusWindow();
 
   const popupRef = useRef<HTMLDivElement>(null);
 
@@ -52,7 +52,7 @@ function SuspendingPreviewPopup({
   let value: ProtocolValue | null = null;
   if (frameId !== null && pauseId !== null) {
     const [point] = getPointAndTimeForPauseId(pauseId);
-    if (point !== null && isPointInRegions(point, loadedRegions?.loaded ?? [])) {
+    if (focusWindow !== null && point !== null && isPointInRegion(point, focusWindow)) {
       const frame = getFrameSuspense(client, pauseId, frameId);
       if (frame?.location.some(location => location.sourceId === sourceId)) {
         const result = pauseEvaluationsCache.read(client, pauseId, frameId, expression, undefined);

--- a/packages/replay-next/components/sources/utils/getPauseAndFrameId.ts
+++ b/packages/replay-next/components/sources/utils/getPauseAndFrameId.ts
@@ -1,28 +1,23 @@
-import {
-  ExecutionPoint,
-  FrameId,
-  loadedRegions as LoadedRegions,
-  PauseId,
-} from "@replayio/protocol";
+import { ExecutionPoint, FrameId, PauseId, TimeStampedPointRange } from "@replayio/protocol";
 import { isPromiseLike } from "suspense";
 
 import { topFrameCache } from "replay-next/src/suspense/FrameCache";
 import { pauseIdCache } from "replay-next/src/suspense/PauseCache";
 import { createFetchAsyncFromFetchSuspense } from "replay-next/src/utils/suspense";
 import { ReplayClientInterface } from "shared/client/types";
-import { isPointInRegions } from "shared/utils/time";
+import { isPointInRegion } from "shared/utils/time";
 
 export function getPauseAndFrameIdSuspends(
   replayClient: ReplayClientInterface,
   executionPoint: ExecutionPoint,
   time: number,
-  loadedRegions: LoadedRegions | null,
+  focusWindow: TimeStampedPointRange | null,
   throwOnFail: boolean
 ): {
   frameId: FrameId | null;
   pauseId: PauseId | null;
 } {
-  const isLoaded = loadedRegions !== null && isPointInRegions(executionPoint, loadedRegions.loaded);
+  const isLoaded = focusWindow !== null && isPointInRegion(executionPoint, focusWindow);
   if (!isLoaded) {
     return { frameId: null, pauseId: null };
   }

--- a/packages/replay-next/src/contexts/SelectedFrameContext.tsx
+++ b/packages/replay-next/src/contexts/SelectedFrameContext.tsx
@@ -13,11 +13,10 @@ import {
   useState,
 } from "react";
 
+import { useIsPointWithinFocusWindow } from "replay-next/src/hooks/useIsPointWithinFocusWindow";
 import { topFrameCache } from "replay-next/src/suspense/FrameCache";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
-import { isPointInRegions } from "shared/utils/time";
 
-import useLoadedRegions from "../hooks/useRegions";
 import { pauseIdCache } from "../suspense/PauseCache";
 import { TimelineContext } from "./TimelineContext";
 
@@ -73,14 +72,13 @@ export function SelectedFrameContextRoot({
 
 function DefaultSelectedFrameContextAdapter() {
   const client = useContext(ReplayClientContext);
-  const loadedRegions = useLoadedRegions(client);
   const { executionPoint, time } = useContext(TimelineContext);
   const { setSelectedPauseAndFrameId } = useContext(SelectedFrameContext);
 
-  const isLoaded = loadedRegions !== null && isPointInRegions(executionPoint, loadedRegions.loaded);
+  const isWithinFocusWindow = useIsPointWithinFocusWindow(executionPoint);
 
   useLayoutEffect(() => {
-    if (!isLoaded) {
+    if (!isWithinFocusWindow) {
       return;
     }
 
@@ -115,7 +113,7 @@ function DefaultSelectedFrameContextAdapter() {
     return () => {
       cancelled = true;
     };
-  }, [client, executionPoint, time, isLoaded, setSelectedPauseAndFrameId]);
+  }, [client, executionPoint, isWithinFocusWindow, setSelectedPauseAndFrameId, time]);
 
   return null;
 }

--- a/packages/replay-next/src/hooks/useCurrentPauseIdSuspense.ts
+++ b/packages/replay-next/src/hooks/useCurrentPauseIdSuspense.ts
@@ -1,24 +1,21 @@
 import { PauseId } from "@replayio/protocol";
 import { useContext } from "react";
 
+import { useIsPointWithinFocusWindow } from "replay-next/src/hooks/useIsPointWithinFocusWindow";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
-import { isPointInRegions } from "shared/utils/time";
 
 import { TimelineContext } from "../contexts/TimelineContext";
 import { pauseIdCache } from "../suspense/PauseCache";
-import useLoadedRegions from "./useRegions";
 
 export default function useCurrentPauseIdSuspense(): PauseId | null {
   const client = useContext(ReplayClientContext);
-  const loadedRegions = useLoadedRegions(client);
-
   const { executionPoint, time } = useContext(TimelineContext);
 
-  // If we are not currently paused at an explicit point, find the nearest point and pause there.
-  const isLoaded = loadedRegions !== null && isPointInRegions(executionPoint, loadedRegions.loaded);
-  if (isLoaded) {
-    return pauseIdCache.read(client, executionPoint, time);
+  const isInFocusWindow = useIsPointWithinFocusWindow(executionPoint);
+  if (!isInFocusWindow) {
+    return null;
   }
 
-  return null;
+  // If we are not currently paused at an explicit point, find the nearest point and pause there.
+  return pauseIdCache.read(client, executionPoint, time);
 }

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/NewFrames.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/NewFrames.tsx
@@ -12,16 +12,17 @@ import {
 import { ThreadFront } from "protocol/thread/thread";
 import ErrorBoundary from "replay-next/components/ErrorBoundary";
 import { copyToClipboard } from "replay-next/components/sources/utils/clipboard";
+import { useCurrentFocusWindow } from "replay-next/src/hooks/useCurrentFocusWindow";
+import { useIsPointWithinFocusWindow } from "replay-next/src/hooks/useIsPointWithinFocusWindow";
 import { getPointAndTimeForPauseId, pauseIdCache } from "replay-next/src/suspense/PauseCache";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
+import { isPointInRegion } from "shared/utils/time";
 import { enterFocusMode } from "ui/actions/timeline";
-import { getLoadedRegions } from "ui/reducers/app";
 import { getSourcesLoading } from "ui/reducers/sources";
 import { getFocusWindow } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { getPauseFramesSuspense } from "ui/suspense/frameCache";
 import { getAsyncParentPauseIdSuspense } from "ui/suspense/util";
-import { isPointInRegions } from "ui/utils/timeline";
 
 import { selectFrame as selectFrameAction } from "../../../actions/pause/selectFrame";
 import { toggleFrameworkGrouping as setFrameworkGroupingAction } from "../../../reducers/ui";
@@ -120,7 +121,7 @@ function PauseFrames({
 }) {
   const sourcesState = useAppSelector(state => state.sources);
   const currentPauseId = useAppSelector(getPauseId);
-  const loadedRegions = useAppSelector(getLoadedRegions);
+  const focusWindow = useCurrentFocusWindow();
   const cx = useAppSelector(getThreadContext);
   const frameworkGroupingOn = useAppSelector(getFrameworkGroupingState);
   const selectedFrameId = useAppSelector(getSelectedFrameId);
@@ -129,12 +130,7 @@ function PauseFrames({
   function selectFrame(cx: Context, frame: PauseFrame) {
     if (pauseId !== currentPauseId) {
       const [point, time] = getPointAndTimeForPauseId(pauseId);
-      if (
-        point === null ||
-        time === null ||
-        !loadedRegions ||
-        !isPointInRegions(loadedRegions.loaded, point)
-      ) {
+      if (point === null || time === null || !focusWindow || !isPointInRegion(point, focusWindow)) {
         return;
       }
       ThreadFront.timeWarpToPause({ point, time, pauseId }, true);
@@ -192,14 +188,15 @@ interface FramesProps {
 function Frames({ panel, point, time }: FramesProps) {
   const replayClient = useContext(ReplayClientContext);
   const sourcesLoading = useAppSelector(getSourcesLoading);
-  const loadedRegions = useAppSelector(getLoadedRegions);
   const dispatch = useAppDispatch();
 
-  if (sourcesLoading || !loadedRegions) {
+  const isInFocusRegion = useIsPointWithinFocusWindow(point);
+
+  if (sourcesLoading) {
     return null;
   }
 
-  if (!isPointInRegions(loadedRegions.loaded, point)) {
+  if (!isInFocusRegion) {
     return (
       <div className="pane frames">
         <div className="pane-info empty">

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/NewFrames.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/NewFrames.tsx
@@ -17,6 +17,7 @@ import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { enterFocusMode } from "ui/actions/timeline";
 import { getLoadedRegions } from "ui/reducers/app";
 import { getSourcesLoading } from "ui/reducers/sources";
+import { getFocusWindow } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { getPauseFramesSuspense } from "ui/suspense/frameCache";
 import { getAsyncParentPauseIdSuspense } from "ui/suspense/util";
@@ -41,10 +42,10 @@ function FramesRenderer({
 }) {
   const replayClient = useContext(ReplayClientContext);
   const sourcesState = useAppSelector(state => state.sources);
-  const loadedRegions = useAppSelector(getLoadedRegions);
+  const focusWindow = useAppSelector(getFocusWindow);
   const dispatch = useAppDispatch();
 
-  if (!loadedRegions?.loaded) {
+  if (focusWindow === null) {
     return null;
   }
 
@@ -61,7 +62,7 @@ function FramesRenderer({
     replayClient,
     pauseId,
     asyncIndex,
-    loadedRegions?.loaded
+    focusWindow
   );
   if (asyncParentPauseId === null) {
     return (

--- a/src/devtools/client/debugger/src/reducers/pause.ts
+++ b/src/devtools/client/debugger/src/reducers/pause.ts
@@ -20,6 +20,7 @@ import { sourceOutlineCache } from "replay-next/src/suspense/SourceOutlineCache"
 import { ReplayClientInterface } from "shared/client/types";
 import { getPreferredLocation, getSelectedSourceId } from "ui/reducers/sources";
 import { SourceDetails } from "ui/reducers/sources";
+import { getFocusWindow } from "ui/reducers/timeline";
 import { getContextFromAction } from "ui/setup/redux/middleware/context";
 import type { UIState } from "ui/state";
 import { features } from "ui/utils/prefs";
@@ -125,7 +126,7 @@ export const executeCommandOperation = createAsyncThunk<
   const { extra, getState } = thunkApi;
   const { replayClient } = extra;
   const state = getState();
-  const loadedRegions = getLoadedRegions(state)!;
+  const focusWindow = getFocusWindow(state);
   const sourceId = getSelectedSourceId(state);
   const symbols = sourceId ? await sourceOutlineCache.readAsync(replayClient, sourceId) : undefined;
   const nextPoint = await getResumePoint(replayClient, state, command);
@@ -133,7 +134,7 @@ export const executeCommandOperation = createAsyncThunk<
   const resp = await resumeOperations[command](replayClient, {
     point: nextPoint,
     sourceId,
-    loadedRegions,
+    focusWindow,
     locationsToSkip:
       // skip over points that are mapped to the beginning of a function body
       // see SCS-172

--- a/src/devtools/client/debugger/src/reducers/pause.ts
+++ b/src/devtools/client/debugger/src/reducers/pause.ts
@@ -123,7 +123,7 @@ export const executeCommandOperation = createAsyncThunk<
   { state: UIState; extra: ThunkExtraArgs }
 >("pause/executeCommand", async ({ cx, command }, thunkApi) => {
   const { extra, getState } = thunkApi;
-  const { ThreadFront, replayClient } = extra;
+  const { replayClient } = extra;
   const state = getState();
   const loadedRegions = getLoadedRegions(state)!;
   const sourceId = getSelectedSourceId(state);

--- a/src/ui/actions/eventListeners/jumpToCode.ts
+++ b/src/ui/actions/eventListeners/jumpToCode.ts
@@ -30,9 +30,9 @@ import {
 } from "ui/actions/eventListeners/eventListenerUtils";
 import { setViewMode } from "ui/actions/layout";
 import { JumpToCodeStatus } from "ui/components/shared/JumpToCodeButton";
-import { getLoadedRegions } from "ui/reducers/app";
 import { getViewMode } from "ui/reducers/layout";
 import { SourcesState, getPreferredLocation, getSourceDetailsEntities } from "ui/reducers/sources";
+import { getFocusWindow } from "ui/reducers/timeline";
 import { UIState } from "ui/state";
 import { ParsedJumpToCodeAnnotation } from "ui/suspense/annotationsCaches";
 
@@ -195,15 +195,16 @@ export function jumpToClickEventFunctionLocation(
       }
       const actualEnd = end!;
 
-      const loadedRegions = getLoadedRegions(getState());
+      const focusWindow = getFocusWindow(getState());
 
       // Safety check: don't ask for points if this time isn't loaded
-      const isEndTimeInLoadedRegion = loadedRegions?.loaded.some(
-        region => region.begin.time <= actualEnd.time && region.end.time >= actualEnd.time
-      );
+      const isEndTimeInLoadedRegion =
+        focusWindow != null &&
+        focusWindow.begin.time <= actualEnd.time &&
+        focusWindow.end.time >= actualEnd.time;
 
       if (!isEndTimeInLoadedRegion) {
-        return "not_loaded";
+        return "not_focused";
       }
 
       // Go ahead and ensure that we're on DevTools mode right away,

--- a/src/ui/actions/network.ts
+++ b/src/ui/actions/network.ts
@@ -11,8 +11,7 @@ import {
 import { pauseIdCache } from "replay-next/src/suspense/PauseCache";
 import { isPointInRegion } from "shared/utils/time";
 import { RequestSummary } from "ui/components/NetworkMonitor/utils";
-import { getLoadedRegions } from "ui/reducers/app";
-import { isPointInRegions } from "ui/utils/timeline";
+import { getFocusWindow } from "ui/reducers/timeline";
 
 import { UIThunkAction } from ".";
 
@@ -87,11 +86,11 @@ export function seekToRequestFrame(
 ): UIThunkAction {
   return async (dispatch, getState, { ThreadFront }) => {
     const state = getState();
-    const loadedRegions = getLoadedRegions(state);
+    const focusWindow = getFocusWindow(state);
     const point = request.point;
 
-    // Don't select a request that's not within a loaded region.
-    if (!request || !loadedRegions || !isPointInRegions(loadedRegions.loaded, point.point)) {
+    // Don't select a request that's not within a focus window
+    if (!request || !focusWindow || !isPointInRegion(point.point, focusWindow)) {
       return;
     }
 

--- a/src/ui/components/shared/JumpToCodeButton.tsx
+++ b/src/ui/components/shared/JumpToCodeButton.tsx
@@ -5,11 +5,11 @@ import React, { useState } from "react";
 import Icon from "replay-next/components/Icon";
 import { isExecutionPointsGreaterThan } from "replay-next/src/utils/time";
 
-export type JumpToCodeFailureReason = "not_loaded" | "no_hits";
+export type JumpToCodeFailureReason = "not_focused" | "no_hits";
 export type JumpToCodeStatus = JumpToCodeFailureReason | "not_checked" | "loading" | "found";
 
 export const errorMessages: Record<JumpToCodeFailureReason, string> = {
-  not_loaded: "Not loaded",
+  not_focused: "Not focused",
   no_hits: "No results",
 };
 

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -24,7 +24,7 @@ import {
 import { getNonLoadingRegionTimeRanges } from "ui/utils/app";
 import { getSystemColorSchemePreference } from "ui/utils/environment";
 import { prefs } from "ui/utils/prefs";
-import { isPointInRegions, isTimeInRegions, overlap } from "ui/utils/timeline";
+import { isTimeInRegions, overlap } from "ui/utils/timeline";
 
 export const initialAppState: AppState = {
   awaitingSourcemaps: false,
@@ -259,19 +259,6 @@ export const getNonLoadingTimeRanges = (state: UIState) => {
 
   return getNonLoadingRegionTimeRanges(loadingRegions, endTime);
 };
-export const getIsInLoadedRegion = createSelector(
-  getLoadedRegions,
-  (state: UIState) => state.pause.executionPoint,
-  (regions, currentPausePoint) => {
-    const loadedRegions = regions?.loaded;
-
-    if (!currentPausePoint || !loadedRegions || loadedRegions.length === 0) {
-      return false;
-    }
-
-    return isPointInRegions(loadedRegions, currentPausePoint);
-  }
-);
 export const getUploading = (state: UIState) => state.app.uploading;
 export const getAwaitingSourcemaps = (state: UIState) => state.app.awaitingSourcemaps;
 export const getSessionId = (state: UIState) => state.app.sessionId;

--- a/src/ui/suspense/util.ts
+++ b/src/ui/suspense/util.ts
@@ -3,6 +3,7 @@ import { PauseId } from "@replayio/protocol";
 import { framesCache } from "replay-next/src/suspense/FrameCache";
 import { frameStepsCache } from "replay-next/src/suspense/FrameStepsCache";
 import { pauseIdCache } from "replay-next/src/suspense/PauseCache";
+import { isExecutionPointsWithinRange } from "replay-next/src/utils/time";
 import { ReplayClientInterface } from "shared/client/types";
 import { FocusWindow } from "ui/state/timeline";
 
@@ -13,30 +14,31 @@ export function getAsyncParentPauseIdSuspense(
   pauseId: PauseId,
   asyncIndex: number,
   focusWindow: FocusWindow
-): PauseId | null | undefined {
+): PauseId | null {
   while (asyncIndex > 0) {
     const frames = framesCache.read(replayClient, pauseId)!;
     if (!frames?.length) {
-      return;
+      return null;
     }
+
     const steps = frameStepsCache.read(replayClient, pauseId, frames[frames.length - 1].frameId);
     if (!steps || steps.length === 0) {
-      return;
+      return null;
     }
 
     const executionPoint = steps[0].point;
     if (
       focusWindow === null ||
-      focusWindow.begin.point > executionPoint ||
-      focusWindow.end.point < executionPoint
+      !isExecutionPointsWithinRange(executionPoint, focusWindow.begin.point, focusWindow.end.point)
     ) {
       return null;
     }
 
     const parentPauseId = pauseIdCache.read(replayClient, steps[0].point, steps[0].time);
     if (parentPauseId === pauseId) {
-      return;
+      return null;
     }
+
     pauseId = parentPauseId;
     asyncIndex--;
   }


### PR DESCRIPTION
Update all of the "helper functions" from FE-1546 to use focus window instead of loaded regions:
* getIsInLoadedRegion
* jumpToClickEventFunctionLocation
* getAsyncParentPauseIdSuspense
* getPauseAndFrameId

As well as these components:
* PreviewPopup
* DefaultSelectedFrameContextAdapter
* NewFrames (PauseFrames and Frames sub-components)

And this hook:
* useCurrentPauseIdSuspense