### PR TITLE
Fix redirecting to a team after accepting a team invite

### DIFF
--- a/src/ui/hooks/workspaces_user.ts
+++ b/src/ui/hooks/workspaces_user.ts
@@ -185,7 +185,10 @@ export function useAcceptPendingInvitation(onCompleted: () => void) {
       }
     `,
     {
-      refetchQueries: ["GetNonPendingWorkspaces", "GetPendingWorkspaces"],
+      // We refetch non-pending workspaces here so that the user's newly-accepted workspace is
+      // available to be redirected to immediately. Fetching pending workspaces introduces
+      // a race condition, so we let the polling update that sometime later instead.
+      refetchQueries: ["GetNonPendingWorkspaces"],
       onCompleted,
     }
   );


### PR DESCRIPTION
We had a bug before where after accepting a team invite, the user would be redirected to their library instead of the team they just accepted.

This was because of [a check](https://github.com/replayio/devtools/blob/953569f0974d02142c37cab08d7616f39a0848a6/src/ui/components/Library/Library.tsx#L87-L90) where we validate that the route's teamID is either in the array of `pendingWorkspaces`, or `nonPendingWorkspaces`. Because these are fetched in different queries, there's a race condition where the new team would be removed from `pendingWorkspaces`, but `nonPendingWorkspaces` hasn't updated to add that team yet. In that scenario, the library assumes it's an invalid team ID and redirects you to your library.

I'm not sure if there's a specific reason for fetching the pending and non-pending workspaces in separate queries. We could probably consolidate those to avoid this problem altogether, and just have a `pending: true` value on pending workspaces/invites.

This fix works by not refetching the `nonPendingWorkspace` after accepting the invite. By keeping it stale, we eliminate the race condition. And it's not stale for long, since the two queries poll every 5s.

Replay: https://app.replay.io/recording/redirect-after-user-invite--75ab3c3b-1fdb-4833-8c9f-549cad0650c9