### PR TITLE
Prevent the RDT UI from shutting down the bridge when jumping

### DIFF
--- a/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
+++ b/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
@@ -380,6 +380,12 @@ function createReactDevTools(
   );
 
   const bridge = createBridge(target, wall);
+
+  // Override shutdown behavior to avoid the RDT UI from closing the bridge connection
+  bridge.shutdown = function () {
+    // no-op
+  };
+
   const store = createStore(bridge, {
     checkBridgeProtocolCompatibility: false,
     supportsNativeInspection: true,


### PR DESCRIPTION
This PR:

- Overrides the `bridge.shutdown()` method on the RDT internal `Bridge` class instance we create, to keep the RDT UI from killing the connection when we jump back to a point before React was in the page

I haven't yet figured out _why_ the RDT UI is trying to shut down the bridge. I can see that it's happening in a `useLayoutEffect` unmount callback inside the `DevTools` component, but I'm not sure why it's trying to unmount.

But, I can confirm that without this fix I see a bunch of "can't send message X through a bridge that's been shut down messages" if you jump to the start of a recording and then back later after React has mounted, and _with_ the fix I can jump back and forth just fine and the RDT UI continues to work as expected.