### PR TITLE
Fixing onboarding colors

### DIFF
--- a/src/ui/components/shared/OnboardingModal/OnboardingModal.module.css
+++ b/src/ui/components/shared/OnboardingModal/OnboardingModal.module.css
@@ -1,0 +1,71 @@
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 2.25rem;
+}
+
+.header {
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.children {
+  color: var(--body-color);
+}
+
+.navigation {
+  display: flex;
+  justify-content: flex-end;
+  font-size: 1rem;
+}
+
+.skipButton {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 0.375rem;
+  border: none;
+  background: var(--background-color-primary-button);
+  padding: 0.375rem 0.75rem;
+  font-size: 1rem;
+  font-weight: 500;
+  color: white;
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  cursor: pointer;
+}
+
+.doneButton {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 0.375rem;
+  border: none;
+  background: var(--background-color-primary-button);
+  padding: 0.375rem 0.75rem;
+  font-size: 1rem;
+  font-weight: 500;
+  color: white;
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  cursor: pointer;
+}
+
+.modalContent {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 1.5rem;
+  border-radius: 0.375rem;
+  background: var(--modal-bgcolor);
+  border: 1px solid var(--modal-border);
+  padding: 2.25rem;
+  font-size: 1rem;
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
+}
+
+.absoluteBottom {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 0.375rem;
+  border-radius: 0.375rem;
+  background: var(--modal-bgcolor);
+}

--- a/src/ui/components/shared/OnboardingModal/OnboardingModal.tsx
+++ b/src/ui/components/shared/OnboardingModal/OnboardingModal.tsx
@@ -6,13 +6,16 @@ import hooks from "ui/hooks";
 import { Nag } from "ui/hooks/users";
 
 import Modal from "../NewModal";
+import styles from "./OnboardingModal.module.css";
 
 const slides = [
   {
     header: "Welcome to Replay! 👋",
     content: (
       <>
-        <div className="pb-6 text-lg">{`This is your library, where replays from your team live. Click on one to view it, or click "Launch Replay" at the top right to record your own.`}</div>
+        <div
+          className={styles.content}
+        >{`This is your library, where replays from your team live. Click on one to view it, or click "Launch Replay" at the top right to record your own.`}</div>
       </>
     ),
   },
@@ -26,9 +29,9 @@ function SlideContent({
   children: React.ReactElement | React.ReactElement[];
 }) {
   return (
-    <div className="space-y-9">
-      <h2 className="text-2xl font-bold ">{headerText}</h2>
-      <div className="text-gray-500">{children}</div>
+    <div className={styles.content}>
+      <h2 className={styles.header}>{headerText}</h2>
+      <div className={styles.children}>{children}</div>
     </div>
   );
 }
@@ -52,23 +55,12 @@ function Navigation({
   };
 
   return (
-    <div className="items-right text-base">
-      {/* <div className="flex flex-row items-center space-x-2">
-        <input
-          type="checkbox"
-          id="keep-showing"
-          checked={checked}
-          onChange={() => setChecked(!checked)}
-        />
-        <label htmlFor="keep-showing" className="text-gray-500 select-none">
-          Show this on startup
-        </label>
-      </div> */}
+    <div className={styles.navigation}>
       <div>
         <button
           onClick={onSkipOrDone}
           type="button"
-          className="float-right inline-flex items-center rounded-md border border-transparent bg-primaryAccent px-3 py-1.5 text-base font-medium text-white shadow-sm hover:bg-primaryAccentHover focus:outline-none focus:ring-2 focus:ring-primaryAccent focus:ring-offset-2"
+          className={current == total ? styles.doneButton : styles.skipButton}
         >
           {current == total ? "Got it!" : "Skip"}
         </button>
@@ -84,10 +76,7 @@ function OnboardingModal({ hideModal }: PropsFromRedux) {
 
   return (
     <Modal options={{ maskTransparency: "translucent" }}>
-      <div
-        className="relative flex flex-col justify-between space-y-6 rounded-lg bg-white p-9 text-lg shadow-xl"
-        style={{ width: "520px" }}
-      >
+      <div className={styles.modalContent} style={{ width: "520px" }}>
         <SlideContent headerText={header}>{content}</SlideContent>
         <Navigation
           current={current}
@@ -96,7 +85,7 @@ function OnboardingModal({ hideModal }: PropsFromRedux) {
           hideModal={hideModal}
         />
         <div
-          className="absolute bottom-0 left-0 h-1.5 rounded-md bg-white"
+          className={styles.absoluteBottom}
           style={{ width: `${(current / slides.length) * 100}%` }}
         />
       </div>

--- a/src/ui/components/shared/OnboardingModal/OnboardingModal.tsx
+++ b/src/ui/components/shared/OnboardingModal/OnboardingModal.tsx
@@ -13,7 +13,9 @@ const slides = [
     header: "Welcome to Replay! 👋",
     content: (
       <>
-        <div className={styles.content}>{`This is your library, where replays live.`}</div>
+        <div
+          className={styles.content}
+        >{`This is your library, where replays live. Take a look around!`}</div>
       </>
     ),
   },

--- a/src/ui/components/shared/OnboardingModal/OnboardingModal.tsx
+++ b/src/ui/components/shared/OnboardingModal/OnboardingModal.tsx
@@ -13,9 +13,7 @@ const slides = [
     header: "Welcome to Replay! 👋",
     content: (
       <>
-        <div
-          className={styles.content}
-        >{`This is your library, where replays from your team live. Click on one to view it, or click "Launch Replay" at the top right to record your own.`}</div>
+        <div className={styles.content}>{`This is your library, where replays live.`}</div>
       </>
     ),
   },

--- a/src/ui/components/shared/OnboardingModal/OnboardingModal.tsx
+++ b/src/ui/components/shared/OnboardingModal/OnboardingModal.tsx
@@ -15,7 +15,7 @@ const slides = [
       <>
         <div
           className={styles.content}
-        >{`This is your library, where replays live. Take a look around!`}</div>
+        >{`This is your library, where replays live. Click one to play it!`}</div>
       </>
     ),
   },


### PR DESCRIPTION
This was a screen that escaped when we upgraded everything to work better with dark theme. Fixed:

On prod:
![image](https://github.com/replayio/devtools/assets/9154902/3d89dc4a-6a85-46cb-b1cb-56f452db6ed0)

With fix:
![image](https://github.com/replayio/devtools/assets/9154902/e5b94b71-8307-4bf7-bb1e-c588729f773f)
