### PR TITLE
Jump to correct point instead of internals

### DIFF
--- a/src/ui/actions/eventListeners/eventListenerUtils.ts
+++ b/src/ui/actions/eventListeners/eventListenerUtils.ts
@@ -73,6 +73,11 @@ export const IGNORABLE_PARTIAL_SOURCE_URLS = [
   "__cypress/runner/",
 ];
 
+export const MORE_IGNORABLE_PARTIAL_URLS = IGNORABLE_PARTIAL_SOURCE_URLS.concat(
+  // Ignore _any_ 3rd-party package for now
+  "node_modules"
+);
+
 export function shouldIgnoreEventFromSource(
   sourceDetails?: SourceDetails,
   ignorableURLS = IGNORABLE_PARTIAL_SOURCE_URLS

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -24,6 +24,8 @@ import {
   pointsBoundingTimeCache,
   sessionEndPointCache,
 } from "replay-next/src/suspense/ExecutionPointsCache";
+import { frameStepsCache } from "replay-next/src/suspense/FrameStepsCache";
+import { pauseIdCache } from "replay-next/src/suspense/PauseCache";
 import { screenshotCache } from "replay-next/src/suspense/ScreenshotCache";
 import {
   isTimeStampedPointRangeEqual,
@@ -37,7 +39,9 @@ import {
   isTest,
   updateUrlWithParams,
 } from "shared/utils/environment";
+import { MORE_IGNORABLE_PARTIAL_URLS } from "ui/actions/eventListeners/eventListenerUtils";
 import { getFirstComment } from "ui/hooks/comments/comments";
+import { SourcesState } from "ui/reducers/sources";
 import {
   getCurrentTime,
   getFocusWindow,
@@ -55,6 +59,13 @@ import {
   setPlaybackPrecachedTime,
 } from "ui/reducers/timeline";
 import { FocusWindow, HoveredItem, PlaybackOptions, TimeRange } from "ui/state/timeline";
+import { getPauseFramesAsync } from "ui/suspense/frameCache";
+import {
+  encodeObjectToURL,
+  getPausePointParams,
+  isTest,
+  updateUrlWithParams,
+} from "ui/utils/environment";
 import KeyShortcuts, { isEditableElement } from "ui/utils/key-shortcuts";
 import { trackEvent } from "ui/utils/telemetry";
 import { rangeForFocusWindow } from "ui/utils/timeline";
@@ -261,6 +272,44 @@ export function seek(
       ThreadFront.timeWarp(point, time, openSource);
     }
     return true;
+  };
+}
+
+export function jumpToReduxCode(
+  point: ExecutionPoint,
+  time: number,
+  sourcesState: SourcesState
+): UIThunkAction {
+  return async (dispatch, _, { replayClient }) => {
+    dispatch(framePositionsCleared());
+
+    const pauseId = await pauseIdCache.readAsync(replayClient, point, time);
+    const frames = (await getPauseFramesAsync(replayClient, pauseId, sourcesState)) ?? [];
+    const filteredPauseFrames = frames.filter(frame => {
+      const { source } = frame;
+      if (!source) {
+        return false;
+      }
+
+      // Filter out everything in `node_modules`, so we have just app code left
+      // TODO There may be times when we care about renders queued by lib code
+      // TODO See about just filtering out React instead?
+      return !MORE_IGNORABLE_PARTIAL_URLS.some(partialUrl => source.url?.includes(partialUrl));
+    });
+
+    const frameSteps = await frameStepsCache.readAsync(
+      replayClient,
+      pauseId,
+      // The first 2 elements in filtered pause frames are from replay's redux stub, so they should be ignored
+      // The 3rd element is the user function that calls it, and will most likely be the `dispatch` call
+      filteredPauseFrames[2].protocolId
+    );
+
+    if (frameSteps) {
+      const frameStep = frameSteps[0];
+
+      dispatch(seek(frameStep.point, frameStep.time, true));
+    }
   };
 }
 

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -60,12 +60,6 @@ import {
 } from "ui/reducers/timeline";
 import { FocusWindow, HoveredItem, PlaybackOptions, TimeRange } from "ui/state/timeline";
 import { getPauseFramesAsync } from "ui/suspense/frameCache";
-import {
-  encodeObjectToURL,
-  getPausePointParams,
-  isTest,
-  updateUrlWithParams,
-} from "ui/utils/environment";
 import KeyShortcuts, { isEditableElement } from "ui/utils/key-shortcuts";
 import { trackEvent } from "ui/utils/telemetry";
 import { rangeForFocusWindow } from "ui/utils/timeline";

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -24,8 +24,6 @@ import {
   pointsBoundingTimeCache,
   sessionEndPointCache,
 } from "replay-next/src/suspense/ExecutionPointsCache";
-import { frameStepsCache } from "replay-next/src/suspense/FrameStepsCache";
-import { pauseIdCache } from "replay-next/src/suspense/PauseCache";
 import { screenshotCache } from "replay-next/src/suspense/ScreenshotCache";
 import {
   isTimeStampedPointRangeEqual,
@@ -39,9 +37,7 @@ import {
   isTest,
   updateUrlWithParams,
 } from "shared/utils/environment";
-import { MORE_IGNORABLE_PARTIAL_URLS } from "ui/actions/eventListeners/eventListenerUtils";
 import { getFirstComment } from "ui/hooks/comments/comments";
-import { SourcesState } from "ui/reducers/sources";
 import {
   getCurrentTime,
   getFocusWindow,
@@ -59,7 +55,6 @@ import {
   setPlaybackPrecachedTime,
 } from "ui/reducers/timeline";
 import { FocusWindow, HoveredItem, PlaybackOptions, TimeRange } from "ui/state/timeline";
-import { getPauseFramesAsync } from "ui/suspense/frameCache";
 import KeyShortcuts, { isEditableElement } from "ui/utils/key-shortcuts";
 import { trackEvent } from "ui/utils/telemetry";
 import { rangeForFocusWindow } from "ui/utils/timeline";
@@ -266,44 +261,6 @@ export function seek(
       ThreadFront.timeWarp(point, time, openSource);
     }
     return true;
-  };
-}
-
-export function jumpToReduxCode(
-  point: ExecutionPoint,
-  time: number,
-  sourcesState: SourcesState
-): UIThunkAction {
-  return async (dispatch, _, { replayClient }) => {
-    dispatch(framePositionsCleared());
-
-    const pauseId = await pauseIdCache.readAsync(replayClient, point, time);
-    const frames = (await getPauseFramesAsync(replayClient, pauseId, sourcesState)) ?? [];
-    const filteredPauseFrames = frames.filter(frame => {
-      const { source } = frame;
-      if (!source) {
-        return false;
-      }
-
-      // Filter out everything in `node_modules`, so we have just app code left
-      // TODO There may be times when we care about renders queued by lib code
-      // TODO See about just filtering out React instead?
-      return !MORE_IGNORABLE_PARTIAL_URLS.some(partialUrl => source.url?.includes(partialUrl));
-    });
-
-    const frameSteps = await frameStepsCache.readAsync(
-      replayClient,
-      pauseId,
-      // The first 2 elements in filtered pause frames are from replay's redux stub, so they should be ignored
-      // The 3rd element is the user function that calls it, and will most likely be the `dispatch` call
-      filteredPauseFrames[2].protocolId
-    );
-
-    if (frameSteps) {
-      const frameStep = frameSteps[0];
-
-      dispatch(seek(frameStep.point, frameStep.time, true));
-    }
   };
 }
 

--- a/src/ui/components/ReactPanel.tsx
+++ b/src/ui/components/ReactPanel.tsx
@@ -35,7 +35,7 @@ import { streamingSourceContentsCache } from "replay-next/src/suspense/SourcesCa
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { ReplayClientInterface } from "shared/client/types";
 import { UIThunkAction } from "ui/actions";
-import { IGNORABLE_PARTIAL_SOURCE_URLS } from "ui/actions/eventListeners/eventListenerUtils";
+import { MORE_IGNORABLE_PARTIAL_URLS } from "ui/actions/eventListeners/eventListenerUtils";
 import { findFunctionOutlineForLocation } from "ui/actions/eventListeners/jumpToCode";
 import { seek } from "ui/actions/timeline";
 import { JumpToCodeButton, JumpToCodeStatus } from "ui/components/shared/JumpToCodeButton";
@@ -52,11 +52,6 @@ import { getPauseFramesAsync } from "ui/suspense/frameCache";
 
 import MaterialIcon from "./shared/MaterialIcon";
 import styles from "./Events/Event.module.css";
-
-const MORE_IGNORABLE_PARTIAL_URLS = IGNORABLE_PARTIAL_SOURCE_URLS.concat(
-  // Ignore _any_ 3rd-party package for now
-  "node_modules"
-);
 
 interface ReactQueuedRenderDetails extends TimeStampedPoint {
   pauseFrames: PauseFrame[];

--- a/src/ui/components/SecondaryToolbox/ReduxDevTools.tsx
+++ b/src/ui/components/SecondaryToolbox/ReduxDevTools.tsx
@@ -6,7 +6,7 @@ import { useImperativeCacheValue } from "suspense";
 
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { isPointInRegion } from "shared/utils/time";
-import { seek } from "ui/actions/timeline";
+import { jumpToReduxCode } from "ui/actions/timeline";
 import { getCurrentTime, getFocusWindow } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { reduxDevToolsAnnotationsCache } from "ui/suspense/annotationsCaches";
@@ -81,9 +81,10 @@ function ActionItem({
   setSelectedPoint: (point: ExecutionPoint | null) => void;
   firstAnnotationInTheFuture: boolean;
 }) {
+  const sourcesState = useAppSelector(state => state.sources);
   const dispatch = useAppDispatch();
   const onSeek = () => {
-    dispatch(seek(annotation.point, annotation.time, true));
+    dispatch(jumpToReduxCode(annotation.point, annotation.time, sourcesState));
   };
 
   return (


### PR DESCRIPTION
This PR fixes the issue in #9397 where the jump to code button would take to internal replay methods instead of user redux code.