### PR TITLE
use unified experimental setting for protocol query cache project

### DIFF
--- a/packages/protocol/socket.ts
+++ b/packages/protocol/socket.ts
@@ -135,8 +135,7 @@ export type ExperimentalSettings = {
   keepAllTraces?: boolean;
   disableIncrementalSnapshots?: boolean;
   disableConcurrentControllerLoading?: boolean;
-  enableHasAnnotationKindQueryStorage?: boolean;
-  enableFindAnnotationsQueryStorage?: boolean;
+  enableProtocolQueryCache?: boolean;
 };
 
 type SessionCallbacks = {

--- a/packages/shared/user-data/GraphQL/config.ts
+++ b/packages/shared/user-data/GraphQL/config.ts
@@ -65,19 +65,13 @@ export const config = {
     label: "Disable query-level caching for stable request types",
     legacyKey: "devtools.features.disableStableQueryCache",
   },
-  backend_enableFindAnnotationsQueryStorage: {
+  backend_enableProtocolQueryCache: {
     defaultValue: Boolean(false),
-    description: "Enable storage of previously generated response to Session.findAnnotations",
+    description:
+      "Enable storage of previously generated response for a subset of protocol commands",
     internalOnly: true,
-    label: "Enable query-level storage for Session.findAnnotations",
-    legacyKey: "devtools.features.enableFindAnnotationsQueryStorage",
-  },
-  backend_enableHasAnnotationKindQueryStorage: {
-    defaultValue: Boolean(false),
-    description: "Enable storage of previously generated response to Session.hasAnnotationKind",
-    internalOnly: true,
-    label: "Enable query-level storage for Session.hasAnnotationKind",
-    legacyKey: "devtools.features.enableHasAnnotationKindQueryStorage",
+    label: "Enable query-level storage for a subset of protocol commands",
+    legacyKey: "devtools.hafeatures.enableProtocolQueryCache",
   },
   backend_enableRoutines: {
     defaultValue: Boolean(false),

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -205,12 +205,7 @@ export function createSocket(
         disableConcurrentControllerLoading: userData.get(
           "backend_disableConcurrentControllerLoading"
         ),
-        enableFindAnnotationsQueryStorage: userData.get(
-          "backend_enableFindAnnotationsQueryStorage"
-        ),
-        enableHasAnnotationKindQueryStorage: userData.get(
-          "backend_enableHasAnnotationKindQueryStorage"
-        ),
+        enableProtocolQueryCache: userData.get("backend_enableProtocolQueryCache"),
       };
       if (userData.get("backend_newControllerOnRefresh")) {
         experimentalSettings.controllerKey = String(Date.now());

--- a/src/ui/components/shared/UserSettingsModal/panels/Experimental.tsx
+++ b/src/ui/components/shared/UserSettingsModal/panels/Experimental.tsx
@@ -18,8 +18,7 @@ export const PREFERENCES: PreferencesKey[] = [
   "feature_reduxDevTools",
   "backend_disableIncrementalSnapshots",
   "backend_disableConcurrentControllerLoading",
-  "backend_enableFindAnnotationsQueryStorage",
-  "backend_enableHasAnnotationKindQueryStorage",
+  "backend_enableProtocolQueryCache",
 ];
 
 export function Experimental() {


### PR DESCRIPTION
Earlier I was going the route of using one experimental setting per command that I was converting to use the cache, but that is proving to be unwieldy and not worth the effort.

https://linear.app/replay/issue/BAC-3649/use-unified-experimental-setting-for-protocol-query-cache-project