### PR TITLE
Send honeycomb events when the error boundary is hit

### DIFF
--- a/packages/protocol/socket.ts
+++ b/packages/protocol/socket.ts
@@ -239,6 +239,7 @@ export async function sendMessage<M extends CommandMethods>(
   const response = await new Promise<CommandResponse>(resolve =>
     gMessageWaiters.set(id, { method, resolve })
   );
+
   if (response.error) {
     gSessionCallbacks?.onResponseError(response);
 
@@ -265,7 +266,8 @@ export async function sendMessage<M extends CommandMethods>(
     ) {
       captureException(callerStackTrace, { extra: { code, message, method, params } });
     }
-    throw commandError(finalMessage, code);
+
+    throw commandError(finalMessage, code, { params, method, id });
   }
 
   return response.result as any;

--- a/packages/replay-next/components/comments/CommentList.tsx
+++ b/packages/replay-next/components/comments/CommentList.tsx
@@ -17,7 +17,7 @@ export default function CommentList() {
   const commentList = commentsCache.read(graphQLClient, accessToken, recordingId);
 
   return (
-    <ErrorBoundary>
+    <ErrorBoundary name="CommentList">
       <Suspense fallback={<Loader />}>
         <div className={styles.List}>
           <div className={styles.Header}>Comments</div>

--- a/packages/replay-next/components/console/ConsoleInput.tsx
+++ b/packages/replay-next/components/console/ConsoleInput.tsx
@@ -56,7 +56,7 @@ export default function ConsoleInput({ inputRef }: { inputRef?: RefObject<Impera
   }
 
   return (
-    <ErrorBoundary resetKey={executionPoint} fallback={<ErrorFallback />}>
+    <ErrorBoundary name="ConsoleInput" resetKey={executionPoint} fallback={<ErrorFallback />}>
       <Suspense fallback={<Loader />}>
         <ConsoleInputSuspends inputRef={inputRef} />
       </Suspense>

--- a/packages/replay-next/components/console/ConsoleRoot.tsx
+++ b/packages/replay-next/components/console/ConsoleRoot.tsx
@@ -44,7 +44,7 @@ export default function ConsoleRoot({
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   return (
-    <ErrorBoundary>
+    <ErrorBoundary name="ConsoleRoot">
       <Suspense fallback={<IndeterminateLoader />}>
         <ConsoleFiltersContextRoot>
           <LoggablesContextRoot messageListRef={messageListRef}>
@@ -211,7 +211,7 @@ function Console({
               </div>
             }
           >
-            <ErrorBoundary fallbackClassName={styles.ErrorBoundaryFallback}>
+            <ErrorBoundary name="ConsoleRoot" fallbackClassName={styles.ErrorBoundaryFallback}>
               <div className={styles.MessageColumn} onClick={onClick}>
                 {nagHeader}
 

--- a/packages/replay-next/components/console/MessagesList.tsx
+++ b/packages/replay-next/components/console/MessagesList.tsx
@@ -40,6 +40,7 @@ type CurrentTimeIndicatorPlacement = Loggable | "begin" | "end";
 
 const ErrorBoundary = ({ children }: { children: ReactNode }) => (
   <_ErrorBoundary
+    name="MessagesList"
     fallback={
       <div className={rendererStyles.Row}>
         <div className={rendererStyles.ErrorBoundaryFallback}>Something went wrong.</div>

--- a/packages/replay-next/components/console/filters/FilterToggles.tsx
+++ b/packages/replay-next/components/console/filters/FilterToggles.tsx
@@ -1,9 +1,9 @@
-import { ErrorBoundary } from "@sentry/react";
 import camelCase from "lodash/camelCase";
 import React, { PropsWithChildren, ReactNode, Suspense, useContext, useMemo } from "react";
 import { isPromiseLike } from "suspense";
 
 import { Badge, Checkbox } from "design";
+import ErrorBoundary from "replay-next/components/ErrorBoundary";
 import Icon from "replay-next/components/Icon";
 import { ConsoleFiltersContext } from "replay-next/src/contexts/ConsoleFiltersContext";
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
@@ -167,6 +167,7 @@ function Toggle({
 function CountErrorBoundary({ children }: PropsWithChildren) {
   return (
     <ErrorBoundary
+      name="FilterToggles"
       fallback={
         <span title="Something went wrong loading message counts.">
           <Icon className={styles.ExceptionsErrorIcon} type="warning" />

--- a/packages/replay-next/components/console/renderers/LogPointRenderer.tsx
+++ b/packages/replay-next/components/console/renderers/LogPointRenderer.tsx
@@ -80,6 +80,7 @@ function LogPointRenderer({
       <span className={styles.LogContents} data-test-name="LogContents">
         <BadgeRenderer badge={logPointInstance.point.badge} showNewBadgeFlash={showNewBadgeFlash} />
         <ErrorBoundary
+          name="LogPointRenderer"
           fallback={<div className={styles.ErrorBoundaryFallback}>Something went wrong.</div>}
         >
           <Suspense key={logPointInstance.point.content} fallback={<Loader />}>

--- a/packages/replay-next/components/console/renderers/MessageRenderer.tsx
+++ b/packages/replay-next/components/console/renderers/MessageRenderer.tsx
@@ -120,6 +120,7 @@ function MessageRenderer({
     <span className={styles.LogContents} data-test-name="LogContents">
       {message.text && <span className={styles.MessageText}>{message.text}</span>}
       <ErrorBoundary
+        name="MessageRenderer"
         fallback={<div className={styles.ErrorBoundaryFallback}>Something went wrong.</div>}
       >
         {primaryContent}

--- a/packages/replay-next/pages/tests/utils/createTest.tsx
+++ b/packages/replay-next/pages/tests/utils/createTest.tsx
@@ -12,7 +12,7 @@ export default function createTest(Component: FunctionComponent<any>, defaultRec
     usePreferredColorScheme();
 
     return (
-      <ErrorBoundary>
+      <ErrorBoundary name="createTest">
         <Suspense fallback="Loading...">
           <Initializer recordingId={recordingId}>
             <Component />

--- a/packages/replay-next/src/suspense/ExceptionsCache.ts
+++ b/packages/replay-next/src/suspense/ExceptionsCache.ts
@@ -2,7 +2,6 @@ import { PauseId, PointDescription, PointSelector, Value } from "@replayio/proto
 import { createCache } from "suspense";
 
 import { ReplayClientInterface } from "shared/client/types";
-import { ProtocolError, commandError } from "shared/utils/error";
 
 import { createInfallibleSuspenseCache } from "../utils/suspense";
 import { createAnalysisCache } from "./AnalysisCache";

--- a/packages/replay-next/src/suspense/FrameCache.ts
+++ b/packages/replay-next/src/suspense/FrameCache.ts
@@ -16,6 +16,7 @@ export const framesCache: Cache<
   getKey: ([client, pauseId]) => pauseId,
   load: async ([client, pauseId]) => {
     const framesResult = await client.getAllFrames(pauseId);
+
     const sources = await sourcesByIdCache.readAsync(client);
     cachePauseData(client, sources, pauseId, framesResult.data, framesResult.frames);
     const cached = framesCache.getValueIfCached(client, pauseId);

--- a/packages/replay-next/src/utils/telemetry.ts
+++ b/packages/replay-next/src/utils/telemetry.ts
@@ -7,7 +7,6 @@ export function setDefaultTags(tags: Object) {
 
 export async function recordData(event: string, tags: Object = {}): Promise<void> {
   const eventTags = { ...defaultTags, ...tags };
-
   if (process.env.NODE_ENV !== "development" || process.env.NEXT_PUBLIC_RECORD_REPLAY_TELEMETRY) {
     try {
       const response = await fetch("https://telemetry.replay.io/", {

--- a/packages/shared/utils/error.ts
+++ b/packages/shared/utils/error.ts
@@ -1,7 +1,16 @@
 export interface CommandError extends Error {
   name: "CommandError";
   code: number;
+  args?: CommandArgs;
 }
+
+type CommandArgs = {
+  method: string;
+  params: Object;
+  id: number;
+  pauseId?: string;
+  sessionId?: string;
+};
 
 export enum ProtocolError {
   InternalError = 1,
@@ -24,10 +33,12 @@ export enum ProtocolError {
   FocusWindowChange = 76,
 }
 
-export const commandError = (message: string, code: number): CommandError => {
+export const commandError = (message: string, code: number, args?: CommandArgs): CommandError => {
   const err = new Error(message) as CommandError;
   err.name = "CommandError";
   err.code = code;
+  err.message = message;
+  err.args = args;
   return err;
 };
 

--- a/src/devtools/client/debugger/src/components/Editor/Footer.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Footer.tsx
@@ -22,7 +22,10 @@ function SourceFooter() {
   return (
     <div className="source-footer-wrapper">
       <div className="source-footer">
-        <ErrorBoundary fallback={<div className="error">An error occurred while replaying</div>}>
+        <ErrorBoundary
+          name="SourceFooter"
+          fallback={<div className="error">An error occurred while replaying</div>}
+        >
           <Suspense>
             <SourcemapToggleSuspends cursorPosition={cursorPosition} />
             <SourcemapVisualizerLinkSuspends cursorPosition={cursorPosition} />

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/NewFrames.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/NewFrames.tsx
@@ -100,7 +100,8 @@ function FramesRenderer({
       <PauseFrames pauseId={pauseId} frames={frames} panel={panel} />
       <ErrorBoundary
         key={pauseId}
-        fallback={<div className="pane-info empty">Error loading frames</div>}
+        name="NewFrames"
+        fallback={<div className="pane-info empty">Error loading frames :(</div>}
       >
         <Suspense fallback={<div className="pane-info empty">Loading async frames…</div>}>
           <FramesRenderer panel={panel} pauseId={pauseId} asyncIndex={asyncIndex + 1} />
@@ -216,7 +217,8 @@ function Frames({ panel, point, time }: FramesProps) {
     <div className="pane frames" data-test-id="FramesPanel">
       <ErrorBoundary
         key={pauseId}
-        fallback={<div className="pane-info empty">Error loading frames</div>}
+        name="Frames"
+        fallback={<div className="pane-info empty">Error loading frames :((</div>}
       >
         <Suspense fallback={<div className="pane-info empty">Loading…</div>}>
           <div role="list">

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/NewScopes.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/NewScopes.tsx
@@ -135,6 +135,7 @@ export default function Scopes() {
     <div className="scopes-content">
       <Redacted className="pane scopes-list" data-test-name="ScopesList">
         <ErrorBoundary
+          name="NewScopes"
           key={`${selectedFrameId?.pauseId}:${selectedFrameId?.frameId}`}
           fallback={<div className="pane-info">Error loading scopes</div>}
         >

--- a/src/devtools/client/debugger/src/components/SourceOutline/SourceOutline.tsx
+++ b/src/devtools/client/debugger/src/components/SourceOutline/SourceOutline.tsx
@@ -194,7 +194,7 @@ export default function SourceOutlineWrapper() {
   }
 
   return (
-    <ErrorBoundary key={selectedSource?.id}>
+    <ErrorBoundary name="SourceOutlineWrapper" key={selectedSource?.id}>
       <Suspense fallback={null}>
         <SourceOutline
           cursorPosition={cursorPosition || null}

--- a/src/ui/components/TestSuite/views/TestRecording/TestEventDetails.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestEventDetails.tsx
@@ -23,7 +23,7 @@ export default function TestEventDetails({ collapsed }: { collapsed: boolean }) 
   }
 
   return (
-    <ErrorBoundary>
+    <ErrorBoundary name="TestEventDetails">
       <UserActionEventDetails
         timeStampedPoint={testEvent.data.result.timeStampedPoint}
         variable={testEvent.data.result.variable}

--- a/src/ui/components/TestSuite/views/TestSuitePanel.tsx
+++ b/src/ui/components/TestSuite/views/TestSuitePanel.tsx
@@ -12,7 +12,7 @@ import styles from "./TestSuitePanel.module.css";
 // TODO Show better/custom error fallback to failed test suites
 export default function TestSuitePanel() {
   return (
-    <ErrorBoundary fallback={<TestSuiteErrorFallback />}>
+    <ErrorBoundary name="TestSuitePanel" fallback={<TestSuiteErrorFallback />}>
       <Suspense
         fallback={
           <div className={styles.Loading} data-test-name="TestSuitePanel">

--- a/src/ui/components/Timeline/PreviewMarkers.tsx
+++ b/src/ui/components/Timeline/PreviewMarkers.tsx
@@ -16,7 +16,7 @@ import Marker from "./Marker";
 
 export default function PreviewMarkers() {
   return (
-    <ErrorBoundary fallback={null}>
+    <ErrorBoundary fallback={null} name="PreviewMarkers">
       <Suspense fallback={null}>
         <PreviewMarkersSuspends />
       </Suspense>


### PR DESCRIPTION
This PR starts sending honeycomb `component-errorboundary` events when we show the error boundary. Better yet, we also include the command id, code, method, as well so that we can see what caused the error 