### PR TITLE
Keep existing RDT UI component around and reset tree contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "react": "0.0.0-experimental-49f741046-20230305",
     "react-canvas-confetti": "^1.3.0",
     "react-circular-progressbar": "^2.0.4",
-    "react-devtools-inline": "^4.24.5",
+    "react-devtools-inline": "4.24.7",
     "react-devtools-inline_4_18_0": "npm:react-devtools-inline@4.18.0",
     "react-dom": "0.0.0-experimental-49f741046-20230305",
     "react-error-boundary": "^4.0.10",
@@ -242,7 +242,8 @@
     "react-is": "18.2.0",
     "ts-invariant": "0.10.3",
     "typescript": "5.0.2",
-    "react-json-view@1.21.3": "patch:react-json-view@npm:1.21.3#.yarn/patches/react-json-view-npm-1.21.3-7827bb54c4.patch"
+    "react-json-view@1.21.3": "patch:react-json-view@npm:1.21.3#.yarn/patches/react-json-view-npm-1.21.3-7827bb54c4.patch",
+    "react-devtools-inline@4.24.7": "patch:react-devtools-inline@npm:4.24.7#.yarn/patches/react-devtools-inline-npm-4.24.7-9582a0f8d6.patch"
   },
   "importSort": {
     ".js, .jsx, .ts, .tsx": {

--- a/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
+++ b/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
@@ -1,5 +1,5 @@
 import { ExecutionPoint, NodeBounds, ObjectId, Object as ProtocolObject } from "@replayio/protocol";
-import React, { useContext, useEffect, useMemo, useState } from "react";
+import React, { useContext, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { SerializedElement, Store, Wall } from "react-devtools-inline/frontend";
 import { useImperativeCacheValue } from "suspense";
 
@@ -7,12 +7,13 @@ import { selectLocation } from "devtools/client/debugger/src/actions/sources";
 import { getThreadContext } from "devtools/client/debugger/src/reducers/pause";
 import { highlightNode, unhighlightNode } from "devtools/client/inspector/markup/actions/markup";
 import { ThreadFront } from "protocol/thread";
-import { compareNumericStrings } from "protocol/utils";
+import { assert } from "protocol/utils";
 import { useIsPointWithinFocusWindow } from "replay-next/src/hooks/useIsPointWithinFocusWindow";
 import { useNag } from "replay-next/src/hooks/useNag";
 import { RecordingTarget, recordingTargetCache } from "replay-next/src/suspense/BuildIdCache";
 import { objectCache } from "replay-next/src/suspense/ObjectPreviews";
 import { evaluate } from "replay-next/src/utils/evaluate";
+import { isExecutionPointsLessThan } from "replay-next/src/utils/time";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { ReplayClientInterface } from "shared/client/types";
 import { Nag } from "shared/graphql/types";
@@ -38,6 +39,7 @@ import { getJSON } from "ui/utils/objectFetching";
 import { trackEvent } from "ui/utils/telemetry";
 
 import { injectReactDevtoolsBackend } from "./react-devtools/injectReactDevtoolsBackend";
+import { generateTreeResetOpsForPoint } from "./react-devtools/rdtProcessing";
 
 type ReactDevToolsInlineModule = typeof import("react-devtools-inline/frontend");
 
@@ -61,6 +63,7 @@ class ReplayWall implements Wall {
   private highlightedElementId?: number;
   private recordingTarget: RecordingTarget | null = null;
   store?: StoreWithInternals;
+  pauseId?: string;
 
   constructor(
     private enablePicker: (opts: NodeOptsWithoutBounds) => void,
@@ -71,9 +74,12 @@ class ReplayWall implements Wall {
     private setProtocolCheckFailed: (failed: boolean) => void,
     private fetchMouseTargetsForPause: () => Promise<NodeBounds[] | undefined>,
     private replayClient: ReplayClientInterface,
-    private dismissInspectComponentNag: () => void,
-    private pauseId: string | undefined
+    private dismissInspectComponentNag: () => void
   ) {}
+
+  setPauseId(pauseId: string) {
+    this.pauseId = pauseId;
+  }
 
   // called by the frontend to register a listener for receiving backend messages
   listen(listener: (msg: any) => void) {
@@ -232,7 +238,8 @@ class ReplayWall implements Wall {
     });
 
     if (response.returned) {
-      const result: any = await getJSON(this.replayClient, this.pauseId!, response.returned);
+      assert(this.pauseId, "Must have a pause ID to handle a response!");
+      const result: any = await getJSON(this.replayClient, this.pauseId, response.returned);
 
       if (result) {
         this._listener?.({ event: result.event, payload: result.data });
@@ -346,8 +353,6 @@ function jumpToComponentPreferredSource(componentPreview: ProtocolObject): UIThu
 
 function createReactDevTools(
   reactDevToolsInlineModule: ReactDevToolsInlineModule,
-  annotations: ParsedReactDevToolsAnnotation[],
-  currentPoint: ExecutionPoint,
   enablePicker: (opts: NodeOptsWithoutBounds) => void,
   initializePicker: () => void,
   disablePicker: () => void,
@@ -356,8 +361,7 @@ function createReactDevTools(
   setProtocolCheckFailed: (failed: boolean) => void,
   fetchMouseTargetsForPause: () => Promise<NodeBounds[] | undefined>,
   replayClient: ReplayClientInterface,
-  dismissInspectComponentNag: () => void,
-  pauseId: string | undefined
+  dismissInspectComponentNag: () => void
 ) {
   const { createBridge, createStore, initialize } = reactDevToolsInlineModule;
 
@@ -371,9 +375,9 @@ function createReactDevTools(
     setProtocolCheckFailed,
     fetchMouseTargetsForPause,
     replayClient,
-    dismissInspectComponentNag,
-    pauseId
+    dismissInspectComponentNag
   );
+
   const bridge = createBridge(target, wall);
   const store = createStore(bridge, {
     checkBridgeProtocolCompatibility: false,
@@ -381,12 +385,6 @@ function createReactDevTools(
   });
   wall.store = store as StoreWithInternals;
   const ReactDevTools = initialize(target, { bridge, store });
-
-  for (const { contents, point } of annotations) {
-    if (contents.event === "operations" && compareNumericStrings(point, currentPoint) <= 0) {
-      wall.sendAnnotation(contents);
-    }
-  }
 
   return [ReactDevTools, wall] as const;
 }
@@ -435,11 +433,37 @@ async function loadReactDevToolsInlineModuleFromProtocol(
 
 const nodePickerInstance = new NodePickerClass();
 
+const EMPTY_ANNOTATIONS: ParsedReactDevToolsAnnotation[] = [];
+
+// A `usePrevious` hook that stores in `useState` instead of a ref.
+// Does double-render, but technically "safer" in theory.
+// Source: https://www.developerway.com/posts/implementing-advanced-use-previous-hook
+const usePreviousPersistent = <T,>(value: T) => {
+  const [state, setState] = useState<{ value: T; prev: T | null }>({
+    value: value,
+    prev: null,
+  });
+
+  const current = state.value;
+
+  if (value !== current) {
+    setState({
+      value: value,
+      prev: current,
+    });
+  }
+
+  return state.prev;
+};
+
 export default function ReactDevtoolsPanel() {
   const client = useContext(ReplayClientContext);
   const currentPoint = useAppSelector(getCurrentPoint);
+  const previousPoint = usePreviousPersistent(currentPoint);
+
   const isPointWithinFocusWindow = useIsPointWithinFocusWindow(currentPoint);
   const pauseId = useAppSelector(state => state.pause.id);
+
   const [, dismissInspectComponentNag] = useNag(Nag.INSPECT_COMPONENT);
   const [protocolCheckFailed, setProtocolCheckFailed] = useState(false);
   const { status: annotationsStatus, value: parsedAnnotations } = useImperativeCacheValue(
@@ -457,7 +481,7 @@ export default function ReactDevtoolsPanel() {
     useState<ReactDevToolsInlineModule | null>(null);
 
   const annotations: ParsedReactDevToolsAnnotation[] =
-    annotationsStatus === "resolved" ? parsedAnnotations : [];
+    annotationsStatus === "resolved" ? parsedAnnotations : EMPTY_ANNOTATIONS;
 
   // Try to load the DevTools module whenever the current point changes.
   // Eventually we'll reach a point that has the DevTools protocol embedded.
@@ -472,14 +496,11 @@ export default function ReactDevtoolsPanel() {
     }
   });
 
-  const {
-    dispatchHighlightNode,
-    dispatchUnhighlightNode,
-    dispatchFetchMouseTargets,
-    initializePicker,
-    enablePicker,
-    disablePicker,
-  } = useMemo(() => {
+  const [ReactDevTools, wall] = useMemo(() => {
+    if (!reactDevToolsInlineModule) {
+      return [null, null] as const;
+    }
+
     function dispatchHighlightNode(nodeId: string) {
       dispatch(highlightNode(nodeId));
     }
@@ -514,15 +535,53 @@ export default function ReactDevtoolsPanel() {
       dispatch(nodePickerDisabled());
     }
 
-    return {
+    const [ReactDevTools, wall] = createReactDevTools(
+      reactDevToolsInlineModule,
+      enablePicker,
+      initializePicker,
+      disablePicker,
       dispatchHighlightNode,
       dispatchUnhighlightNode,
+      setProtocolCheckFailed,
       dispatchFetchMouseTargets,
-      initializePicker,
-      enablePicker,
-      disablePicker,
-    };
-  }, [dispatch]);
+      replayClient,
+      dismissInspectComponentNag
+    );
+    return [ReactDevTools, wall] as const;
+  }, [dispatch, reactDevToolsInlineModule, replayClient, dismissInspectComponentNag]);
+
+  useLayoutEffect(() => {
+    if (
+      !ReactDevTools ||
+      !wall ||
+      !currentPoint ||
+      !pauseId ||
+      !annotations ||
+      !annotations.length
+    ) {
+      return;
+    }
+
+    wall.setPauseId(pauseId);
+
+    if (previousPoint !== null) {
+      // We keep the one RDT UI component instance alive, but operations are additive over time.
+      // In order to reset the displayed component tree, we first need to generate a set of fake
+      // "remove this React root" operations based on where we _were_ paused, and inject those.
+      const clearTreeOperations = generateTreeResetOpsForPoint(previousPoint, annotations);
+
+      for (const rootRemovalOp of clearTreeOperations) {
+        wall.sendAnnotation({ event: "operations", payload: rootRemovalOp });
+      }
+    }
+
+    // Now that the displayed tree is empty, we can inject all operations up to the _current_ point in time.
+    for (const { contents, point } of annotations) {
+      if (contents.event === "operations" && isExecutionPointsLessThan(point, currentPoint)) {
+        wall.sendAnnotation(contents);
+      }
+    }
+  }, [ReactDevTools, wall, previousPoint, currentPoint, annotations, pauseId]);
 
   if (currentPoint === null) {
     return null;
@@ -555,12 +614,13 @@ export default function ReactDevtoolsPanel() {
   const firstOperation = annotations.find(annotation => annotation.contents.event == "operations");
   const reactInitPoint = firstOperation?.point ?? null;
 
-  const isReactDevToolsReady = reactDevToolsInlineModule !== null;
+  const isReactDevToolsReady =
+    reactDevToolsInlineModule !== null && ReactDevTools !== null && wall !== null;
   const isReady =
     isReactDevToolsReady &&
     reactInitPoint !== null &&
     currentPoint !== null &&
-    compareNumericStrings(reactInitPoint, currentPoint) <= 0;
+    isExecutionPointsLessThan(reactInitPoint, currentPoint);
 
   if (!isReady) {
     return (
@@ -577,24 +637,6 @@ export default function ReactDevtoolsPanel() {
       </div>
     );
   }
-
-  // Still not sure on the entire behavior here, but apparently wrapping
-  // this in a `useMemo` is a _bad_ idea and breaks the E2E test
-  const [ReactDevTools, wall] = createReactDevTools(
-    reactDevToolsInlineModule,
-    annotations,
-    currentPoint,
-    enablePicker,
-    initializePicker,
-    disablePicker,
-    dispatchHighlightNode,
-    dispatchUnhighlightNode,
-    setProtocolCheckFailed,
-    dispatchFetchMouseTargets,
-    replayClient,
-    dismissInspectComponentNag,
-    pauseId
-  );
 
   return (
     <ReactDevTools

--- a/src/ui/components/SecondaryToolbox/react-devtools/printOperations.ts
+++ b/src/ui/components/SecondaryToolbox/react-devtools/printOperations.ts
@@ -1,0 +1,196 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// This file contains React utilities pulled from https://github.com/facebook/react/blob/5309f102854475030fb91ab732141411b49c1126/packages/react-devtools-shared/src/utils.js#L195
+// We do not run this in production, but we do use it for testing the
+// React routine locally so we keep it in the repo for that usecase.
+
+export const TREE_OPERATION_ADD = 1;
+export const TREE_OPERATION_REMOVE = 2;
+export const TREE_OPERATION_REORDER_CHILDREN = 3;
+export const TREE_OPERATION_UPDATE_TREE_BASE_DURATION = 4;
+export const TREE_OPERATION_UPDATE_ERRORS_OR_WARNINGS = 5;
+export const TREE_OPERATION_REMOVE_ROOT = 6;
+export const TREE_OPERATION_SET_SUBTREE_MODE = 7;
+
+export const ElementTypeClass = 1;
+export const ElementTypeContext = 2;
+export const ElementTypeFunction = 5;
+export const ElementTypeForwardRef = 6;
+export const ElementTypeHostComponent = 7;
+export const ElementTypeMemo = 8;
+export const ElementTypeOtherOrUnknown = 9;
+export const ElementTypeProfiler = 10;
+export const ElementTypeRoot = 11;
+export const ElementTypeSuspense = 12;
+export const ElementTypeSuspenseList = 13;
+export const ElementTypeTracingMarker = 14;
+
+export const PROFILING_FLAG_BASIC_SUPPORT = 0b01;
+export const PROFILING_FLAG_TIMELINE_SUPPORT = 0b10;
+
+const encodedStringCache: Map<string, number[]> = new Map();
+
+export function utfDecodeString(array: Array<number>): string {
+  // Avoid spreading the array (e.g. String.fromCodePoint(...array))
+  // Functions arguments are first placed on the stack before the function is called
+  // which throws a RangeError for large arrays.
+  // See github.com/facebook/react/issues/22293
+  let string = "";
+  for (let i = 0; i < array.length; i++) {
+    const char = array[i];
+    string += String.fromCodePoint(char);
+  }
+  return string;
+}
+
+function surrogatePairToCodePoint(charCode1: number, charCode2: number): number {
+  return ((charCode1 & 0x3ff) << 10) + (charCode2 & 0x3ff) + 0x10000;
+}
+
+// Credit for this encoding approach goes to Tim Down:
+// https://stackoverflow.com/questions/4877326/how-can-i-tell-if-a-string-contains-multibyte-characters-in-javascript
+export function utfEncodeString(string: string): Array<number> {
+  const cached = encodedStringCache.get(string);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const encoded = [];
+  let i = 0;
+  let charCode;
+  while (i < string.length) {
+    charCode = string.charCodeAt(i);
+    // Handle multibyte unicode characters (like emoji).
+    if ((charCode & 0xf800) === 0xd800) {
+      encoded.push(surrogatePairToCodePoint(charCode, string.charCodeAt(++i)));
+    } else {
+      encoded.push(charCode);
+    }
+    ++i;
+  }
+
+  encodedStringCache.set(string, encoded);
+
+  return encoded;
+}
+
+export function printOperationsArray(operations: Array<number>) {
+  // The first two values are always rendererID and rootID
+  const rendererID = operations[0];
+  const rootID = operations[1];
+
+  const logs = [`operations for renderer:${rendererID} and root:${rootID}`];
+
+  let i = 2;
+
+  // Reassemble the string table.
+  const stringTable: string[] = [
+    null as any, // ID = 0 corresponds to the null string.
+  ];
+  const stringTableSize = operations[i++];
+  const stringTableEnd = i + stringTableSize;
+  while (i < stringTableEnd) {
+    const nextLength = operations[i++];
+    const nextString = utfDecodeString(operations.slice(i, i + nextLength));
+    stringTable.push(nextString);
+    i += nextLength;
+  }
+
+  while (i < operations.length) {
+    const operation = operations[i];
+
+    switch (operation) {
+      case TREE_OPERATION_ADD: {
+        const id = operations[i + 1];
+        const type = operations[i + 2];
+
+        i += 3;
+
+        if (type === ElementTypeRoot) {
+          logs.push(`Add new root node ${id}`);
+
+          i++; // isStrictModeCompliant
+          i++; // supportsProfiling
+          i++; // supportsStrictMode
+          i++; // hasOwnerMetadata
+        } else {
+          const parentID = operations[i];
+          i++;
+
+          i++; // ownerID
+
+          const displayNameStringID = operations[i];
+          const displayName = stringTable[displayNameStringID];
+          i++;
+
+          i++; // key
+
+          logs.push(`Add node ${id} (${displayName || "null"}) as child of ${parentID}`);
+        }
+        break;
+      }
+      case TREE_OPERATION_REMOVE: {
+        const removeLength = operations[i + 1];
+        i += 2;
+
+        for (let removeIndex = 0; removeIndex < removeLength; removeIndex++) {
+          const id = operations[i];
+          i += 1;
+
+          logs.push(`Remove node ${id}`);
+        }
+        break;
+      }
+      case TREE_OPERATION_REMOVE_ROOT: {
+        i += 1;
+
+        logs.push(`Remove root ${rootID}`);
+        break;
+      }
+      case TREE_OPERATION_SET_SUBTREE_MODE: {
+        const id = operations[i + 1];
+        const mode = operations[i + 1];
+
+        i += 3;
+
+        logs.push(`Mode ${mode} set for subtree with root ${id}`);
+        break;
+      }
+      case TREE_OPERATION_REORDER_CHILDREN: {
+        const id = operations[i + 1];
+        const numChildren = operations[i + 2];
+        i += 3;
+        const children = operations.slice(i, i + numChildren);
+        i += numChildren;
+
+        logs.push(`Re-order node ${id} children ${children.join(",")}`);
+        break;
+      }
+      case TREE_OPERATION_UPDATE_TREE_BASE_DURATION:
+        // Base duration updates are only sent while profiling is in progress.
+        // We can ignore them at this point.
+        // The profiler UI uses them lazily in order to generate the tree.
+        i += 3;
+        break;
+      case TREE_OPERATION_UPDATE_ERRORS_OR_WARNINGS: {
+        const id = operations[i + 1];
+        const numErrors = operations[i + 2];
+        const numWarnings = operations[i + 3];
+
+        i += 4;
+
+        logs.push(`Node ${id} has ${numErrors} errors and ${numWarnings} warnings`);
+        break;
+      }
+      default:
+        throw Error(`Unsupported Bridge operation "${operation}"`);
+    }
+  }
+
+  return logs.join("\n  ");
+}

--- a/src/ui/components/SecondaryToolbox/react-devtools/rdtProcessing.ts
+++ b/src/ui/components/SecondaryToolbox/react-devtools/rdtProcessing.ts
@@ -165,9 +165,14 @@ export function parseTreeOperations(treeOperations: number[]): ParsedReactDevtoo
   // We're now going to iterate through just the actual
   // tree operations portion of the original operations array
   let i = 0;
+  let loopCounter = 0;
 
   // Iteration logic and index comments copied from `printOperations.ts`
   while (i < treeOperations.length) {
+    if (++loopCounter > 100000) {
+      throw new Error("TREE_OPERATION_PARSING_INFINITE_LOOP");
+    }
+
     const operation = treeOperations[i];
 
     switch (operation) {
@@ -259,6 +264,8 @@ export function parseTreeOperations(treeOperations: number[]): ParsedReactDevtoo
       case TREE_OPERATION_SET_SUBTREE_MODE: {
         const rootId = treeOperations[i + 1];
         const mode = treeOperations[i + 2];
+
+        i += 3;
 
         const operation: TreeOperationSetSubtreeMode = {
           type: TREE_OPERATION_SET_SUBTREE_MODE,

--- a/src/ui/components/SecondaryToolbox/react-devtools/rdtProcessing.ts
+++ b/src/ui/components/SecondaryToolbox/react-devtools/rdtProcessing.ts
@@ -1,0 +1,528 @@
+/* Copyright 2022 Record Replay Inc. */
+
+// React DevTools routine result processing logic
+
+import { ExecutionPoint, TimeStampedPoint } from "@replayio/protocol";
+
+import { isExecutionPointsWithinRange } from "replay-next/src/utils/time";
+import { ParsedReactDevToolsAnnotation } from "ui/suspense/annotationsCaches";
+
+import {
+  ElementTypeRoot,
+  TREE_OPERATION_ADD,
+  TREE_OPERATION_REMOVE,
+  TREE_OPERATION_REMOVE_ROOT,
+  TREE_OPERATION_REORDER_CHILDREN,
+  TREE_OPERATION_SET_SUBTREE_MODE,
+  TREE_OPERATION_UPDATE_ERRORS_OR_WARNINGS,
+  TREE_OPERATION_UPDATE_TREE_BASE_DURATION,
+  utfDecodeString,
+  utfEncodeString,
+} from "./printOperations";
+
+export interface OperationsInfo {
+  point: ExecutionPoint;
+  time: number;
+  deconstructedOperations: DeconstructedOperationsPieces;
+}
+
+interface RootNodeOperation extends TimeStampedPoint {
+  type: "root-added" | "root-removed";
+  rendererId: number;
+  rootId: number;
+}
+
+export interface DeconstructedOperationsPieces {
+  rendererId: number;
+  rootId: number;
+  stringTable: string[];
+  treeOperations: ParsedReactDevtoolsTreeOperations[];
+}
+
+// The React DevTools logic defines a set of "tree operations" that describe
+// changes to the contents of the React component tree. Those operations are
+// serialized as part of a single large numeric operations array, which is very
+// hard to read or work with. This file contains logic to parse that array into
+// specific structures with named fields, which are easier to work with, and then
+// reconstruct an equivalent numeric operations array based on these structures.
+interface TreeOperationAddRootContents {
+  nodeType: "root";
+  isStrictModeCompliant: boolean;
+  supportsProfiling: boolean;
+  supportsStrictMode: boolean;
+  hasOwnerMetadata: boolean;
+}
+
+interface TreeOperationAddNodeContents {
+  nodeType: "node";
+  parentId: number;
+  ownerId: number;
+  stringTableIndex: number;
+  keyStringTableIndex: number;
+}
+
+interface TreeOperationAddBase {
+  type: typeof TREE_OPERATION_ADD;
+  nodeId: number;
+  nodeType: number;
+}
+
+interface TreeOperationAddRoot extends TreeOperationAddBase {
+  name: "addRoot";
+  contents: TreeOperationAddRootContents;
+}
+
+interface TreeOperationAddNode extends TreeOperationAddBase {
+  name: "addNode";
+  contents: TreeOperationAddNodeContents;
+}
+
+interface TreeOperationRemove {
+  type: typeof TREE_OPERATION_REMOVE;
+  name: "remove";
+  nodeIds: number[];
+}
+
+interface TreeOperationRemoveRoot {
+  type: typeof TREE_OPERATION_REMOVE_ROOT;
+  name: "removeRoot";
+}
+
+interface TreeOperationSetSubtreeMode {
+  type: typeof TREE_OPERATION_SET_SUBTREE_MODE;
+  name: "setSubtreeMode";
+  rootId: number;
+  mode: number;
+}
+
+interface TreeOperationReorderChildren {
+  type: typeof TREE_OPERATION_REORDER_CHILDREN;
+  name: "reorderChildren";
+  nodeId: number;
+  children: number[];
+}
+
+interface TreeOperationUpdateTreeBaseDuration {
+  type: typeof TREE_OPERATION_UPDATE_TREE_BASE_DURATION;
+  name: "updateTreeBaseDuration";
+  id: number;
+  baseDuration: number;
+}
+
+interface TreeOperationUpdateErrorsOrWarnings {
+  type: typeof TREE_OPERATION_UPDATE_ERRORS_OR_WARNINGS;
+  name: "updateErrorsOrWarnings";
+  nodeId: number;
+  errors: number;
+  warnings: number;
+}
+
+export type ParsedReactDevtoolsTreeOperations =
+  | TreeOperationAddRoot
+  | TreeOperationAddNode
+  | TreeOperationRemove
+  | TreeOperationRemoveRoot
+  | TreeOperationSetSubtreeMode
+  | TreeOperationReorderChildren
+  | TreeOperationUpdateTreeBaseDuration
+  | TreeOperationUpdateErrorsOrWarnings;
+
+export function deconstructOperationsArray(originalOperations: number[]) {
+  const rendererId = originalOperations[0];
+  const rootId = originalOperations[1];
+
+  let i = 2;
+
+  // Reassemble the string table.
+  const stringTable: string[] = [
+    null as any, // ID = 0 corresponds to the null string.
+  ];
+
+  const stringTableSize = originalOperations[i++];
+  const stringTableEnd = i + stringTableSize;
+  while (i < stringTableEnd) {
+    const nextLength = originalOperations[i++];
+    const nextString = utfDecodeString(originalOperations.slice(i, i + nextLength));
+    stringTable.push(nextString);
+    i += nextLength;
+  }
+
+  const numericTreeOperations = originalOperations.slice(stringTableEnd);
+
+  const parsedTreeOperations = parseTreeOperations(numericTreeOperations);
+
+  return {
+    rendererId,
+    rootId,
+    stringTable,
+    treeOperations: parsedTreeOperations,
+  };
+}
+
+export function parseTreeOperations(treeOperations: number[]): ParsedReactDevtoolsTreeOperations[] {
+  const parsedOperations: ParsedReactDevtoolsTreeOperations[] = [];
+
+  // We're now going to iterate through just the actual
+  // tree operations portion of the original operations array
+  let i = 0;
+
+  // Iteration logic and index comments copied from `printOperations.ts`
+  while (i < treeOperations.length) {
+    const operation = treeOperations[i];
+
+    switch (operation) {
+      case TREE_OPERATION_ADD: {
+        const nodeId = treeOperations[i + 1];
+        const type = treeOperations[i + 2];
+
+        i += 3;
+
+        if (type === ElementTypeRoot) {
+          // Booleans are encoded as 1 or 0
+          const isStrictModeCompliant = treeOperations[i++] === 1;
+          const supportsProfiling = treeOperations[i++] === 1;
+          const supportsStrictMode = treeOperations[i++] === 1;
+          const hasOwnerMetadata = treeOperations[i++] === 1;
+
+          const operation: TreeOperationAddRoot = {
+            type: TREE_OPERATION_ADD,
+            name: "addRoot",
+            nodeId,
+            nodeType: type,
+            contents: {
+              nodeType: "root",
+              isStrictModeCompliant,
+              supportsProfiling,
+              supportsStrictMode,
+              hasOwnerMetadata,
+            },
+          };
+
+          parsedOperations.push(operation);
+        } else {
+          const parentId = treeOperations[i++];
+          const ownerId = treeOperations[i++];
+          const stringTableIndex = treeOperations[i++];
+          const keyStringTableIndex = treeOperations[i++];
+
+          const operation: TreeOperationAddNode = {
+            type: TREE_OPERATION_ADD,
+            name: "addNode",
+            nodeId,
+            nodeType: type,
+            contents: {
+              nodeType: "node",
+              stringTableIndex,
+              parentId,
+              ownerId,
+              keyStringTableIndex,
+            },
+          };
+
+          parsedOperations.push(operation);
+        }
+
+        break;
+      }
+      case TREE_OPERATION_REMOVE: {
+        const removeLength = treeOperations[i + 1];
+        i += 2;
+
+        const nodeIds: number[] = [];
+
+        for (let removeIndex = 0; removeIndex < removeLength; removeIndex++) {
+          const id = treeOperations[i];
+          nodeIds.push(id);
+          i += 1;
+        }
+
+        const operation: TreeOperationRemove = {
+          type: TREE_OPERATION_REMOVE,
+          name: "remove",
+          nodeIds,
+        };
+
+        parsedOperations.push(operation);
+        break;
+      }
+      case TREE_OPERATION_REMOVE_ROOT: {
+        i += 1;
+
+        const operation: TreeOperationRemoveRoot = {
+          type: TREE_OPERATION_REMOVE_ROOT,
+          name: "removeRoot",
+        };
+
+        parsedOperations.push(operation);
+        break;
+      }
+      case TREE_OPERATION_SET_SUBTREE_MODE: {
+        const rootId = treeOperations[i + 1];
+        const mode = treeOperations[i + 2];
+
+        const operation: TreeOperationSetSubtreeMode = {
+          type: TREE_OPERATION_SET_SUBTREE_MODE,
+          name: "setSubtreeMode",
+          rootId,
+          mode,
+        };
+
+        parsedOperations.push(operation);
+        break;
+      }
+      case TREE_OPERATION_REORDER_CHILDREN: {
+        const nodeId = treeOperations[i + 1];
+        const numChildren = treeOperations[i + 2];
+        i += 3;
+        const children = treeOperations.slice(i, i + numChildren);
+
+        i += numChildren;
+
+        const operation: TreeOperationReorderChildren = {
+          type: TREE_OPERATION_REORDER_CHILDREN,
+          name: "reorderChildren",
+          nodeId,
+          children,
+        };
+
+        parsedOperations.push(operation);
+        break;
+      }
+      case TREE_OPERATION_UPDATE_TREE_BASE_DURATION: {
+        const id = treeOperations[i + 1];
+        const baseDuration = treeOperations[i + 2];
+        // Base duration updates are only sent while profiling is in progress.
+        // We can ignore them at this point.
+        // The profiler UI uses them lazily in order to generate the tree.
+        i += 3;
+
+        const operation: TreeOperationUpdateTreeBaseDuration = {
+          type: TREE_OPERATION_UPDATE_TREE_BASE_DURATION,
+          name: "updateTreeBaseDuration",
+          id,
+          baseDuration,
+        };
+
+        parsedOperations.push(operation);
+        break;
+      }
+      case TREE_OPERATION_UPDATE_ERRORS_OR_WARNINGS: {
+        const nodeId = treeOperations[i + 1];
+        const errors = treeOperations[i + 2];
+        const warnings = treeOperations[i + 3];
+
+        i += 4;
+
+        const operation: TreeOperationUpdateErrorsOrWarnings = {
+          type: TREE_OPERATION_UPDATE_ERRORS_OR_WARNINGS,
+          name: "updateErrorsOrWarnings",
+          nodeId,
+          errors,
+          warnings,
+        };
+
+        parsedOperations.push(operation);
+        break;
+      }
+      default:
+        throw new Error("UNEXPECTED_PARSED_OPERATION_TYPE");
+    }
+  }
+
+  return parsedOperations;
+}
+
+// Given the deconstructed pieces that comprised an operations array
+// in readable form, reconstruct the original numeric operations array.
+export function reconstructOperationsArray(
+  rendererId: number,
+  rootId: number,
+  stringTable: string[],
+  treeOperations: ParsedReactDevtoolsTreeOperations[]
+) {
+  const finalStringTable = stringTable.slice();
+  // The string table likely has the extra `null` placeholder.
+  // We need to remove it before encoding.
+  if (finalStringTable[0] === null) {
+    finalStringTable.shift();
+  }
+
+  const reencodedStringTable = finalStringTable
+    .map(string => {
+      const encoded = utfEncodeString(string);
+      return [encoded.length, ...encoded];
+    })
+    .flat();
+
+  const reencodedTreeOperations = treeOperations
+    .map(op => {
+      const instructions: number[] = [op.type];
+
+      switch (op.type) {
+        case TREE_OPERATION_ADD: {
+          const { nodeId, nodeType, contents } = op;
+          instructions.push(nodeId, nodeType);
+
+          if (contents.nodeType === "root") {
+            const {
+              isStrictModeCompliant,
+              supportsProfiling,
+              supportsStrictMode,
+              hasOwnerMetadata,
+            } = contents;
+
+            instructions.push(
+              isStrictModeCompliant ? 1 : 0,
+              supportsProfiling ? 1 : 0,
+              supportsStrictMode ? 1 : 0,
+              hasOwnerMetadata ? 1 : 0
+            );
+          } else {
+            const { stringTableIndex, parentId, ownerId, keyStringTableIndex } = contents;
+
+            instructions.push(parentId, ownerId, stringTableIndex, keyStringTableIndex);
+          }
+          break;
+        }
+        case TREE_OPERATION_REMOVE: {
+          const { nodeIds } = op;
+          instructions.push(nodeIds.length, ...nodeIds);
+          break;
+        }
+        case TREE_OPERATION_REMOVE_ROOT: {
+          // No additional fields other than the operation type,
+          // since the root ID is already in the operations array
+          break;
+        }
+        case TREE_OPERATION_SET_SUBTREE_MODE: {
+          const { rootId, mode } = op;
+          instructions.push(rootId, mode);
+          break;
+        }
+        case TREE_OPERATION_REORDER_CHILDREN: {
+          const { nodeId, children } = op;
+          instructions.push(nodeId, children.length, ...children);
+          break;
+        }
+        case TREE_OPERATION_UPDATE_TREE_BASE_DURATION: {
+          const { id, baseDuration } = op;
+          instructions.push(id, baseDuration);
+          break;
+        }
+        case TREE_OPERATION_UPDATE_ERRORS_OR_WARNINGS: {
+          const { nodeId, errors, warnings } = op;
+          instructions.push(nodeId, errors, warnings);
+          break;
+        }
+        default:
+          throw new Error("UNEXPECTED_PARSED_OPERATION_TYPE");
+      }
+
+      return instructions;
+    })
+    .flat();
+
+  const operations: number[] = [
+    // The original renderer ID and root ID
+    rendererId,
+    rootId,
+    // The new string table length, in number of discrete numeric indices (not number of strings)
+    reencodedStringTable.length,
+    // The entire new string table contents,
+    // containing all string length + individual character numeric value groups
+    ...reencodedStringTable,
+    // All tree operations values
+    ...reencodedTreeOperations,
+  ];
+
+  return operations;
+}
+
+const deconstructedOperationsByPoint = new Map<string, DeconstructedOperationsPieces>();
+
+export function generateTreeResetOpsForPoint(
+  executionPoint: ExecutionPoint,
+  annotations: ParsedReactDevToolsAnnotation[]
+) {
+  const rootNodeEvents: RootNodeOperation[] = [];
+
+  const removalOperations: number[][] = [];
+
+  // Find every time that a React root was added or removed
+  for (const { point, time, contents } of annotations) {
+    if (contents.event !== "operations") {
+      continue;
+    }
+
+    const { payload } = contents;
+    let deconstructedOperations: DeconstructedOperationsPieces;
+
+    // Avoid recalculating these repeatedly
+    if (deconstructedOperationsByPoint.has(point)) {
+      deconstructedOperations = deconstructedOperationsByPoint.get(point)!;
+    } else {
+      deconstructedOperations = deconstructOperationsArray(payload);
+      deconstructedOperationsByPoint.set(point, deconstructedOperations);
+    }
+
+    const { rendererId, rootId, treeOperations: parsedOperations } = deconstructedOperations;
+
+    for (const op of parsedOperations) {
+      if (op.type === TREE_OPERATION_ADD && op.contents.nodeType === "root") {
+        rootNodeEvents.push({
+          type: "root-added",
+          rendererId,
+          rootId,
+          point,
+          time,
+        });
+      } else if (op.type == TREE_OPERATION_REMOVE_ROOT) {
+        rootNodeEvents.push({
+          type: "root-removed",
+          rendererId,
+          rootId,
+          point,
+          time,
+        });
+      }
+    }
+  }
+
+  let activeRoots: Map<number, Set<number>> = new Map();
+
+  const rootEventsInTimeframe = rootNodeEvents.filter(({ point }) =>
+    isExecutionPointsWithinRange(point, "0", executionPoint)
+  );
+
+  for (const rootEvent of rootEventsInTimeframe) {
+    const { rendererId, rootId } = rootEvent;
+
+    if (!activeRoots.has(rendererId)) {
+      activeRoots.set(rendererId, new Set());
+    }
+
+    const activeRootsForRenderer = activeRoots.get(rendererId)!;
+    if (rootEvent.type === "root-added") {
+      activeRootsForRenderer.add(rootId);
+    } else {
+      activeRootsForRenderer.delete(rootId);
+    }
+
+    // These don't even include a root ID, since it's already in the operations array header
+    const removeRootOp: TreeOperationRemoveRoot = {
+      type: TREE_OPERATION_REMOVE_ROOT,
+      name: "removeRoot",
+    };
+
+    // Assume that every nav wipes out the page entirely.
+    // TODO [FE-1667] This doesn't deal with iframes yet - not sure how to handle iframe navs?
+    for (const [rendererId, activeRootsForRenderer] of activeRoots.entries()) {
+      for (const _activeRoot of activeRootsForRenderer) {
+        const removalOp = reconstructOperationsArray(rendererId, rootId, [], [removeRootOp]);
+        removalOperations.push(removalOp);
+      }
+    }
+  }
+
+  return removalOperations;
+}

--- a/src/ui/suspense/annotationsCaches.ts
+++ b/src/ui/suspense/annotationsCaches.ts
@@ -13,7 +13,7 @@ import { processReduxAnnotations } from "ui/components/SecondaryToolbox/redux-de
 export interface ParsedReactDevToolsAnnotation extends TimeStampedPoint {
   contents: {
     event: "operations";
-    operations: number[];
+    payload: number[];
   };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14783,13 +14783,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-devtools-inline@npm:^4.24.5":
+"react-devtools-inline@npm:4.24.7":
   version: 4.24.7
   resolution: "react-devtools-inline@npm:4.24.7"
   dependencies:
     source-map-js: ^0.6.2
     sourcemap-codec: ^1.4.8
   checksum: 94c60252d78f4ce3544cd067f1d9d50b75c1c948f37f95484e24e5229705d02113398ce43ac95d7baa3cd2f7a4f1fa5094bd97bb0c0e52f74e0f33b2d43314f7
+  languageName: node
+  linkType: hard
+
+"react-devtools-inline@patch:react-devtools-inline@npm:4.24.7#.yarn/patches/react-devtools-inline-npm-4.24.7-9582a0f8d6.patch::locator=recordreplay-devtools%40workspace%3A.":
+  version: 4.24.7
+  resolution: "react-devtools-inline@patch:react-devtools-inline@npm%3A4.24.7#.yarn/patches/react-devtools-inline-npm-4.24.7-9582a0f8d6.patch::version=4.24.7&hash=16cfed&locator=recordreplay-devtools%40workspace%3A."
+  dependencies:
+    source-map-js: ^0.6.2
+    sourcemap-codec: ^1.4.8
+  checksum: 619eef6d9027c231daeb18a7229153d01b3e7e5c0a8881411a861c18f19703aac1cf56209683eed54411c0f93bda46effab96c30b47a20c11ecbf21886909624
   languageName: node
   linkType: hard
 
@@ -15284,7 +15294,7 @@ __metadata:
     react: 0.0.0-experimental-49f741046-20230305
     react-canvas-confetti: ^1.3.0
     react-circular-progressbar: ^2.0.4
-    react-devtools-inline: ^4.24.5
+    react-devtools-inline: 4.24.7
     react-devtools-inline_4_18_0: "npm:react-devtools-inline@4.18.0"
     react-dom: 0.0.0-experimental-49f741046-20230305
     react-error-boundary: ^4.0.10


### PR DESCRIPTION
This PR:

- Reworks our `ReactDevTools.tsx` file to only create the actual RDT component type _once_ and effectively "reset" its contents as the user jumps from point to point, instead of re-creating the entire component instance every time they jump to a point.
   - Ports the RDT operations processing logic I wrote for the backend routine in order to support generating the "remove root" operations on the client
- Patches the `react-devtools-inline` package to turn off a `console.warn("No element found!")` warning that was spewing in certain cases after the logic change (such as having done a search for some components by name, then jumping to a different point).  This was due to the component still having internal state for last identified component IDs that may no longer be relevant.  (Adjusting that behavior would be potential fodder for a future fork of the RDT UI.)