### PR TITLE
Memoize recordings array in library to prevent over-renders

### DIFF
--- a/src/ui/components/Library/Team/View/Recordings/Recordings.tsx
+++ b/src/ui/components/Library/Team/View/Recordings/Recordings.tsx
@@ -1,6 +1,6 @@
 import { RecordingId } from "@replayio/protocol";
 import sortBy from "lodash/sortBy";
-import { useMemo, useState } from "react";
+import { memo, useMemo, useState } from "react";
 
 import { Recording } from "shared/graphql/types";
 import { SecondaryButton } from "ui/components/shared/Button";
@@ -9,7 +9,9 @@ import RecordingRow from "./RecordingListItem/RecordingListItem";
 import { RecordingsError } from "./RecordingsError";
 import styles from "../../../Library.module.css";
 
-export function Recordings({
+const NUM_ROWS_PER_PAGE = 50;
+
+export const Recordings = memo(function Recordings({
   recordings,
   selectedIds,
   setSelectedIds,
@@ -28,7 +30,7 @@ export function Recordings({
       const order = ascOrder ? 1 : -1;
       return order * new Date(recording.date).getTime();
     });
-    return showMore ? sortedRecordings : sortedRecordings.slice(0, 100);
+    return showMore ? sortedRecordings : sortedRecordings.slice(0, NUM_ROWS_PER_PAGE);
   }, [recordings, showMore]);
 
   const addSelectedId = (recordingId: RecordingId) => setSelectedIds([...selectedIds, recordingId]);
@@ -51,7 +53,7 @@ export function Recordings({
           {...{ addSelectedId, removeSelectedId, isEditing }}
         />
       ))}
-      {!showMore && recordings.length > 100 && (
+      {!showMore && recordings.length > NUM_ROWS_PER_PAGE && (
         <div className="flex justify-center p-4">
           <SecondaryButton className="" color="blue" onClick={() => toggleShowMore(!showMore)}>
             Show More
@@ -60,4 +62,4 @@ export function Recordings({
       )}
     </div>
   );
-}
+});

--- a/src/ui/hooks/recordings.ts
+++ b/src/ui/hooks/recordings.ts
@@ -481,6 +481,8 @@ export function useUpdateIsPrivate() {
     updateIsPrivate({ variables: { recordingId, isPrivate } });
 }
 
+const EMPTY_ARRAY = [] as any[];
+
 export function useIsOwner() {
   const recordingId = useGetRecordingId();
   const { userId } = useGetUserId();
@@ -522,20 +524,26 @@ export function useGetPersonalRecordings(
     }
   );
 
+  const recordings: Recording[] = useMemo(() => {
+    if (loading || error) {
+      return EMPTY_ARRAY;
+    }
+
+    if (data?.viewer) {
+      return data.viewer.recordings.edges.map(({ node }) => convertRecording(node)!);
+    }
+
+    return EMPTY_ARRAY;
+  }, [data, error, loading]);
+
   if (loading) {
     return { error: null, recordings: null, loading };
-  }
-
-  if (error) {
+  } else if (error) {
     console.error("Failed to fetch recordings:", error);
     return { error, recordings: null, loading };
+  } else {
+    return { error: null, recordings, loading };
   }
-
-  let recordings: Recording[] = [];
-  if (data?.viewer) {
-    recordings = data.viewer.recordings.edges.map(({ node }) => convertRecording(node)!);
-  }
-  return { error: null, recordings, loading };
 }
 
 export function useGetWorkspaceRecordings(


### PR DESCRIPTION
The reason it was laggy before is because we were re-rendering the whole page (every row) after each keystroke (even though we don't apply the filter until you type Enter), and we were doing that because the `useGetPersonalRecordings` hook always created a new array each time it was called.

### Before
<img width="1159" alt="Screen Shot 2023-06-30 at 1 30 39 PM" src="https://github.com/replayio/devtools/assets/29597/f872edee-3b62-4628-a0b9-67b8ee6add44">

### After
<img width="850" alt="Screen Shot 2023-06-30 at 1 30 02 PM" src="https://github.com/replayio/devtools/assets/29597/3b9a34b2-9027-4b59-9e34-40b69f6c630d">
