### PR TITLE
Replay next/link with <a> tag for back-to-dashboard button

### DIFF
--- a/src/ui/components/Header/Header.tsx
+++ b/src/ui/components/Header/Header.tsx
@@ -1,6 +1,5 @@
 import { RecordingId } from "@replayio/protocol";
 import classNames from "classnames";
-import Link from "next/link";
 import { ClipboardEvent, KeyboardEvent, useLayoutEffect, useRef, useState } from "react";
 
 import { RecordingTarget } from "replay-next/src/suspense/BuildIdCache";
@@ -172,13 +171,6 @@ export default function Header() {
 
   const dashboardUrl = window.location.origin;
 
-  const onNavigateBack: React.MouseEventHandler = event => {
-    if (event.metaKey) {
-      return window.open(dashboardUrl, "library-tab");
-    }
-    window.open(dashboardUrl, "library-tab");
-  };
-
   if (loading) {
     return <div className={styles.Header}></div>;
   }
@@ -187,9 +179,9 @@ export default function Header() {
     <div className={styles.Header}>
       <div className="relative flex flex-grow flex-row items-center overflow-hidden">
         {isAuthenticated && (
-          <Link href={dashboardUrl}>
+          <a href={dashboardUrl}>
             <IconWithTooltip icon={backIcon} content={"Back to Library"} />
-          </Link>
+          </a>
         )}
         {recording && recordingId ? (
           <HeaderTitle recording={recording} recordingId={recordingId} />


### PR DESCRIPTION
The Next link messes with browser history in a way that prevents you from going "back" to the recording (if you mistakenly click it).

cc @Domiii 