### PR TITLE
New copy for access request screen

### DIFF
--- a/src/ui/components/shared/Error.tsx
+++ b/src/ui/components/shared/Error.tsx
@@ -104,7 +104,7 @@ function RequestRecordingAccessButton() {
       setExpectedError({
         message: "Hang tight!",
         content:
-          "We've let the owner know about your request. We'll notify you by e-mail once it's been accepted",
+          "We notified the owner that you requested access and will email you when you're approved.",
         action: "library",
       })
     );


### PR DESCRIPTION
Addresses https://linear.app/replay/issue/DES-751/nicer-hang-tight-screen

Copy changes:

"let the owner know" -> "notified the owner"
"about your request" -> "that you requested access"
"we'll notify by e-mail" -> "will email"
"approved" -> "accepted"
