### PR TITLE
Source line rendering changes [DRAFT]

### DIFF
--- a/packages/replay-next/components/sources/CurrentLineHighlight.module.css
+++ b/packages/replay-next/components/sources/CurrentLineHighlight.module.css
@@ -23,3 +23,16 @@
 .ViewSourceHighlight {
   background: var(--background-color-current-execution-point);
 }
+
+.CurrentExecutionPointColumn {
+  margin-left: calc(
+    var(--line-number-size) + 2ch + var(--line-hit-count-size) + 2ch +
+      (var(--highlight-num-breakpoint-toggles) * var(--column-breakpoint-width)) +
+      var(--highlight-char-offset)
+  );
+  height: 100%;
+  width: var(--highlight-char-length);
+  background: var(--background-color-current-execution-point-column);
+  font-family: var(--font-family-monospace);
+  font-size: var(--font-size-regular);
+}

--- a/packages/replay-next/components/sources/CurrentLineHighlight.tsx
+++ b/packages/replay-next/components/sources/CurrentLineHighlight.tsx
@@ -100,10 +100,12 @@ function CurrentLineHighlightSuspends({
         columnBreakpointIndex = breakableColumnIndices.findIndex(
           column => column === highlightColumnBegin
         );
-        if (columnBreakpointIndex < breakableColumnIndices.length - 1) {
-          highlightColumnEnd = breakableColumnIndices[columnBreakpointIndex + 1] - 1;
-        } else if (plainText !== null) {
-          highlightColumnEnd = plainText.length - 1;
+        if (columnBreakpointIndex >= 0) {
+          if (columnBreakpointIndex < breakableColumnIndices.length - 1) {
+            highlightColumnEnd = breakableColumnIndices[columnBreakpointIndex + 1] - 1;
+          } else if (plainText !== null) {
+            highlightColumnEnd = plainText.length - 1;
+          }
         }
       }
     }

--- a/packages/replay-next/components/sources/SourceList.tsx
+++ b/packages/replay-next/components/sources/SourceList.tsx
@@ -31,7 +31,6 @@ import { Source } from "replay-next/src/suspense/SourcesCache";
 import { StreamingParser } from "replay-next/src/suspense/SyntaxParsingCache";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { POINT_BEHAVIOR_DISABLED, POINT_BEHAVIOR_ENABLED } from "shared/client/types";
-import { useGraphQLUserData } from "shared/user-data/GraphQL/useGraphQLUserData";
 import { toPointRange } from "shared/utils/time";
 
 import useFontBasedListMeasurements from "./hooks/useFontBasedListMeasurements";
@@ -150,8 +149,6 @@ export default function SourceList({
     }
   }, [focusedSource, lineCount, markPendingFocusUpdateProcessed, pendingFocusUpdate, sourceId]);
 
