### PR TITLE
Fix selecting items in quick open modal

### DIFF
--- a/packages/e2e-tests/tests/quick_open_modal-01.test.ts
+++ b/packages/e2e-tests/tests/quick_open_modal-01.test.ts
@@ -1,0 +1,27 @@
+import test from "@playwright/test";
+
+import { openDevToolsTab, startTest } from "../helpers";
+import { openSource } from "../helpers/source-explorer-panel";
+import { getCommandKey } from "../helpers/utils";
+
+test("quick_open_modal-01: Test basic searching functionality", async ({ page }) => {
+  await startTest(page, "node/basic.js");
+  await openDevToolsTab(page);
+
+  await openSource(page, "basic.js");
+
+  await page.keyboard.press(`${getCommandKey()}+Shift+O`);
+  await page.focus('[data-test-id="QuickOpenInput"]');
+
+  await page.keyboard.type("bar");
+
+  const sourceRow = await page.waitForSelector(
+    '[data-test-id="QuickOpenResultsList"]:has-text("bar")'
+  );
+
+  sourceRow.click();
+
+  await page.waitForSelector(
+    `[data-test-id="SourceLine-8"]>[data-test-name="ViewSourceHighlight"]`
+  );
+});

--- a/src/devtools/client/debugger/src/components/QuickOpenModal.tsx
+++ b/src/devtools/client/debugger/src/components/QuickOpenModal.tsx
@@ -245,7 +245,7 @@ class QuickOpenModal extends Component<QuickOpenModalProps, QOMState> {
     }
 
     if (this.isFunctionQuery()) {
-      const start = item.location?.start;
+      const start = item.location?.begin;
       trackEvent("quick_open.select_function");
 
       return this.gotoLocation({
@@ -268,7 +268,7 @@ class QuickOpenModal extends Component<QuickOpenModalProps, QOMState> {
     if (this.isFunctionQuery() && !project) {
       return highlightLineRange({
         ...(item.location != null
-          ? { end: item.location.end!.line, start: item.location.start.line }
+          ? { end: item.location.end!.line, start: item.location.begin.line }
           : {}),
         sourceId: selectedSource.id,
       });

--- a/src/devtools/client/debugger/src/utils/quick-open.ts
+++ b/src/devtools/client/debugger/src/utils/quick-open.ts
@@ -29,7 +29,7 @@ export interface SearchResult {
   value: string;
   title: string;
   secondaryTitle?: string;
-  location?: { start: Location; end?: Location };
+  location?: { begin: Location; end?: Location };
   icon?: string;
   url?: string;
   subtitle?: string | number;

--- a/src/devtools/client/debugger/src/utils/quick-open.ts
+++ b/src/devtools/client/debugger/src/utils/quick-open.ts
@@ -109,7 +109,7 @@ export function formatProjectFunctions(
         subtitle: loc.line,
         secondaryTitle: getTruncatedFileName(source),
         value: name,
-        location: { start: loc },
+        location: { begin: loc },
       };
     })
     .flat()


### PR DESCRIPTION
The actual type of `SearchResult.location` should be `{ begin: Location; end?: Location }` instead of `{ start: Location; end?: Location }`. The latter errors as `start` doesn't exist in the response