### PR TITLE
Fix flaky breakpoints-04 e2e test

### DIFF
--- a/packages/e2e-tests/helpers/pause-information-panel.ts
+++ b/packages/e2e-tests/helpers/pause-information-panel.ts
@@ -110,7 +110,6 @@ export async function openPauseInformationPanel(page: Page): Promise<void> {
   const pane = getBreakpointsAccordionPane(page);
 
   let isVisible = await pane.isVisible();
-
   if (!isVisible) {
     await page.locator('[data-test-name="ToolbarButton-PauseInformation"]').click();
   }

--- a/packages/e2e-tests/helpers/pause-information-panel.ts
+++ b/packages/e2e-tests/helpers/pause-information-panel.ts
@@ -151,7 +151,7 @@ export async function openScopeBlocks(page: Page, text: string): Promise<void> {
 export async function resumeToLine(page: Page, line: number): Promise<void> {
   await debugPrint(page, `Resuming to line ${chalk.bold(line)}`, "resumeToLine");
 
-  await clickCommandBarButton(page, "Resume F8");
+  await clickCommandBarButton(page, "Resume");
 
   await waitForPaused(page, line);
 }
@@ -161,7 +161,7 @@ export async function clickCommandBarButton(page: Page, title: string): Promise<
 
   await openPauseInformationPanel(page);
 
-  const button = page.locator(`[title="${title}"]`);
+  const button = page.locator(`[title*="${title}"]`);
   await button.isEnabled();
   await button.click();
 }

--- a/packages/e2e-tests/helpers/pause-information-panel.ts
+++ b/packages/e2e-tests/helpers/pause-information-panel.ts
@@ -160,7 +160,7 @@ export async function clickCommandBarButton(page: Page, title: string): Promise<
 
   await openPauseInformationPanel(page);
 
-  const button = page.locator(`[title*="${title}"]`);
+  const button = page.locator(`[title^="${title}"]`);
   await button.isEnabled();
   await button.click();
 }

--- a/packages/e2e-tests/helpers/source-panel.ts
+++ b/packages/e2e-tests/helpers/source-panel.ts
@@ -5,7 +5,7 @@ import { Badge } from "shared/client/types";
 
 import { hideTypeAheadSuggestions, type as typeLexical } from "./lexical";
 import { findPoints, openPauseInformationPanel, removePoint } from "./pause-information-panel";
-import { openSource, openSourceExplorerPanel } from "./source-explorer-panel";
+import { openSource } from "./source-explorer-panel";
 import {
   clearTextArea,
   debugPrint,
@@ -36,7 +36,6 @@ export async function addBreakpoint(
   await openDevToolsTab(page);
 
   if (url) {
-    await openSourceExplorerPanel(page);
     await openSource(page, url);
   }
 
@@ -221,7 +220,6 @@ export async function addLogpoint(
   await openDevToolsTab(page);
 
   if (url) {
-    await openSourceExplorerPanel(page);
     await openSource(page, url);
   }
   if (waitForSourceOutline) {
@@ -478,7 +476,6 @@ export async function removeBreakpoint(
   await openDevToolsTab(page);
 
   if (url) {
-    await openSourceExplorerPanel(page);
     await openSource(page, url);
   }
 
@@ -523,7 +520,6 @@ export async function removeLogPoint(
   );
 
   await openDevToolsTab(page);
-  await openSourceExplorerPanel(page);
   await openSource(page, url);
 
   const line = await getSourceLine(page, lineNumber);
@@ -671,7 +667,6 @@ export async function waitForLogpoint(
   await openDevToolsTab(page);
 
   if (url) {
-    await openSourceExplorerPanel(page);
     await openSource(page, url);
   }
 
@@ -688,8 +683,6 @@ export async function verifyLogpointStep(
   }
 ): Promise<void> {
   const { lineNumber, url } = options;
-
-  await openSourceExplorerPanel(page);
 
   if (url) {
     await openSource(page, url);

--- a/packages/e2e-tests/tests/node_control_flow.test.ts
+++ b/packages/e2e-tests/tests/node_control_flow.test.ts
@@ -14,7 +14,6 @@ test("node_control_flow: catch, finally, generators, and async/await", async ({ 
   // Default timeout is 30s. Mostly taking 40s in local dev. Bump to 120s.
   test.setTimeout(120000);
   await startTest(page, "node/control_flow.js");
-  await openSourceExplorerPanel(page);
 
   await openSource(page, "control_flow.js");
 


### PR DESCRIPTION
Looking at one of the e2e test failures, Replay [bb6f7921-7ef1-4830-8f52-de0d810d6041](https://app.replay.io/recording/bb6f7921-7ef1-4830-8f52-de0d810d6041), shows an interesting thing– the test was clicking away from the "Pause Information" panel, to the "Sources" panel, seemingly while it was _also_ trying to verify the frames and scopes sub-panel contents.

I don't know why this is– (I don't see any missing `await` statements)– but I do know that clicking the "Sources" panel was not necessary. The `addBreakpoint` helper function only does this if the source isn't already open, but for some reason– various helper methods in `source-panel` explicitly called both methods every time. (I could visually confirm this while watching a test run locally.)

Removing the superfluous calls should be enough to fix the flaky behavior of this test, and possibly others.

That test pretty much always fails lately, so let's see what it does on this PR.