### PR TITLE
Adjust testsuites dark theme

### DIFF
--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -226,7 +226,7 @@
   --color-current: #f02d5e;
   --color-default: #ffffff;
   --color-dim: #aaaaaa;
-  --color-dimmer: #666666;
+  --color-dimmer: #5f6977;
   --color-error: #ffb3d2;
   --color-link: var(--color-brand);
   --color-primary-button: #ffffff;

--- a/src/ui/components/Library/Library.module.css
+++ b/src/ui/components/Library/Library.module.css
@@ -132,3 +132,84 @@
   background-color: var(--theme-base-100);
   color: var(--body-color);
 }
+
+.recordingLink {
+  display: flex;
+  width: 100%;
+  flex-grow: 1;
+  cursor: pointer;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  overflow: hidden;
+  transition: all 0.15s ease-in-out;
+}
+
+.linkContent {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 1rem;
+}
+
+.icon {
+  margin-left: 2rem;
+  height: 1rem;
+  width: 1rem;
+}
+
+.iconWrapper {
+  display: flex;
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s ease-in-out;
+}
+
+.iconMotion {
+  margin: auto;
+  height: 1.5rem;
+  width: 1.5rem;
+  border-radius: 50%;
+}
+
+.fileInfo {
+  display: flex;
+  flex-shrink: 1;
+  flex-grow: 1;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.title {
+  display: block;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.filePath {
+  display: block;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  color: var(--color-dimmer);
+  font-size: 0.75rem;
+}
+
+.comments {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  flex-direction: row;
+  gap: 1rem;
+  color: var(--body-color);
+}
+
+.commentIcon {
+  width: 1rem;
+}
+
+.libraryRow {
+}

--- a/src/ui/components/Library/Team/View/TestRuns/BranchIcon.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/BranchIcon.tsx
@@ -17,7 +17,7 @@ export function BranchIcon({
   return (
     <div className="flex-column flex h-4 min-w-fit items-center gap-1" title={title}>
       {svgPath !== null && (
-        <svg className="h-4 w-4" viewBox="0 0 16 16" fill="currentColor">
+        <svg className="h-4 w-4" viewBox="0 0 16 16">
           <path d="M0 0h16v16H0z" fill="none" />
           <path d={svgPath} fill={fillColor} />
         </svg>

--- a/src/ui/components/Library/Team/View/TestRuns/BranchIcon.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/BranchIcon.tsx
@@ -17,7 +17,7 @@ export function BranchIcon({
   return (
     <div className="flex-column flex h-4 min-w-fit items-center gap-1" title={title}>
       {svgPath !== null && (
-        <svg className="h-4 w-4" viewBox="0 0 16 16">
+        <svg className="h-4 w-4" viewBox="0 0 16 16" fill="currentColor">
           <path d="M0 0h16v16H0z" fill="none" />
           <path d={svgPath} fill={fillColor} />
         </svg>

--- a/src/ui/components/Library/Team/View/TestRuns/Overview/TestResultListItem.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/Overview/TestResultListItem.tsx
@@ -64,16 +64,16 @@ export function TestResultListItem({
   return (
     <a
       href={`/recording/${recording.id}`}
-      className={`flex w-full flex-grow cursor-pointer flex-row items-center justify-center gap-2 truncate px-4 py-2 transition duration-150 ${styles.libraryRow}`}
+      className={`${styles.recordingLink} ${styles.libraryRow}`}
       style={{
         paddingLeft: `${depth * 1}rem`,
       }}
     >
-      <div className="flex flex-row items-center gap-1">
-        {secondaryBadgeCount != null && <Icon className="ml-2 h-4 w-4" type="arrow-nested" />}
-        <div className="flex cursor-pointer items-center justify-center transition ">
+      <div className={styles.linkContent}>
+        {secondaryBadgeCount != null && <Icon className={`${styles.icon}`} type="arrow-nested" />}
+        <div className={styles.iconWrapper}>
           <motion.div
-            className="m-auto h-6 w-6 rounded-full hover:cursor-pointer"
+            className={styles.iconMotion}
             whileHover={{ scale: 1.1 }}
             whileTap={{ scale: 1.0, boxShadow: "0px 0px 1px rgba(0,0,0,0.2)" }}
             transition={{ duration: 0.05 }}
@@ -84,17 +84,17 @@ export function TestResultListItem({
           </motion.div>
         </div>
       </div>
-      <div className="flex shrink grow flex-col truncate">
-        <div className="block truncate">{title || "Test"}</div>
+      <div className={styles.fileInfo}>
+        <div className={styles.title}>{title || "Test"}</div>
         {filePath && (
-          <div className="block truncate text-xs text-gray-600">
+          <div className={styles.filePath}>
             <HighlightedText haystack={filePath} needle={filterByText} />
           </div>
         )}
       </div>
       {numComments > 0 && (
-        <div className="align-items-center flex shrink-0 flex-row space-x-1 text-gray-600">
-          <img src="/images/comment-outline.svg" className="w-3" />
+        <div className={styles.comments}>
+          <img src="/images/comment-outline.svg" className={styles.commentIcon} />
           <span>{numComments}</span>
         </div>
       )}


### PR DESCRIPTION
**New on left, old on right**

Zoomed out:
<img width="1066" alt="image" src="https://github.com/replayio/devtools/assets/9154902/cebb5c09-1f55-41cd-9bfe-37af34978c3d">

Zoomed in:
<img width="738" alt="image" src="https://github.com/replayio/devtools/assets/9154902/7604998f-926e-4ad6-b42e-fb3fac7f59e4">

* Moved a bunch of tailwind classes into css modules
* Lightened and standardised the color on the secondary line of text