### PR TITLE
Add fast-forward and rewind to line context menu options

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "shared": "workspace:*",
     "slugify": "^1.6.5",
     "suspense": "^0.0.44",
-    "use-context-menu": "^0.4.10"
+    "use-context-menu": "^0.4.11"
   },
   "devDependencies": {
     "@babel/core": "^7.17.8",

--- a/packages/e2e-tests/helpers/context-menu.ts
+++ b/packages/e2e-tests/helpers/context-menu.ts
@@ -24,11 +24,9 @@ export async function selectContextMenuItem(
   } else if (contextMenuTestName) {
     contextMenuLocator = scope.locator(`[data-test-name="${contextMenuTestName}"]`);
   } else if (contextMenuItemText) {
-    contextMenuLocator = scope.locator(
-      `[data-test-name="ContextMenu"]:has-text("${contextMenuItemText}")`
-    );
+    contextMenuLocator = scope.locator(`[data-context-menu]:has-text("${contextMenuItemText}")`);
   } else {
-    contextMenuLocator = scope.locator('[data-test-name="ContextMenu"]');
+    contextMenuLocator = scope.locator("[data-context-menu]");
   }
 
   let contextMenuItemLocator: Locator;

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -20,7 +20,7 @@
     "@playwright/test": "^1.35.0",
     "@recordreplay/playwright": "^1.18.3",
     "@replayio/cypress": "^0.5.0",
-    "@replayio/playwright": "^1.0.4",
+    "@replayio/playwright": "latest",
     "cli-spinners": "^2.7.0",
     "cypress": "^12.5.1",
     "log-update": "^4",

--- a/packages/replay-next/components/console/LoggablesContext.tsx
+++ b/packages/replay-next/components/console/LoggablesContext.tsx
@@ -20,7 +20,7 @@ import {
   UncaughtException,
   getInfallibleExceptionPointsSuspense,
 } from "replay-next/src/suspense/ExceptionsCache";
-import { getHitPointsForLocationSuspense } from "replay-next/src/suspense/HitPointsCache";
+import { hitPointsForLocationCache } from "replay-next/src/suspense/HitPointsCache";
 import { loggableSort } from "replay-next/src/utils/loggables";
 import { isInNodeModules } from "replay-next/src/utils/messages";
 import { suspendInParallel } from "replay-next/src/utils/suspense";
@@ -197,11 +197,11 @@ function LoggablesContextInner({
       const pointBehavior = pointBehaviors[point.key];
       if (pointBehavior?.shouldLog === POINT_BEHAVIOR_ENABLED) {
         // TODO This isn't a safe time to suspend (inside of useMemo())
-        const [hitPoints, status] = getHitPointsForLocationSuspense(
+        const [hitPoints, status] = hitPointsForLocationCache.read(
           client,
+          toPointRange(focusRange),
           point.location,
-          point.condition,
-          toPointRange(focusRange)
+          point.condition
         );
 
         switch (status) {

--- a/packages/replay-next/components/sources/HoverButton.tsx
+++ b/packages/replay-next/components/sources/HoverButton.tsx
@@ -1,9 +1,10 @@
-import { ExecutionPoint, TimeStampedPoint } from "@replayio/protocol";
-import findLast from "lodash/findLast";
+import { TimeStampedPoint } from "@replayio/protocol";
 import { useContext } from "react";
 
 import Icon from "replay-next/components/Icon";
 import useGetDefaultLogPointContent from "replay-next/components/sources/hooks/useGetDefaultLogPointContent";
+import { findLastHitPoint } from "replay-next/components/sources/utils/findLastHitPoint";
+import { findNextHitPoint } from "replay-next/components/sources/utils/findNextHitPoints";
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
 import { KeyboardModifiersContext } from "replay-next/src/contexts/KeyboardModifiersContext";
 import {
@@ -15,21 +16,17 @@ import {
 import { SessionContext } from "replay-next/src/contexts/SessionContext";
 import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
 import { useNag } from "replay-next/src/hooks/useNag";
-import { getHitPointsForLocationSuspense } from "replay-next/src/suspense/HitPointsCache";
+import { hitPointsForLocationCache } from "replay-next/src/suspense/HitPointsCache";
 import { Source } from "replay-next/src/suspense/SourcesCache";
-import {
-  compareExecutionPoints,
-  isExecutionPointsGreaterThan,
-  isExecutionPointsLessThan,
-} from "replay-next/src/utils/time";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import {
+  HitPointStatus,
+  LineHitCounts,
   POINT_BEHAVIOR_DISABLED,
   POINT_BEHAVIOR_ENABLED,
   Point,
   PointBehavior,
 } from "shared/client/types";
-import { LineHitCounts } from "shared/client/types";
 import { TOO_MANY_POINTS_TO_FIND } from "shared/constants";
 import { Nag } from "shared/graphql/types";
 
@@ -60,10 +57,136 @@ export default function HoverButton({
   pointBehavior: PointBehavior | null;
   source: Source;
 }) {
+  const { isMetaKeyActive } = useContext(KeyboardModifiersContext);
+
+  // Don't render a hover button for lines that have no hits at all
+  if (!lineHitCounts) {
+    return null;
+  }
+
+  if (isMetaKeyActive) {
+    return (
+      <MetaHoverButton
+        buttonClassName={buttonClassName}
+        iconClassName={iconClassName}
+        lineHitCounts={lineHitCounts}
+        lineNumber={lineNumber}
+        source={source}
+      />
+    );
+  } else {
+    return (
+      <NormalHoverButton
+        addPoint={addPoint}
+        buttonClassName={buttonClassName}
+        deletePoints={deletePoints}
+        editPendingPointText={editPendingPointText}
+        editPointBehavior={editPointBehavior}
+        iconClassName={iconClassName}
+        lineHitCounts={lineHitCounts}
+        lineNumber={lineNumber}
+        point={point}
+        pointBehavior={pointBehavior}
+        source={source}
+      />
+    );
+  }
+}
+
+function MetaHoverButton({
+  buttonClassName,
+  iconClassName,
+  lineHitCounts,
+  lineNumber,
+  source,
+}: {
+  buttonClassName: string;
+  iconClassName: string;
+  lineHitCounts: LineHitCounts | null;
+  lineNumber: number;
+  source: Source;
+}) {
   const { range: focusRange } = useContext(FocusContext);
-  const { isMetaKeyActive, isShiftKeyActive } = useContext(KeyboardModifiersContext);
-  const client = useContext(ReplayClientContext);
+  const { isShiftKeyActive } = useContext(KeyboardModifiersContext);
+  const replayClient = useContext(ReplayClientContext);
   const { executionPoint, update } = useContext(TimelineContext);
+
+  let hitPoints: TimeStampedPoint[] | null = null;
+  let hitPointStatus: HitPointStatus | null = null;
+  if (lineHitCounts != null && lineHitCounts.count < TOO_MANY_POINTS_TO_FIND && focusRange) {
+    const tuple = hitPointsForLocationCache.read(
+      replayClient,
+      { begin: focusRange.begin.point, end: focusRange.end.point },
+      {
+        column: lineHitCounts.firstBreakableColumnIndex,
+        line: lineNumber,
+        sourceId: source.id,
+      },
+      null
+    );
+
+    hitPoints = tuple[0];
+    hitPointStatus = tuple[1];
+  }
+
+  let targetPoint: TimeStampedPoint | null = null;
+  if (hitPoints !== null && hitPointStatus !== "too-many-points-to-find") {
+    if (isShiftKeyActive) {
+      targetPoint = findLastHitPoint(hitPoints, executionPoint);
+    } else {
+      targetPoint = findNextHitPoint(hitPoints, executionPoint);
+    }
+  }
+
+  const disabled = targetPoint == null;
+
+  const onClick = () => {
+    if (targetPoint != null) {
+      update(targetPoint.time, targetPoint.point, false);
+    }
+  };
+
+  return (
+    <button
+      className={`${buttonClassName} ${styles.Button}`}
+      data-test-name="ContinueToButton"
+      data-test-state={isShiftKeyActive ? "previous" : "next"}
+      disabled={disabled}
+      onClick={onClick}
+    >
+      <Icon
+        className={iconClassName}
+        type={isShiftKeyActive ? "continue-to-previous" : "continue-to-next"}
+      />
+    </button>
+  );
+}
+
+function NormalHoverButton({
+  addPoint,
+  buttonClassName,
+  deletePoints,
+  editPendingPointText,
+  editPointBehavior,
+  iconClassName,
+  lineHitCounts,
+  lineNumber,
+  point,
+  pointBehavior,
+  source,
+}: {
+  addPoint: AddPoint;
+  buttonClassName: string;
+  deletePoints: DeletePoints;
+  editPendingPointText: EditPendingPointText;
+  editPointBehavior: EditPointBehavior;
+  iconClassName: string;
+  lineHitCounts: LineHitCounts;
+  lineNumber: number;
+  point: Point | null;
+  pointBehavior: PointBehavior | null;
+  source: Source;
+}) {
   const { currentUserInfo } = useContext(SessionContext);
 
   const getDefaultLogPointContent = useGetDefaultLogPointContent({
@@ -74,154 +197,79 @@ export default function HoverButton({
 
   const [showNag, dismissNag] = useNag(Nag.FIRST_BREAKPOINT_ADD);
 
-  // Don't render a hover button for lines that have no hits at all.
-  if (!lineHitCounts) {
-    return null;
-  }
-
+  // Don't render hover buttons when other user's hit points already exist on the line
   if (point?.user && point.user.id !== currentUserInfo?.id) {
     return null;
   }
 
-  if (isMetaKeyActive) {
-    const [hitPoints, hitPointStatus] =
-      lineHitCounts == null || lineHitCounts.count >= TOO_MANY_POINTS_TO_FIND || !focusRange
-        ? [null, null]
-        : getHitPointsForLocationSuspense(
-            client,
-            {
-              column: lineHitCounts.firstBreakableColumnIndex,
-              line: lineNumber,
-              sourceId: source.sourceId,
-            },
-            null,
-            { begin: focusRange.begin.point, end: focusRange.end.point }
-          );
-
-    let targetPoint: TimeStampedPoint | null = null;
-    if (hitPoints !== null && hitPointStatus !== "too-many-points-to-find") {
-      if (isShiftKeyActive) {
-        targetPoint = findLastHitPoint(hitPoints, executionPoint);
-      } else {
-        targetPoint = findHitPoint(hitPoints, executionPoint);
-      }
+  const addLogPoint = () => {
+    const content = getDefaultLogPointContent();
+    if (!content) {
+      return;
     }
 
-    const disabled = targetPoint == null;
+    dismissNag();
 
-    const onClick = () => {
-      if (targetPoint != null) {
-        update(targetPoint.time, targetPoint.point, false);
-      }
+    const location = {
+      column: lineHitCounts.firstBreakableColumnIndex,
+      line: lineNumber,
+      sourceId: source.sourceId,
     };
 
-    return (
-      <button
-        className={`${buttonClassName} ${styles.Button}`}
-        data-test-name="ContinueToButton"
-        data-test-state={isShiftKeyActive ? "previous" : "next"}
-        disabled={disabled}
-        onClick={onClick}
-      >
-        <Icon
-          className={iconClassName}
-          type={isShiftKeyActive ? "continue-to-previous" : "continue-to-next"}
-        />
-      </button>
-    );
-  } else {
-    const addLogPoint = () => {
-      const content = getDefaultLogPointContent();
-      if (!content) {
-        return;
-      }
+    if (point) {
+      editPendingPointText(point.key, { content });
+      editPointBehavior(
+        point.key,
+        { shouldLog: POINT_BEHAVIOR_ENABLED },
+        point.user?.id === currentUserInfo?.id
+      );
+    } else {
+      addPoint(
+        {
+          content,
+        },
+        {
+          shouldLog: POINT_BEHAVIOR_ENABLED,
+        },
+        location
+      );
+    }
+  };
 
-      dismissNag();
+  const {
+    shouldBreak = POINT_BEHAVIOR_DISABLED,
+    shouldLog = point?.content ? POINT_BEHAVIOR_ENABLED : POINT_BEHAVIOR_DISABLED,
+  } = pointBehavior || {};
 
-      const location = {
-        column: lineHitCounts.firstBreakableColumnIndex,
-        line: lineNumber,
-        sourceId: source.sourceId,
-      };
+  // If a point's behavior has been temporarily disabled, the hover button should take that into account.
+  const hasOrDidBreak = shouldBreak !== POINT_BEHAVIOR_DISABLED;
+  const hasOrDidLog = shouldLog !== POINT_BEHAVIOR_DISABLED;
 
-      if (point) {
-        editPendingPointText(point.key, { content });
+  const togglePoint = () => {
+    if (point) {
+      if (!hasOrDidLog || hasOrDidBreak) {
+        const newShouldLog = hasOrDidLog ? POINT_BEHAVIOR_DISABLED : POINT_BEHAVIOR_ENABLED;
         editPointBehavior(
           point.key,
-          { shouldLog: POINT_BEHAVIOR_ENABLED },
+          {
+            shouldLog: newShouldLog,
+          },
           point.user?.id === currentUserInfo?.id
         );
       } else {
-        addPoint(
-          {
-            content,
-          },
-          {
-            shouldLog: POINT_BEHAVIOR_ENABLED,
-          },
-          location
-        );
+        deletePoints(point.key);
       }
-    };
-
-    const {
-      shouldBreak = POINT_BEHAVIOR_DISABLED,
-      shouldLog = point?.content ? POINT_BEHAVIOR_ENABLED : POINT_BEHAVIOR_DISABLED,
-    } = pointBehavior || {};
-
-    // If a point's behavior has been temporarily disabled, the hover button should take that into account.
-    const hasOrDidBreak = shouldBreak !== POINT_BEHAVIOR_DISABLED;
-    const hasOrDidLog = shouldLog !== POINT_BEHAVIOR_DISABLED;
-
-    const togglePoint = () => {
-      if (point) {
-        if (!hasOrDidLog || hasOrDidBreak) {
-          const newShouldLog = hasOrDidLog ? POINT_BEHAVIOR_DISABLED : POINT_BEHAVIOR_ENABLED;
-          editPointBehavior(
-            point.key,
-            {
-              shouldLog: newShouldLog,
-            },
-            point.user?.id === currentUserInfo?.id
-          );
-        } else {
-          deletePoints(point.key);
-        }
-      }
-    };
-
-    return (
-      <button
-        className={`${buttonClassName} ${showNag ? styles.ButtonWithNag : styles.Button}`}
-        data-test-name="LogPointToggle"
-        data-test-state={hasOrDidLog ? "on" : "off"}
-        onClick={hasOrDidLog ? togglePoint : addLogPoint}
-      >
-        <Icon className={iconClassName} type={hasOrDidLog ? "remove" : "add"} />
-      </button>
-    );
-  }
-}
-
-const findHitPoint = (hitPoints: TimeStampedPoint[], executionPoint: ExecutionPoint) => {
-  const hitPoint = hitPoints.find(point => compareExecutionPoints(point.point, executionPoint) > 0);
-  if (hitPoint != null) {
-    if (isExecutionPointsGreaterThan(hitPoint.point, executionPoint)) {
-      return hitPoint;
     }
-  }
-  return null;
-};
+  };
 
-const findLastHitPoint = (hitPoints: TimeStampedPoint[], executionPoint: ExecutionPoint) => {
-  const hitPoint = findLast(
-    hitPoints,
-    point => compareExecutionPoints(point.point, executionPoint) < 0
+  return (
+    <button
+      className={`${buttonClassName} ${showNag ? styles.ButtonWithNag : styles.Button}`}
+      data-test-name="LogPointToggle"
+      data-test-state={hasOrDidLog ? "on" : "off"}
+      onClick={hasOrDidLog ? togglePoint : addLogPoint}
+    >
+      <Icon className={iconClassName} type={hasOrDidLog ? "remove" : "add"} />
+    </button>
   );
-  if (hitPoint != null) {
-    if (isExecutionPointsLessThan(hitPoint.point, executionPoint)) {
-      return hitPoint;
-    }
-  }
-  return null;
-};
+}

--- a/packages/replay-next/components/sources/SourceListRow.tsx
+++ b/packages/replay-next/components/sources/SourceListRow.tsx
@@ -336,6 +336,7 @@ const SourceListRow = memo(
     };
 
     const { contextMenu, onContextMenu } = useSourceContextMenu({
+      lineHitCounts,
       lineNumber,
       sourceId: source.sourceId,
       sourceUrl: source.url ?? null,

--- a/packages/replay-next/components/sources/log-point-panel/LogPointPanel.tsx
+++ b/packages/replay-next/components/sources/log-point-panel/LogPointPanel.tsx
@@ -25,7 +25,7 @@ import { SessionContext } from "replay-next/src/contexts/SessionContext";
 import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
 import { useNag } from "replay-next/src/hooks/useNag";
 import useSuspendAfterMount from "replay-next/src/hooks/useSuspendAfterMount";
-import { getHitPointsForLocationSuspense } from "replay-next/src/suspense/HitPointsCache";
+import { hitPointsForLocationCache } from "replay-next/src/suspense/HitPointsCache";
 import { getSourceSuspends } from "replay-next/src/suspense/SourcesCache";
 import { findIndexBigInt } from "replay-next/src/utils/array";
 import { validate } from "replay-next/src/utils/points";
@@ -92,11 +92,11 @@ function PointPanel(props: ExternalProps) {
     if (!focusRange) {
       return null;
     }
-    return getHitPointsForLocationSuspense(
+    return hitPointsForLocationCache.read(
       client,
+      { begin: focusRange.begin.point, end: focusRange.end.point },
       pointForSuspense.location,
-      pointForSuspense.condition,
-      { begin: focusRange.begin.point, end: focusRange.end.point }
+      pointForSuspense.condition
     );
   }) ?? [[], null];
 

--- a/packages/replay-next/components/sources/useSourceContextMenu.tsx
+++ b/packages/replay-next/components/sources/useSourceContextMenu.tsx
@@ -1,5 +1,7 @@
-import { SourceId } from "@replayio/protocol";
+import assert from "assert";
+import { SourceId, TimeStampedPoint } from "@replayio/protocol";
 import { unstable_useCacheRefresh as useCacheRefresh, useContext, useTransition } from "react";
+import { useImperativeCacheValue } from "suspense";
 import { ContextMenuDivider, ContextMenuItem, useContextMenu } from "use-context-menu";
 
 import { copyToClipboard } from "replay-next/components/sources/utils/clipboard";
@@ -7,27 +9,54 @@ import {
   COMMENT_TYPE_SOURCE_CODE,
   createTypeDataForSourceCodeComment,
 } from "replay-next/components/sources/utils/comments";
+import { findLastHitPoint } from "replay-next/components/sources/utils/findLastHitPoint";
+import { findNextHitPoint } from "replay-next/components/sources/utils/findNextHitPoints";
+import { FocusContext } from "replay-next/src/contexts/FocusContext";
 import { GraphQLClientContext } from "replay-next/src/contexts/GraphQLClientContext";
 import { InspectorContext } from "replay-next/src/contexts/InspectorContext";
 import { SessionContext } from "replay-next/src/contexts/SessionContext";
 import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
+import { hitPointsForLocationCache } from "replay-next/src/suspense/HitPointsCache";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
+import { HitPointStatus, LineHitCounts } from "shared/client/types";
 import { addComment as addCommentGraphQL } from "shared/graphql/Comments";
 
 export default function useSourceContextMenu({
+  lineHitCounts,
   lineNumber,
   sourceId,
   sourceUrl,
 }: {
+  lineHitCounts: LineHitCounts | null;
   lineNumber: number;
   sourceId: SourceId;
   sourceUrl: string | null;
 }) {
-  const client = useContext(ReplayClientContext);
+  const { range: focusRange } = useContext(FocusContext);
   const graphQLClient = useContext(GraphQLClientContext);
   const { showCommentsPanel } = useContext(InspectorContext);
-  const { accessToken, recordingId, trackEvent } = useContext(SessionContext);
+  const replayClient = useContext(ReplayClientContext);
+  const { accessToken, endpoint, recordingId, trackEvent } = useContext(SessionContext);
   const { executionPoint: currentExecutionPoint, time: currentTime } = useContext(TimelineContext);
+
+  // Don't Suspend during mount; the context menu should show immediately
+  // even if we're still fetching hit points
+  const { value } = useImperativeCacheValue(
+    hitPointsForLocationCache,
+    replayClient,
+    {
+      begin: focusRange ? focusRange.begin.point : "0",
+      end: focusRange ? focusRange.end.point : endpoint,
+    },
+    {
+      column: lineHitCounts?.firstBreakableColumnIndex ?? 0,
+      line: lineNumber,
+      sourceId,
+    },
+    null
+  );
+
+  const [hitPoints, hitPointStatus] = value ?? [null, null];
 
   const [isPending, startTransition] = useTransition();
   const invalidateCache = useCacheRefresh();
@@ -39,7 +68,12 @@ export default function useSourceContextMenu({
       }
       trackEvent("breakpoint.add_comment");
 
-      const typeData = await createTypeDataForSourceCodeComment(client, sourceId, lineNumber, 0);
+      const typeData = await createTypeDataForSourceCodeComment(
+        replayClient,
+        sourceId,
+        lineNumber,
+        0
+      );
 
       await addCommentGraphQL(graphQLClient, accessToken!, recordingId, {
         content: "",
@@ -78,11 +112,78 @@ export default function useSourceContextMenu({
       <ContextMenuItem disabled={disableCopySourceUri} onSelect={copySourceUri}>
         Copy source URI
       </ContextMenuItem>
+      <ContextMenuDivider />
+      <StepBackToLineMenuItem
+        hitPoints={hitPoints}
+        hitPointStatus={hitPointStatus}
+        lineNumber={lineNumber}
+      />
+      <StepForwardToLineMenuItem
+        hitPoints={hitPoints}
+        hitPointStatus={hitPointStatus}
+        lineNumber={lineNumber}
+      />
     </>,
     {
       requireClickToShow: true,
       dataTestId: `ContextMenu-Source-${lineNumber}`,
       dataTestName: "ContextMenu-Source",
     }
+  );
+}
+
+function StepBackToLineMenuItem({
+  hitPoints,
+  hitPointStatus,
+  lineNumber,
+}: {
+  hitPoints: TimeStampedPoint[] | null;
+  hitPointStatus: HitPointStatus | null;
+  lineNumber: number;
+}) {
+  const { executionPoint, update } = useContext(TimelineContext);
+
+  let targetPoint: TimeStampedPoint | null = null;
+  if (hitPoints !== null && hitPointStatus !== "too-many-points-to-find") {
+    targetPoint = findLastHitPoint(hitPoints, executionPoint);
+  }
+
+  const onSelect = () => {
+    assert(targetPoint != null);
+    update(targetPoint.time, targetPoint.point, false);
+  };
+
+  return (
+    <ContextMenuItem disabled={targetPoint == null} onSelect={onSelect}>
+      Rewind to line {lineNumber}
+    </ContextMenuItem>
+  );
+}
+
+function StepForwardToLineMenuItem({
+  hitPoints,
+  hitPointStatus,
+  lineNumber,
+}: {
+  hitPoints: TimeStampedPoint[] | null;
+  hitPointStatus: HitPointStatus | null;
+  lineNumber: number;
+}) {
+  const { executionPoint, update } = useContext(TimelineContext);
+
+  let targetPoint: TimeStampedPoint | null = null;
+  if (hitPoints !== null && hitPointStatus !== "too-many-points-to-find") {
+    targetPoint = findNextHitPoint(hitPoints, executionPoint);
+  }
+
+  const onSelect = () => {
+    assert(targetPoint != null);
+    update(targetPoint.time, targetPoint.point, false);
+  };
+
+  return (
+    <ContextMenuItem disabled={targetPoint == null} onSelect={onSelect}>
+      Fast forward to line {lineNumber}
+    </ContextMenuItem>
   );
 }

--- a/packages/replay-next/components/sources/utils/findLastHitPoint.ts
+++ b/packages/replay-next/components/sources/utils/findLastHitPoint.ts
@@ -1,0 +1,17 @@
+import { ExecutionPoint, TimeStampedPoint } from "@replayio/protocol";
+import findLast from "lodash/findLast";
+
+import { compareExecutionPoints, isExecutionPointsLessThan } from "replay-next/src/utils/time";
+
+export function findLastHitPoint(hitPoints: TimeStampedPoint[], executionPoint: ExecutionPoint) {
+  const hitPoint = findLast(
+    hitPoints,
+    point => compareExecutionPoints(point.point, executionPoint) < 0
+  );
+  if (hitPoint != null) {
+    if (isExecutionPointsLessThan(hitPoint.point, executionPoint)) {
+      return hitPoint;
+    }
+  }
+  return null;
+}

--- a/packages/replay-next/components/sources/utils/findNextHitPoints.ts
+++ b/packages/replay-next/components/sources/utils/findNextHitPoints.ts
@@ -1,0 +1,13 @@
+import { ExecutionPoint, TimeStampedPoint } from "@replayio/protocol";
+
+import { compareExecutionPoints, isExecutionPointsGreaterThan } from "replay-next/src/utils/time";
+
+export function findNextHitPoint(hitPoints: TimeStampedPoint[], executionPoint: ExecutionPoint) {
+  const hitPoint = hitPoints.find(point => compareExecutionPoints(point.point, executionPoint) > 0);
+  if (hitPoint != null) {
+    if (isExecutionPointsGreaterThan(hitPoint.point, executionPoint)) {
+      return hitPoint;
+    }
+  }
+  return null;
+}

--- a/packages/replay-next/package.json
+++ b/packages/replay-next/package.json
@@ -26,7 +26,7 @@
     "react-virtualized-auto-sizer": "^1.0.19",
     "shared": "workspace:*",
     "suspense": "^0.0.44",
-    "use-context-menu": "^0.4.10",
+    "use-context-menu": "^0.4.11",
     "uuid": "^7.0.3"
   },
   "devDependencies": {

--- a/packages/replay-next/playwright/package.json
+++ b/packages/replay-next/playwright/package.json
@@ -3,9 +3,9 @@
   "packageManager": "yarn@3.2.1",
   "devDependencies": {
     "@playwright/test": "^1.35.0",
-    "@replayio/playwright": "^0.3.21",
+    "@replayio/playwright": "latest",
     "chalk": "^4"
-  }, 
+  },
   "scripts": {
     "playwright:install": "playwright install chromium",
     "test": "playwright test tests",

--- a/packages/replay-next/playwright/tests/source-and-console/shared.ts
+++ b/packages/replay-next/playwright/tests/source-and-console/shared.ts
@@ -1,2 +1,3 @@
 export const sourceId = "h1";
 export const altSourceId = "1";
+export const fileName = "source-and-console.html";

--- a/packages/replay-next/playwright/tests/source-and-console/should-support-continue-to-next-and-previous-functionality.ts
+++ b/packages/replay-next/playwright/tests/source-and-console/should-support-continue-to-next-and-previous-functionality.ts
@@ -1,24 +1,49 @@
-/* TODO
-   Make this test pass in Docker; it passes in OSX (headless or regular Chrome)
-test("should support continue to next and previous functionality", async ({ page }, testInfo) =>  {
+import { expect, test } from "@playwright/test";
+
+import {
+  continueTo,
+  isContinueToNextOptionEnabled,
+  isContinueToPreviousOptionEnabled,
+  verifyCurrentExecutionPoint,
+} from "replay-next/playwright/tests/utils/source";
+
+import { beforeEach } from "./beforeEach";
+import { fileName, sourceId } from "./shared";
+
+beforeEach();
+
+test("should support continue to next and previous functionality", async ({ page }, testInfo) => {
   // Continue to next should be enabled initially;
   // Continue to previous should not be.
-  await expect(await isContinueToNextButtonEnabled(page, sourceId, 14)).toBe(true);
-  await expect(await isContinueToPreviousButtonEnabled(page, sourceId, 14)).toBe(false);
+  await expect(await isContinueToNextOptionEnabled(page, sourceId, 14)).toBe(true);
+  await expect(await isContinueToPreviousOptionEnabled(page, sourceId, 14)).toBe(false);
 
   // Go to line 14.
-  await verifyCurrentExecutionPoint(page, 14, false);
-  await continueTo(page, { lineNumber: 14, direction: "next", sourceId });
-  await verifyCurrentExecutionPoint(page, 14);
+  await verifyCurrentExecutionPoint(page, fileName, 14, false);
+  await continueTo(page, { lineNumber: 14, direction: "next", sourceId, use: "hover-button" });
+  await verifyCurrentExecutionPoint(page, fileName, 14);
 
   // Continue to next and previous buttons should both now be disabled for line 14.
   // Continue to previous should be enabled for line 13
   // And continue to next should be enabled for line 15.
-  await expect(await isContinueToNextButtonEnabled(page, sourceId, 13)).toBe(false);
-  await expect(await isContinueToPreviousButtonEnabled(page, sourceId, 13)).toBe(true);
-  await expect(await isContinueToNextButtonEnabled(page, sourceId, 14)).toBe(false);
-  await expect(await isContinueToPreviousButtonEnabled(page, sourceId, 14)).toBe(false);
-  await expect(await isContinueToNextButtonEnabled(page, sourceId, 15)).toBe(true);
-  await expect(await isContinueToPreviousButtonEnabled(page, sourceId, 15)).toBe(false);
+  await expect(await isContinueToNextOptionEnabled(page, sourceId, 13)).toBe(false);
+  await expect(await isContinueToPreviousOptionEnabled(page, sourceId, 13)).toBe(true);
+  await expect(await isContinueToNextOptionEnabled(page, sourceId, 14)).toBe(false);
+  await expect(await isContinueToPreviousOptionEnabled(page, sourceId, 14)).toBe(false);
+  await expect(await isContinueToNextOptionEnabled(page, sourceId, 15)).toBe(true);
+  await expect(await isContinueToPreviousOptionEnabled(page, sourceId, 15)).toBe(false);
+
+  // Verify the same things but using the context menu.
+
+  await continueTo(page, { lineNumber: 13, direction: "previous", sourceId, use: "context-menu" });
+  await verifyCurrentExecutionPoint(page, fileName, 13);
+
+  await continueTo(page, { lineNumber: 14, direction: "next", sourceId, use: "context-menu" });
+  await verifyCurrentExecutionPoint(page, fileName, 14);
+
+  await continueTo(page, { lineNumber: 15, direction: "next", sourceId, use: "context-menu" });
+  await verifyCurrentExecutionPoint(page, fileName, 15);
+
+  await continueTo(page, { lineNumber: 14, direction: "previous", sourceId, use: "context-menu" });
+  await verifyCurrentExecutionPoint(page, fileName, 14);
 });
-*/

--- a/packages/replay-next/playwright/tests/utils/context-menu.ts
+++ b/packages/replay-next/playwright/tests/utils/context-menu.ts
@@ -12,6 +12,15 @@ export async function findContextMenuItem(page: Page, partialText: string): Prom
   return page.locator(`[data-test-name="ContextMenuItem"]`, { hasText: partialText });
 }
 
+export async function hideContextMenu(page: Page) {
+  const contextMenu = page.locator("[data-context-menu]");
+  if ((await contextMenu.count()) > 0) {
+    await debugPrint(page, "Hiding context menu", "hideContextMenu");
+
+    await page.keyboard.press("Escape");
+  }
+}
+
 export async function showContextMenu(page: Page, locator: Locator) {
   const textContent = await locator.textContent();
 
@@ -23,7 +32,7 @@ export async function showContextMenu(page: Page, locator: Locator) {
 
   await locator.click({ button: "right", force: true });
 
-  const contextMenu = page.locator('[data-test-name="ContextMenu"]');
+  const contextMenu = page.locator("[data-context-menu]");
 
   await waitFor(async () => {
     const count = await contextMenu.count();

--- a/packages/replay-next/playwright/tests/utils/general.ts
+++ b/packages/replay-next/playwright/tests/utils/general.ts
@@ -44,7 +44,7 @@ export async function debugPrint(page: Page | null, message: string, scope?: str
   if (page !== null) {
     await page.evaluate(
       ({ message, scope }) => {
-        console.log(`${message} %c${scope || ""}`, "color: #999;");
+        console.log(`${message} %c${scope || ""}`);
       },
       { message, scope }
     );

--- a/packages/replay-next/playwright/tests/utils/general.ts
+++ b/packages/replay-next/playwright/tests/utils/general.ts
@@ -44,7 +44,7 @@ export async function debugPrint(page: Page | null, message: string, scope?: str
   if (page !== null) {
     await page.evaluate(
       ({ message, scope }) => {
-        console.log(`${message} %c${scope || ""}`);
+        console.log(`${message} %c${scope || ""}`, "color: #999;");
       },
       { message, scope }
     );

--- a/packages/replay-next/playwright/tests/utils/source.ts
+++ b/packages/replay-next/playwright/tests/utils/source.ts
@@ -508,9 +508,10 @@ export async function hoverOverLine(
     }
     suffix = `with ${chalk.bold(keys.join(" and "))}`;
   }
+
   await debugPrint(
     page,
-    `Hovering over source "${chalk.bold(sourceId)}" line ${chalk.bold(lineNumber)} ${suffix}`,
+    `Start hovering over source "${chalk.bold(sourceId)}" line ${chalk.bold(lineNumber)} ${suffix}`,
     "hoverOverLine"
   );
 
@@ -533,6 +534,14 @@ export async function hoverOverLine(
   await numberLocator.hover({ force: true });
 
   return async () => {
+    await debugPrint(
+      page,
+      `Stop hovering over source "${chalk.bold(sourceId)}" line ${chalk.bold(
+        lineNumber
+      )} ${suffix}`,
+      "hoverOverLine"
+    );
+
     await stopHovering(page);
     if (withMetaKey) {
       await page.keyboard.up(getCommandKey());
@@ -552,6 +561,12 @@ export async function isSeekOptionEnabled(
   }
 ): Promise<boolean> {
   const { direction, lineNumber, sourceId } = options;
+
+  await debugPrint(
+    page,
+    `Is continue to ${chalk.bold(direction)} enabled for line ${chalk.bold(lineNumber)}?`,
+    "isContinueToButtonEnabled"
+  );
 
   const lineLocator = page.locator(`[data-test-id="SourceLine-${lineNumber}"]`);
 

--- a/packages/replay-next/playwright/tests/utils/source.ts
+++ b/packages/replay-next/playwright/tests/utils/source.ts
@@ -517,6 +517,11 @@ export async function hoverOverLine(
 
   await goToLine(page, sourceId, lineNumber);
 
+  // Hover over the line number itself, not the line, to avoid triggering protocol preview requests.
+  const lineLocator = page.locator(`[data-test-id="SourceLine-${lineNumber}"]`);
+  const numberLocator = lineLocator.locator(`[data-test-id="SourceLine-LineNumber-${lineNumber}"]`);
+  await numberLocator.hover({ force: true });
+
   if (withShiftKey) {
     await page.keyboard.down("Shift");
   } else {
@@ -527,11 +532,6 @@ export async function hoverOverLine(
   } else {
     await page.keyboard.up(getCommandKey());
   }
-
-  // Hover over the line number itself, not the line, to avoid triggering protocol preview requests.
-  const lineLocator = page.locator(`[data-test-id="SourceLine-${lineNumber}"]`);
-  const numberLocator = lineLocator.locator(`[data-test-id="SourceLine-LineNumber-${lineNumber}"]`);
-  await numberLocator.hover({ force: true });
 
   return async () => {
     await debugPrint(

--- a/packages/replay-next/playwright/tests/utils/source.ts
+++ b/packages/replay-next/playwright/tests/utils/source.ts
@@ -1,6 +1,12 @@
 import { Locator, Page, expect } from "@playwright/test";
 import chalk from "chalk";
 
+import {
+  findContextMenuItem,
+  hideContextMenu,
+  showContextMenu,
+} from "replay-next/playwright/tests/utils/context-menu";
+
 import { getConsoleSearchInput } from "./console";
 import {
   clearTextArea,
@@ -104,17 +110,18 @@ export async function continueTo(
     direction: "next" | "previous";
     lineNumber: number;
     sourceId: string;
+    use: "hover-button" | "context-menu";
   }
 ) {
-  const { direction, lineNumber, sourceId } = options;
+  const { direction, lineNumber, sourceId, use } = options;
 
   await debugPrint(
     page,
     sourceId == null
-      ? `Continuing to ${chalk.bold(direction)} line ${chalk.bold(lineNumber)}`
+      ? `Continuing to ${chalk.bold(direction)} line ${chalk.bold(lineNumber)} via ${use}`
       : `Continuing to ${chalk.bold(direction)} line ${chalk.bold(
           lineNumber
-        )} for source "${chalk.bold(sourceId)}"`,
+        )} for source "${chalk.bold(sourceId)}" via ${use}`,
     "continueToNext"
   );
 
@@ -125,20 +132,35 @@ export async function continueTo(
 
   const lineLocator = page.locator(`[data-test-id="SourceLine-${lineNumber}"]`);
 
-  const stopHovering = await hoverOverLine(page, {
-    lineNumber,
-    sourceId,
-    withMetaKey: true,
-    withShiftKey: direction === "previous",
-  });
+  switch (use) {
+    case "context-menu": {
+      await showContextMenu(page, lineLocator);
+      const menuItem = await findContextMenuItem(
+        page,
+        direction === "next" ? "Fast forward" : "Rewind"
+      );
+      await menuItem.click();
 
-  const button = lineLocator.locator('[data-test-name="ContinueToButton"]');
-  const state = await button.getAttribute("data-test-state");
-  if (direction === state) {
-    await button.click();
+      break;
+    }
+    case "hover-button": {
+      const stopHovering = await hoverOverLine(page, {
+        lineNumber,
+        sourceId,
+        withMetaKey: true,
+        withShiftKey: direction === "previous",
+      });
+
+      const button = lineLocator.locator('[data-test-name="ContinueToButton"]');
+      const state = await button.getAttribute("data-test-state");
+      if (direction === state) {
+        await button.click();
+      }
+
+      await stopHovering();
+      break;
+    }
   }
-
-  await stopHovering();
 }
 
 export async function editLogPoint(
@@ -521,7 +543,7 @@ export async function hoverOverLine(
   };
 }
 
-export async function isContinueToButtonEnabled(
+export async function isSeekOptionEnabled(
   page: Page,
   options: {
     direction: "previous" | "next";
@@ -531,6 +553,8 @@ export async function isContinueToButtonEnabled(
 ): Promise<boolean> {
   const { direction, lineNumber, sourceId } = options;
 
+  const lineLocator = page.locator(`[data-test-id="SourceLine-${lineNumber}"]`);
+
   const stopHovering = await hoverOverLine(page, {
     lineNumber,
     sourceId,
@@ -538,29 +562,37 @@ export async function isContinueToButtonEnabled(
     withShiftKey: direction === "previous",
   });
 
-  const lineLocator = page.locator(`[data-test-id="SourceLine-${lineNumber}"]`);
   const button = lineLocator.locator('[data-test-name="ContinueToButton"]');
-  const isEnabled = await button.isEnabled();
+  const isHoverButtonEnabled = await button.isEnabled();
 
   await stopHovering();
 
-  return isEnabled;
+  await showContextMenu(page, lineLocator);
+  const menuItem = await findContextMenuItem(
+    page,
+    direction === "next" ? "Fast forward" : "Rewind"
+  );
+  const isContextMenuItemEnabled = await menuItem.isEnabled();
+
+  await hideContextMenu(page);
+
+  return isContextMenuItemEnabled && isHoverButtonEnabled;
 }
 
-export async function isContinueToNextButtonEnabled(
+export async function isContinueToNextOptionEnabled(
   page: Page,
   sourceId: string,
   lineNumber: number
 ): Promise<boolean> {
-  return isContinueToButtonEnabled(page, { direction: "next", lineNumber, sourceId });
+  return isSeekOptionEnabled(page, { direction: "next", lineNumber, sourceId });
 }
 
-export async function isContinueToPreviousButtonEnabled(
+export async function isContinueToPreviousOptionEnabled(
   page: Page,
   sourceId: string,
   lineNumber: number
 ): Promise<boolean> {
-  return isContinueToButtonEnabled(page, { direction: "previous", lineNumber, sourceId });
+  return isSeekOptionEnabled(page, { direction: "previous", lineNumber, sourceId });
 }
 
 export async function isLineCurrentSearchResult(page: Page, lineNumber: number): Promise<boolean> {

--- a/packages/replay-next/playwright/yarn.lock
+++ b/packages/replay-next/playwright/yarn.lock
@@ -48,26 +48,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@replayio/playwright@npm:^0.3.21":
-  version: 0.3.21
-  resolution: "@replayio/playwright@npm:0.3.21"
+"@replayio/playwright@npm:latest":
+  version: 1.0.6
+  resolution: "@replayio/playwright@npm:1.0.6"
   dependencies:
-    "@replayio/replay": ^0.12.2
-    "@replayio/test-utils": ^0.5.1
+    "@replayio/replay": ^0.13.1
+    "@replayio/test-utils": ^1.0.5
     uuid: ^8.3.2
   peerDependencies:
     "@playwright/test": 1.19.x
   bin:
     replayio-playwright: bin/replayio-playwright.js
-  checksum: 918ebaa78584990a947e2927cae015cdfc8835e09120e1959714b92eba96f73d1eb21e6ce01bf4c87fc1ce7a664f920669787864f3f63f1d6b21fa2007dd55a6
+  checksum: 01c7452775f217a32f37acd8e374da6b06253c32be2ed262053b27b7d651a983bb07545c3cff19f6ec053f149ac7b3a1a7c57fb2ab0d5fa0065d2a3d57fe4a64
   languageName: node
   linkType: hard
 
-"@replayio/replay@npm:^0.12.2":
-  version: 0.12.2
-  resolution: "@replayio/replay@npm:0.12.2"
+"@replayio/replay@npm:^0.13.1":
+  version: 0.13.1
+  resolution: "@replayio/replay@npm:0.13.1"
   dependencies:
-    "@replayio/sourcemap-upload": ^1.0.5
+    "@replayio/sourcemap-upload": ^1.0.7
     commander: ^7.2.0
     debug: ^4.3.4
     is-uuid: ^1.0.2
@@ -79,33 +79,33 @@ __metadata:
     ws: ^7.5.0
   bin:
     replay: bin/replay.js
-  checksum: b9015c38e1e64fd9abbc112e532e18a4dbddeff6bc37fe3c85d1397caaa0e69094451d2be0d0940070c375e0252eec18f26f3987dac875aec92b525d1ab769e9
+  checksum: d3aec605a2e924367164d71518a47a34ea990a80a6dbde8284878357312065811b71907ba61ba273534bfd7da50299104bce8db6f697b7ddf253b6588d59a142
   languageName: node
   linkType: hard
 
-"@replayio/sourcemap-upload@npm:^1.0.5":
-  version: 1.0.5
-  resolution: "@replayio/sourcemap-upload@npm:1.0.5"
+"@replayio/sourcemap-upload@npm:^1.0.7":
+  version: 1.0.7
+  resolution: "@replayio/sourcemap-upload@npm:1.0.7"
   dependencies:
     commander: ^7.2.0
     debug: ^4.3.1
     glob: ^7.1.6
     node-fetch: ^2.6.1
     string.prototype.matchall: ^4.0.5
-  checksum: 05a9a8b8f2360c3186e8b56680c4b72b12c4bd6f8d17e32fceab468a070bc78e102cea3157f85f765bfbad5de1bd6602339d233793fc0be489943cadab01e2ab
+  checksum: 29b37ce15bf348720748a46f7d27b445531bc52074eb88087a0ae1bf958b3bf8fcd19637612b4ec293c8cd82175977d5b3e87377456e7ae724d456aa385e2a69
   languageName: node
   linkType: hard
 
-"@replayio/test-utils@npm:^0.5.1":
-  version: 0.5.1
-  resolution: "@replayio/test-utils@npm:0.5.1"
+"@replayio/test-utils@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "@replayio/test-utils@npm:1.0.5"
   dependencies:
-    "@replayio/replay": ^0.12.2
+    "@replayio/replay": ^0.13.1
     "@types/node-fetch": ^2.6.2
     debug: ^4.3.4
     node-fetch: ^2.6.7
     uuid: ^8.3.2
-  checksum: dc9cff9d0237e6b7906917da36bfeb009f30ac166d79b31fa1351f2d253451fe14edb363a74fe26114f0eb4412e61fd7f9fac8fcdd9a57868a012c9059353566
+  checksum: ea1e91017fde8856c9e30734138ce2a911dc135d427b26fff945ee95abbcd4c1c9ca94a591aa36e563f02c6d797ba7ce215d20f648bf18e7a0dabda901853ab0
   languageName: node
   linkType: hard
 
@@ -1539,7 +1539,7 @@ __metadata:
   resolution: "tests@workspace:."
   dependencies:
     "@playwright/test": ^1.35.0
-    "@replayio/playwright": ^0.3.21
+    "@replayio/playwright": latest
     chalk: ^4
   languageName: unknown
   linkType: soft

--- a/packages/replay-next/src/suspense/HitPointsCache.ts
+++ b/packages/replay-next/src/suspense/HitPointsCache.ts
@@ -83,7 +83,6 @@ export const hitPointsForLocationCache = createCache<
   HitPointsAndStatusTuple
 >({
   debugLabel: "HitPointsForLocationCache",
-  debugLogging: true,
   getKey: ([replayClient, range, location, condition]) =>
     `[${range.begin}-${range.end}]:${location.sourceId}:${location.line}:${location.column}:${condition}`,
   load: async ([replayClient, range, location, condition]) => {

--- a/packages/shared/client/ReplayClient.ts
+++ b/packages/shared/client/ReplayClient.ts
@@ -76,7 +76,7 @@ import {
 } from "./types";
 
 export const MAX_POINTS_TO_FIND = 10_000;
-export const MAX_POINTS_TO_RUN_EVALUATION = 1_500;
+export const MAX_POINTS_TO_RUN_EVALUATION = 200;
 
 const STREAMING_THROTTLE_DURATION = 100;
 

--- a/packages/shared/client/ReplayClient.ts
+++ b/packages/shared/client/ReplayClient.ts
@@ -76,7 +76,7 @@ import {
 } from "./types";
 
 export const MAX_POINTS_TO_FIND = 10_000;
-export const MAX_POINTS_TO_RUN_EVALUATION = 200;
+export const MAX_POINTS_TO_RUN_EVALUATION = 1_500;
 
 const STREAMING_THROTTLE_DURATION = 100;
 

--- a/src/ui/actions/eventListeners/jumpToCode.ts
+++ b/src/ui/actions/eventListeners/jumpToCode.ts
@@ -15,7 +15,7 @@ import type { ThreadFront as TF } from "protocol/thread";
 import { RecordingTarget, recordingTargetCache } from "replay-next/src/suspense/BuildIdCache";
 import { eventCountsCache, eventPointsCache } from "replay-next/src/suspense/EventsCache";
 import { topFrameCache } from "replay-next/src/suspense/FrameCache";
-import { getHitPointsForLocationAsync } from "replay-next/src/suspense/HitPointsCache";
+import { hitPointsForLocationCache } from "replay-next/src/suspense/HitPointsCache";
 import { objectCache } from "replay-next/src/suspense/ObjectPreviews";
 import { pauseEvaluationsCache, pauseIdCache } from "replay-next/src/suspense/PauseCache";
 import { sourceOutlineCache } from "replay-next/src/suspense/SourceOutlineCache";
@@ -269,11 +269,11 @@ export function jumpToClickEventFunctionLocation(
         if (nextBreakablePosition) {
           // We think we know the first position _inside_ the function.
           // Run analysis to find the next time this position got hit.
-          const [hitPoints] = await getHitPointsForLocationAsync(
+          const [hitPoints] = await hitPointsForLocationCache.readAsync(
             replayClient,
+            { begin: executionPoint, end: end.point },
             nextBreakablePosition,
-            null,
-            { begin: executionPoint, end: end.point }
+            null
           );
 
           const [firstHitPoint] = hitPoints;

--- a/src/ui/components/ProtocolViewer.tsx
+++ b/src/ui/components/ProtocolViewer.tsx
@@ -20,7 +20,7 @@ import { ThreadFront } from "protocol/thread";
 import Loader from "replay-next/components/Loader";
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
 import { breakpointPositionsCache } from "replay-next/src/suspense/BreakpointPositionsCache";
-import { getHitPointsForLocationAsync } from "replay-next/src/suspense/HitPointsCache";
+import { hitPointsForLocationCache } from "replay-next/src/suspense/HitPointsCache";
 import {
   LogPointAnalysisResult,
   getLogPointAnalysisResultAsync,
@@ -580,7 +580,12 @@ export const recordedProtocolMessagesCache: Cache<
         };
 
         // Get all the times that first line was hit
-        const [hitPoints] = await getHitPointsForLocationAsync(replayClient, position, null, range);
+        const [hitPoints] = await hitPointsForLocationCache.readAsync(
+          replayClient,
+          range,
+          position,
+          null
+        );
 
         // For every hit, grab the first arg, which should be the `event`
         // that is either the request, response, or error data

--- a/src/ui/components/ReactPanel.tsx
+++ b/src/ui/components/ReactPanel.tsx
@@ -28,7 +28,7 @@ import IndeterminateLoader from "replay-next/components/IndeterminateLoader";
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
 import { breakpointPositionsCache } from "replay-next/src/suspense/BreakpointPositionsCache";
 import { frameStepsCache } from "replay-next/src/suspense/FrameStepsCache";
-import { getHitPointsForLocationAsync } from "replay-next/src/suspense/HitPointsCache";
+import { hitPointsForLocationCache } from "replay-next/src/suspense/HitPointsCache";
 import { pauseIdCache } from "replay-next/src/suspense/PauseCache";
 import { sourceOutlineCache } from "replay-next/src/suspense/SourceOutlineCache";
 import { streamingSourceContentsCache } from "replay-next/src/suspense/SourcesCache";
@@ -42,10 +42,10 @@ import { JumpToCodeButton, JumpToCodeStatus } from "ui/components/shared/JumpToC
 import {
   SourceDetails,
   SourcesState,
+  getPreferredLocation,
   getSourceIdsByUrl,
   getSourceToDisplayForUrl,
 } from "ui/reducers/sources";
-import { getPreferredLocation } from "ui/reducers/sources";
 import { getCurrentTime } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { getPauseFramesAsync } from "ui/suspense/frameCache";
@@ -279,18 +279,18 @@ const queuedRendersStreamingCache: StreamingCache<
         return;
       }
 
-      const scheduleFiberUpdatePromise = getHitPointsForLocationAsync(
+      const scheduleFiberUpdatePromise = hitPointsForLocationCache.readAsync(
         replayClient,
+        { begin: range.begin.point, end: range.end.point },
         { ...firstScheduleUpdateFiberPosition, sourceId: reactDomSource.id },
-        null,
-        { begin: range.begin.point, end: range.end.point }
+        null
       );
 
-      const onCommitFiberHitsPromise = getHitPointsForLocationAsync(
+      const onCommitFiberHitsPromise = hitPointsForLocationCache.readAsync(
         replayClient,
+        { begin: range.begin.point, end: range.end.point },
         { ...firstOnCommitRootPosition, sourceId: reactDomSource.id },
-        null,
-        { begin: range.begin.point, end: range.end.point }
+        null
       );
 
       const [[scheduleUpdateHitPoints], [onCommitFiberHitPoints]] = await Promise.all([

--- a/src/ui/components/Timeline/PreviewMarkers.tsx
+++ b/src/ui/components/Timeline/PreviewMarkers.tsx
@@ -1,13 +1,16 @@
-import type { PointDescription } from "@replayio/protocol";
+import type { PointDescription, SourceId } from "@replayio/protocol";
 import { Suspense, useContext } from "react";
+import { useImperativeCacheValue } from "suspense";
 
 import { binarySearch } from "protocol/utils";
 import ErrorBoundary from "replay-next/components/ErrorBoundary";
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
+import { SessionContext } from "replay-next/src/contexts/SessionContext";
 import { SourcesContext } from "replay-next/src/contexts/SourcesContext";
-import { getHitPointsForLocationSuspense } from "replay-next/src/suspense/HitPointsCache";
+import { hitPointsForLocationCache } from "replay-next/src/suspense/HitPointsCache";
 import { sourceHitCountsCache } from "replay-next/src/suspense/SourceHitCountsCache";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
+import { SourceLocationRange } from "shared/client/types";
 import { toPointRange } from "shared/utils/time";
 import { selectors } from "ui/reducers";
 import { useAppSelector } from "ui/setup/hooks";
@@ -15,65 +18,82 @@ import { useAppSelector } from "ui/setup/hooks";
 import Marker from "./Marker";
 
 export default function PreviewMarkers() {
+  const { focusedSource, hoveredLineIndex, visibleLines } = useContext(SourcesContext);
+
+  const sourceId = focusedSource?.sourceId ?? null;
+
+  if (hoveredLineIndex == null || sourceId == null || visibleLines == null) {
+    return <div className="preview-markers-container" />;
+  }
+
   return (
     <ErrorBoundary fallback={null} name="PreviewMarkers">
       <Suspense fallback={null}>
-        <PreviewMarkersSuspends />
+        <PreviewMarkersSuspends
+          lineNumber={hoveredLineIndex + 1}
+          sourceId={sourceId}
+          visibleLines={visibleLines}
+        />
       </Suspense>
     </ErrorBoundary>
   );
 }
 
-function PreviewMarkersSuspends() {
+function PreviewMarkersSuspends({
+  lineNumber,
+  sourceId,
+  visibleLines,
+}: {
+  lineNumber: number;
+  sourceId: SourceId;
+  visibleLines: SourceLocationRange;
+}) {
   const currentTime = useAppSelector(selectors.getCurrentTime);
   const hoveredItem = useAppSelector(selectors.getHoveredItem);
   const timelineDimensions = useAppSelector(selectors.getTimelineDimensions);
   const zoomRegion = useAppSelector(selectors.getZoomRegion);
   const markTimeStampedPoint = useAppSelector(selectors.getMarkTimeStampedPoint);
 
+  const { endpoint } = useContext(SessionContext);
   const replayClient = useContext(ReplayClientContext);
 
-  const { focusedSource, hoveredLineIndex, visibleLines } = useContext(SourcesContext);
   const { range: focusRange } = useContext(FocusContext);
 
-  const focusedSourceId = focusedSource?.sourceId ?? null;
+  const hitCounts = sourceHitCountsCache.read(
+    visibleLines.start.line ?? 0,
+    visibleLines.end.line ?? 0,
+    replayClient,
+    sourceId,
+    focusRange ? toPointRange(focusRange) : null
+  );
+  const hitCountsForLineIndex = binarySearch(
+    0,
+    hitCounts.length,
+    index => lineNumber - hitCounts[index][0]
+  );
 
-  let firstColumnWithHitCounts = null;
-  if (focusedSourceId !== null && hoveredLineIndex !== null && visibleLines !== null) {
-    const hitCounts = sourceHitCountsCache.read(
-      visibleLines?.start.line ?? 0,
-      visibleLines?.end.line ?? 0,
-      replayClient,
-      focusedSourceId,
-      focusRange ? toPointRange(focusRange) : null
-    );
-    const hitCountsForLineIndex = binarySearch(
-      0,
-      hitCounts.length,
-      index => hoveredLineIndex + 1 - hitCounts[index][0]
-    );
-    const hitCountsForLine = hitCounts[hitCountsForLineIndex];
-    if (hitCountsForLine && hitCountsForLine[0] === hoveredLineIndex + 1) {
-      firstColumnWithHitCounts = hitCountsForLine[1].firstBreakableColumnIndex;
-    }
+  const hitCountsForLine = hitCounts[hitCountsForLineIndex];
+  let firstColumnWithHitCounts = undefined;
+  if (hitCountsForLine && hitCountsForLine[0] === lineNumber) {
+    firstColumnWithHitCounts = hitCountsForLine[1].firstBreakableColumnIndex;
   }
 
-  const [hitPoints, hitPointStatus] =
-    focusRange &&
-    focusedSourceId !== null &&
-    firstColumnWithHitCounts !== null &&
-    hoveredLineIndex !== null
-      ? getHitPointsForLocationSuspense(
-          replayClient,
-          {
-            sourceId: focusedSourceId,
-            column: firstColumnWithHitCounts,
-            line: hoveredLineIndex + 1,
-          },
-          null,
-          { begin: focusRange.begin.point, end: focusRange.end.point }
-        )
-      : [null, null];
+  const { value } = useImperativeCacheValue(
+    hitPointsForLocationCache,
+    replayClient,
+    {
+      begin: focusRange ? focusRange.begin.point : "0",
+      end: focusRange ? focusRange.end.point : endpoint,
+    },
+    {
+      column: firstColumnWithHitCounts ?? 0,
+      line: lineNumber,
+      sourceId,
+    },
+    null
+  );
+
+  const [hitPoints, hitPointStatus] = value ?? [null, null];
 
   const showHitPointMarkers =
     hitPoints != null &&

--- a/yarn.lock
+++ b/yarn.lock
@@ -3692,18 +3692,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@replayio/playwright@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "@replayio/playwright@npm:1.0.4"
+"@replayio/playwright@npm:latest":
+  version: 1.0.6
+  resolution: "@replayio/playwright@npm:1.0.6"
   dependencies:
-    "@replayio/replay": ^0.12.13
-    "@replayio/test-utils": ^1.0.3
+    "@replayio/replay": ^0.13.1
+    "@replayio/test-utils": ^1.0.5
     uuid: ^8.3.2
   peerDependencies:
     "@playwright/test": 1.19.x
   bin:
     replayio-playwright: bin/replayio-playwright.js
-  checksum: c0dc19d36f5835e646ba339c6523263a93c9412394118543a08b16b5b167d71b549a29f0a0d0658d99834a3404b7b8ad8e047741072e08cfce0c1ffddd306c25
+  checksum: 01c7452775f217a32f37acd8e374da6b06253c32be2ed262053b27b7d651a983bb07545c3cff19f6ec053f149ac7b3a1a7c57fb2ab0d5fa0065d2a3d57fe4a64
   languageName: node
   linkType: hard
 
@@ -3711,26 +3711,6 @@ __metadata:
   version: 0.54.0
   resolution: "@replayio/protocol@npm:0.54.0"
   checksum: 595a235105492fe47d655c32a2d8318e9ae29e012985dc93ddcaf985dffbebdc26d8ddb0c9221667e2024afab26d429779af3113449dda287324a74d5e886441
-  languageName: node
-  linkType: hard
-
-"@replayio/replay@npm:^0.12.13":
-  version: 0.12.13
-  resolution: "@replayio/replay@npm:0.12.13"
-  dependencies:
-    "@replayio/sourcemap-upload": ^1.0.7
-    commander: ^7.2.0
-    debug: ^4.3.4
-    is-uuid: ^1.0.2
-    jsonata: ^1.8.6
-    node-fetch: ^2.6.8
-    p-map: ^4.0.0
-    superstruct: ^0.15.4
-    text-table: ^0.2.0
-    ws: ^7.5.0
-  bin:
-    replay: bin/replay.js
-  checksum: a8bdda8bdfed5c8c1332391f721fd947ed9c034e80f9cae991137d41bfb3bab764db0d6c809ca89c7573dea161a529c38857ee067ccea3d3f591d89998370d6b
   languageName: node
   linkType: hard
 
@@ -3751,6 +3731,26 @@ __metadata:
   bin:
     replay: bin/replay.js
   checksum: bb2b6c7a2bb6f9167352f4ce29eb532cd8d788679782d6bebb49655d86dd785d3c6be2e7c6292b3be9d50401dfedda1b4367f10bfe62e96143cd327c642012a5
+  languageName: node
+  linkType: hard
+
+"@replayio/replay@npm:^0.13.1":
+  version: 0.13.1
+  resolution: "@replayio/replay@npm:0.13.1"
+  dependencies:
+    "@replayio/sourcemap-upload": ^1.0.7
+    commander: ^7.2.0
+    debug: ^4.3.4
+    is-uuid: ^1.0.2
+    jsonata: ^1.8.6
+    node-fetch: ^2.6.8
+    p-map: ^4.0.0
+    superstruct: ^0.15.4
+    text-table: ^0.2.0
+    ws: ^7.5.0
+  bin:
+    replay: bin/replay.js
+  checksum: d3aec605a2e924367164d71518a47a34ea990a80a6dbde8284878357312065811b71907ba61ba273534bfd7da50299104bce8db6f697b7ddf253b6588d59a142
   languageName: node
   linkType: hard
 
@@ -3793,16 +3793,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@replayio/test-utils@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "@replayio/test-utils@npm:1.0.3"
+"@replayio/test-utils@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "@replayio/test-utils@npm:1.0.5"
   dependencies:
-    "@replayio/replay": ^0.12.13
+    "@replayio/replay": ^0.13.1
     "@types/node-fetch": ^2.6.2
     debug: ^4.3.4
     node-fetch: ^2.6.7
     uuid: ^8.3.2
-  checksum: d483efdb3080c6a93de81847d367e172eb74318be7d23737883921909003dd5d436508af34944872485dc4e94863d25d81ef8fdcbd6d7029e51088e4bf0f8939
+  checksum: ea1e91017fde8856c9e30734138ce2a911dc135d427b26fff945ee95abbcd4c1c9ca94a591aa36e563f02c6d797ba7ce215d20f648bf18e7a0dabda901853ab0
   languageName: node
   linkType: hard
 
@@ -9667,7 +9667,7 @@ __metadata:
     "@playwright/test": ^1.35.0
     "@recordreplay/playwright": ^1.18.3
     "@replayio/cypress": ^0.5.0
-    "@replayio/playwright": ^1.0.4
+    "@replayio/playwright": latest
     chalk: ^4
     cli-spinners: ^2.7.0
     cypress: ^12.5.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -15325,7 +15325,7 @@ __metadata:
     ts-node: ^10.7.0
     tsconfig-paths: ^3.14.1
     typescript: ^5.0.4
-    use-context-menu: ^0.4.10
+    use-context-menu: ^0.4.11
     utf-8-validate: ^5.0.8
     uuid: ^7.0.3
     v8-to-istanbul: ^9.0.1
@@ -15521,7 +15521,7 @@ __metadata:
     shared: "workspace:*"
     suspense: ^0.0.44
     typescript: 5.0.2
-    use-context-menu: ^0.4.10
+    use-context-menu: ^0.4.11
     uuid: ^7.0.3
   languageName: unknown
   linkType: soft
@@ -17712,13 +17712,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-context-menu@npm:^0.4.10":
-  version: 0.4.10
-  resolution: "use-context-menu@npm:0.4.10"
+"use-context-menu@npm:^0.4.11":
+  version: 0.4.11
+  resolution: "use-context-menu@npm:0.4.11"
   peerDependencies:
     react: ^16.14.0 || ^17 || ^18
     react-dom: ^16.14.0 || ^17 || ^18
-  checksum: 7d6732b86efe75d164a998ecaaec261d3e73b991de62ba0af68241aef4fe7b6c4e35956a144f71b963f1333e6a53353f947fbeed36016c6ba57f758b2ed6cd5c
+  checksum: 5ddfc243ae794690a7dc8a3afeff999dacee188bfea1287df31861763ac0c1065aff5d23d7ab9da782100b79cbaa590a2bdcdd8eb073a066cdbcfd1f9c864744
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### [Loom overview](https://www.loom.com/share/a6a48309bef94312936f8d1ff1e9bf0d)

- [x] Upgrade `use-context-menu` package from 0.4.10 to 0.4.11 so that context menus are always shown within _transitions_.
- [x] Replaced the `getHitPointsForLocationSuspense` function with a `hitPointsForLocationCache` so that it works with `use-context-menu` APIs like `useImperativeCacheValue`.
- [x] Updated `PreviewMarkers` to fetch hit point data imperatively to avoid potentially suspending for a long time on recordings like 55943a4c-7521-416d-8d63-cd2136876f54 that have weird performance characteristics.
- [x] Add "fast forward" and "rewind" options to Source context menu (before they were only visible on hover if you pressed the meta key).
- [x] Add e2e test coverage for new context menu items.

---

<img width="617" alt="Screen Shot 2023-07-13 at 10 51 14 AM" src="https://github.com/replayio/devtools/assets/29597/516104f2-1e7e-48e7-ba4c-b5a2f37d2f96">
