### PR TITLE
Use absolute dates for test panel relative date hover tooltip

### DIFF
--- a/src/ui/components/TestSuite/components/LabeledIcon.tsx
+++ b/src/ui/components/TestSuite/components/LabeledIcon.tsx
@@ -7,17 +7,19 @@ export default function LabeledIcon({
   icon,
   label,
   dataTestName,
+  title,
 }: {
   className?: string;
   icon: string;
   label: string;
   dataTestName?: string;
+  title?: string;
 }) {
   return (
     <div
       className={`${className} ${styles.LabeledIcon}`}
       data-test-name={dataTestName}
-      title={label}
+      title={title ?? label}
     >
       <MaterialIcon className={styles.Icon}>{icon}</MaterialIcon>
       <label className={styles.Label}>{label}</label>

--- a/src/ui/components/TestSuite/views/GroupedTestCases/Panel.tsx
+++ b/src/ui/components/TestSuite/views/GroupedTestCases/Panel.tsx
@@ -34,6 +34,7 @@ export default function Panel() {
   const testTree = useMemo(() => createTestTree(testRecordings), [testRecordings]);
 
   const recording = RecordingCache.read(recordingId);
+  const date = new Date(recording.date);
 
   return (
     <>
@@ -71,6 +72,7 @@ export default function Panel() {
             className={styles.Attribute}
             icon="schedule"
             label={getTruncatedRelativeDate(recording.date)}
+            title={`${date.toLocaleDateString()} ${date.toLocaleTimeString()}`}
             dataTestName="TestSuiteDate"
           />
           <Source />


### PR DESCRIPTION
This PR:

- Tweaks the hover tooltip for the Test Panel relative date display to show an absolute date instead of the exact same relative date


Before:

![image](https://github.com/replayio/devtools/assets/1128784/88134708-522f-4681-9c9c-ac0563c9cf19)


after:

![image](https://github.com/replayio/devtools/assets/1128784/dfa4b6e5-2e7f-4c56-b607-b30f0c446fab)
