### PR TITLE
Support new :id and :attempt Test Suite attributes

### DIFF
--- a/packages/shared/graphql/types.ts
+++ b/packages/shared/graphql/types.ts
@@ -272,6 +272,7 @@ export type CypressAnnotationMessage = {
   logVariable?: "cmd" | "log";
   id?: string;
   url?: string;
+  testId: number | string;
 };
 export interface Annotation {
   point: ExecutionPoint;

--- a/src/ui/components/TestSuite/views/GroupedTestCases/TestRecordingTreeRow.module.css
+++ b/src/ui/components/TestSuite/views/GroupedTestCases/TestRecordingTreeRow.module.css
@@ -53,3 +53,8 @@
 .ErrorTitle {
   font-weight: bold;
 }
+
+.Attempt {
+  font-size: var(--font-size-small);
+  color: var(--color-dim);
+}

--- a/src/ui/components/TestSuite/views/GroupedTestCases/TestRecordingTreeRow.tsx
+++ b/src/ui/components/TestSuite/views/GroupedTestCases/TestRecordingTreeRow.tsx
@@ -17,7 +17,7 @@ export default function TestRecordingTreeRow({
 
   const onClick = () => startTransition(onClickProp);
 
-  const { error, result, source } = testRecording;
+  const { attempt, error, result, source } = testRecording;
   const { title } = source;
 
   return (
@@ -29,7 +29,9 @@ export default function TestRecordingTreeRow({
     >
       <TestResultIcon result={result} />
       <div className={styles.Column}>
-        <div className={styles.Title}>{title}</div>
+        <div className={styles.Title}>
+          {title} {attempt > 1 && <span className={styles.Attempt}>(retry {attempt - 1})</span>}
+        </div>
         {error && (
           <div className={styles.Error}>
             <span className={styles.ErrorTitle}>Error:</span> {error.message}


### PR DESCRIPTION
Pairs with [SCS-1165](https://linear.app/replay/issue/SCS-1165/test-suites-support-retries-in-cypress). Should be ready to merge as soon as  https://github.com/replayio/replay-cli/pull/193 lands.

cc @jonbell-lot23 for visual treatment of retries:

<img width="314" alt="Screen Shot 2023-06-23 at 12 03 20 PM" src="https://github.com/replayio/devtools/assets/29597/6862bbe1-33b1-478d-a5e7-0249c696643f">
