### PR TITLE
Improve persistence for per-recording User preferences

### DIFF
--- a/src/ui/setup/helpers.ts
+++ b/src/ui/setup/helpers.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-restricted-imports
 import { client, sendMessage, triggerEvent } from "protocol/socket";
 import { UIStore } from "ui/actions";
-import { asyncStore, features, prefs } from "ui/utils/prefs";
+import { features, prefs } from "ui/utils/prefs";
 import { getRecordingId } from "ui/utils/recording";
 
 import { ReplaySession, getReplaySession } from "./prefs";
@@ -14,7 +14,6 @@ declare global {
     store: UIStore;
     prefs: typeof prefs;
     features: typeof features;
-    asyncStore: typeof asyncStore;
     dumpPrefs: () => string;
     local: () => void;
     prod: () => void;
@@ -35,7 +34,6 @@ export async function setupAppHelper(store: UIStore) {
     store,
     prefs,
     features,
-    asyncStore,
     triggerEvent,
     replaySession,
     client,

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -98,7 +98,3 @@ export const features = new PrefsHelper("devtools.features", {
 });
 
 export type Features = typeof features;
-
-export const asyncStore = asyncStoreHelper("devtools", {
-  replaySessions: ["Json", "replay-sessions", {} as Record<string, ReplaySession>],
-});


### PR DESCRIPTION
Replays with comments:
* Before: [858c9af5-b4cb-4ff0-8747-63aeaccb513d](https://app.replay.io/recording/fe-1606-recently-selected-tab-is-not-updated-before--858c9af5-b4cb-4ff0-8747-63aeaccb513d)
* After: [fdc666cf-cccd-4453-b187-07f4e8036db8](https://app.replay.io/recording/fe-1606-recently-selected-tab-is-updated-after--fdc666cf-cccd-4453-b187-07f4e8036db8)

Improve the strategy we use to remember the user's most recent view state for each recording by...
* Fixing bad in-memory cached current value
* Memoize to avoid over-updating
* Reduce the debounce delay to avoid missing updates (we could probably remove debounce entirely but I left some small amount in place)