### PR TITLE
Set bias based on inferred user intent when focus window modified

### DIFF
--- a/packages/replay-next/src/utils/time.test.ts
+++ b/packages/replay-next/src/utils/time.test.ts
@@ -1,6 +1,6 @@
 import { TimeStampedPoint, TimeStampedPointRange } from "@replayio/protocol";
 
-import { formatDuration, formatTimestamp, isRangeEqual, isRangeSubset } from "./time";
+import { formatDuration, formatTimestamp } from "./time";
 
 describe("Time util", () => {
   function toTSP(time: number): TimeStampedPoint {
@@ -51,42 +51,6 @@ describe("Time util", () => {
     it("should round fractional values", () => {
       expect(formatTimestamp(1.3, true)).toEqual("0:00.001");
       expect(formatTimestamp(1.7, true)).toEqual("0:00.002");
-    });
-  });
-
-  describe("isRangeEqual", () => {
-    it("should properly handle combinations of null values", () => {
-      expect(isRangeEqual(null, null)).toEqual(true);
-      expect(isRangeEqual(toTSPR(1, 3), null)).toEqual(false);
-      expect(isRangeEqual(null, toTSPR(1, 3))).toEqual(false);
-    });
-
-    it("should properly handle non-null ranges", () => {
-      expect(isRangeEqual(toTSPR(1, 3), toTSPR(1, 3))).toEqual(true);
-      expect(isRangeEqual(toTSPR(1, 3), toTSPR(0, 0))).toEqual(false);
-      expect(isRangeEqual(toTSPR(1, 3), toTSPR(1, 1))).toEqual(false);
-      expect(isRangeEqual(toTSPR(1, 3), toTSPR(3, 3))).toEqual(false);
-    });
-  });
-
-  describe("isRangeSubset", () => {
-    it("should properly handle combinations of null values", () => {
-      expect(isRangeSubset(null, null)).toBe(true);
-      expect(isRangeSubset(null, toTSPR(1, 3))).toBe(true);
-      expect(isRangeSubset(toTSPR(1, 3), null)).toBe(false);
-    });
-
-    it("should properly handle non-null ranges", () => {
-      expect(isRangeSubset(toTSPR(1, 3), toTSPR(1, 3))).toBe(true);
-      expect(isRangeSubset(toTSPR(1, 3), toTSPR(2, 3))).toBe(true);
-      expect(isRangeSubset(toTSPR(1, 3), toTSPR(1, 2))).toBe(true);
-      expect(isRangeSubset(toTSPR(1, 3), toTSPR(2, 2))).toBe(true);
-
-      expect(isRangeSubset(toTSPR(1, 3), toTSPR(0, 3))).toBe(false);
-      expect(isRangeSubset(toTSPR(1, 3), toTSPR(1, 4))).toBe(false);
-      expect(isRangeSubset(toTSPR(1, 3), toTSPR(2, 4))).toBe(false);
-      expect(isRangeSubset(toTSPR(1, 3), toTSPR(0, 2))).toBe(false);
-      expect(isRangeSubset(toTSPR(1, 3), toTSPR(0, 4))).toBe(false);
     });
   });
 });

--- a/packages/replay-next/src/utils/time.ts
+++ b/packages/replay-next/src/utils/time.ts
@@ -1,4 +1,4 @@
-import { ExecutionPoint, TimeStampedPointRange } from "@replayio/protocol";
+import { ExecutionPoint } from "@replayio/protocol";
 import differenceInCalendarDays from "date-fns/differenceInCalendarDays";
 import differenceInMinutes from "date-fns/differenceInMinutes";
 import differenceInMonths from "date-fns/differenceInMonths";
@@ -6,17 +6,6 @@ import differenceInWeeks from "date-fns/differenceInWeeks";
 import differenceInYears from "date-fns/differenceInYears";
 import padStart from "lodash/padStart";
 import prettyMilliseconds from "pretty-ms";
-
-export function areRangesEqual(
-  prevRanges: Array<TimeStampedPointRange>,
-  nextRanges: Array<TimeStampedPointRange>
-): boolean {
-  return (
-    prevRanges.find((prevRange, index) => {
-      return !isRangeEqual(prevRange, nextRanges[index]);
-    }) == null
-  );
-}
 
 export function compareExecutionPoints(a: ExecutionPoint, b: ExecutionPoint): number {
   return Number(BigInt(a) - BigInt(b));
@@ -81,42 +70,5 @@ export function formatTimestamp(ms: number, showHighPrecision: boolean = false) 
     return `${minutesString}:${secondsString}.${millisecondsString}`;
   } else {
     return `${minutesString}:${secondsString}`;
-  }
-}
-
-export function isRangeEqual(
-  prevRange: TimeStampedPointRange | null,
-  nextRange: TimeStampedPointRange | null
-): boolean {
-  if (prevRange === null && nextRange === null) {
-    return true;
-  } else if (prevRange !== null && nextRange !== null) {
-    return (
-      nextRange.begin.point === prevRange.begin.point && nextRange.end.point === prevRange.end.point
-    );
-  } else {
-    return false;
-  }
-}
-
-export function isRangeSubset(
-  prevRange: TimeStampedPointRange | null,
-  nextRange: TimeStampedPointRange | null
-): boolean {
-  if (prevRange === null && nextRange === null) {
-    return true;
-  } else if (prevRange === null) {
-    // There was no previous range constraint.
-    // No matter what the new range is, it will be a subset.
-    return true;
-  } else if (nextRange === null) {
-    // There is no new range constraint.
-    // No matter what the previous range was, the new one is not a subset.
-    return false;
-  } else {
-    return !(
-      isExecutionPointsLessThan(nextRange.begin.point, prevRange.begin.point) ||
-      isExecutionPointsGreaterThan(nextRange.end.point, prevRange.end.point)
-    );
   }
 }

