### PR TITLE
Missing Cypress plug-in (iteration)

### DIFF
--- a/packages/shared/test-suites/RecordingTestMetadata.ts
+++ b/packages/shared/test-suites/RecordingTestMetadata.ts
@@ -332,239 +332,245 @@ export async function processCypressTestRecording(
     const navigationEvents: RecordingTestMetadataV3.NavigationEvent[] = [];
 
     // Skipped tests won't contain any annotations (include begin/end point)
-    if (result !== "skipped") {
-      // Note that event annotations may be interleaved,
-      // meaning that we can't step through both arrays in one pass.
-      // Instead we have to loop over the annotations array once to group data by event id–
-      // (and also find the navigation and test start/end annotations)–
-      // then we can iterate over the user-action events.
-      const userActionEventIdToAnnotations: Record<string, Annotation[]> = {};
+    switch (result) {
+      case "skipped":
+      case "unknown": {
+        break;
+      }
+      default: {
+        // Note that event annotations may be interleaved,
+        // meaning that we can't step through both arrays in one pass.
+        // Instead we have to loop over the annotations array once to group data by event id–
+        // (and also find the navigation and test start/end annotations)–
+        // then we can iterate over the user-action events.
+        const userActionEventIdToAnnotations: Record<string, Annotation[]> = {};
 
-      for (let index = 0; index < annotations.length; index++) {
-        const annotation = annotations[index];
-        switch (annotation.message.event) {
-          case "event:navigation": {
-            assert(annotation.message.url, "Navigation annotation must have a URL");
+        for (let index = 0; index < annotations.length; index++) {
+          const annotation = annotations[index];
+          switch (annotation.message.event) {
+            case "event:navigation": {
+              assert(annotation.message.url, "Navigation annotation must have a URL");
 
-            const navigationEvent: RecordingTestMetadataV3.NavigationEvent = {
-              data: {
-                url: annotation.message.url,
-              },
-              timeStampedPoint: {
+              const navigationEvent: RecordingTestMetadataV3.NavigationEvent = {
+                data: {
+                  url: annotation.message.url,
+                },
+                timeStampedPoint: {
+                  point: annotation.point,
+                  time: annotation.time,
+                },
+                type: "navigation",
+              };
+
+              navigationEvents.push(navigationEvent);
+              break;
+            }
+            case "step:end":
+            case "step:enqueue":
+            case "step:start": {
+              const id = annotation.message.id;
+              assert(id != null, "Annotation event must have an id");
+              if (userActionEventIdToAnnotations[id] == null) {
+                userActionEventIdToAnnotations[id] = [annotation];
+              } else {
+                userActionEventIdToAnnotations[id].push(annotation);
+              }
+              break;
+            }
+            case "test:start": {
+              beginPoint = {
                 point: annotation.point,
                 time: annotation.time,
-              },
-              type: "navigation",
-            };
-
-            navigationEvents.push(navigationEvent);
-            break;
-          }
-          case "step:end":
-          case "step:enqueue":
-          case "step:start": {
-            const id = annotation.message.id;
-            assert(id != null, "Annotation event must have an id");
-            if (userActionEventIdToAnnotations[id] == null) {
-              userActionEventIdToAnnotations[id] = [annotation];
-            } else {
-              userActionEventIdToAnnotations[id].push(annotation);
+              };
+              break;
             }
-            break;
-          }
-          case "test:start": {
-            beginPoint = {
-              point: annotation.point,
-              time: annotation.time,
-            };
-            break;
-          }
-          case "test:end": {
-            endPoint = {
-              point: annotation.point,
-              time: annotation.time,
-            };
-            break;
-          }
-          default: {
-            console.warn(`Unexpected annotation type: ${annotation.message.event}`);
+            case "test:end": {
+              endPoint = {
+                point: annotation.point,
+                time: annotation.time,
+              };
+              break;
+            }
+            default: {
+              console.warn(`Unexpected annotation type: ${annotation.message.event}`);
+            }
           }
         }
-      }
 
-      assert(beginPoint !== null, "Test must have a begin point");
-      assert(endPoint !== null, "Test must have a end point");
+        assert(beginPoint !== null, "Test must have a begin point");
+        assert(endPoint !== null, "Test must have a end point");
 
-      for (let sectionName in partialEvents) {
-        // TODO [SCS-1186] Ignore beforeAll/afterAll sections for now;
-        // We'll need to make some changes to both Devtools UI and the Replay plug-in to handle these
-        switch (sectionName) {
-          case "afterAll":
-          case "beforeAll":
-            continue;
-        }
-
-        const testEvents = events[sectionName as RecordingTestMetadataV3.TestSectionName];
-
-        const partialTestEvents =
-          partialEvents[sectionName as RecordingTestMetadataV3.TestSectionName];
-        partialTestEvents.forEach(partialTestEvent => {
-          const {
-            category,
-            command,
-            error = null,
-            id,
-            parentId = null,
-            scope = null,
-          } = partialTestEvent.data;
-
-          assert(category, `Test event must have "category" property`, {
-            command: command.name,
-            id,
-          });
-
-          assert(command, `Test event must have "command" property`, {
-            id,
-            category,
-          });
-
-          assert(id, `Test event must have "id" property`, {
-            command: command.name,
-            category,
-          });
-
-          // The client does not show certain types of chained events in the list
-          // they clutter without adding much value
-          if (parentId !== null) {
-            switch (command.name) {
-              case "as":
-              case "then":
-                return null;
-            }
+        for (let sectionName in partialEvents) {
+          // TODO [SCS-1186] Ignore beforeAll/afterAll sections for now;
+          // We'll need to make some changes to both Devtools UI and the Replay plug-in to handle these
+          switch (sectionName) {
+            case "afterAll":
+            case "beforeAll":
+              continue;
           }
 
-          const annotations = userActionEventIdToAnnotations[id];
+          const testEvents = events[sectionName as RecordingTestMetadataV3.TestSectionName];
 
-          assert(annotations != null, `Missing annotations for test event`, {
-            command: command.name,
-            id,
-          });
-
-          let beginPoint: TimeStampedPoint | null = null;
-          let endPoint: TimeStampedPoint | null = null;
-          let resultPoint: TimeStampedPoint | null = null;
-          let resultVariable: string | null = null;
-          let viewSourceTimeStampedPoint: TimeStampedPoint | null = null;
-
-          const isChaiAssertion = command.name === "assert";
-          // TODO [FE-1419] name === "assert" && !annotations.enqueue;
-
-          annotations.forEach(annotation => {
-            switch (annotation.message.event) {
-              case "step:end": {
-                endPoint = {
-                  point: annotation.point,
-                  time: annotation.time,
-                };
-
-                resultPoint = {
-                  point: annotation.point,
-                  time: annotation.time,
-                };
-                resultVariable = annotation.message.logVariable ?? null;
-                break;
-              }
-              case "step:enqueue": {
-                if (!isChaiAssertion) {
-                  viewSourceTimeStampedPoint = {
-                    point: annotation.point,
-                    time: annotation.time,
-                  };
-                }
-                break;
-              }
-              case "step:start": {
-                beginPoint = {
-                  point: annotation.point,
-                  time: annotation.time,
-                };
-
-                if (isChaiAssertion) {
-                  viewSourceTimeStampedPoint = {
-                    point: annotation.point,
-                    time: annotation.time,
-                  };
-                }
-                break;
-              }
-            }
-          });
-
-          assert(beginPoint !== null, `Missing "step:start" annotation for test event`, {
-            id,
-            isChaiAssertion,
-          });
-
-          assert(viewSourceTimeStampedPoint !== null, `Missing annotation for test event`, {
-            annotationType: isChaiAssertion ? "step:start" : "step:enqueue",
-            id,
-            isChaiAssertion,
-          });
-
-          testEvents.push({
-            data: {
-              category: category,
-              command: {
-                arguments: command.arguments,
-                name: command.name,
-              },
-              error,
+          const partialTestEvents =
+            partialEvents[sectionName as RecordingTestMetadataV3.TestSectionName];
+          partialTestEvents.forEach(partialTestEvent => {
+            const {
+              category,
+              command,
+              error = null,
               id,
-              parentId,
-              result:
-                resultVariable && resultPoint
-                  ? {
-                      timeStampedPoint: resultPoint,
-                      variable: resultVariable,
-                    }
-                  : null,
-              scope,
-              viewSourceTimeStampedPoint,
-            },
-            timeStampedPointRange: {
-              begin: beginPoint,
-              end: endPoint || beginPoint,
-            },
-            type: "user-action",
+              parentId = null,
+              scope = null,
+            } = partialTestEvent.data;
+
+            assert(category, `Test event must have "category" property`, {
+              command: command.name,
+              id,
+            });
+
+            assert(command, `Test event must have "command" property`, {
+              id,
+              category,
+            });
+
+            assert(id, `Test event must have "id" property`, {
+              command: command.name,
+              category,
+            });
+
+            // The client does not show certain types of chained events in the list
+            // they clutter without adding much value
+            if (parentId !== null) {
+              switch (command.name) {
+                case "as":
+                case "then":
+                  return null;
+              }
+            }
+
+            const annotations = userActionEventIdToAnnotations[id];
+
+            assert(annotations != null, `Missing annotations for test event`, {
+              command: command.name,
+              id,
+            });
+
+            let beginPoint: TimeStampedPoint | null = null;
+            let endPoint: TimeStampedPoint | null = null;
+            let resultPoint: TimeStampedPoint | null = null;
+            let resultVariable: string | null = null;
+            let viewSourceTimeStampedPoint: TimeStampedPoint | null = null;
+
+            const isChaiAssertion = command.name === "assert";
+            // TODO [FE-1419] name === "assert" && !annotations.enqueue;
+
+            annotations.forEach(annotation => {
+              switch (annotation.message.event) {
+                case "step:end": {
+                  endPoint = {
+                    point: annotation.point,
+                    time: annotation.time,
+                  };
+
+                  resultPoint = {
+                    point: annotation.point,
+                    time: annotation.time,
+                  };
+                  resultVariable = annotation.message.logVariable ?? null;
+                  break;
+                }
+                case "step:enqueue": {
+                  if (!isChaiAssertion) {
+                    viewSourceTimeStampedPoint = {
+                      point: annotation.point,
+                      time: annotation.time,
+                    };
+                  }
+                  break;
+                }
+                case "step:start": {
+                  beginPoint = {
+                    point: annotation.point,
+                    time: annotation.time,
+                  };
+
+                  if (isChaiAssertion) {
+                    viewSourceTimeStampedPoint = {
+                      point: annotation.point,
+                      time: annotation.time,
+                    };
+                  }
+                  break;
+                }
+              }
+            });
+
+            assert(beginPoint !== null, `Missing "step:start" annotation for test event`, {
+              id,
+              isChaiAssertion,
+            });
+
+            assert(viewSourceTimeStampedPoint !== null, `Missing annotation for test event`, {
+              annotationType: isChaiAssertion ? "step:start" : "step:enqueue",
+              id,
+              isChaiAssertion,
+            });
+
+            testEvents.push({
+              data: {
+                category: category,
+                command: {
+                  arguments: command.arguments,
+                  name: command.name,
+                },
+                error,
+                id,
+                parentId,
+                result:
+                  resultVariable && resultPoint
+                    ? {
+                        timeStampedPoint: resultPoint,
+                        variable: resultVariable,
+                      }
+                    : null,
+                scope,
+                viewSourceTimeStampedPoint,
+              },
+              timeStampedPointRange: {
+                begin: beginPoint,
+                end: endPoint || beginPoint,
+              },
+              type: "user-action",
+            });
           });
+        }
+
+        // Finds the section that contains a given point
+        // defaults to the main (test body) section if no matches found
+        const findSection = (point: ExecutionPoint) => {
+          const sections = Object.values(events);
+          for (let index = sections.length - 1; index >= 0; index--) {
+            const events = sections[index];
+            const firstEvent = events[0];
+            if (firstEvent && comparePoints(getTestEventExecutionPoint(firstEvent)!, point) <= 0) {
+              return events;
+            }
+          }
+          return events.main;
+        };
+
+        const networkRequestEvents = await processNetworkData(replayClient, beginPoint, endPoint);
+        // Now that section boundaries have been defined by user-actions,
+        // merge in navigation and network events.
+        navigationEvents.forEach(navigationEvent => {
+          const events = findSection(navigationEvent.timeStampedPoint.point);
+          insert(events, navigationEvent, compareTestEventExecutionPoints);
+        });
+        networkRequestEvents.forEach(networkRequestEvent => {
+          const events = findSection(networkRequestEvent.timeStampedPoint.point);
+          insert(events, networkRequestEvent, compareTestEventExecutionPoints);
         });
       }
-
-      // Finds the section that contains a given point
-      // defaults to the main (test body) section if no matches found
-      const findSection = (point: ExecutionPoint) => {
-        const sections = Object.values(events);
-        for (let index = sections.length - 1; index >= 0; index--) {
-          const events = sections[index];
-          const firstEvent = events[0];
-          if (firstEvent && comparePoints(getTestEventExecutionPoint(firstEvent)!, point) <= 0) {
-            return events;
-          }
-        }
-        return events.main;
-      };
-
-      const networkRequestEvents = await processNetworkData(replayClient, beginPoint, endPoint);
-      // Now that section boundaries have been defined by user-actions,
-      // merge in navigation and network events.
-      navigationEvents.forEach(navigationEvent => {
-        const events = findSection(navigationEvent.timeStampedPoint.point);
-        insert(events, navigationEvent, compareTestEventExecutionPoints);
-      });
-      networkRequestEvents.forEach(networkRequestEvent => {
-        const events = findSection(networkRequestEvent.timeStampedPoint.point);
-        insert(events, networkRequestEvent, compareTestEventExecutionPoints);
-      });
     }
 
     return {
@@ -616,7 +622,7 @@ export async function processGroupedTestCases(
             const test = await processCypressTestRecording(
               {
                 ...legacyTest,
-                result: "skipped",
+                result: "unknown",
               },
               [],
               replayClient

--- a/packages/shared/test-suites/RecordingTestMetadata.ts
+++ b/packages/shared/test-suites/RecordingTestMetadata.ts
@@ -884,7 +884,7 @@ function detectMissingCypressPlugin(
     return !hasIncompleteTest;
   }
 
-  return true;
+  return false;
 }
 
 async function processNetworkData(


### PR DESCRIPTION
### [View without whitespace](https://github.com/replayio/devtools/pull/9461/files?w=1)

Change client-side detection of missing Cypress plug-in scenario a bit:
* Change test result to `"unknown"` (which also has the effect of skipping annotations parsing).
* Remove fake begin/end annotations in favor of just skipping the annotation processing. (This felt yuck before.)

Note this PR includes @ryanjduffy's fix from #9459 (SCS-1196) so that I could use the status `"unknown"` for these tests (rather than the less accurate `"skipped"`).

### Before
![Screen Shot 2023-07-06 at 8 48 26 AM](https://github.com/replayio/devtools/assets/29597/f87008a5-7225-498c-9412-ee14172f704a)

### After
![Screen Shot 2023-07-06 at 8 56 10 AM](https://github.com/replayio/devtools/assets/29597/259d35cd-8a09-45d6-b2e6-2875ffba1fad)
