### PR TITLE
Change default shared breakpoint state from "off-temporarily" to "off"

### DIFF
--- a/packages/replay-next/components/sources/SourceListRow.tsx
+++ b/packages/replay-next/components/sources/SourceListRow.tsx
@@ -371,11 +371,7 @@ const SourceListRow = memo(
           break;
         case POINT_BEHAVIOR_DISABLED:
         default:
-          if (pointForDefaultPriority.user?.id !== currentUserInfo?.id) {
-            breakPointTestState = "off-temporarily";
-          } else {
-            breakPointTestState = "off";
-          }
+          breakPointTestState = "off";
           break;
       }
     }


### PR DESCRIPTION
# Background

In Replay, a "point" (a source file, line number, and column number) can have either or both of the following behaviors:
* Break point: Pause whenever the runtime executes that source code location
* Log point (or "print statement"): Log something to the console whenever the runtime executes that source code location

These "points" can be shared between users who have access to a recording. All of this is modeled with two concept: the "point" and it's "behaviors":

#### Point

Points are saved to GraphQL (for authenticated users) and to `localStorage` (for unauthenticated users). They can be viewed by all users who have access to a recording. They can only be edited or deleted by the user who created them.
```ts
{
  // This a client-assigned value is used as the primary key on the server.
  // It exists to simplify equality checks and PointBehavior mapping.
  key: PointKey;

  // These attributes are fixed after Point creation
  createdAt: Date;
  location: Location;
  recordingId: RecordingId;
  user: PartialUser | null;

  // These attributes are editable, although only by the Point's owner
  badge: Badge | null;
  condition: string | null;
  content: string;
}
```
#### Point behavior

Point behaviors are saved to `IndexedDB`. (They are remembered between sessions but are not shared with other users.) They control a given point behaves locally (e.g. does it log to the console) and are modifiable by everyone (regardless of who created a point).
```ts
{
  key: PointKey;
  shouldBreak: POINT_BEHAVIOR;
  shouldLog: POINT_BEHAVIOR;
}
```


# The problem

Unfortunately, the above data model means that shared points have some ambiguity. (For points that were shared from another user, Replay can't infer whether the point was a log point or a break point.)

For example, if I add two log points and two break points to a recording, the Pause Information panel looks like this for me:

![Screen Shot 2023-07-05 at 10 35 26 AM](https://github.com/replayio/devtools/assets/29597/07e2a636-b459-486a-b409-a63be6c19b30)

But for another user it looks like this:

![Screen Shot 2023-07-05 at 10 35 42 AM](https://github.com/replayio/devtools/assets/29597/ed9de3dd-b3f3-457c-8354-c94d74a0854b)

This is not so bad, but in the source viewer it's worse. Given the above scenario, my Source viewer would look like this:

![Screen Shot 2023-07-05 at 10 50 42 AM](https://github.com/replayio/devtools/assets/29597/e81aae97-0a38-4e6f-b344-9167086e4d71)

But for another user it would look like this (every point shows both log point and break point controls):

![Screen Shot 2023-07-05 at 10 50 34 AM](https://github.com/replayio/devtools/assets/29597/bccfa59e-72ff-4fee-94f6-0cc205cf8ea7)

# The solution

If we want to better synchronize this UI state, we would need to change both the frontend and backend to add an additional attribute to point to track which mode(s) the author of the point used.

Barring the above, this PR proposes an intermediate change: assume everything is a log point. In other words, another user's Source view would look like this:

![Screen Shot 2023-07-05 at 10 54 24 AM](https://github.com/replayio/devtools/assets/29597/c8faaed1-149b-48a7-928f-1a7b7b1a427e)

The major downsides of this change are:
* It makes everything look like a log point (even if it wasn't meant to be)
* It makes shared break points invisible in the Source viewer unless you opened the Pause Information panel and toggled them on.

My gut tells me that this is probably a good incremental step. In part, this is because I don't find break points very useful in Replay really. I think log points (or "print statements") are way more useful, and maybe we're making things harder on ourselves than we need to and we should consider dropping break points entirely.