--- a/packages/replay-next/src/utils/timeStampedPoint.test.ts
+++ b/packages/replay-next/src/utils/timeStampedPoint.test.ts
@@ -1,0 +1,98 @@
+import { TimeStampedPoint, TimeStampedPointRange } from "@replayio/protocol";
+
+import {
+  isTimeStampedPointRangeEqual,
+  isTimeStampedPointRangeGreaterThan,
+  isTimeStampedPointRangeLessThan,
+  isTimeStampedPointRangeSubset,
+} from "replay-next/src/utils/timeStampedPoints";
+
+describe("TimeStampedPoint util", () => {
+  function toTSP(time: number): TimeStampedPoint {
+    return { time, point: `${time * 1000}` };
+  }
+
+  function toTSPR(beginTime: number, endTime: number): TimeStampedPointRange {
+    return { begin: toTSP(beginTime), end: toTSP(endTime) };
+  }
+
+  describe("isTimeStampedPointRangeEqual", () => {
+    it("should support combinations of null values", () => {
+      expect(isTimeStampedPointRangeEqual(null, null)).toEqual(true);
+      expect(isTimeStampedPointRangeEqual(toTSPR(1, 3), null)).toEqual(false);
+      expect(isTimeStampedPointRangeEqual(null, toTSPR(1, 3))).toEqual(false);
+    });
+
+    it("should support non-null values", () => {
+      expect(isTimeStampedPointRangeEqual(toTSPR(1, 3), toTSPR(1, 3))).toEqual(true);
+      expect(isTimeStampedPointRangeEqual(toTSPR(1, 3), toTSPR(0, 0))).toEqual(false);
+      expect(isTimeStampedPointRangeEqual(toTSPR(1, 3), toTSPR(1, 1))).toEqual(false);
+      expect(isTimeStampedPointRangeEqual(toTSPR(1, 3), toTSPR(3, 3))).toEqual(false);
+    });
+  });
+
+  describe("isTimeStampedPointRangeGreaterThan", () => {
+    it("should work", () => {
+      // Equal
+      expect(isTimeStampedPointRangeGreaterThan(toTSPR(1, 3), toTSPR(1, 3))).toBe(false);
+
+      // Less than
+      expect(isTimeStampedPointRangeGreaterThan(toTSPR(4, 8), toTSPR(1, 4))).toBe(false);
+      expect(isTimeStampedPointRangeGreaterThan(toTSPR(4, 8), toTSPR(3, 6))).toBe(false);
+      expect(isTimeStampedPointRangeGreaterThan(toTSPR(4, 8), toTSPR(0, 3))).toBe(false);
+
+      // Greater than
+      expect(isTimeStampedPointRangeGreaterThan(toTSPR(1, 4), toTSPR(4, 8))).toBe(true);
+      expect(isTimeStampedPointRangeGreaterThan(toTSPR(3, 6), toTSPR(4, 8))).toBe(true);
+      expect(isTimeStampedPointRangeGreaterThan(toTSPR(0, 3), toTSPR(4, 8))).toBe(true);
+      expect(isTimeStampedPointRangeGreaterThan(toTSPR(0, 3), toTSPR(0, 4))).toBe(true);
+
+      // Ambiguous
+      expect(isTimeStampedPointRangeGreaterThan(toTSPR(2, 8), toTSPR(3, 5))).toBe(false);
+      expect(isTimeStampedPointRangeGreaterThan(toTSPR(4, 6), toTSPR(1, 9))).toBe(false);
+    });
+  });
+
+  describe("isTimeStampedPointRangeLessThan", () => {
+    it("should work", () => {
+      // Equal
+      expect(isTimeStampedPointRangeLessThan(toTSPR(1, 3), toTSPR(1, 3))).toBe(false);
+
+      // Less than
+      expect(isTimeStampedPointRangeLessThan(toTSPR(4, 8), toTSPR(1, 4))).toBe(true);
+      expect(isTimeStampedPointRangeLessThan(toTSPR(4, 8), toTSPR(3, 6))).toBe(true);
+      expect(isTimeStampedPointRangeLessThan(toTSPR(4, 8), toTSPR(0, 3))).toBe(true);
+      expect(isTimeStampedPointRangeLessThan(toTSPR(4, 8), toTSPR(3, 8))).toBe(true);
+
+      // Greater than
+      expect(isTimeStampedPointRangeLessThan(toTSPR(1, 4), toTSPR(4, 8))).toBe(false);
+      expect(isTimeStampedPointRangeLessThan(toTSPR(3, 6), toTSPR(4, 8))).toBe(false);
+      expect(isTimeStampedPointRangeLessThan(toTSPR(0, 3), toTSPR(4, 8))).toBe(false);
+
+      // Ambiguous
+      expect(isTimeStampedPointRangeLessThan(toTSPR(2, 8), toTSPR(3, 5))).toBe(false);
+      expect(isTimeStampedPointRangeLessThan(toTSPR(4, 6), toTSPR(1, 9))).toBe(false);
+    });
+  });
+
+  describe("isTimeStampedPointRangeSubset", () => {
+    it("should properly handle combinations of null values", () => {
+      expect(isTimeStampedPointRangeSubset(null, null)).toBe(true);
+      expect(isTimeStampedPointRangeSubset(null, toTSPR(1, 3))).toBe(true);
+      expect(isTimeStampedPointRangeSubset(toTSPR(1, 3), null)).toBe(false);
+    });
+
+    it("should properly handle non-null ranges", () => {
+      expect(isTimeStampedPointRangeSubset(toTSPR(1, 3), toTSPR(1, 3))).toBe(true);
+      expect(isTimeStampedPointRangeSubset(toTSPR(1, 3), toTSPR(2, 3))).toBe(true);
+      expect(isTimeStampedPointRangeSubset(toTSPR(1, 3), toTSPR(1, 2))).toBe(true);
+      expect(isTimeStampedPointRangeSubset(toTSPR(1, 3), toTSPR(2, 2))).toBe(true);
+
+      expect(isTimeStampedPointRangeSubset(toTSPR(1, 3), toTSPR(0, 3))).toBe(false);
+      expect(isTimeStampedPointRangeSubset(toTSPR(1, 3), toTSPR(1, 4))).toBe(false);
+      expect(isTimeStampedPointRangeSubset(toTSPR(1, 3), toTSPR(2, 4))).toBe(false);
+      expect(isTimeStampedPointRangeSubset(toTSPR(1, 3), toTSPR(0, 2))).toBe(false);
+      expect(isTimeStampedPointRangeSubset(toTSPR(1, 3), toTSPR(0, 4))).toBe(false);
+    });
+  });
+});

