### PR TITLE
Adjust error color to be less bright

### DIFF
--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -513,8 +513,8 @@
   --testsuites-capsule-error-color: white;
   --testsuites-capsule-success-bgcolor: var(--testsuites-success-color);
   --testsuites-capsule-success-color: rgb(16, 114, 0);
-  --testsuites-error-bgcolor-hover: rgba(237, 36, 36, 0.672);
-  --testsuites-error-bgcolor: rgba(237, 36, 36, 0.672);
+  --testsuites-error-bgcolor-hover: rgba(88, 58, 80, 1);
+  --testsuites-error-bgcolor: rgba(88, 58, 80, 1);
   --testsuites-error-border-color: var(--testsuites-error-icon-bgcolor);
   --testsuites-error-color: #ffe0e0;
   --testsuites-error-icon-bgcolor: rgb(237, 36, 36);

--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -513,8 +513,8 @@
   --testsuites-capsule-error-color: white;
   --testsuites-capsule-success-bgcolor: var(--testsuites-success-color);
   --testsuites-capsule-success-color: rgb(16, 114, 0);
-  --testsuites-error-bgcolor-hover: rgba(88, 58, 80, 1);
-  --testsuites-error-bgcolor: rgba(88, 58, 80, 1);
+  --testsuites-error-bgcolor-hover: #4f1615;
+  --testsuites-error-bgcolor: #4f1615;
   --testsuites-error-border-color: var(--testsuites-error-icon-bgcolor);
   --testsuites-error-color: #ffe0e0;
   --testsuites-error-icon-bgcolor: rgb(237, 36, 36);


### PR DESCRIPTION
Old on left, new on right:
![image](https://github.com/replayio/devtools/assets/9154902/65efe4ed-a227-416b-8108-f61f98ab67b2)

![image](https://github.com/replayio/devtools/assets/9154902/90b1420d-ac3d-4194-858b-0a73b223b6e7)

Here's where I was [experimenting in Figma](https://www.figma.com/file/mAotNZRv6M5X0zHIFKPzFY/Replay-Design-Doc?type=design&node-id=17774-308275&mode=design):
![image](https://github.com/replayio/devtools/assets/9154902/daed8542-f185-437d-891e-19e14a36372c)

Addresses https://linear.app/replay/issue/DES-799/our-error-red-is-pretty-bright-align-closer-to-cypress