### PR TITLE
Remove isTest check for recordings and workspaces

### DIFF
--- a/packages/shared/graphql/generated/GetRecording.ts
+++ b/packages/shared/graphql/generated/GetRecording.ts
@@ -150,6 +150,7 @@ export interface GetRecording_recording {
   operations: any | null;
   resolution: any | null;
   metadata: any | null;
+  isTest: boolean;
   comments: GetRecording_recording_comments[];
   activeSessions: GetRecording_recording_activeSessions[] | null;
   owner: GetRecording_recording_owner | null;

--- a/packages/shared/graphql/types.ts
+++ b/packages/shared/graphql/types.ts
@@ -247,6 +247,7 @@ export interface Recording {
   resolution?: { resolvedAt: string; resolvedBy: string };
   collaboratorRequests?: CollaboratorRequest[] | null;
   metadata?: RecordingMetadata;
+  isTest?: boolean;
 }
 
 export interface RecordingMetadata {

--- a/pages/recording/[[...id]].tsx
+++ b/pages/recording/[[...id]].tsx
@@ -160,24 +160,7 @@ function RecordingPage({
 
       setRecording(rec);
 
-      const isTestReplay = rec.metadata?.test && rec.metadata?.source;
-      const isTestWorkspace = rec.workspace?.isTest;
-
-      if (rec.private) {
-        if (isTestReplay && !isTestWorkspace) {
-          setExpectedError({
-            content: "This recording is not available.",
-            message: "The recording must belong to a test suite",
-          });
-        } else if (!isTestReplay && isTestWorkspace) {
-          setExpectedError({
-            content: "This recording is not available.",
-            message: "The recording cannot be in a test suite",
-          });
-        }
-      }
-
-      if (rec.metadata?.test) {
+      if (rec.isTest) {
         trackEvent("session_start.test");
       }
 

--- a/src/ui/graphql/recordings.ts
+++ b/src/ui/graphql/recordings.ts
@@ -26,6 +26,7 @@ export const GET_RECORDING = gql`
       operations
       resolution
       metadata
+      isTest
       comments {
         id
         isPublished

--- a/src/ui/hooks/recordings.ts
+++ b/src/ui/hooks/recordings.ts
@@ -286,6 +286,7 @@ export function convertRecording(
     date: rec.createdAt,
     comments: rec.comments,
     userRole: "userRole" in rec ? (rec.userRole as RecordingRole) : undefined,
+    isTest: "isTest" in rec ? rec.isTest : undefined,
   };
 
   if ("workspace" in rec) {

--- a/test/mock/src/graphql/recordings.ts
+++ b/test/mock/src/graphql/recordings.ts
@@ -98,6 +98,7 @@ export function createGetRecordingMock(opts: {
     uuid: opts.recordingId || "mock-recording-id",
     workspace: null as any, // TypeScript fail
     metadata: null,
+    isTest: false,
 
     ...opts.recording,
   };


### PR DESCRIPTION
and use the recording.isTest graphql property for tracking test recordings.

When a user tries to open a test recording in a non-test workspace (or vice versa), session creation will fail and the frontend will show [the error message from the backend](https://github.com/replayio/backend/blob/82f8f71408553415e48ffc493f1504ec2dd47261/src/protocol/errors.ts#L186).