### PR TITLE
Fix process-test-metadata telemetry

### DIFF
--- a/packages/replay-next/src/utils/telemetry.ts
+++ b/packages/replay-next/src/utils/telemetry.ts
@@ -37,7 +37,10 @@ export function assertWithTelemetry(
   tags: Object = {}
 ): asserts assertion {
   if (!assertion) {
-    recordData(type, tags);
+    recordData(type, {
+      message,
+      ...tags,
+    });
   }
 
   return assert(assertion, message);

--- a/packages/shared/test-suites/RecordingTestMetadata.ts
+++ b/packages/shared/test-suites/RecordingTestMetadata.ts
@@ -17,7 +17,7 @@ import { AnnotationsCache } from "ui/components/TestSuite/suspense/AnnotationsCa
 export type SemVer = string;
 
 function assert(value: unknown, message: string, tags: Object = {}): asserts value {
-  return assertWithTelemetry(value, "process-test-metadata", message, tags);
+  return assertWithTelemetry(value, message, "process-test-metadata", tags);
 }
 
 // This type is only minimally supported by the frontend


### PR DESCRIPTION
* Swaps the args to `assertWithTelemetry` call so we receive the expected values in telemetry
* Add `message` to the telemetry data for a bit more context on the error