### PR TITLE
Change debug label for React jump location cache

### DIFF
--- a/src/ui/components/ReactPanel.tsx
+++ b/src/ui/components/ReactPanel.tsx
@@ -78,7 +78,7 @@ export const reactRenderQueuedJumpLocationCache: Cache<
   PointWithLocation | undefined
 > = createCache({
   config: { immutable: true },
-  debugLabel: "NextInteractionEvent",
+  debugLabel: "ReactRenderQueuedJumpLocation",
   getKey: ([replayClient, earliestAppCodeFrame, sourcesState]) => earliestAppCodeFrame.pauseId,
   load: async ([replayClient, earliestAppCodeFrame, sourcesState]) => {
     let userPauseFrameTime: TimeStampedPoint | undefined = undefined;


### PR DESCRIPTION
Pretty minor change—`reactRenderQueuedJumpLocationCache` had `debugLabel` set as `NextInteractionEvent`. This was probably copied over along with `nextInteractionEventCache` and not updated.