### PR TITLE
Don't update the focus window when entering focus mode

### DIFF
--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -732,7 +732,6 @@ export function enterFocusMode(): UIThunkAction {
 
     // If there's no focus range, or it's the full recording,
     // shrink it to ~30% of the overall recording and center it around the current time.
-    let initialFocusWindow: TimeRange;
     if (
       prevFocusWindow == null ||
       (prevFocusWindow.begin.time === zoomRegion.beginTime &&
@@ -741,15 +740,13 @@ export function enterFocusMode(): UIThunkAction {
       const focusWindowSize =
         (zoomRegion.endTime - zoomRegion.beginTime) * DEFAULT_FOCUS_WINDOW_PERCENTAGE;
 
-      initialFocusWindow = {
+      const initialFocusWindow = {
         begin: Math.max(zoomRegion.beginTime, currentTime - focusWindowSize / 2),
         end: Math.min(zoomRegion.endTime, currentTime + focusWindowSize / 2),
       };
-    } else {
-      initialFocusWindow = { begin: prevFocusWindow.begin.time, end: prevFocusWindow.end.time };
-    }
 
-    await dispatch(updateFocusWindow(initialFocusWindow));
+      await dispatch(updateFocusWindow(initialFocusWindow));
+    }
 
     await dispatch(
       setTimelineState({


### PR DESCRIPTION
unless we want to set an initial focus window because the current one covers the entire recording.

The real cause for FE-1628 is the slow `Session.getPointsBoundingTime` command, I've filed BAC-3556 for that.
But this PR would improve the situation and it's a bad idea anyway to update the current focus window to one with the same begin/end times but slightly different points.