### PR TITLE
Only ignore the redux paths inside node_modules

### DIFF
--- a/src/devtools/client/debugger/src/utils/pause/frames/getLibraryFromUrl.ts
+++ b/src/devtools/client/debugger/src/utils/pause/frames/getLibraryFromUrl.ts
@@ -88,7 +88,7 @@ const libraryMap = [
   },
   {
     label: "Redux",
-    pattern: /redux/i,
+    pattern: /node_modules\/redux/i,
   },
   {
     label: "Dojo",

--- a/src/devtools/client/debugger/src/utils/pause/frames/getLibraryFromUrl.ts
+++ b/src/devtools/client/debugger/src/utils/pause/frames/getLibraryFromUrl.ts
@@ -88,7 +88,7 @@ const libraryMap = [
   },
   {
     label: "Redux",
-    pattern: /node_modules\/redux/i,
+    pattern: /node_modules\/(redux|react-redux|@reduxjs\/toolkit)/i,
   },
   {
     label: "Dojo",


### PR DESCRIPTION
The previous regex was too lose and would also end up grouping redux file paths in user code like `src/redux/utils.js` under Redux in callstacks and frames. Ideally it should only the `node_modules/redux` path should be doing this.