### PR TITLE
Test Suites: Better format flaky tests

### DIFF
--- a/packages/e2e-tests/examples.json
+++ b/packages/e2e-tests/examples.json
@@ -41,5 +41,5 @@
   "cypress/doc_inspector_styles": "aa6201d2-1e83-408b-8247-cf3d26ac421a",
   "doc_minified_chromium.html": "5cdb2ffe-beff-4d35-9689-9242bd277f2d",
   "cypress-realworld/bankaccounts.spec.js": "bbf9dc4f-9d87-4b7e-89e8-1b21e8570de4",
-  "flake/adding-spec.ts": "a8ebd71b-2acf-4c65-9c35-df110924c71c"
+  "flake/adding-spec.ts": "7c5c4653-bb34-4cea-ab24-a2a189c4ef6b"
 }

--- a/packages/e2e-tests/tests/cypress-01_basic-panel.test.ts
+++ b/packages/e2e-tests/tests/cypress-01_basic-panel.test.ts
@@ -75,10 +75,10 @@ test("cypress-01: Basic Test Suites panel functionality", async ({ page }) => {
 
   // Relative dates can change over time.
   // Check for either the "X units ago" text, or the literal date.
-  expect(await getTestSuiteDate(page).textContent()).toMatch(/ ago|(6\/5\/2023)/);
+  expect(await getTestSuiteDate(page).textContent()).toMatch(/ ago|(7\/12\/2023)/);
   expect(await getTestSuiteUser(page).textContent()).toMatch("ryanjduffy");
-  expect(await getTestSuiteBranch(page).textContent()).toMatch("ryan/metadata-v2");
-  expect(await getTestSuiteDuration(page).textContent()).toMatch("0:15");
+  expect(await getTestSuiteBranch(page).textContent()).toMatch("main");
+  expect(await getTestSuiteDuration(page).textContent()).toMatch("0:12");
 
   // can open tests
   await firstTest.click();
@@ -88,13 +88,12 @@ test("cypress-01: Basic Test Suites panel functionality", async ({ page }) => {
     expect(selectedRow).toHaveCount(1);
   });
 
-  // This recording has a "beforeEach" and a body,
-  // but not "after" hooks
+  // This recording only has a "test body" section
   const sections = getTestSections(selectedRow);
-  await expect(sections).toHaveCount(2);
+  await expect(sections).toHaveCount(1);
+
   // These are CSS-transformed to uppercase
-  expect(await sections.nth(0).textContent()).toMatch(/before each/i);
-  expect(await sections.nth(1).textContent()).toMatch(/test body/i);
+  expect(await sections.nth(0).textContent()).toMatch(/test body/i);
 
   const steps = getTestCaseSteps(selectedRow);
   await expect(steps).toHaveCount(17);

--- a/src/ui/components/TestSuite/components/TestResultIcon.module.css
+++ b/src/ui/components/TestSuite/components/TestResultIcon.module.css
@@ -1,7 +1,6 @@
 .SuccessIcon {
   background-color: var(--testsuites-success-color);
 }
-
 .SuccessText {
   color: var(--testsuites-success-color);
 }
@@ -9,7 +8,6 @@
 .ErrorIcon {
   background-color: var(--testsuites-error-icon-bgcolor);
 }
-
 .ErrorText {
   color: var(--testsuites-error-color);
 }
@@ -17,7 +15,6 @@
 .SkippedIcon {
   background-color: var(--testsuites-skipped-color);
 }
-
 .SkippedText {
   color: var(--testsuites-skipped-color);
 }

--- a/src/ui/components/TestSuite/views/GroupedTestCases/TestRecordingTree.tsx
+++ b/src/ui/components/TestSuite/views/GroupedTestCases/TestRecordingTree.tsx
@@ -7,10 +7,12 @@ import { TestSuiteContext } from "ui/components/TestSuite/views/TestSuiteContext
 import styles from "./TestRecordingTree.module.css";
 
 export function TestRecordingTree({
+  flakyTestIds,
   isNested = false,
   scope = null,
   testTree,
 }: {
+  flakyTestIds: Set<string | number>;
   isNested?: boolean;
   scope?: string | null;
   testTree: TestTree;
@@ -28,6 +30,7 @@ export function TestRecordingTree({
       {Object.keys(testTree.scopes).map(scope => (
         <TestRecordingTree
           key={scope}
+          flakyTestIds={flakyTestIds}
           isNested={isNested || !!parentScope}
           scope={scope}
           testTree={testTree.scopes[scope]}
@@ -37,6 +40,7 @@ export function TestRecordingTree({
         <ol className={styles.List}>
           {testTree.testRecordings.map((testRecording, index) => (
             <TestRecordingTreeRow
+              flakyTestIds={flakyTestIds}
               key={index}
               onClick={() => setTestRecording(testRecording)}
               testRecording={testRecording}

--- a/src/ui/components/TestSuite/views/GroupedTestCases/TestRecordingTreeRow.module.css
+++ b/src/ui/components/TestSuite/views/GroupedTestCases/TestRecordingTreeRow.module.css
@@ -54,7 +54,19 @@
   font-weight: bold;
 }
 
-.Attempt {
+.NestedIcon {
+  height: 1rem;
+  width: 1rem;
+  flex: 0 0 1rem;
+  margin-left: 1rem;
+}
+
+.AttemptLabel {
+  text-transform: capitalize;
+  margin-right: 1ch;
+}
+
+.AttemptNumber {
   font-size: var(--font-size-small);
   color: var(--color-dim);
 }

--- a/src/ui/components/TestSuite/views/GroupedTestCases/TestRecordingTreeRow.tsx
+++ b/src/ui/components/TestSuite/views/GroupedTestCases/TestRecordingTreeRow.tsx
@@ -24,7 +24,8 @@ export default function TestRecordingTreeRow({
   const { title } = source;
 
   const isFlaky = flakyTestIds.has(id);
-  const showTitle = isFlaky ? result === "passed" : attempt === 1;
+  // TODO [SCS-1268] Remove undefined check
+  const showTitle = isFlaky ? result === "passed" : attempt === undefined || attempt === 1;
 
   let attemptLabel;
   switch (result) {

--- a/src/ui/components/TestSuite/views/GroupedTestCases/TestRecordingTreeRow.tsx
+++ b/src/ui/components/TestSuite/views/GroupedTestCases/TestRecordingTreeRow.tsx
@@ -1,5 +1,6 @@
 import { useTransition } from "react";
 
+import Icon from "replay-next/components/Icon";
 import { TestRecording } from "shared/test-suites/RecordingTestMetadata";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
 import { TestResultIcon } from "ui/components/TestSuite/components/TestResultIcon";
@@ -7,9 +8,11 @@ import { TestResultIcon } from "ui/components/TestSuite/components/TestResultIco
 import styles from "./TestRecordingTreeRow.module.css";
 
 export default function TestRecordingTreeRow({
+  flakyTestIds,
   onClick: onClickProp,
   testRecording,
 }: {
+  flakyTestIds: Set<string | number>;
   onClick: () => void;
   testRecording: TestRecording;
 }) {
@@ -17,8 +20,23 @@ export default function TestRecordingTreeRow({
 
   const onClick = () => startTransition(onClickProp);
 
-  const { attempt, error, result, source } = testRecording;
+  const { attempt, error, id, result, source } = testRecording;
   const { title } = source;
+
+  const isFlaky = flakyTestIds.has(id);
+  const showTitle = isFlaky ? result === "passed" : attempt === 1;
+
+  let attemptLabel;
+  switch (result) {
+    case "failed":
+    case "timedOut":
+      attemptLabel = "failed";
+      break;
+    case "skipped":
+    case "unknown":
+      attemptLabel = "skipped";
+      break;
+  }
 
   return (
     <li
@@ -27,12 +45,20 @@ export default function TestRecordingTreeRow({
       data-test-name="TestRecordingTreeRow"
       onClick={onClick}
     >
+      {showTitle || <Icon className={styles.NestedIcon} type="arrow-nested" />}
       <TestResultIcon result={result} />
       <div className={styles.Column}>
         <div className={styles.Title}>
-          {title} {attempt > 1 && <span className={styles.Attempt}>(retry {attempt - 1})</span>}
+          {showTitle ? (
+            title
+          ) : (
+            <>
+              <span className={styles.AttemptLabel}>{attemptLabel}</span>
+              <span className={styles.AttemptNumber}>(attempt {attempt})</span>
+            </>
+          )}
         </div>
-        {error && (
+        {showTitle && error && (
           <div className={styles.Error}>
             <span className={styles.ErrorTitle}>Error:</span> {error.message}
           </div>


### PR DESCRIPTION
- [x] Flaky tests should sorted so that passing test is at top, with failed attempts nested beneat
- [x] Only display full test title for first attempt (or passing attempt); just show attempt number beneath

| Before | After |
| :---: | :---: |
| <img width="469" alt="Screen Shot 2023-07-11 at 12 46 16 PM" src="https://github.com/replayio/devtools/assets/29597/ae751e4e-29de-449b-8aa7-16c32c7633b5"> | <img width="435" alt="Screen Shot 2023-07-11 at 12 43 47 PM" src="https://github.com/replayio/devtools/assets/29597/cbae6266-1120-4263-985f-d622c8f0639a"> |
| <img width="469" alt="Screen Shot 2023-07-11 at 12 46 22 PM" src="https://github.com/replayio/devtools/assets/29597/115c9b0f-3e34-4aae-a61b-65be8a48c776"> | <img width="431" alt="Screen Shot 2023-07-11 at 12 42 42 PM" src="https://github.com/replayio/devtools/assets/29597/0e3fc035-8a8a-497d-8557-5902e8461a10"> |

cc @jonbell-lot23 @jasonLaster 