### PR TITLE
Remove ThreadFront.evaluate

### DIFF
--- a/packages/replay-next/src/suspense/PauseCache.ts
+++ b/packages/replay-next/src/suspense/PauseCache.ts
@@ -55,7 +55,8 @@ export const pauseEvaluationsCache: Cache<
     pauseId: PauseId,
     frameId: FrameId | null,
     expression: string,
-    uid?: string
+    uid?: string,
+    pure?: boolean
   ],
   Omit<Result, "data">
 > = createCache({
@@ -63,8 +64,8 @@ export const pauseEvaluationsCache: Cache<
   debugLabel: "PauseEvaluations",
   getKey: ([replayClient, pauseId, frameId, expression, uid = ""]) =>
     `${pauseId}:${frameId}:${expression}:${uid}`,
-  load: async ([replayClient, pauseId, frameId, expression, uid = ""]) => {
-    const result = await replayClient.evaluateExpression(pauseId, expression, frameId);
+  load: async ([replayClient, pauseId, frameId, expression, uid = "", pure]) => {
+    const result = await replayClient.evaluateExpression(pauseId, expression, frameId, pure);
     const sources = await sourcesByIdCache.readAsync(replayClient);
     cachePauseData(replayClient, sources, pauseId, result.data);
     return { exception: result.exception, failed: result.failed, returned: result.returned };

--- a/packages/replay-next/src/utils/evaluate.ts
+++ b/packages/replay-next/src/utils/evaluate.ts
@@ -1,0 +1,43 @@
+import { FrameId, PauseId } from "@replayio/protocol";
+
+import { ThreadFront } from "protocol/thread/thread";
+import { ReplayClientInterface } from "shared/client/types";
+
+import { recordingCapabilitiesCache } from "../suspense/BuildIdCache";
+import { cachePauseData } from "../suspense/PauseCache";
+import { sourcesByIdCache } from "../suspense/SourcesCache";
+
+export async function evaluate({
+  replayClient,
+  pauseId,
+  text,
+  frameId,
+  pure = false,
+}: {
+  replayClient: ReplayClientInterface;
+  pauseId?: PauseId;
+  text: string;
+  frameId?: FrameId;
+  pure?: boolean;
+}) {
+  if (!pauseId) {
+    pauseId = await ThreadFront.getCurrentPauseId(replayClient);
+  }
+  const abilities = await recordingCapabilitiesCache.readAsync(replayClient);
+  const result = await replayClient.evaluateExpression(
+    pauseId,
+    text,
+    frameId ?? null,
+    abilities.supportsPureEvaluation && pure
+  );
+  const sources = await sourcesByIdCache.readAsync(replayClient);
+  cachePauseData(replayClient, sources, pauseId, result.data);
+
+  if (result.returned) {
+    return { exception: null, returned: result.returned };
+  } else if (result.exception) {
+    return { exception: result.exception, returned: null };
+  } else {
+    return { exception: null, returned: null };
+  }
+}

--- a/packages/shared/client/ReplayClient.ts
+++ b/packages/shared/client/ReplayClient.ts
@@ -183,7 +183,8 @@ export class ReplayClient implements ReplayClientInterface {
   async evaluateExpression(
     pauseId: PauseId,
     expression: string,
-    frameId: FrameId | null
+    frameId: FrameId | null,
+    pure?: boolean
   ): Promise<EvaluationResult> {
     const sessionId = this.getSessionIdThrows();
 
@@ -198,7 +199,7 @@ export class ReplayClient implements ReplayClientInterface {
       const response = await client.Pause.evaluateInGlobal(
         {
           expression,
-          pure: false,
+          pure,
         },
         sessionId,
         pauseId
@@ -209,7 +210,7 @@ export class ReplayClient implements ReplayClientInterface {
         {
           frameId,
           expression,
-          pure: false,
+          pure,
           useOriginalScopes: true,
         },
         sessionId,

--- a/packages/shared/client/types.ts
+++ b/packages/shared/client/types.ts
@@ -159,7 +159,8 @@ export interface ReplayClientInterface {
   evaluateExpression(
     pauseId: PauseId,
     expression: string,
-    frameId: FrameId | null
+    frameId: FrameId | null,
+    pure?: boolean
   ): Promise<EvaluationResult>;
   findAnnotations(kind: string, listener: AnnotationListener): Promise<void>;
   findKeyboardEvents(onKeyboardEvents: (events: keyboardEvents) => void): Promise<void>;

--- a/src/devtools/client/webconsole/utils/autocomplete-eager.ts
+++ b/src/devtools/client/webconsole/utils/autocomplete-eager.ts
@@ -2,7 +2,7 @@ import { PauseId, Value } from "@replayio/protocol";
 import { useContext, useMemo } from "react";
 
 import { getSelectedFrameId } from "devtools/client/debugger/src/selectors";
-import { ThreadFront } from "protocol/thread";
+import { pauseEvaluationsCache } from "replay-next/src/suspense/PauseCache";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { ReplayClientInterface } from "shared/client/types";
 import { useAppSelector } from "ui/setup/hooks";
@@ -18,13 +18,14 @@ export async function getEvaluatedProperties(
   fetchObject: ObjectFetcher
 ): Promise<string[]> {
   try {
-    const { returned, exception } = await ThreadFront.evaluate({
+    const { returned, exception } = await pauseEvaluationsCache.readAsync(
       replayClient,
       pauseId,
-      frameId,
-      text: expression,
-      pure: true,
-    });
+      frameId ?? null,
+      expression,
+      undefined,
+      true
+    );
     if (returned?.object && !exception) {
       const properties = await getPropertiesForObject(returned.object, fetchObject, 1);
       return properties;
@@ -47,13 +48,14 @@ async function eagerEvaluateExpression(
   frameId?: string
 ): Promise<Value | null> {
   try {
-    const { returned, exception } = await ThreadFront.evaluate({
+    const { returned, exception } = await pauseEvaluationsCache.readAsync(
       replayClient,
       pauseId,
-      frameId,
-      text: expression,
-      pure: true,
-    });
+      frameId ?? null,
+      expression,
+      undefined,
+      true
+    );
     if (returned && !exception) {
       return returned;
     }

--- a/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
+++ b/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
@@ -12,6 +12,7 @@ import { useIsPointWithinFocusWindow } from "replay-next/src/hooks/useIsPointWit
 import { useNag } from "replay-next/src/hooks/useNag";
 import { RecordingTarget, recordingTargetCache } from "replay-next/src/suspense/BuildIdCache";
 import { objectCache } from "replay-next/src/suspense/ObjectPreviews";
+import { evaluate } from "replay-next/src/utils/evaluate";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { ReplayClientInterface } from "shared/client/types";
 import { Nag } from "shared/graphql/types";
@@ -145,7 +146,7 @@ class ReplayWall implements Wall {
           }
           this.highlightedElementId = id;
 
-          const response = await ThreadFront.evaluate({
+          const response = await evaluate({
             replayClient: this.replayClient,
             text: `${getDOMNodes}(${rendererID}, ${id})[0]`,
           });
@@ -223,7 +224,7 @@ class ReplayWall implements Wall {
 
   // send a request to the backend in the recording and the reply to the frontend
   private async sendRequest(event: string, payload: any) {
-    const response = await ThreadFront.evaluate({
+    const response = await evaluate({
       replayClient: this.replayClient,
       text: ` window.__RECORD_REPLAY_REACT_DEVTOOLS_SEND_MESSAGE__("${event}", ${JSON.stringify(
         payload
@@ -248,7 +249,7 @@ class ReplayWall implements Wall {
       const rendererID = this.store!.rootIDToRendererID.get(rootID)!;
       const elementIDs = JSON.stringify(this.collectElementIDs(rootID));
       const expr = `${elementIDs}.reduce((map, id) => { for (node of ${getDOMNodes}(${rendererID}, id) || []) { map.set(node, id); } return map; }, new Map())`;
-      const response = await ThreadFront.evaluate({
+      const response = await evaluate({
         replayClient: this.replayClient,
         text: expr,
       });
@@ -313,7 +314,7 @@ class ReplayWall implements Wall {
       (${retrieveSelectedReactComponentFunction})()
     `;
 
-      const res = await ThreadFront.evaluate({
+      const res = await evaluate({
         replayClient: this.replayClient,
         text: findSavedComponentFunctionCommand,
       });
@@ -411,7 +412,7 @@ async function loadReactDevToolsInlineModuleFromProtocol(
 
   if (recordingTarget === "gecko") {
     // For Gecko recordings, introspect the page to determine what RDT version was used
-    const response = await ThreadFront.evaluate({
+    const response = await evaluate({
       replayClient,
       text: ` __RECORD_REPLAY_REACT_DEVTOOLS_SEND_MESSAGE__("getBridgeProtocol", undefined)`,
     });

--- a/src/ui/components/SecondaryToolbox/redux-devtools/injectReduxDevtoolsProcessing.ts
+++ b/src/ui/components/SecondaryToolbox/redux-devtools/injectReduxDevtoolsProcessing.ts
@@ -1,10 +1,9 @@
 import { ExecutionPoint, Value } from "@replayio/protocol";
 import { Cache, createCache } from "suspense";
 
-import type { ThreadFront as TF } from "protocol/thread";
-import { ThreadFront } from "protocol/thread";
 import { topFrameCache } from "replay-next/src/suspense/FrameCache";
 import { pauseIdCache } from "replay-next/src/suspense/PauseCache";
+import { evaluate } from "replay-next/src/utils/evaluate";
 import { ReplayClientInterface } from "shared/client/types";
 
 import type { Delta } from "./JSONDiff";
@@ -108,13 +107,12 @@ function diffStates() {
 }
 
 async function evaluateNoArgsFunction(
-  ThreadFront: typeof TF,
   replayClient: ReplayClientInterface,
   fn: Function,
   pauseId?: string,
   frameId?: string
 ) {
-  return await ThreadFront.evaluate({
+  return await evaluate({
     replayClient,
     text: `(${fn})()`,
     pauseId,
@@ -144,7 +142,6 @@ export const actionStateValuesCache: Cache<
     }
 
     const actionRes = await evaluateNoArgsFunction(
-      ThreadFront,
       replayClient,
       getActionObjectId,
       pauseId,
@@ -152,7 +149,6 @@ export const actionStateValuesCache: Cache<
     );
 
     const stateRes = await evaluateNoArgsFunction(
-      ThreadFront,
       replayClient,
       getStateObjectId,
       pauseId,
@@ -186,14 +182,13 @@ export const diffCache: Cache<
 
     const jsondiffpatchSource = require("./jsondiffpatch.umd.slim.raw.js").default;
 
-    await ThreadFront.evaluate({
+    await evaluate({
       replayClient,
       pauseId,
       text: jsondiffpatchSource,
     });
 
     const diffResult = await evaluateNoArgsFunction(
-      ThreadFront,
       replayClient,
       diffStates,
       pauseId,


### PR DESCRIPTION
`ThreadFront.evaluate()` was used in 3 places:
- for `autocomplete-eager.ts` I used the `pauseEvaluationsCache`
- for react and redux devtools I used a copy of the `evaluate()` function that doesn't cache its results: here we're using evaluations to inject or communicate with the react/redux devtools backend, caching these evaluations didn't seem to make sense or may even cause bugs

I also removed the repaint-after-evaluation logic, it was broken anyway (it's meant for user evaluations in the replay console but the console didn't use `ThreadFront.evalute()` anymore). I've created FE-1654 for reimplementing it.