### PR TITLE
Polish Pause Info pane

### DIFF
--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/Breakpoints.module.css
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/Breakpoints.module.css
@@ -13,10 +13,9 @@
 }
 
 .Empty {
-  white-space: normal;
-  border-radius: 0.5rem;
-  background-color: var(--chrome);
-  font-size: var(--font-size-small);
-  padding: 0.25rem 0.5rem;
-  margin: 0 0.25rem;
+  font-style: italic;
+  text-align: center;
+  padding: 0.5em;
+  user-select: none;
+  cursor: default;
 }

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/BreakpointsPane.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/BreakpointsPane.tsx
@@ -1,10 +1,5 @@
 import Breakpoints from "./Breakpoints";
 
 export default function BreakpointsPane() {
-  return (
-    <Breakpoints
-      emptyContent="Click on a line number in the editor to add a breakpoint"
-      type="breakpoint"
-    />
-  );
+  return <Breakpoints emptyContent="No breakpoints set" type="breakpoint" />;
 }

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/NewFrames.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/NewFrames.tsx
@@ -218,7 +218,7 @@ function Frames({ panel, point, time }: FramesProps) {
         key={pauseId}
         fallback={<div className="pane-info empty">Error loading frames</div>}
       >
-        <Suspense fallback={<div className="pane-info empty">Loading…</div>}>
+        <Suspense fallback={<div className="pane-info empty">Loading...</div>}>
           <div role="list">
             <FramesRenderer pauseId={pauseId} panel={panel} />
           </div>
@@ -230,7 +230,13 @@ function Frames({ panel, point, time }: FramesProps) {
 
 export default function FramesSuspenseWrapper(props: FramesProps) {
   return (
-    <Suspense fallback={<div className="pane-info empty">Loading…</div>}>
+    <Suspense
+      fallback={
+        <div className="pane">
+          <div className="pane-info empty">Loading...</div>
+        </div>
+      }
+    >
       <Frames {...props} />
     </Suspense>
   );

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/LogpointsPane.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/LogpointsPane.tsx
@@ -5,15 +5,7 @@ import Breakpoints from "./Breakpoints";
 export default function LogpointsPane() {
   return (
     <Breakpoints
-      emptyContent={
-        <>
-          {`Click on the `}
-          <span className="inline-flex rounded-sm bg-gray-400 text-white">
-            <MaterialIcon iconSize="xs">add</MaterialIcon>
-          </span>
-          {` in the editor to add a print statement`}
-        </>
-      }
+      emptyContent={<>{`Click in the editor to add a print statement`}</>}
       type="logpoint"
     />
   );

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/LogpointsPane.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/LogpointsPane.tsx
@@ -5,7 +5,7 @@ import Breakpoints from "./Breakpoints";
 export default function LogpointsPane() {
   return (
     <Breakpoints
-      emptyContent={<>{`Click in the editor to add a print statement`}</>}
+      emptyContent="Click in the editor to add a print statement"
       type="logpoint"
     />
   );

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/NewObjectInspector.module.css
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/NewObjectInspector.module.css
@@ -6,5 +6,5 @@
 }
 
 .Empty {
-  font-family: Inter;
+  font-family: var(--font-family-default);
 }

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/NewObjectInspector.module.css
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/NewObjectInspector.module.css
@@ -4,3 +4,7 @@
   flex-direction: column;
   padding: 0 0.25rem;
 }
+
+.Empty {
+  font-family: Inter;
+}

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/NewScopes.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/NewScopes.tsx
@@ -25,8 +25,8 @@ function ScopesRenderer() {
   const selectedFrameId = useAppSelector(getSelectedFrameId);
   if (!selectedFrameId) {
     return (
-      <div className="pane">
-        <div className="pane-info empty">Not paused at a point with any scopes</div>
+      <div className="pane pane-info">
+        <div className={styles.Empty}>Not paused at a point with any scopes</div>
       </div>
     );
   }

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/index.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/index.tsx
@@ -33,20 +33,20 @@ export default function SecondaryPanes() {
       <FrameTimeline />
       <Accordion>
         <AccordionPane
-          header="Breakpoints"
-          className="breakpoints-pane"
-          expanded={breakpointsVisible}
-          onToggle={() => setBreakpointsVisible(!breakpointsVisible)}
-        >
-          <BreakpointsPane />
-        </AccordionPane>
-        <AccordionPane
           header="Print Statements"
           className="breakpoints-pane"
           expanded={logpointsVisible}
           onToggle={() => setLogpointsVisible(!logpointsVisible)}
         >
           <LogpointsPane />
+        </AccordionPane>
+        <AccordionPane
+          header="Breakpoints"
+          className="breakpoints-pane"
+          expanded={breakpointsVisible}
+          onToggle={() => setBreakpointsVisible(!breakpointsVisible)}
+        >
+          <BreakpointsPane />
         </AccordionPane>
         <AccordionPane
           header="Call Stack"


### PR DESCRIPTION
![image](https://github.com/replayio/devtools/assets/9154902/8ddad8fe-e4d5-4908-b690-99f342dc345b)

Addresses [DES-760](https://linear.app/replay/issue/DES-760/pause-info-cleanup)
[Figma link](https://www.figma.com/file/mAotNZRv6M5X0zHIFKPzFY/Replay-Design-Doc?type=design&node-id=17781-308367&mode=design&t=1mgxxUNLx9ZlYgjO-4)

- [x] Standardized fonts (we were using sans-serif in some places and serif in others)
- [x] Standardized visual treatment (we were using boxes in some places and no boxes in others)
- [x] Fixed misalignment for "loading..." message
- [x] Put print statements on the top instead of breakpoints

Additional notes:

* We're trying to de-emphasize breakpoints, so it's fine to remove the call to action
* Print statements is something we want to highlight, but we do a good job with that in our NUX Tour. By the time a person clicks into Pause Info, it's highly likely they already know about the feature. Plus, the grey plus icon was misaligned and looked broken before. Better to standardize it.
