### PR TITLE
Skip processing annotations for cypress tests with unknown result

### DIFF
--- a/packages/shared/test-suites/RecordingTestMetadata.ts
+++ b/packages/shared/test-suites/RecordingTestMetadata.ts
@@ -331,8 +331,9 @@ export async function processCypressTestRecording(
 
     const navigationEvents: RecordingTestMetadataV3.NavigationEvent[] = [];
 
-    // Skipped tests won't contain any annotations (include begin/end point)
-    if (result !== "skipped") {
+    // Tests that were not run (skipped and unknown) won't contain any
+    // annotations (include begin/end point)
+    if (result !== "skipped" && result !== "unknown") {
       // Note that event annotations may be interleaved,
       // meaning that we can't step through both arrays in one pass.
       // Instead we have to loop over the annotations array once to group data by event id–


### PR DESCRIPTION
Like `skipped` tests, test with an `unknown` result in Cypress will not have annotations because they were not run (usually because a pre-condition like `before` or `beforeEach` failed).

This proposed change will skip processing annotations for these tests as well since we do not expect to find them.

Replay that repros the issue: https://app.replay.io/recording/cypresse2e1-basictodocyjs--697311c4-0692-44f1-83da-800ecc57f567
Replay of the fix: https://app.replay.io/recording/scs-1196-fix--5d78f4fe-f455-4c0e-b092-c9d8f1afc040