--- a/packages/replay-next/src/utils/timeStampedPoints.ts
+++ b/packages/replay-next/src/utils/timeStampedPoints.ts
@@ -1,0 +1,111 @@
+import { TimeStampedPointRange } from "@replayio/protocol";
+
+import {
+  isExecutionPointsGreaterThan,
+  isExecutionPointsLessThan,
+} from "replay-next/src/utils/time";
+
+/**
+ * When comparing timestamped point ranges, there are 4 possible outcomes:
+ *
+ * 1. Ranges are equal
+ *
+ * ••[•••]•••••
+ * ••[•••]•••••
+ *
+ * 2. Next is less than prev
+ *
+ * ••••••[•••]•
+ * ••[•••]•••••
+ *
+ * ••••[•••]•••
+ * ••[•••]•••••
+ *
+ * ••••[•••]•••
+ * •••[••••]•••
+ *
+ * 2. Next is greater than prev
+ *
+ * •[•••]••••••
+ * •••[••••••]•
+ *
+ * ••[•••]••••••
+ * •••••••[•••]•
+ *
+ * ••[•••]••••••
+ * ••[•••••]••••
+ *
+ * 4. Ambiguous
+ *
+ * ••[••••••]••
+ * ••••[•••]•••
+ *
+ * •••[••]•••••
+ * •[••••••]•••
+ *
+ * ••[•••••]•••
+ * •••[••••]•••
+ *
+ * •[••••]•••••
+ * •[••]•••••••
+ */
+
+export function areTimeStampedPointRangesEqual(
+  prev: Array<TimeStampedPointRange>,
+  next: Array<TimeStampedPointRange>
+): boolean {
+  return (
+    prev.find((prev, index) => {
+      return !isTimeStampedPointRangeEqual(prev, next[index]);
+    }) == null
+  );
+}
+
+export function isTimeStampedPointRangeEqual(
+  prev: TimeStampedPointRange | null,
+  next: TimeStampedPointRange | null
+): boolean {
+  if (prev === null && next === null) {
+    return true;
+  } else if (prev !== null && next !== null) {
+    return next.begin.point === prev.begin.point && next.end.point === prev.end.point;
+  } else {
+    return false;
+  }
+}
+
+export function isTimeStampedPointRangeGreaterThan(
+  prev: TimeStampedPointRange,
+  next: TimeStampedPointRange
+): boolean {
+  return next.begin.point >= prev.begin.point && next.end.point > prev.end.point;
+}
+
+export function isTimeStampedPointRangeLessThan(
+  prev: TimeStampedPointRange,
+  next: TimeStampedPointRange
+): boolean {
+  return next.begin.point < prev.begin.point && next.end.point <= prev.end.point;
+}
+
+export function isTimeStampedPointRangeSubset(
+  prev: TimeStampedPointRange | null,
+  next: TimeStampedPointRange | null
+): boolean {
+  if (prev === null && next === null) {
+    return true;
+  } else if (prev === null) {
+    // There was no previous range constraint.
+    // No matter what the new range is, it will be a subset.
+    return true;
+  } else if (next === null) {
+    // There is no new range constraint.
+    // No matter what the previous range was, the new one is not a subset.
+    return false;
+  } else {
+    return !(
+      isExecutionPointsLessThan(next.begin.point, prev.begin.point) ||
+      isExecutionPointsGreaterThan(next.end.point, prev.end.point)
+    );
+  }
+}

