### PR TITLE
Experimenting with scopes rendering for FE-1500

### DIFF
--- a/packages/replay-next/components/inspector/Inspector.tsx
+++ b/packages/replay-next/components/inspector/Inspector.tsx
@@ -7,6 +7,14 @@ import {
 import KeyValueRenderer from "./KeyValueRendererWithContextMenu";
 import styles from "./Inspector.module.css";
 
+declare global {
+  var rendered: Map<string, number> | undefined;
+  var totalRendered: number | undefined;
+}
+if (typeof window !== "undefined") {
+  window.rendered = new Map();
+}
+
 export default function Inspector({
   className,
   context,
@@ -22,6 +30,12 @@ export default function Inspector({
   pauseId: PauseId;
   protocolValue: ProtocolValue | ProtocolNamedValue;
 }) {
+  if (window.rendered && "name" in protocolValue) {
+    const name = `${protocolValue.name} - ${protocolValue.object}`;
+    window.rendered.set(name, (window.rendered.get(name) ?? 0) + 1);
+    window.totalRendered = (window.totalRendered ?? 0) + 1;
+  }
+
   const keyValue = (
     <KeyValueRenderer
       context={context}

--- a/packages/replay-next/components/inspector/ScopesInspector.tsx
+++ b/packages/replay-next/components/inspector/ScopesInspector.tsx
@@ -27,13 +27,15 @@ export default function ScopesInspector({
         <Expandable
           className={styles.Expandable}
           children={protocolValues.map((protocolValue, index) => (
-            <Inspector
-              context="default"
-              key={index}
-              path={addPathSegment(path, protocolValue.name)}
-              pauseId={pauseId}
-              protocolValue={protocolValue}
-            />
+            <Suspense key={index} fallback={<div>{protocolValue.name}: Loading...</div>}>
+              <Inspector
+                context="default"
+                key={index}
+                path={addPathSegment(path, protocolValue.name)}
+                pauseId={pauseId}
+                protocolValue={protocolValue}
+              />
+            </Suspense>
           ))}
           defaultOpen={expandByDefault}
           header={name}


### PR DESCRIPTION
This PR is just an experiment to work on FE-1500.
STR:
- open http://localhost:8080/recording/react-app--cf8417fc-8c82-42df-8c56-94356a172522?point=324518553672943161447660830851097&time=239
- open the "Block" scope - this will take several seconds
- after that you can look at the `rendered` global in the browser console to see how often `Inspector` was rendered for each scope binding