-  const [showHitCounts] = useGraphQLUserData("source_showHitCounts");
-
   const [minHitCount, maxHitCount] = getCachedMinMaxSourceHitCounts(sourceId, focusRange);
 
   useLayoutEffect(() => {
@@ -199,7 +196,6 @@ export default function SourceList({
       pointsForDefaultPriority,
       pointsForSuspense,
       showColumnBreakpoints,
-      showHitCounts,
       source,
       streamingParser,
     }),
@@ -216,7 +212,6 @@ export default function SourceList({
       pointPanelWithConditionalHeight,
       pointsForDefaultPriority,
       pointsForSuspense,
-      showHitCounts,
       showColumnBreakpoints,
       source,
       streamingParser,
@@ -290,7 +285,7 @@ export default function SourceList({
 
   const maxLineIndexStringLength = `${lineCount}`.length;
   const maxHitCountStringLength =
-    showHitCounts && maxHitCount !== null ? `${formatHitCount(maxHitCount)}`.length : 0;
+    maxHitCount !== null ? `${formatHitCount(maxHitCount)}`.length : 0;
 
   const widthMinusScrollbar = width - scrollbarWidth;
 

--- a/packages/replay-next/components/sources/SourceListRow.tsx
+++ b/packages/replay-next/components/sources/SourceListRow.tsx
@@ -62,7 +62,6 @@ export type ItemData = {
   pointsForSuspense: Point[];
   pointBehaviors: PointBehaviorsObject;
   showColumnBreakpoints: boolean;
-  showHitCounts: boolean;
   source: Source;
   streamingParser: StreamingParser;
 };
@@ -101,7 +100,6 @@ const SourceListRow = memo(
       pointsForDefaultPriority,
       pointsForSuspense,
       showColumnBreakpoints,
-      showHitCounts,
       source,
       streamingParser,
     } = data;
@@ -412,11 +410,9 @@ const SourceListRow = memo(
           </div>
 
           <div className={`${styles.LineHitCountBar} ${hitCountBarClassName}`} />
-          {showHitCounts && (
-            <div className={`${styles.LineHitCountLabel} ${hitCountLabelClassName}`}>
-              {hitCount !== null ? formatHitCount(hitCount) : ""}
-            </div>
-          )}
+          <div className={`${styles.LineHitCountLabel} ${hitCountLabelClassName}`}>
+            {hitCount !== null ? formatHitCount(hitCount) : ""}
+          </div>
 
           <div className={styles.LineSegmentsAndPointPanel} data-test-name="SourceLine-Contents">
             {searchResultsForLine?.map((result, resultIndex) => (
@@ -463,7 +459,13 @@ const SourceListRow = memo(
           )}
         </div>
 
-        <CurrentLineHighlight lineNumber={lineNumber} sourceId={sourceId} />
+        <CurrentLineHighlight
+          breakableColumnIndices={breakableColumnIndices}
+          lineNumber={lineNumber}
+          plainText={plainText}
+          showBreakpointMarkers={showBreakpointMarkers}
+          sourceId={sourceId}
+        />
 
         {contextMenu}
       </div>

--- a/packages/replay-next/components/sources/useSourceContextMenu.tsx
+++ b/packages/replay-next/components/sources/useSourceContextMenu.tsx
@@ -13,8 +13,6 @@ import { SessionContext } from "replay-next/src/contexts/SessionContext";
 import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { addComment as addCommentGraphQL } from "shared/graphql/Comments";
-import { useGraphQLUserData } from "shared/user-data/GraphQL/useGraphQLUserData";
-import { userData } from "shared/user-data/GraphQL/UserData";
 
 export default function useSourceContextMenu({
   lineNumber,
@@ -30,8 +28,6 @@ export default function useSourceContextMenu({
   const { showCommentsPanel } = useContext(InspectorContext);
   const { accessToken, recordingId, trackEvent } = useContext(SessionContext);
   const { executionPoint: currentExecutionPoint, time: currentTime } = useContext(TimelineContext);
-
-  const [showHitCounts, setShowHitCounts] = useGraphQLUserData("source_showHitCounts");
 
   const [isPending, startTransition] = useTransition();
   const invalidateCache = useCacheRefresh();
@@ -81,9 +77,6 @@ export default function useSourceContextMenu({
       )}
       <ContextMenuItem disabled={disableCopySourceUri} onSelect={copySourceUri}>
         Copy source URI
-      </ContextMenuItem>
-      <ContextMenuItem onSelect={() => setShowHitCounts(!showHitCounts)}>
-        {showHitCounts ? "Hide" : "Show"} hit counts
       </ContextMenuItem>
     </>,
     {

--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -200,6 +200,7 @@
   --background-color-contrast-5: #081121;
 
   --background-color-current-execution-point: #25364e;
+  --background-color-current-execution-point-column: #2663c080;
   --background-color-current-search-result: #25364e;
   --background-color-default: #081120;
   --background-color-disabled-button: #454950;
@@ -726,6 +727,7 @@
   --background-color-secondary-button: #f02d5e;
 
   --background-color-current-execution-point: #eaf3ff;
+  --background-color-current-execution-point-column: #b8d7ff;
   --background-color-current-search-result: #eaf3ff;
   --background-color-inputs: var(--theme-text-field-bgcolor);
   --background-color-resize-handle: #cfcfcf;

--- a/packages/shared/user-data/GraphQL/UserData.test.ts
+++ b/packages/shared/user-data/GraphQL/UserData.test.ts
@@ -67,19 +67,20 @@ describe("UserData", () => {
       switch (key) {
         case LOCAL_STORAGE_KEY:
           return JSON.stringify({
-            source_showHitCounts: false,
+            layout_sidePanelCollapsed: false,
           });
         default:
           return null;
       }
     });
 
-    window.location.search = "?features=feature_basicProcessingLoadingBar,source_showHitCounts";
+    window.location.search =
+      "?features=feature_basicProcessingLoadingBar,layout_sidePanelCollapsed";
 
     const userData = require("./UserData").userData;
 
     // false in localStorage but true in URL
-    expect(userData.get("source_showHitCounts")).toBe(true);
+    expect(userData.get("layout_sidePanelCollapsed")).toBe(true);
 
     // null in localStorage, defaults to false, but true in URL
     expect(userData.get("feature_basicProcessingLoadingBar")).toBe(true);

--- a/packages/shared/user-data/GraphQL/config.ts
+++ b/packages/shared/user-data/GraphQL/config.ts
@@ -299,12 +299,6 @@ export const config = {
     defaultValue: Boolean(false),
     legacyKey: "devtools.features.repaintEvaluations",
   },
-
-  source_showHitCounts: {
-    defaultValue: Boolean(true),
-    label: "Show hit count numbers for each source line",
-    legacyKey: "Replay:ShowHitCounts",
-  },
 } satisfies ConfigurablePreferences;
 
 export const ENUMS = {

--- a/src/ui/components/shared/UserSettingsModal/panels/Preferences.tsx
+++ b/src/ui/components/shared/UserSettingsModal/panels/Preferences.tsx
@@ -29,10 +29,6 @@ export function Preferences() {
           values={ENUMS.defaultViewMode}
         />
         <BooleanPreference
-          preference={config.source_showHitCounts}
-          preferencesKey="source_showHitCounts"
-        />
-        <BooleanPreference
           preference={config.global_enableLargeText}
           preferencesKey="global_enableLargeText"
         />


### PR DESCRIPTION
- [x] Remove hit point counts conditional. (These are now always-on.)
- [x] Add column highlighting for current execution point. (Mimic Chrome UI.)
- [x] Account for column breakpoint spacing

> **Note** I'd really like to remove column breakpoints UI from the client. I don't think they add much value, and I don't think we plan to encourage their use going forward (rather it would be nicer to reformat the source). As it is, they can really complicated UI features like this.

### Prior art (Chrome)
![image](https://github.com/replayio/devtools/assets/29597/b2206384-be55-40ae-a344-259b651d1110)

### Replay
![Screen Shot 2023-07-07 at 3 33 57 PM](https://github.com/replayio/devtools/assets/29597/e800c26f-d60a-44e9-9c44-19cded2117bf)

![Screen Shot 2023-07-07 at 2 58 06 PM](https://github.com/replayio/devtools/assets/29597/33985ea9-cfca-4031-9a0b-9da6a52bc6d3)

![Screen Shot 2023-07-07 at 3 23 18 PM](https://github.com/replayio/devtools/assets/29597/b030810a-f24b-4083-95d2-eb3baebb58f1)

cc @jonbell-lot23 