### PR TITLE
Fix current execution column highlight

### DIFF
--- a/packages/replay-next/components/sources/SourceListRow.module.css
+++ b/packages/replay-next/components/sources/SourceListRow.module.css
@@ -204,6 +204,7 @@
   width: 100%;
   height: var(--line-height);
   padding-left: 1ch;
+  z-index: 1;
 }
 
 .CurrentLine {


### PR DESCRIPTION
### Before:

<img width="679" alt="Screen Shot 2023-07-16 at 11 13 29 PM" src="https://github.com/replayio/devtools/assets/29597/705f903a-c840-4b7e-88ff-bd86ad4b28d9">

<img width="685" alt="Screen Shot 2023-07-16 at 11 13 40 PM" src="https://github.com/replayio/devtools/assets/29597/9d6c738e-8891-4ef4-b53f-7b1a86083b75">

### After:

<img width="684" alt="Screen Shot 2023-07-16 at 11 19 34 PM" src="https://github.com/replayio/devtools/assets/29597/6a4130d2-afef-4d25-8f7d-48e9961be4b0">

<img width="694" alt="Screen Shot 2023-07-16 at 11 19 24 PM" src="https://github.com/replayio/devtools/assets/29597/6247c890-e59f-496d-92dc-127fd182bf14">