### PR TITLE
Add missing bias param to focus request

### DIFF
--- a/packages/replay-next/src/contexts/FocusContext.tsx
+++ b/packages/replay-next/src/contexts/FocusContext.tsx
@@ -89,7 +89,7 @@ export function FocusContextRoot({ children }: PropsWithChildren<{}>) {
     }
 
     const timeoutId = setTimeout(() => {
-      client.requestFocusWindow({ begin: range.begin.time, end: range.end.time });
+      client.requestFocusWindow({ begin: range.begin.time, bias, end: range.end.time });
     }, FOCUS_DEBOUNCE_DURATION);
 
     return () => {
@@ -109,7 +109,7 @@ export function FocusContextRoot({ children }: PropsWithChildren<{}>) {
 
   const updateFocusRange = useCallback(
     async (range: TimeStampedPointRange | null, options: UpdateOptions) => {
-      const { bias, debounce, sync } = options;
+      const { bias, debounce } = options;
 
       setBias(bias);
       setRange(range);


### PR DESCRIPTION
This should have been there all along, right?

I don't think we're passing this param to the method anywhere, but if we did– it would have been missing.