### PR TITLE
add experimental setting to support getting cached results for the command `Session.findAnnotations`

### DIFF
--- a/packages/protocol/socket.ts
+++ b/packages/protocol/socket.ts
@@ -136,6 +136,7 @@ export type ExperimentalSettings = {
   disableIncrementalSnapshots?: boolean;
   disableConcurrentControllerLoading?: boolean;
   enableHasAnnotationKindQueryStorage?: boolean;
+  enableFindAnnotationsQueryStorage?: boolean;
 };
 
 type SessionCallbacks = {

--- a/packages/shared/user-data/GraphQL/config.ts
+++ b/packages/shared/user-data/GraphQL/config.ts
@@ -65,6 +65,13 @@ export const config = {
     label: "Disable query-level caching for stable request types",
     legacyKey: "devtools.features.disableStableQueryCache",
   },
+  backend_enableFindAnnotationsQueryStorage: {
+    defaultValue: Boolean(false),
+    description: "Enable storage of previously generated response to Session.findAnnotations",
+    internalOnly: true,
+    label: "Enable query-level storage for Session.findAnnotations",
+    legacyKey: "devtools.features.enableFindAnnotationsQueryStorage",
+  },
   backend_enableHasAnnotationKindQueryStorage: {
     defaultValue: Boolean(false),
     description: "Enable storage of previously generated response to Session.hasAnnotationKind",

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -205,6 +205,9 @@ export function createSocket(
         disableConcurrentControllerLoading: userData.get(
           "backend_disableConcurrentControllerLoading"
         ),
+        enableFindAnnotationsQueryStorage: userData.get(
+          "backend_enableFindAnnotationsQueryStorage"
+        ),
         enableHasAnnotationKindQueryStorage: userData.get(
           "backend_enableHasAnnotationKindQueryStorage"
         ),

--- a/src/ui/components/shared/UserSettingsModal/panels/Experimental.tsx
+++ b/src/ui/components/shared/UserSettingsModal/panels/Experimental.tsx
@@ -18,6 +18,7 @@ export const PREFERENCES: PreferencesKey[] = [
   "feature_reduxDevTools",
   "backend_disableIncrementalSnapshots",
   "backend_disableConcurrentControllerLoading",
+  "backend_enableFindAnnotationsQueryStorage", 
   "backend_enableHasAnnotationKindQueryStorage",
 ];
 

--- a/src/ui/components/shared/UserSettingsModal/panels/Experimental.tsx
+++ b/src/ui/components/shared/UserSettingsModal/panels/Experimental.tsx
@@ -18,7 +18,7 @@ export const PREFERENCES: PreferencesKey[] = [
   "feature_reduxDevTools",
   "backend_disableIncrementalSnapshots",
   "backend_disableConcurrentControllerLoading",
-  "backend_enableFindAnnotationsQueryStorage", 
+  "backend_enableFindAnnotationsQueryStorage",
   "backend_enableHasAnnotationKindQueryStorage",
 ];
 


### PR DESCRIPTION
This supports a change on the back end that will allow users to get cached results for the `Session.findAnnotations` command. This is an internal setting for now.

https://linear.app/replay/issue/BAC-3622/use-query-storage-for-findannotations

Accompanying backend change:

https://github.com/replayio/backend/pull/8208