### PR TITLE
[Test Suites] Add client-side plug-in integration error warning

### DIFF
--- a/src/ui/components/TestSuite/views/GroupedTestCases/Panel.module.css
+++ b/src/ui/components/TestSuite/views/GroupedTestCases/Panel.module.css
@@ -71,6 +71,9 @@
   border-bottom: 1px solid var(--theme-border);
   background-color: var(--background-color-warning);
   color: var(--color-warning);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .ErrorLink {

--- a/src/ui/components/TestSuite/views/GroupedTestCases/Panel.tsx
+++ b/src/ui/components/TestSuite/views/GroupedTestCases/Panel.tsx
@@ -104,13 +104,16 @@ function EnvironmentError({ error }: { error: TestEnvironmentError }) {
     });
   }, [error, recordingId]);
 
+  const message = error.message ?? "Something went wrong";
+
   return (
     <div className={styles.Error}>
-      Something went wrong (error code <strong>{error.code}</strong>).{" "}
+      <div>
+        Error {error.code}: {message}
+      </div>
       <a className={styles.ErrorLink} href="http://replay.io/discord" target="discord">
         Contact us on Discord
       </a>
-      .
     </div>
   );
 }


### PR DESCRIPTION
![Screen Shot 2023-07-05 at 3 21 29 PM](https://github.com/replayio/devtools/assets/29597/8179f720-78ea-40a8-8141-4d597ddab848)

I have misgivings about this approach for a few reasons:
* Separations of concerns. (Frontend passively displays environment and test errors– except for this kind.)
* Ambiguous state. (Test with no assertions vs misconfigured plug-in.)

In addition to that, filling in mock annotations and environment errors feels sketchy.

Seems like our tech stack does not have a great way of detecting and handling this otherwise. (I'd love an alternative proposal for this.)