### PR TITLE
Possible fix for FE-1500

### DIFF
--- a/packages/replay-next/components/Expandable.tsx
+++ b/packages/replay-next/components/Expandable.tsx
@@ -64,13 +64,13 @@ export default function Expandable({
     const newIsOpen = !isOpen;
 
     // In case this change triggers a re-render that suspends, it should be in a transition.
-    startTransition(() => {
+    // startTransition(() => {
       onChange(newIsOpen);
       setIsOpen(newIsOpen);
       if (persistenceKey !== undefined) {
         persistIsExpanded(persistenceKey, newIsOpen);
       }
-    });
+    // });
   };
 
   const onKeyDown = (event: KeyboardEvent) => {
@@ -83,13 +83,13 @@ export default function Expandable({
         const newIsOpen = !isOpen;
 
         // In case this change triggers a re-render that suspends, it should be in a transition.
-        startTransition(() => {
+        // startTransition(() => {
           onChange(newIsOpen);
           setIsOpen(newIsOpen);
           if (persistenceKey !== undefined) {
             persistIsExpanded(persistenceKey, newIsOpen);
           }
-        });
+        // });
         break;
     }
   };

--- a/packages/replay-next/components/inspector/ScopesInspector.tsx
+++ b/packages/replay-next/components/inspector/ScopesInspector.tsx
@@ -1,8 +1,11 @@
 import { NamedValue, PauseId } from "@replayio/protocol";
-import { Suspense } from "react";
+import { Suspense, useContext } from "react";
 
 import Expandable from "replay-next/components/Expandable";
 import Loader from "replay-next/components/Loader";
+import { objectCache } from "replay-next/src/suspense/ObjectPreviews";
+import { suspendInParallel } from "replay-next/src/utils/suspense";
+import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
 import Inspector from "./Inspector";
 import { addPathSegment } from "./PropertiesRenderer";
@@ -21,6 +24,15 @@ export default function ScopesInspector({
   pauseId: PauseId;
   protocolValues: NamedValue[];
 }) {
+  const client = useContext(ReplayClientContext);
+  suspendInParallel(
+    ...protocolValues.map(value => () => {
+      if (value.object) {
+        objectCache.read(client, pauseId, value.object, "full");
+      }
+    })
+  );
+
   return (
     <div className={styles.ScopesInspector} data-test-name="ScopesInspector">
       <Suspense fallback={<Loader />}>


### PR DESCRIPTION
To fix the overrendering of scope values (FE-1500), with this PR they are being prefetched in `ScopesInspector`, i.e. that component suspends until all the object previews for scope values have been received.
Interestingly, that doesn't suffice to fix the issue: I also had to remove `startTransition()` from `Expandable`, so we're not using a transition anymore...
See #9467 for STRs.