--- a/src/ui/reducers/timeline.ts
+++ b/src/ui/reducers/timeline.ts
@@ -5,7 +5,7 @@ import sortBy from "lodash/sortBy";
 import { getPausePointParams } from "shared/utils/environment";
 import { MAX_FOCUS_REGION_DURATION } from "ui/actions/timeline";
 import { UIState } from "ui/state";
-import { FocusWindow, HoveredItem, TimeRange, TimelineState } from "ui/state/timeline";
+import { FocusWindow, HoveredItem, TimelineState } from "ui/state/timeline";
 import { mergeSortedPointLists } from "ui/utils/timeline";
 
 function initialTimelineState(): TimelineState {
@@ -96,7 +96,7 @@ export const {
   setPlaybackPrecachedTime,
   setPlaybackFocusWindow,
   setPlaybackStalled,
-  setFocusWindow: setFocusWindow,
+  setFocusWindow,
   setTimelineState,
   pointsReceived,
   paintsReceived,


### PR DESCRIPTION
Compare before Replay ([caa25627-3de6-4ae5-932b-497f51fc75a9](https://app.replay.io/recording/cant-get-to-the-beginning-of-the-recording--caa25627-3de6-4ae5-932b-497f51fc75a9)) to after Replay ([b9553beb-ed12-477c-9705-1250ceaeba31](https://app.replay.io/recording/fe-1636-refining-focus-window--b9553beb-ed12-477c-9705-1250ceaeba31)).

cc @jcmorrow 