### PR TITLE
Remove dots from chained events in testsuites

### DIFF
--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
@@ -142,11 +142,7 @@ export default memo(function UserActionEventRow({
       onMouseLeave={() => setIsHovered(false)}
     >
       <div className={styles.Text}>
-        {eventNumber != null ? (
-          <span className={styles.Number}>{eventNumber}</span>
-        ) : (
-          <span className={styles.ChainedEvent}>.</span>
-        )}
+        {eventNumber != null ? <span className={styles.Number}>{eventNumber}</span> : null}
         <span
           className={`${styles.Name} ${styles.Name}`}
           data-name={command.name}


### PR DESCRIPTION
Before/after:
![image](https://github.com/replayio/devtools/assets/9154902/8c758ffc-d1cb-4f66-bf40-726a925eda7e)

Addresss https://linear.app/replay/issue/DES-759/should-a-dot-precede-the-assert