### PR TITLE
Add experimental Redux DevTools preference (off by default)

### DIFF
--- a/packages/shared/user-data/GraphQL/config.ts
+++ b/packages/shared/user-data/GraphQL/config.ts
@@ -195,6 +195,12 @@ export const config = {
     label: "Enable React Panel",
     legacyKey: "devtools.features.reactPanel",
   },
+  feature_reduxDevTools: {
+    defaultValue: Boolean(false),
+    description: "Enable experimental Redux DevTools panel",
+    label: "Enable Redux DevTools",
+    legacyKey: null,
+  },
 
   global_disableLogRocket: {
     defaultValue: Boolean(false),

--- a/src/ui/components/SecondaryToolbox/index.tsx
+++ b/src/ui/components/SecondaryToolbox/index.tsx
@@ -40,13 +40,6 @@ const ReactDevToolsPanel = React.lazy(() => import("./ReactDevTools"));
 
 const ReduxDevToolsPanel = React.lazy(() => import("./ReduxDevTools"));
 
-interface PanelButtonsProps {
-  hasReactComponents: boolean;
-  hasReduxAnnotations: boolean;
-  toolboxLayout: ToolboxLayout;
-  recordingCapabilities: RecordingCapabilities;
-}
-
 interface PanelButtonProps {
   panel: SecondaryPanelName;
   children?: React.ReactNode;
@@ -74,15 +67,22 @@ const PanelButton = ({ panel, children }: PanelButtonProps) => {
   );
 };
 
-const PanelButtons: FC<PanelButtonsProps> = ({
+function PanelButtons({
   hasReactComponents,
   hasReduxAnnotations,
   toolboxLayout,
   recordingCapabilities,
-}) => {
+}: {
+  hasReactComponents: boolean;
+  hasReduxAnnotations: boolean;
+  toolboxLayout: ToolboxLayout;
+  recordingCapabilities: RecordingCapabilities;
+}) {
   const { supportsElementsInspector, supportsNetworkRequests, supportsRepaintingGraphics } =
     recordingCapabilities;
+
   const [chromiumNetMonitorEnabled] = useGraphQLUserData("feature_chromiumNetMonitor");
+  const [reduxDevToolsEnabled] = useGraphQLUserData("feature_reduxDevTools");
 
   return (
     <div className="panel-buttons theme-tab-font-size flex flex-row items-center overflow-hidden">
@@ -95,13 +95,15 @@ const PanelButtons: FC<PanelButtonsProps> = ({
         </PanelButton>
       )}
       {hasReactComponents && <PanelButton panel="react-components">React</PanelButton>}
-      {hasReduxAnnotations && <PanelButton panel="redux-devtools">Redux</PanelButton>}
+      {hasReduxAnnotations && reduxDevToolsEnabled && (
+        <PanelButton panel="redux-devtools">Redux</PanelButton>
+      )}
       {(chromiumNetMonitorEnabled || supportsNetworkRequests) && (
         <PanelButton panel="network">Network</PanelButton>
       )}
     </div>
   );
-};
+}
 
 function ConsolePanel() {
   return (

--- a/src/ui/components/shared/UserSettingsModal/panels/Experimental.tsx
+++ b/src/ui/components/shared/UserSettingsModal/panels/Experimental.tsx
@@ -15,6 +15,7 @@ export const PREFERENCES: PreferencesKey[] = [
   "backend_rerunRoutines",
   "backend_disableRecordingAssetsInDatabase",
   "feature_reactPanel",
+  "feature_reduxDevTools",
   "backend_disableIncrementalSnapshots",
   "backend_disableConcurrentControllerLoading",
 ];


### PR DESCRIPTION
Note that this experimental setting is shown to all users. Neither the flag, nor the feature itself, is gated by any Launch Darkly checks.

We do only show the panel for recordings that have Redux annotations (so ones made with a recent build of Chromium on Windows) but from what I can tell, that's the only conditional check that exists (prior to this setting).

![Screen Shot 2023-07-07 at 7 41 17 AM](https://github.com/replayio/devtools/assets/29597/16678b49-5f75-4e07-807c-4e1101f92ad0)
