### PR TITLE
Always show recording date, and show as its own row

### DIFF
--- a/src/ui/components/Events/ReplayInfo.module.css
+++ b/src/ui/components/Events/ReplayInfo.module.css
@@ -1,0 +1,5 @@
+.icon {
+  font-size: 1.25rem;
+  height: 1.25rem;
+  width: 1.25rem;
+}

--- a/src/ui/components/Events/ReplayInfo.tsx
+++ b/src/ui/components/Events/ReplayInfo.tsx
@@ -4,10 +4,10 @@ import { ConnectedProps, connect } from "react-redux";
 import { OperationsData } from "shared/graphql/types";
 import { getDisplayedUrl } from "shared/utils/environment";
 import * as actions from "ui/actions/app";
+import { getTruncatedRelativeDate } from "ui/components/Library/Team/View/Recordings/RecordingListItem/RecordingListItem";
 import hooks from "ui/hooks";
 import { getRecordingTarget } from "ui/reducers/app";
 import { useAppSelector } from "ui/setup/hooks";
-import { formatRelativeTime } from "ui/utils/comments";
 import { getRecordingId, showDurationWarning } from "ui/utils/recording";
 import useAuth0 from "ui/utils/useAuth0";
 
@@ -16,7 +16,9 @@ import Icon from "../shared/Icon";
 import MaterialIcon from "../shared/MaterialIcon";
 import { getPrivacySummaryAndIcon } from "../shared/SharingModal/PrivacyDropdown";
 import PrivacyDropdown from "../shared/SharingModal/PrivacyDropdown";
+import LabeledIcon from "../TestSuite/components/LabeledIcon";
 import { getUniqueDomains } from "../UploadScreen/Privacy";
+import styles from "./ReplayInfo.module.css";
 
 const Row = ({ children, onClick }: { children: ReactNode; onClick?: () => void }) => {
   const classes = "flex flex-row space-x-2 p-1 px-4 items-center text-left overflow-hidden";
@@ -42,7 +44,9 @@ function ReplayInfo({ setModal }: PropsFromRedux) {
     return null;
   }
 
-  const time = formatRelativeTime(new Date(recording.date));
+  const time = getTruncatedRelativeDate(recording.date);
+  const date = new Date(recording.date);
+  const fullDateString = date.toLocaleString();
   const { summary, icon } = getPrivacySummaryAndIcon(recording);
 
   const showOperations = () => {
@@ -53,17 +57,29 @@ function ReplayInfo({ setModal }: PropsFromRedux) {
   return (
     <div className="flex-column flex items-center overflow-hidden border-splitter bg-bodyBgcolor">
       <div className="mt-.5 mb-2 flex w-full cursor-default flex-col self-stretch overflow-hidden px-1.5 pb-0 text-xs">
-        {recording.user ? (
-          <Row>
-            <AvatarImage
-              className="avatar rounded-full"
-              style={{ height: "1.25rem", width: "1.25rem" }}
-              src={recording.user.picture}
+        <Row>
+          {recording.user ? (
+            <>
+              <AvatarImage
+                className="avatar rounded-full"
+                style={{ height: "1.25rem", width: "1.25rem" }}
+                src={recording.user.picture}
+              />
+              <div>{recording.user.name}</div>
+              <div className="opacity-50" title={fullDateString}>
+                {time}
+              </div>
+            </>
+          ) : (
+            <LabeledIcon
+              iconClassname={styles.icon}
+              icon="schedule"
+              label={time}
+              title={fullDateString}
+              dataTestName="RecordingDate"
             />
-            <div>{recording.user.name}</div>
-            <div className="opacity-50">{time}</div>
-          </Row>
-        ) : null}
+          )}
+        </Row>
         <div>
           {isAuthenticated ? (
             <Row>
@@ -122,6 +138,7 @@ function ReplayInfo({ setModal }: PropsFromRedux) {
           <OperationsRow operations={recording.operations} onClick={showOperations} />
         ) : null}
         {showEnvironmentVariables ? <EnvironmentVariablesRow /> : null}
+
         {showDurationWarning(recording) ? <DurationWarningRow /> : null}
       </div>
     </div>

--- a/src/ui/components/TestSuite/components/LabeledIcon.tsx
+++ b/src/ui/components/TestSuite/components/LabeledIcon.tsx
@@ -8,12 +8,14 @@ export default function LabeledIcon({
   label,
   dataTestName,
   title,
+  iconClassname = "",
 }: {
   className?: string;
   icon: string;
   label: string;
   dataTestName?: string;
   title?: string;
+  iconClassname?: string;
 }) {
   return (
     <div
@@ -21,7 +23,7 @@ export default function LabeledIcon({
       data-test-name={dataTestName}
       title={title ?? label}
     >
-      <MaterialIcon className={styles.Icon}>{icon}</MaterialIcon>
+      <MaterialIcon className={`${iconClassname} ${styles.Icon}`}>{icon}</MaterialIcon>
       <label className={styles.Label}>{label}</label>
     </div>
   );


### PR DESCRIPTION
This PR:

- Updates our "Info" panel to _always_ show the recording date (relative, or absolute for >14 days, same as the test suite info panel), and using the same icon as the test suite panel

Previously it was only showing the date if there was a `recording.user` field, and we don't always have a user (such as QA Wolf recordings).  It was also showing the date half-grayed-out.

Previous display with user:

![image](https://github.com/replayio/devtools/assets/1128784/d220d2b7-45e7-4bc7-a427-c148103226af)

New display with user:

![image](https://github.com/replayio/devtools/assets/1128784/4140e650-3d32-4ade-9f5f-eb0189fd81a8)

New display with no user:

![image](https://github.com/replayio/devtools/assets/1128784/683e7a52-3537-47cf-b734-faaca11914bc)
