### PR TITLE
Send honeycomb events when the error boundary is hit

### DIFF
--- a/packages/protocol/socket.ts
+++ b/packages/protocol/socket.ts
@@ -239,6 +239,7 @@ export async function sendMessage<M extends CommandMethods>(
   const response = await new Promise<CommandResponse>(resolve =>
     gMessageWaiters.set(id, { method, resolve })
   );
+
   if (response.error) {
     gSessionCallbacks?.onResponseError(response);
 
@@ -265,7 +266,8 @@ export async function sendMessage<M extends CommandMethods>(
     ) {
       captureException(callerStackTrace, { extra: { code, message, method, params } });
     }
-    throw commandError(finalMessage, code);
+
+    throw commandError(finalMessage, code, { params, method, id });
   }
 
   return response.result as any;

--- a/packages/protocol/socket.ts
+++ b/packages/protocol/socket.ts
@@ -267,7 +267,7 @@ export async function sendMessage<M extends CommandMethods>(
       captureException(callerStackTrace, { extra: { code, message, method, params } });
     }
 
-    throw commandError(finalMessage, code, { params, method, id });
+    throw commandError(finalMessage, code, { id, method, params, pauseId, sessionId });
   }
 
   return response.result as any;

--- a/packages/replay-next/components/ErrorBoundary.tsx
+++ b/packages/replay-next/components/ErrorBoundary.tsx
@@ -15,12 +15,14 @@ type ErrorBoundaryState = {
 type ErrorBoundaryProps = PropsWithChildren<{
   fallback?: ReactNode;
   fallbackClassName?: string;
+
   name: string;
-  /**
-   * If `resetKey` changes after the ErrorBoundary caught an error, it will reset its state.
-   * Use `resetKey` instead of `key` if you don't want the child components to be recreated
-   * (and hence lose their state) every time the key changes.
-   */
+
+  onError?: (error: unknown) => void;
+
+  // If `resetKey` changes after the ErrorBoundary caught an error, it will reset its state.
+  // Use `resetKey` instead of `key` if you don't want the child components to be recreated
+  // (and hence lose their state) every time the key changes.
   resetKey?: string | number;
 }>;
 
@@ -90,11 +92,16 @@ export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBo
         message: "",
         name: "",
         stack: info.componentStack,
-      }).map(frame => ({
-        columnNumber: frame.columnNumber,
-        fileName: frame.fileName,
-        lineNumber: frame.lineNumber,
-      }));
+      })
+        .filter(frame => {
+          // Filter DOM elements from the stack trace.
+          return frame.fileName !== undefined;
+        })
+        .map(frame => ({
+          columnNumber: frame.columnNumber,
+          fileName: frame.fileName,
+          lineNumber: frame.lineNumber,
+        }));
     } catch (error) {}
 
     recordData("component-error-boundary", {

--- a/packages/replay-next/components/ErrorBoundary.tsx
+++ b/packages/replay-next/components/ErrorBoundary.tsx
@@ -1,19 +1,21 @@
 import { captureException } from "@sentry/browser";
+import ErrorStackParser from "error-stack-parser";
 import React, { Component, PropsWithChildren, ReactNode } from "react";
 
 import { recordData } from "replay-next/src/utils/telemetry";
+import { CommandErrorArgs, isCommandError } from "shared/utils/error";
 
 import styles from "./ErrorBoundary.module.css";
 
 type ErrorBoundaryState = {
-  error: Error | null;
+  error: unknown | null;
   erroredOnResetKey: string | number | undefined | null;
 };
 
 type ErrorBoundaryProps = PropsWithChildren<{
   fallback?: ReactNode;
   fallbackClassName?: string;
-  name?: string;
+  name: string;
   /**
    * If `resetKey` changes after the ErrorBoundary caught an error, it will reset its state.
    * Use `resetKey` instead of `key` if you don't want the child components to be recreated
@@ -22,10 +24,16 @@ type ErrorBoundaryProps = PropsWithChildren<{
   resetKey?: string | number;
 }>;
 
+type ParsedStackFrame = {
+  columnNumber: number | undefined;
+  fileName: string | undefined;
+  lineNumber: number | undefined;
+};
+
 export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   state: ErrorBoundaryState = { error: null, erroredOnResetKey: null };
 
-  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+  static getDerivedStateFromError(error: unknown): ErrorBoundaryState {
     return { error, erroredOnResetKey: null };
   }
 
@@ -37,54 +45,92 @@ export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBo
       if (state.erroredOnResetKey === null) {
         // we just caught the error and need to save the current resetKey
         return { erroredOnResetKey: props.resetKey };
-      }
-      if (props.resetKey !== state.erroredOnResetKey) {
+      } else if (props.resetKey !== state.erroredOnResetKey) {
         // the resetKey changed after an error was caught so we need to reset the state
         return { error: null, erroredOnResetKey: null };
       }
     }
+
     return null;
   }
 
-  componentDidCatch(error: Error, info: React.ErrorInfo) {
+  componentDidCatch(error: unknown, info: React.ErrorInfo) {
+    const { name } = this.props;
+
     console.error(error);
 
-    recordData("component-errorboundary", {
-      component: this.props.name || "unknown",
-      message: error.message,
-      error: error,
-      componentStack: info.componentStack,
+    let callStack: ParsedStackFrame[] | undefined = undefined;
+    let commandErrorArgs: CommandErrorArgs | undefined = undefined;
+    let errorMessage: string | undefined = undefined;
+    let errorName: string | undefined = undefined;
+
+    // Any type of value can be thrown in JavaScript.
+    if (error instanceof Error) {
+      errorMessage = error.message;
+      errorName = error.name;
+
+      if (isCommandError(error)) {
+        commandErrorArgs = error.args;
+      }
+
+      try {
+        callStack = ErrorStackParser.parse(error).map(frame => ({
+          columnNumber: frame.columnNumber,
+          fileName: frame.fileName,
+          lineNumber: frame.lineNumber,
+        }));
+      } catch (error) {}
+    } else if (typeof error === "string") {
+      errorMessage = error;
+    }
+
+    let componentStack: ParsedStackFrame[] | undefined = undefined;
+    try {
+      componentStack = ErrorStackParser.parse({
+        message: "",
+        name: "",
+        stack: info.componentStack,
+      }).map(frame => ({
+        columnNumber: frame.columnNumber,
+        fileName: frame.fileName,
+        lineNumber: frame.lineNumber,
+      }));
+    } catch (error) {}
+
+    recordData("component-error-boundary", {
+      boundary: name,
+      error: {
+        name: errorName,
+        message: errorMessage,
+        callStack,
+        componentStack,
+      },
+      command: commandErrorArgs,
     });
 
     captureException(error);
   }
 
   render() {
-    const { fallback, fallbackClassName = "" } = this.props;
+    const { children, fallback, fallbackClassName = "" } = this.props;
     const { error } = this.state;
 
     if (error !== null) {
       return fallback !== undefined ? fallback : <DefaultFallback className={fallbackClassName} />;
     }
 
-    return this.props.children;
+    return children;
   }
-}
-
-function ReplayLogo() {
-  return (
-    <svg className={styles.Logo} fill="currentColor" viewBox="0 0 34 40">
-      <path d="M15.2233 8.58217L8.95319 4.91069L2.68305 1.23921C2.41111 1.08012 2.10269 0.9964 1.78875 0.99646C1.47482 0.99652 1.16642 1.08036 0.894545 1.23955C0.622668 1.39875 0.396884 1.6277 0.239864 1.90341C0.0828448 2.17911 0.000118376 2.49187 0 2.81026V17.496C0.000105567 17.8144 0.0828232 18.1272 0.239837 18.4029C0.396852 18.6786 0.622634 18.9076 0.894513 19.0668C1.16639 19.226 1.47479 19.3098 1.78874 19.3099C2.10268 19.31 2.41111 19.2262 2.68305 19.0671L8.95319 15.3957L15.2233 11.7243C15.4952 11.5651 15.721 11.336 15.878 11.0603C16.035 10.7845 16.1177 10.4717 16.1177 10.1532C16.1177 9.83477 16.035 9.52193 15.878 9.24616C15.721 8.97038 15.4952 8.74138 15.2233 8.58217V8.58217Z"></path>
-      <path d="M15.2233 29.0322L8.95319 25.3608L2.68305 21.6893C2.41111 21.5302 2.10268 21.4465 1.78873 21.4465C1.47479 21.4466 1.16639 21.5304 0.894513 21.6896C0.622634 21.8488 0.396847 22.0778 0.239833 22.3535C0.0828188 22.6292 0.000105567 22.942 0 23.2604V37.9461C0.000105567 38.2645 0.0828188 38.5773 0.239833 38.853C0.396847 39.1287 0.622634 39.3577 0.894513 39.5169C1.16639 39.6761 1.47479 39.7599 1.78873 39.76C2.10268 39.76 2.41111 39.6763 2.68305 39.5172L8.95319 35.8458L15.2233 32.1743C15.4952 32.0151 15.721 31.7861 15.878 31.5103C16.035 31.2346 16.1177 30.9217 16.1177 30.6033C16.1177 30.2848 16.035 29.9719 15.878 29.6962C15.721 29.4204 15.4952 29.1914 15.2233 29.0322Z"></path>
-      <path d="M33.1056 18.809L26.8355 15.1375L20.5654 11.4661C20.2935 11.307 19.985 11.2233 19.6711 11.2233C19.3572 11.2234 19.0488 11.3072 18.7769 11.4664C18.505 11.6256 18.2792 11.8546 18.1222 12.1303C17.9652 12.406 17.8825 12.7187 17.8823 13.0371V27.7229C17.8825 28.0413 17.9652 28.354 18.1222 28.6297C18.2792 28.9055 18.505 29.1344 18.7769 29.2936C19.0488 29.4528 19.3572 29.5366 19.6711 29.5367C19.985 29.5367 20.2935 29.453 20.5654 29.2939L26.8355 25.6225L33.1056 21.9511C33.3775 21.7918 33.6033 21.5628 33.7603 21.2871C33.9173 21.0113 34 20.6985 34 20.38C34 20.0616 33.9173 19.7487 33.7603 19.473C33.6033 19.1972 33.3775 18.9682 33.1056 18.809V18.809Z"></path>
-    </svg>
-  );
 }
 
 function DefaultFallback({ className }: { className: string }) {
   return (
     <div className={`${styles.Error} ${className || ""}`}>
-      <ReplayLogo />
+      <svg className={styles.Logo} fill="currentColor" viewBox="0 0 34 40">
+        <path d="M15.2233 8.58217L8.95319 4.91069L2.68305 1.23921C2.41111 1.08012 2.10269 0.9964 1.78875 0.99646C1.47482 0.99652 1.16642 1.08036 0.894545 1.23955C0.622668 1.39875 0.396884 1.6277 0.239864 1.90341C0.0828448 2.17911 0.000118376 2.49187 0 2.81026V17.496C0.000105567 17.8144 0.0828232 18.1272 0.239837 18.4029C0.396852 18.6786 0.622634 18.9076 0.894513 19.0668C1.16639 19.226 1.47479 19.3098 1.78874 19.3099C2.10268 19.31 2.41111 19.2262 2.68305 19.0671L8.95319 15.3957L15.2233 11.7243C15.4952 11.5651 15.721 11.336 15.878 11.0603C16.035 10.7845 16.1177 10.4717 16.1177 10.1532C16.1177 9.83477 16.035 9.52193 15.878 9.24616C15.721 8.97038 15.4952 8.74138 15.2233 8.58217V8.58217Z"></path>
+        <path d="M15.2233 29.0322L8.95319 25.3608L2.68305 21.6893C2.41111 21.5302 2.10268 21.4465 1.78873 21.4465C1.47479 21.4466 1.16639 21.5304 0.894513 21.6896C0.622634 21.8488 0.396847 22.0778 0.239833 22.3535C0.0828188 22.6292 0.000105567 22.942 0 23.2604V37.9461C0.000105567 38.2645 0.0828188 38.5773 0.239833 38.853C0.396847 39.1287 0.622634 39.3577 0.894513 39.5169C1.16639 39.6761 1.47479 39.7599 1.78873 39.76C2.10268 39.76 2.41111 39.6763 2.68305 39.5172L8.95319 35.8458L15.2233 32.1743C15.4952 32.0151 15.721 31.7861 15.878 31.5103C16.035 31.2346 16.1177 30.9217 16.1177 30.6033C16.1177 30.2848 16.035 29.9719 15.878 29.6962C15.721 29.4204 15.4952 29.1914 15.2233 29.0322Z"></path>
+        <path d="M33.1056 18.809L26.8355 15.1375L20.5654 11.4661C20.2935 11.307 19.985 11.2233 19.6711 11.2233C19.3572 11.2234 19.0488 11.3072 18.7769 11.4664C18.505 11.6256 18.2792 11.8546 18.1222 12.1303C17.9652 12.406 17.8825 12.7187 17.8823 13.0371V27.7229C17.8825 28.0413 17.9652 28.354 18.1222 28.6297C18.2792 28.9055 18.505 29.1344 18.7769 29.2936C19.0488 29.4528 19.3572 29.5366 19.6711 29.5367C19.985 29.5367 20.2935 29.453 20.5654 29.2939L26.8355 25.6225L33.1056 21.9511C33.3775 21.7918 33.6033 21.5628 33.7603 21.2871C33.9173 21.0113 34 20.6985 34 20.38C34 20.0616 33.9173 19.7487 33.7603 19.473C33.6033 19.1972 33.3775 18.9682 33.1056 18.809V18.809Z"></path>
+      </svg>
       <div className={styles.Header}>Our apologies!</div>
       <div className={styles.Message}>
         <p>Something went wrong while replaying.</p>

--- a/packages/replay-next/components/comments/CommentList.tsx
+++ b/packages/replay-next/components/comments/CommentList.tsx
@@ -17,7 +17,7 @@ export default function CommentList() {
   const commentList = commentsCache.read(graphQLClient, accessToken, recordingId);
 
   return (
-    <ErrorBoundary>
+    <ErrorBoundary name="CommentList">
       <Suspense fallback={<Loader />}>
         <div className={styles.List}>
           <div className={styles.Header}>Comments</div>

--- a/packages/replay-next/components/console/ConsoleInput.tsx
+++ b/packages/replay-next/components/console/ConsoleInput.tsx
@@ -56,7 +56,7 @@ export default function ConsoleInput({ inputRef }: { inputRef?: RefObject<Impera
   }
 
   return (
-    <ErrorBoundary resetKey={executionPoint} fallback={<ErrorFallback />}>
+    <ErrorBoundary name="ConsoleInput" resetKey={executionPoint} fallback={<ErrorFallback />}>
       <Suspense fallback={<Loader />}>
         <ConsoleInputSuspends inputRef={inputRef} />
       </Suspense>

--- a/packages/replay-next/components/console/ConsoleRoot.tsx
+++ b/packages/replay-next/components/console/ConsoleRoot.tsx
@@ -44,7 +44,7 @@ export default function ConsoleRoot({
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   return (
-    <ErrorBoundary>
+    <ErrorBoundary name="ConsoleRoot">
       <Suspense fallback={<IndeterminateLoader />}>
         <ConsoleFiltersContextRoot>
           <LoggablesContextRoot messageListRef={messageListRef}>
@@ -211,7 +211,7 @@ function Console({
               </div>
             }
           >
-            <ErrorBoundary fallbackClassName={styles.ErrorBoundaryFallback}>
+            <ErrorBoundary name="ConsoleRoot" fallbackClassName={styles.ErrorBoundaryFallback}>
               <div className={styles.MessageColumn} onClick={onClick}>
                 {nagHeader}
 

--- a/packages/replay-next/components/console/MessagesList.tsx
+++ b/packages/replay-next/components/console/MessagesList.tsx
@@ -40,6 +40,7 @@ type CurrentTimeIndicatorPlacement = Loggable | "begin" | "end";
 
 const ErrorBoundary = ({ children }: { children: ReactNode }) => (
   <_ErrorBoundary
+    name="MessagesList"
     fallback={
       <div className={rendererStyles.Row}>
         <div className={rendererStyles.ErrorBoundaryFallback}>Something went wrong.</div>

--- a/packages/replay-next/components/console/MessagesList.tsx
+++ b/packages/replay-next/components/console/MessagesList.tsx
@@ -24,7 +24,7 @@ import {
 } from "replay-next/src/utils/loggables";
 import { isExecutionPointsLessThan } from "replay-next/src/utils/time";
 
-import _ErrorBoundary from "../ErrorBoundary";
+import DecoratedErrorBoundary from "../ErrorBoundary";
 import { ConsoleSearchContext } from "./ConsoleSearchContext";
 import CurrentTimeIndicator from "./CurrentTimeIndicator";
 import { Loggable, LoggablesContext } from "./LoggablesContext";
@@ -39,7 +39,7 @@ import rendererStyles from "./renderers/shared.module.css";
 type CurrentTimeIndicatorPlacement = Loggable | "begin" | "end";
 
 const ErrorBoundary = ({ children }: { children: ReactNode }) => (
-  <_ErrorBoundary
+  <DecoratedErrorBoundary
     name="MessagesList"
     fallback={
       <div className={rendererStyles.Row}>
@@ -48,7 +48,7 @@ const ErrorBoundary = ({ children }: { children: ReactNode }) => (
     }
   >
     {children}
-  </_ErrorBoundary>
+  </DecoratedErrorBoundary>
 );
 
 // This is an approximation of the console; the UI isn't meant to be the focus of this branch.

--- a/packages/replay-next/components/console/filters/FilterToggles.tsx
+++ b/packages/replay-next/components/console/filters/FilterToggles.tsx
@@ -1,9 +1,9 @@
-import { ErrorBoundary } from "@sentry/react";
 import camelCase from "lodash/camelCase";
 import React, { PropsWithChildren, ReactNode, Suspense, useContext, useMemo } from "react";
 import { isPromiseLike } from "suspense";
 
 import { Badge, Checkbox } from "design";
+import ErrorBoundary from "replay-next/components/ErrorBoundary";
 import Icon from "replay-next/components/Icon";
 import { ConsoleFiltersContext } from "replay-next/src/contexts/ConsoleFiltersContext";
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
@@ -167,6 +167,7 @@ function Toggle({
 function CountErrorBoundary({ children }: PropsWithChildren) {
   return (
     <ErrorBoundary
+      name="FilterToggles"
       fallback={
         <span title="Something went wrong loading message counts.">
           <Icon className={styles.ExceptionsErrorIcon} type="warning" />

--- a/packages/replay-next/components/console/renderers/LogPointRenderer.tsx
+++ b/packages/replay-next/components/console/renderers/LogPointRenderer.tsx
@@ -80,6 +80,7 @@ function LogPointRenderer({
       <span className={styles.LogContents} data-test-name="LogContents">
         <BadgeRenderer badge={logPointInstance.point.badge} showNewBadgeFlash={showNewBadgeFlash} />
         <ErrorBoundary
+          name="LogPointRenderer"
           fallback={<div className={styles.ErrorBoundaryFallback}>Something went wrong.</div>}
         >
           <Suspense key={logPointInstance.point.content} fallback={<Loader />}>

--- a/packages/replay-next/components/console/renderers/MessageRenderer.tsx
+++ b/packages/replay-next/components/console/renderers/MessageRenderer.tsx
@@ -120,6 +120,7 @@ function MessageRenderer({
     <span className={styles.LogContents} data-test-name="LogContents">
       {message.text && <span className={styles.MessageText}>{message.text}</span>}
       <ErrorBoundary
+        name="MessageRenderer"
         fallback={<div className={styles.ErrorBoundaryFallback}>Something went wrong.</div>}
       >
         {primaryContent}

--- a/packages/replay-next/pages/_app.tsx
+++ b/packages/replay-next/pages/_app.tsx
@@ -21,7 +21,7 @@ function Routing({ Component, pageProps }: AppProps) {
         <link rel="icon" type="image/svg+xml" href="/images/favicon.svg" />
         <title>Replay</title>
       </Head>
-      <ErrorBoundary>
+      <ErrorBoundary name="Routing">
         <Component {...pageProps} />
       </ErrorBoundary>
     </>

--- a/packages/replay-next/pages/tests/utils/createTest.tsx
+++ b/packages/replay-next/pages/tests/utils/createTest.tsx
@@ -12,7 +12,7 @@ export default function createTest(Component: FunctionComponent<any>, defaultRec
     usePreferredColorScheme();
 
     return (
-      <ErrorBoundary>
+      <ErrorBoundary name="createTest">
         <Suspense fallback="Loading...">
           <Initializer recordingId={recordingId}>
             <Component />

--- a/packages/replay-next/src/suspense/ExceptionsCache.ts
+++ b/packages/replay-next/src/suspense/ExceptionsCache.ts
@@ -2,7 +2,6 @@ import { PauseId, PointDescription, PointSelector, Value } from "@replayio/proto
 import { createCache } from "suspense";
 
 import { ReplayClientInterface } from "shared/client/types";
-import { ProtocolError, commandError } from "shared/utils/error";
 
 import { createInfallibleSuspenseCache } from "../utils/suspense";
 import { createAnalysisCache } from "./AnalysisCache";

--- a/packages/replay-next/src/suspense/FrameCache.ts
+++ b/packages/replay-next/src/suspense/FrameCache.ts
@@ -16,7 +16,6 @@ export const framesCache: Cache<
   getKey: ([client, pauseId]) => pauseId,
   load: async ([client, pauseId]) => {
     const framesResult = await client.getAllFrames(pauseId);
-
     const sources = await sourcesByIdCache.readAsync(client);
     cachePauseData(client, sources, pauseId, framesResult.data, framesResult.frames);
     const cached = framesCache.getValueIfCached(client, pauseId);

--- a/packages/replay-next/src/suspense/FrameCache.ts
+++ b/packages/replay-next/src/suspense/FrameCache.ts
@@ -16,6 +16,7 @@ export const framesCache: Cache<
   getKey: ([client, pauseId]) => pauseId,
   load: async ([client, pauseId]) => {
     const framesResult = await client.getAllFrames(pauseId);
+
     const sources = await sourcesByIdCache.readAsync(client);
     cachePauseData(client, sources, pauseId, framesResult.data, framesResult.frames);
     const cached = framesCache.getValueIfCached(client, pauseId);

--- a/packages/replay-next/src/utils/telemetry.ts
+++ b/packages/replay-next/src/utils/telemetry.ts
@@ -7,6 +7,7 @@ export function setDefaultTags(tags: Object) {
 
 export async function recordData(event: string, tags: Object = {}): Promise<void> {
   const eventTags = { ...defaultTags, ...tags };
+
   if (process.env.NODE_ENV !== "development" || process.env.NEXT_PUBLIC_RECORD_REPLAY_TELEMETRY) {
     try {
       const response = await fetch("https://telemetry.replay.io/", {

--- a/packages/replay-next/src/utils/telemetry.ts
+++ b/packages/replay-next/src/utils/telemetry.ts
@@ -7,7 +7,6 @@ export function setDefaultTags(tags: Object) {
 
 export async function recordData(event: string, tags: Object = {}): Promise<void> {
   const eventTags = { ...defaultTags, ...tags };
-
   if (process.env.NODE_ENV !== "development" || process.env.NEXT_PUBLIC_RECORD_REPLAY_TELEMETRY) {
     try {
       const response = await fetch("https://telemetry.replay.io/", {

--- a/packages/shared/utils/error.ts
+++ b/packages/shared/utils/error.ts
@@ -1,15 +1,15 @@
 export interface CommandError extends Error {
   name: "CommandError";
   code: number;
-  args?: CommandArgs;
+  args?: CommandErrorArgs;
 }
 
-type CommandArgs = {
+export type CommandErrorArgs = {
+  id: number;
   method: string;
   params: Object;
-  id: number;
-  pauseId?: string;
-  sessionId?: string;
+  pauseId: string | undefined;
+  sessionId: string | undefined;
 };
 
 export enum ProtocolError {
@@ -33,18 +33,28 @@ export enum ProtocolError {
   FocusWindowChange = 76,
 }
 
-export const commandError = (message: string, code: number, args?: CommandArgs): CommandError => {
-  const err = new Error(message) as CommandError;
-  err.name = "CommandError";
-  err.code = code;
-  err.message = message;
-  err.args = args;
-  return err;
+export const commandError = (
+  message: string,
+  code: number,
+  args?: CommandErrorArgs
+): CommandError => {
+  const error = new Error(message) as CommandError;
+  error.name = "CommandError";
+  error.code = code;
+  error.message = message;
+  error.args = args;
+  return error;
 };
 
-export const isCommandError = (error: unknown, code: number): boolean => {
+export function isCommandError(error: unknown, code?: number): error is CommandError {
   if (error instanceof Error) {
-    return error.name === "CommandError" && (error as CommandError).code === code;
+    if (error.name === "CommandError") {
+      if (code === undefined) {
+        return true;
+      } else {
+        return (error as CommandError).code === code;
+      }
+    }
   } else if (typeof error === "string") {
     console.error("Unexpected error type encountered (string):\n", error);
 
@@ -61,4 +71,4 @@ export const isCommandError = (error: unknown, code: number): boolean => {
   }
 
   return false;
-};
+}

--- a/packages/shared/utils/error.ts
+++ b/packages/shared/utils/error.ts
@@ -1,7 +1,16 @@
 export interface CommandError extends Error {
   name: "CommandError";
   code: number;
+  args?: CommandArgs;
 }
+
+type CommandArgs = {
+  method: string;
+  params: Object;
+  id: number;
+  pauseId?: string;
+  sessionId?: string;
+};
 
 export enum ProtocolError {
   InternalError = 1,
@@ -24,10 +33,12 @@ export enum ProtocolError {
   FocusWindowChange = 76,
 }
 
-export const commandError = (message: string, code: number): CommandError => {
+export const commandError = (message: string, code: number, args?: CommandArgs): CommandError => {
   const err = new Error(message) as CommandError;
   err.name = "CommandError";
   err.code = code;
+  err.message = message;
+  err.args = args;
   return err;
 };
 

--- a/src/devtools/client/debugger/src/components/Editor/Footer.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Footer.tsx
@@ -22,7 +22,10 @@ function SourceFooter() {
   return (
     <div className="source-footer-wrapper">
       <div className="source-footer">
-        <ErrorBoundary fallback={<div className="error">An error occurred while replaying</div>}>
+        <ErrorBoundary
+          name="SourceFooter"
+          fallback={<div className="error">An error occurred while replaying</div>}
+        >
           <Suspense>
             <SourcemapToggleSuspends cursorPosition={cursorPosition} />
             <SourcemapVisualizerLinkSuspends cursorPosition={cursorPosition} />

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/NewFrames.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/NewFrames.tsx
@@ -100,7 +100,8 @@ function FramesRenderer({
       <PauseFrames pauseId={pauseId} frames={frames} panel={panel} />
       <ErrorBoundary
         key={pauseId}
-        fallback={<div className="pane-info empty">Error loading frames</div>}
+        name="NewFrames"
+        fallback={<div className="pane-info empty">Error loading frames :(</div>}
       >
         <Suspense fallback={<div className="pane-info empty">Loading async frames…</div>}>
           <FramesRenderer panel={panel} pauseId={pauseId} asyncIndex={asyncIndex + 1} />
@@ -216,7 +217,8 @@ function Frames({ panel, point, time }: FramesProps) {
     <div className="pane frames" data-test-id="FramesPanel">
       <ErrorBoundary
         key={pauseId}
-        fallback={<div className="pane-info empty">Error loading frames</div>}
+        name="Frames"
+        fallback={<div className="pane-info empty">Error loading frames :((</div>}
       >
         <Suspense fallback={<div className="pane-info empty">Loading...</div>}>
           <div role="list">

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/NewScopes.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/NewScopes.tsx
@@ -135,6 +135,7 @@ export default function Scopes() {
     <div className="scopes-content">
       <Redacted className="pane scopes-list" data-test-name="ScopesList">
         <ErrorBoundary
+          name="NewScopes"
           key={`${selectedFrameId?.pauseId}:${selectedFrameId?.frameId}`}
           fallback={<div className="pane-info">Error loading scopes</div>}
         >

--- a/src/devtools/client/debugger/src/components/SourceOutline/SourceOutline.tsx
+++ b/src/devtools/client/debugger/src/components/SourceOutline/SourceOutline.tsx
@@ -194,7 +194,7 @@ export default function SourceOutlineWrapper() {
   }
 
   return (
-    <ErrorBoundary key={selectedSource?.id}>
+    <ErrorBoundary name="SourceOutlineWrapper" key={selectedSource?.id}>
       <Suspense fallback={null}>
         <SourceOutline
           cursorPosition={cursorPosition || null}

--- a/src/ui/components/TestSuite/views/TestRecording/TestEventDetails.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestEventDetails.tsx
@@ -23,7 +23,7 @@ export default function TestEventDetails({ collapsed }: { collapsed: boolean }) 
   }
 
   return (
-    <ErrorBoundary>
+    <ErrorBoundary name="TestEventDetails">
       <UserActionEventDetails
         timeStampedPoint={testEvent.data.result.timeStampedPoint}
         variable={testEvent.data.result.variable}

--- a/src/ui/components/TestSuite/views/TestSuitePanel.tsx
+++ b/src/ui/components/TestSuite/views/TestSuitePanel.tsx
@@ -12,7 +12,7 @@ import styles from "./TestSuitePanel.module.css";
 // TODO Show better/custom error fallback to failed test suites
 export default function TestSuitePanel() {
   return (
-    <ErrorBoundary fallback={<TestSuiteErrorFallback />}>
+    <ErrorBoundary name="TestSuitePanel" fallback={<TestSuiteErrorFallback />}>
       <Suspense
         fallback={
           <div className={styles.Loading} data-test-name="TestSuitePanel">

--- a/src/ui/components/Timeline/PreviewMarkers.tsx
+++ b/src/ui/components/Timeline/PreviewMarkers.tsx
@@ -16,7 +16,7 @@ import Marker from "./Marker";
 
 export default function PreviewMarkers() {
   return (
-    <ErrorBoundary fallback={null}>
+    <ErrorBoundary fallback={null} name="PreviewMarkers">
       <Suspense fallback={null}>
         <PreviewMarkersSuspends />
       </Suspense>


### PR DESCRIPTION
Based off PR #9392...

Send honeycomb `"component-error-boundary"` events when we show the error boundary. These events include error info (e.g. message, call stack and component stacks) and command info (e.g. id, code, and method).

This PR also wraps the root app in our shared `ErrorBoundary` component. This wasn't being done before, meaning that anything we didn't explicitly catch at a lower level wouldn't be logged to Honeycomb.

---

Replay [575777c6-3d0c-49b8-97a8-fd0b027a3286](https://app.replay.io/recording/575777c6-3d0c-49b8-97a8-fd0b027a3286) shows an intentional error caused by a React component trying to access an undefined value. Here is the telemetry data logged:
```js
{
  boundary: "Routing",
  error: {
    name: "ReferenceError",
    message: "asdf is not defined",
    callStack: [
      {
        columnNumber: 5,
        fileName: "webpack-internal:///./src/ui/components/SecondaryToolbox/ReactDevTools.tsx",
        lineNumber: 383,
      },
      // ...
    ],
    componentStack: [
      {
        columnNumber: 5,
        fileName: "webpack-internal:///./src/ui/components/SecondaryToolbox/ReactDevTools.tsx",
        lineNumber: 383,
      },
      {
        columnNumber: 23,
        fileName: "webpack-internal:///./packages/replay-next/components/LazyOffscreen.tsx",
        lineNumber: 17,
      },
      {
        columnNumber: 15,
        fileName: "webpack-internal:///./src/ui/components/SecondaryToolbox/index.tsx",
        lineNumber: 441,
      },
      // ...
    ],
  },
  command: undefined,
}
```

Replay [4cce3cfb-0132-4f21-98fc-260c39bc20d9](https://app.replay.io/recording/4cce3cfb-0132-4f21-98fc-260c39bc20d9) shows an error that I intentionally caused by sending a bad Protocol command. Here is the telemetry data logged:
```js
{
  boundary: "Routing",
  error: {
    name: "CommandError",
    message: 'Internal error (request: Debugger.getSourceOutline, {"sourceId":"fake"})',
    callStack: [
      {
        columnNumber: 19,
        fileName: "webpack-internal:///./packages/shared/utils/error.ts",
        lineNumber: 29,
      },
      {
        columnNumber: 79,
        fileName: "webpack-internal:///./packages/protocol/socket.ts",
        lineNumber: 175,
      },
      {
        columnNumber: 44,
        fileName: "webpack-internal:///./node_modules/@replayio/protocol/js/client/build/client.js",
        lineNumber: 664,
      },
      // ...
    ],
    componentStack: [
      {
        columnNumber: 75,
        fileName: "webpack-internal:///./src/devtools/client/debugger/src/components/SecondaryPanes/FrameTimeline.tsx",
        lineNumber: 220,
      },
      {
        columnNumber: 88,
        fileName: "webpack-internal:///./src/devtools/client/debugger/src/components/SecondaryPanes/index.tsx",
        lineNumber: 33,
      },
      {
        columnNumber: 34,
        fileName: "webpack-internal:///./src/ui/components/SidePanel.tsx",
        lineNumber: 107,
      },
      // ...
    ],
  },
  command: {
    id: 23,
    method: "Debugger.getSourceOutline",
    params: { sourceId: "fake" },
    pauseId: undefined,
    sessionId: "38675407-c787-49be-b3fd-85f381223bd2/b25194aa-847a-4a74-9de9-404963340459",
  },
}
```