### PR TITLE
Test Suites: Show full timestamp in mouse-over tooltip

### DIFF
--- a/src/ui/components/Library/Team/View/TestRuns/Overview/RunSummary.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/Overview/RunSummary.tsx
@@ -63,7 +63,9 @@ export function Attributes({ summary }: { summary: Summary }) {
 
     return (
       <div className="flex flex-row flex-wrap items-center gap-4">
-        <AttributeContainer icon="schedule">{getTruncatedRelativeDate(date)}</AttributeContainer>
+        <AttributeContainer icon="schedule" title={date.toLocaleString()}>
+          {getTruncatedRelativeDate(date)}
+        </AttributeContainer>
         {user ? <AttributeContainer icon="person">{user}</AttributeContainer> : null}
         <BranchIcon
           branchName={branchName}

--- a/src/ui/components/Library/Team/View/TestRuns/TestRunListItem.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunListItem.tsx
@@ -55,7 +55,9 @@ export function TestRunListItem({
 
     attributes = (
       <div className="flex flex-row items-center gap-4 text-xs font-light">
-        <AttributeContainer icon="schedule">{getTruncatedRelativeDate(date)}</AttributeContainer>
+        <AttributeContainer icon="schedule" title={date.toLocaleString()}>
+          {getTruncatedRelativeDate(date)}
+        </AttributeContainer>
         {user && (
           <AttributeContainer icon="person">
             <HighlightedText haystack={user} needle={filterByText} />

--- a/src/ui/components/TestSuite/views/GroupedTestCases/Panel.tsx
+++ b/src/ui/components/TestSuite/views/GroupedTestCases/Panel.tsx
@@ -72,7 +72,7 @@ export default function Panel() {
             className={styles.Attribute}
             icon="schedule"
             label={getTruncatedRelativeDate(recording.date)}
-            title={`${date.toLocaleDateString()} ${date.toLocaleTimeString()}`}
+            title={date.toLocaleString()}
             dataTestName="TestSuiteDate"
           />
           <Source />


### PR DESCRIPTION
<img width="438" alt="Screen Shot 2023-06-30 at 3 28 07 PM" src="https://github.com/replayio/devtools/assets/29597/a74538c0-0d00-4404-a666-75df1d1a9dc4">

<img width="680" alt="Screen Shot 2023-06-30 at 3 31 54 PM" src="https://github.com/replayio/devtools/assets/29597/ad8d435b-657f-41a9-98d5-ae1261199b64">

<img width="753" alt="Screen Shot 2023-06-30 at 3 31 59 PM" src="https://github.com/replayio/devtools/assets/29597/826d7071-175c-4280-82e1-602732f05ba1">
