### PR TITLE
Remove jumping UI when selecting a row in testsuites

### DIFF
--- a/src/ui/components/TestSuite/views/TestRecording/Panel.module.css
+++ b/src/ui/components/TestSuite/views/TestRecording/Panel.module.css
@@ -92,6 +92,6 @@
   height: 100%;
   display: flex;
   flex-direction: column;
-  padding: 0 0.75rem 0.75rem;
+  padding: 0;
   overflow: auto;
 }

--- a/src/ui/components/TestSuite/views/TestRecording/TestSection.module.css
+++ b/src/ui/components/TestSuite/views/TestRecording/TestSection.module.css
@@ -4,4 +4,6 @@
   text-transform: uppercase;
   font-weight: bold;
   line-height: 2rem;
+
+  padding-left: 0.75rem;
 }

--- a/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.module.css
+++ b/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.module.css
@@ -1,7 +1,7 @@
 .Row {
   display: flex;
   justify-content: space-between;
-  padding: 0.5rem 0.75rem;
+  padding: 0.5rem 0.25rem 0.5rem 0.5rem;
   gap: 1ch;
   font-family: var(--font-family-monospace);
   cursor: pointer;
@@ -63,4 +63,8 @@
   height: 1rem;
   width: 1rem;
   flex: 0 0 auto;
+}
+
+.HiddenIcon {
+  display: none;
 }

--- a/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
@@ -119,15 +119,15 @@ export function TestSectionRow({
       onMouseLeave={onMouseLeave}
     >
       {child}
-      {position === "current" && (
-        <button
-          className={styles.DropDownButton}
-          onClick={onContextMenu}
-          data-test-name="TestSectionRowMenuButton"
-        >
-          <Icon className={styles.Icon} type="dots" />
-        </button>
-      )}
+
+      <button
+        className={styles.DropDownButton}
+        onClick={onContextMenu}
+        data-test-name="TestSectionRowMenuButton"
+      >
+        <Icon className={position === "current" ? styles.Icon : styles.HiddenIcon} type="dots" />
+      </button>
+
       {contextMenu}
     </div>
   );


### PR DESCRIPTION
Loom showing the difference: 
https://www.loom.com/share/a1f696b61ee348f5b779933e0a596787

