### PR TITLE
Improve redux panel polish

### DIFF
--- a/src/ui/components/SecondaryToolbox/ReduxDevTools.module.css
+++ b/src/ui/components/SecondaryToolbox/ReduxDevTools.module.css
@@ -61,8 +61,12 @@
 }
 
 .actions [role="list"] [role="listitem"].selected {
-  background-color: var(--theme-selection-background);
+  background: var(--primary-accent);
   color: white;
+}
+
+.actions [role="list"] [role="listitem"].selected:hover {
+  background: var(--primary-accent-hover);
 }
 
 .tabsContainer {
@@ -106,4 +110,20 @@
 .contentsTab:hover {
   background-color: var(--tab-hover-bgcolor);
   color: var(--tab-hover-color);
+}
+
+.list {
+  border-right: 1px solid var(--chrome);
+  height: 100%;
+  overflow-y: auto;
+}
+
+.row {
+  background: var(--body-bgcolor);
+  border-bottom: 1px solid var(--chrome);
+  padding: 0.2rem 0 0.1rem 0.5rem;
+  min-width: fit-content;
+  position: relative;
+  width: 100%;
+  cursor: pointer;
 }

--- a/src/ui/components/SecondaryToolbox/ReduxDevTools.tsx
+++ b/src/ui/components/SecondaryToolbox/ReduxDevTools.tsx
@@ -29,7 +29,7 @@ export const ReduxDevToolsPanel = () => {
     <div className={classnames("flex min-h-full bg-bodyBgcolor p-1 text-xs", styles.actions)}>
       <PanelGroup autoSaveId="ReduxDevTools" direction="horizontal">
         <ResizablePanel collapsible>
-          <div role="list" className="h-full overflow-y-auto">
+          <div role="list" className={styles.list}>
             {reduxAnnotations.map(annotation => (
               <ActionItem
                 key={annotation.point}
@@ -68,7 +68,7 @@ function ActionItem({
   return (
     <div
       key={annotation.point}
-      className={classnames("cursor-pointer text-xs", {
+      className={classnames(styles.row, {
         [styles.selected]: annotation.point === selectedPoint,
       })}
       role="listitem"


### PR DESCRIPTION
Old:
<img width="674" alt="image" src="https://github.com/replayio/devtools/assets/9154902/b130fe2d-f313-446f-a90b-a8f1356c732c">

New:
<img width="674" alt="image" src="https://github.com/replayio/devtools/assets/9154902/7991e026-b11f-4a3d-9ae5-c3681e2f1700">

Aligned to look more like our other rows.
