### PR TITLE
More precise focus window

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -147,7 +147,7 @@ const baseNextConfig = {
     };
 
     const sourceMapRegExp =
-      /node_modules.+(immer|@reduxjs|react-resizable-panels|react-window|suspense).+\.js$/;
+      /node_modules.+(immer|@reduxjs|react-resizable-panels|react-window|suspense|use-context-menu).+\.js$/;
 
     config.module.rules.push({
       test: sourceMapRegExp,

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "shared": "workspace:*",
     "slugify": "^1.6.5",
     "suspense": "^0.0.44",
-    "use-context-menu": "^0.4.11"
+    "use-context-menu": "0.4.10"
   },
   "devDependencies": {
     "@babel/core": "^7.17.8",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@lexical/react": "^0.6.5",
     "@reduxjs/toolkit": "^1.8.4",
     "@replayio/overboard": "^0.4.1",
-    "@replayio/protocol": "^0.54.0",
+    "@replayio/protocol": "^0.55.0",
     "@sentry/react": "^7.9.0",
     "@sentry/tracing": "^7.9.0",
     "@stripe/react-stripe-js": "^1.7.0",

--- a/packages/protocol/socket.ts
+++ b/packages/protocol/socket.ts
@@ -4,7 +4,7 @@ import {
   CommandResult,
   EventMethods,
   EventParams,
-  FocusWindowRequest as FocusWindow,
+  PointRangeFocusRequest as FocusWindow,
   PauseId,
   ProtocolClient,
   SessionId,
@@ -169,7 +169,7 @@ export async function createSession(
     recordingId,
     loadPoint: loadPoint || undefined,
     experimentalSettings,
-    focusWindow,
+    focusRequest: focusWindow,
   });
 
   setSessionCallbacks(sessionCallbacks);

--- a/packages/replay-next/components/console/Focuser.test.tsx
+++ b/packages/replay-next/components/console/Focuser.test.tsx
@@ -70,6 +70,9 @@ describe("Focuser", () => {
 
     fireEvent.click(screen.getByText("Focus off"));
 
-    expect(updateForTimelineImprecise).toHaveBeenCalledWith([0, 60_000], { debounce: false });
+    expect(updateForTimelineImprecise).toHaveBeenCalledWith([0, 60_000], {
+      debounce: false,
+      sync: false,
+    });
   });
 });

--- a/packages/replay-next/components/console/Focuser.tsx
+++ b/packages/replay-next/components/console/Focuser.tsx
@@ -17,14 +17,14 @@ export default function Focuser() {
 
   const toggleFocus = () => {
     if (rangeForDisplay === null) {
-      update([begin * duration, end * duration], { debounce: false });
+      update([begin * duration, end * duration], { debounce: false, sync: false });
     } else {
-      update(null, { debounce: false });
+      update(null, { debounce: false, sync: false });
     }
   };
 
   const onSliderChange = (newStart: number, newEnd: number) => {
-    update([newStart * duration, newEnd * duration], { debounce: true });
+    update([newStart * duration, newEnd * duration], { debounce: true, sync: false });
   };
 
   return (

--- a/packages/replay-next/components/console/useConsoleContextMenu.tsx
+++ b/packages/replay-next/components/console/useConsoleContextMenu.tsx
@@ -35,7 +35,11 @@ export default function useConsoleContextMenu(loggable: Loggable) {
           time: duration,
         },
       },
-      { debounce: true }
+      {
+        bias: "begin",
+        debounce: false,
+        sync: true,
+      }
     );
   };
 
@@ -51,7 +55,11 @@ export default function useConsoleContextMenu(loggable: Loggable) {
           time: getLoggableTime(loggable),
         },
       },
-      { debounce: true }
+      {
+        bias: "end",
+        debounce: false,
+        sync: true,
+      }
     );
   };
 

--- a/packages/replay-next/components/sources/log-point-panel/useLogPointPanelContextMenu.tsx
+++ b/packages/replay-next/components/sources/log-point-panel/useLogPointPanelContextMenu.tsx
@@ -42,7 +42,9 @@ export default function useLogPointPanelContextMenu({
         },
       },
       {
-        debounce: true,
+        bias: "begin",
+        debounce: false,
+        sync: true,
       }
     );
   };
@@ -60,7 +62,11 @@ export default function useLogPointPanelContextMenu({
         },
         end: currentHitPoint,
       },
-      { debounce: true }
+      {
+        bias: "end",
+        debounce: false,
+        sync: true,
+      }
     );
   };
 

--- a/packages/replay-next/package.json
+++ b/packages/replay-next/package.json
@@ -11,7 +11,7 @@
     "@codemirror/state_replay_next": "npm:@codemirror/state@6.1.2",
     "@lezer/common_replay_next": "npm:@lezer/common@1.0.1",
     "@lezer/highlight_replay_next": "npm:@lezer/highlight@1.1.1",
-    "@replayio/protocol": "^0.54.0",
+    "@replayio/protocol": "^0.55.0",
     "date-fns": "^2.28.0",
     "design": "workspace:*",
     "escape-html": "^1.0.3",

--- a/packages/replay-next/package.json
+++ b/packages/replay-next/package.json
@@ -26,7 +26,7 @@
     "react-virtualized-auto-sizer": "^1.0.19",
     "shared": "workspace:*",
     "suspense": "^0.0.44",
-    "use-context-menu": "^0.4.11",
+    "use-context-menu": "0.4.10",
     "uuid": "^7.0.3"
   },
   "devDependencies": {

--- a/packages/replay-next/src/contexts/FocusContext.tsx
+++ b/packages/replay-next/src/contexts/FocusContext.tsx
@@ -96,7 +96,7 @@ export function FocusContextRoot({ children }: PropsWithChildren<{}>) {
     }
 
     const timeoutId = setTimeout(() => {
-      client.requestFocusWindow({ begin: range.begin.time, bias, end: range.end.time });
+      client.requestFocusWindow({ begin: range.begin, bias, end: range.end });
     }, FOCUS_DEBOUNCE_DURATION);
 
     return () => {

--- a/packages/replay-next/src/contexts/FocusContext.tsx
+++ b/packages/replay-next/src/contexts/FocusContext.tsx
@@ -31,7 +31,7 @@ const FOCUS_DEBOUNCE_DURATION = 250;
 export type UpdateOptions = {
   bias?: FocusWindowRequestBias;
   debounce: boolean;
-  sync?: boolean;
+  sync: boolean;
 };
 
 export type FocusContextType = {

--- a/packages/replay-next/src/utils/testing.tsx
+++ b/packages/replay-next/src/utils/testing.tsx
@@ -171,6 +171,10 @@ export function setupWindow(): void {
   globalThis.fetch = fetch;
 }
 
+function timeToFakeExecutionPoint(time: number): string {
+  return String(Math.round(time * 1_000));
+}
+
 // This mock client is mostly useless by itself,
 // but its methods can be overridden individually (or observed/inspected) by test code.
 export function createMockReplayClient() {
@@ -183,13 +187,16 @@ export function createMockReplayClient() {
   mockClient.getAllFrames.mockImplementation(async () => ({ frames: [], data: {} }));
   mockClient.getBreakpointPositions.mockImplementation(async () => []);
   mockClient.getPointsBoundingTime.mockImplementation(async time => ({
-    before: { point: String(time), time },
-    after: { point: String(time), time },
+    before: { point: timeToFakeExecutionPoint(time), time },
+    after: { point: timeToFakeExecutionPoint(time), time },
   }));
-  mockClient.getPointNearTime.mockImplementation(async time => ({ point: String(time), time }));
+  mockClient.getPointNearTime.mockImplementation(async time => ({
+    point: timeToFakeExecutionPoint(time),
+    time,
+  }));
   mockClient.getSessionEndpoint.mockImplementation(async () => ({
-    point: "1000",
-    time: 1000,
+    point: timeToFakeExecutionPoint(1_000),
+    time: 1_000,
   }));
   mockClient.findKeyboardEvents.mockImplementation(async () => {});
   mockClient.findMessages.mockImplementation(async () => ({ messages: [], overflow: false }));

--- a/packages/shared/client/ReplayClient.ts
+++ b/packages/shared/client/ReplayClient.ts
@@ -2,7 +2,6 @@ import {
   BreakpointId,
   Result as EvaluationResult,
   ExecutionPoint,
-  FocusWindowRequest,
   FrameId,
   FunctionMatch,
   loadedRegions as LoadedRegions,
@@ -17,6 +16,7 @@ import {
   PointDescription,
   PointPageLimits,
   PointRange,
+  PointRangeFocusRequest,
   PointSelector,
   getPointsBoundingTimeResult as PointsBoundingTime,
   RecordingId,
@@ -732,11 +732,19 @@ export class ReplayClient implements ReplayClientInterface {
     return mappedLocation;
   }
 
-  async requestFocusWindow(range: FocusWindowRequest): Promise<TimeStampedPointRange> {
+  async requestFocusWindow(params: PointRangeFocusRequest): Promise<TimeStampedPointRange> {
     const sessionId = this.getSessionIdThrows();
-    const { window } = await client.Session.requestFocusRange({ range }, sessionId);
+
+    const { window } = await client.Session.requestFocusWindow(
+      {
+        request: params,
+      },
+      sessionId
+    );
+
     this.focusWindow = window;
     this._dispatchEvent("focusWindowChange", window);
+
     return window;
   }
 

--- a/packages/shared/client/types.ts
+++ b/packages/shared/client/types.ts
@@ -5,7 +5,6 @@ import {
   Result as EvaluationResult,
   EventHandlerType,
   ExecutionPoint,
-  FocusWindowRequest,
   FrameId,
   FunctionMatch,
   HitCount,
@@ -24,6 +23,7 @@ import {
   PointDescription,
   PointLimits,
   PointRange,
+  PointRangeFocusRequest,
   PointSelector,
   getPointsBoundingTimeResult as PointsBoundingTime,
   RecordingId,
@@ -234,7 +234,7 @@ export interface ReplayClientInterface {
   hasAnnotationKind(kind: string): Promise<boolean>;
   initialize(recordingId: string, accessToken: string | null): Promise<SessionId>;
   mapExpressionToGeneratedScope(expression: string, location: Location): Promise<string>;
-  requestFocusWindow(range: FocusWindowRequest): Promise<TimeStampedPointRange>;
+  requestFocusWindow(params: PointRangeFocusRequest): Promise<TimeStampedPointRange>;
   getCurrentFocusWindow(): TimeStampedPointRange | null;
   removeEventListener(type: ReplayClientEvents, handler: Function): void;
   repaintGraphics(pauseId: PauseId): Promise<repaintGraphicsResult>;

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -239,12 +239,7 @@ export function createSocket(
         recordingId,
         loadPoint,
         experimentalSettings,
-        focusWindowFromParams
-          ? {
-              begin: focusWindowFromParams.begin.time,
-              end: focusWindowFromParams.end.time,
-            }
-          : undefined,
+        focusWindowFromParams !== null ? focusWindowFromParams : undefined,
         {
           onEvent: (event: ProtocolEvent) => {
             if (userData.get("feature_logProtocolEvents")) {

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -1,4 +1,11 @@
-import { ExecutionPoint, FocusWindowRequestBias, PauseId, ScreenShot } from "@replayio/protocol";
+import assert from "assert";
+import {
+  ExecutionPoint,
+  FocusWindowRequestBias,
+  PauseId,
+  ScreenShot,
+  TimeStampedPointRange,
+} from "@replayio/protocol";
 import clamp from "lodash/clamp";
 
 import { framePositionsCleared, resumed } from "devtools/client/debugger/src/reducers/pause";
@@ -25,6 +32,7 @@ import {
   sessionEndPointCache,
 } from "replay-next/src/suspense/ExecutionPointsCache";
 import { screenshotCache } from "replay-next/src/suspense/ScreenshotCache";
+import { isExecutionPointsLessThan } from "replay-next/src/utils/time";
 import {
   isTimeStampedPointRangeEqual,
   isTimeStampedPointRangeGreaterThan,
@@ -51,7 +59,6 @@ import {
   getShowFocusModeControls,
   getZoomRegion,
   pointsReceived,
-  setFocusWindow,
   setPlaybackPrecachedTime,
 } from "ui/reducers/timeline";
 import { FocusWindow, HoveredItem, PlaybackOptions, TimeRange } from "ui/state/timeline";
@@ -526,9 +533,7 @@ export function clearHoveredItem(): UIThunkAction {
   };
 }
 
-export function setFocusWindowFromTimeRange(
-  timeRange: TimeRange | null
-): UIThunkAction<Promise<void>> {
+export function setFocusWindowImprecise(timeRange: TimeRange | null): UIThunkAction<Promise<void>> {
   return async (dispatch, getState, { replayClient }) => {
     if (timeRange === null) {
       dispatch(newFocusWindow(null));
@@ -542,14 +547,14 @@ export function setFocusWindowFromTimeRange(
     const begin = pointsBoundingBegin.before;
     const end = pointsBoundingEnd.after;
 
-    dispatch(newFocusWindow({ begin, end }));
+    dispatch(setFocusWindow({ begin, end }));
   };
 }
 
-export function updateFocusWindow(
-  focusWindow: { begin: number; end: number } | null
+export function setFocusWindow(
+  focusWindow: TimeStampedPointRange | null
 ): UIThunkAction<Promise<void>> {
-  return async (dispatch, getState) => {
+  return async (dispatch, getState, { replayClient }) => {
     const state = getState();
     const currentTime = getCurrentTime(state);
 
@@ -564,64 +569,35 @@ export function updateFocusWindow(
       return;
     }
 
-    let { begin: beginTime, end: endTime } = focusWindow;
+    let { begin, end } = focusWindow;
 
-    const zoomRegion = getZoomRegion(state);
     const prevFocusWindow = getFocusWindow(state);
     const prevBeginTime = prevFocusWindow?.begin.time;
     const prevEndTime = prevFocusWindow?.end.time;
 
-    // Basic bounds check.
-    if (beginTime < zoomRegion.beginTime) {
-      beginTime = zoomRegion.beginTime;
-      if (endTime < beginTime) {
-        endTime = beginTime;
-      }
-    }
-    if (endTime > zoomRegion.endTime) {
-      endTime = zoomRegion.endTime;
-      if (beginTime > endTime) {
-        beginTime = endTime;
-      }
-    }
-
     // Make sure our region is valid.
-    if (endTime < beginTime) {
-      // If we need to adjust a dimension, it's the most intuitive to adjust the one that's being updated.
-      if (prevEndTime === endTime) {
-        beginTime = endTime;
-      } else {
-        endTime = beginTime;
-      }
-    }
+    assert(isExecutionPointsLessThan(begin.point, end.point));
 
-    // Cap time to fit within max focus region size.
-    if (endTime === prevEndTime) {
-      endTime = Math.min(endTime, beginTime + MAX_FOCUS_REGION_DURATION);
-    } else {
-      beginTime = Math.max(beginTime, endTime - MAX_FOCUS_REGION_DURATION);
-    }
-
-    // Update the previous to match the handle that's being dragged.
-    if (beginTime !== prevBeginTime && endTime === prevEndTime) {
-      dispatch(setTimelineToTime(beginTime));
-    } else if (beginTime === prevBeginTime && endTime !== prevEndTime) {
-      dispatch(setTimelineToTime(endTime));
+    // Update the paint preview to match the handle that's being dragged.
+    if (begin.time !== prevBeginTime && end.time === prevEndTime) {
+      dispatch(setTimelineToTime(begin.time));
+    } else if (begin.time === prevBeginTime && end.time !== prevEndTime) {
+      dispatch(setTimelineToTime(end.time));
     } else {
       // Else just make sure the preview time stays within the moving window.
       const hoverTime = getHoverTime(state);
       if (hoverTime !== null) {
-        if (hoverTime < beginTime) {
-          dispatch(setTimelineToTime(beginTime));
-        } else if (hoverTime > endTime) {
-          dispatch(setTimelineToTime(endTime));
+        if (hoverTime < begin.time) {
+          dispatch(setTimelineToTime(begin.time));
+        } else if (hoverTime > end.time) {
+          dispatch(setTimelineToTime(end.time));
         }
       } else {
         dispatch(setTimelineToTime(currentTime));
       }
     }
 
-    await dispatch(setFocusWindowFromTimeRange({ begin: beginTime, end: endTime }));
+    await dispatch(newFocusWindow({ begin, end }));
   };
 }
 
@@ -634,7 +610,7 @@ export function setFocusWindowEndTime(end: number, sync: boolean): UIThunkAction
     // Let the focus action/reducer will handle cropping for us.
     const begin = focusWindow?.begin.time ?? 0;
 
-    await dispatch(updateFocusWindow({ begin, end }));
+    await dispatch(setFocusWindowImprecise({ begin, end }));
 
     if (sync) {
       await dispatch(syncFocusedRegion());
@@ -655,7 +631,7 @@ export function setFocusWindowBeginTime(
     // Let the focus action/reducer will handle cropping for us.
     const end = focusWindow?.end.time ?? Number.POSITIVE_INFINITY;
 
-    await dispatch(updateFocusWindow({ begin, end }));
+    await dispatch(setFocusWindowImprecise({ begin, end }));
 
     if (sync) {
       await dispatch(syncFocusedRegion());
@@ -755,7 +731,7 @@ export function enterFocusMode(): UIThunkAction {
         end: Math.min(zoomRegion.endTime, currentTime + focusWindowSize / 2),
       };
 
-      await dispatch(updateFocusWindow(initialFocusWindow));
+      await dispatch(setFocusWindowImprecise(initialFocusWindow));
     }
 
     await dispatch(

--- a/src/ui/components/FocusContextReduxAdapter.tsx
+++ b/src/ui/components/FocusContextReduxAdapter.tsx
@@ -5,7 +5,8 @@ import { FocusContext, UpdateOptions } from "replay-next/src/contexts/FocusConte
 import { TimeRange } from "replay-next/src/types";
 import {
   enterFocusMode,
-  setFocusWindowFromTimeRange,
+  setFocusWindow,
+  setFocusWindowImprecise,
   syncFocusedRegion,
   updateFocusWindowParam,
 } from "ui/actions/timeline";
@@ -25,16 +26,7 @@ export default function FocusContextReduxAdapter({ children }: PropsWithChildren
     async (value: TimeStampedPointRange | null, options: UpdateOptions) => {
       const { sync } = options;
 
-      await dispatch(
-        setFocusWindowFromTimeRange(
-          value !== null
-            ? {
-                begin: value.begin.time,
-                end: value.end.time,
-              }
-            : null
-        )
-      );
+      await dispatch(setFocusWindow(value));
 
       if (sync) {
         await dispatch(syncFocusedRegion());
@@ -49,7 +41,7 @@ export default function FocusContextReduxAdapter({ children }: PropsWithChildren
       const { sync } = options;
 
       await dispatch(
-        setFocusWindowFromTimeRange(
+        setFocusWindowImprecise(
           value !== null
             ? {
                 begin: value[0],

--- a/src/ui/components/Timeline/FocusInputs.tsx
+++ b/src/ui/components/Timeline/FocusInputs.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { getFormattedTime } from "shared/utils/time";
-import { updateFocusWindow } from "ui/actions/timeline";
+import { setFocusWindowImprecise } from "ui/actions/timeline";
 import { selectors } from "ui/reducers";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { getSecondsFromFormattedTime } from "ui/utils/timeline";
@@ -36,7 +36,7 @@ export default function FocusInputs() {
             newBeginTime <= focusWindow.end.time ? focusWindow.end.time : newBeginTime;
 
           await dispatch(
-            updateFocusWindow({
+            setFocusWindowImprecise({
               begin: newBeginTime,
               end: newEndTime,
             })
@@ -56,7 +56,7 @@ export default function FocusInputs() {
             newEndTime >= focusWindow.begin.time ? focusWindow.begin.time : newEndTime;
 
           await dispatch(
-            updateFocusWindow({
+            setFocusWindowImprecise({
               begin: newBeginTime,
               end: newEndTime,
             })

--- a/src/ui/components/Timeline/Focuser.tsx
+++ b/src/ui/components/Timeline/Focuser.tsx
@@ -1,6 +1,7 @@
 import classNames from "classnames";
 import React, { useEffect, useRef, useState } from "react";
 
+import { MAX_FOCUS_REGION_DURATION } from "ui/actions/timeline";
 import { selectors } from "ui/reducers";
 import { AppDispatch } from "ui/setup";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
@@ -101,8 +102,8 @@ function Focuser({ editMode, setEditMode, updateFocusWindowThrottled }: Props) {
         );
 
         const displayedFocusWindow = displayedFocusWindowRef.current;
-        const beginTime = displayedFocusWindow.beginTime;
-        const endTime = displayedFocusWindow.endTime;
+        let beginTime = displayedFocusWindow.beginTime;
+        let endTime = displayedFocusWindow.endTime;
 
         switch (editMode.type) {
           case "drag": {
@@ -124,10 +125,20 @@ function Focuser({ editMode, setEditMode, updateFocusWindowThrottled }: Props) {
             break;
           }
           case "resize-end": {
+            // If we're resizing the window, make sure we honor the max focus window size
+            if (mouseTime - beginTime > MAX_FOCUS_REGION_DURATION) {
+              beginTime = mouseTime - MAX_FOCUS_REGION_DURATION;
+            }
+
             updateDisplayedFocusWindow(beginTime, mouseTime);
             break;
           }
           case "resize-start": {
+            // If we're resizing the window, make sure we honor the max focus window size
+            if (endTime - mouseTime > MAX_FOCUS_REGION_DURATION) {
+              endTime = mouseTime + MAX_FOCUS_REGION_DURATION;
+            }
+
             updateDisplayedFocusWindow(mouseTime, endTime);
             break;
           }

--- a/src/ui/components/Timeline/Focuser.tsx
+++ b/src/ui/components/Timeline/Focuser.tsx
@@ -50,6 +50,10 @@ function Focuser({ editMode, setEditMode, updateFocusWindowThrottled }: Props) {
     beginTime: focusWindow?.begin.time ?? zoomRegion.beginTime,
     endTime: focusWindow?.end.time ?? zoomRegion.endTime,
   });
+  const displayedFocusWindowRef = useRef(displayedFocusWindow);
+  useEffect(() => {
+    displayedFocusWindowRef.current = displayedFocusWindow;
+  });
 
   const containerRef = useRef<HTMLDivElement>(null);
   const draggableAreaRef = useRef<HTMLDivElement>(null);
@@ -95,8 +99,10 @@ function Focuser({ editMode, setEditMode, updateFocusWindowThrottled }: Props) {
           container.getBoundingClientRect(),
           zoomRegion
         );
-        const beginTime = focusWindow.begin.time;
-        const endTime = focusWindow.end.time;
+
+        const displayedFocusWindow = displayedFocusWindowRef.current;
+        const beginTime = displayedFocusWindow.beginTime;
+        const endTime = displayedFocusWindow.endTime;
 
         switch (editMode.type) {
           case "drag": {

--- a/src/ui/components/Timeline/Timeline.tsx
+++ b/src/ui/components/Timeline/Timeline.tsx
@@ -3,9 +3,9 @@ import { MouseEvent, useLayoutEffect, useRef, useState } from "react";
 import { throttle } from "shared/utils/function";
 import {
   seekToTime,
+  setFocusWindowImprecise,
   setTimelineToTime,
   stopPlayback,
-  updateFocusWindow,
 } from "ui/actions/timeline";
 import useTimelineContextMenu from "ui/components/Timeline/useTimelineContextMenu";
 import { selectors } from "ui/reducers";
@@ -173,5 +173,5 @@ export default function Timeline() {
 }
 
 const updateFocusWindowThrottled = throttle((dispatch: AppDispatch, begin: number, end: number) => {
-  return dispatch(updateFocusWindow({ begin, end }));
+  return dispatch(setFocusWindowImprecise({ begin, end }));
 }, 250);

--- a/src/ui/components/Timeline/useTimelineContextMenu.tsx
+++ b/src/ui/components/Timeline/useTimelineContextMenu.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, UIEvent, useContext, useState } from "react";
+import { UIEvent, useContext, useState } from "react";
 import {
   ContextMenuDivider,
   ContextMenuItem,
@@ -19,8 +19,8 @@ import {
   MAX_FOCUS_REGION_DURATION,
   getUrlParams,
   seekToTime,
+  setFocusWindowImprecise,
   syncFocusedRegion,
-  updateFocusWindow,
 } from "ui/actions/timeline";
 import { useAppDispatch } from "ui/setup/hooks";
 
@@ -67,7 +67,7 @@ export default function useTimelineContextMenu() {
     let end = focusEndTime ?? duration;
     end = Math.min(end, currentTime + MAX_FOCUS_REGION_DURATION);
 
-    await dispatch(updateFocusWindow({ begin: currentTime, end }));
+    await dispatch(setFocusWindowImprecise({ begin: currentTime, end }));
     dispatch(syncFocusedRegion());
   };
 
@@ -75,7 +75,7 @@ export default function useTimelineContextMenu() {
     let begin = focusBeginTime ?? 0;
     begin = Math.max(begin, currentTime - MAX_FOCUS_REGION_DURATION);
 
-    await dispatch(updateFocusWindow({ begin, end: currentTime }));
+    await dispatch(setFocusWindowImprecise({ begin, end: currentTime }));
     dispatch(syncFocusedRegion());
   };
 

--- a/src/ui/reducers/timeline.test.ts
+++ b/src/ui/reducers/timeline.test.ts
@@ -41,11 +41,11 @@ describe("Redux timeline state", () => {
       expect(getFocusWindow(store.getState())).toMatchInlineSnapshot(`
         Object {
           "begin": Object {
-            "point": "67.5",
+            "point": "67500",
             "time": 67.5,
           },
           "end": Object {
-            "point": "82.5",
+            "point": "82500",
             "time": 82.5,
           },
         }
@@ -125,45 +125,7 @@ describe("Redux timeline state", () => {
     });
 
     it("should not allow an invalid focusWindow to be set", async () => {
-      // Before the start of the zoom region
-      await dispatch(
-        actions.setFocusWindowImprecise({
-          begin: 30,
-          end: 40,
-        })
-      );
-      expect(getFocusWindow(store.getState())).toMatchInlineSnapshot(`
-        Object {
-          "begin": Object {
-            "point": "50",
-            "time": 50,
-          },
-          "end": Object {
-            "point": "50",
-            "time": 50,
-          },
-        }
-      `);
-
-      // After the end of the zoom region
-      await dispatch(
-        actions.setFocusWindowImprecise({
-          begin: 110,
-          end: 125,
-        })
-      );
-      expect(getFocusWindow(store.getState())).toMatchInlineSnapshot(`
-        Object {
-          "begin": Object {
-            "point": "100",
-            "time": 100,
-          },
-          "end": Object {
-            "point": "100",
-            "time": 100,
-          },
-        }
-      `);
+      console.error = jest.fn();
 
       // Overlapping
       await dispatch(
@@ -181,15 +143,16 @@ describe("Redux timeline state", () => {
       expect(getFocusWindow(store.getState())).toMatchInlineSnapshot(`
         Object {
           "begin": Object {
-            "point": "80",
-            "time": 80,
+            "point": "60000",
+            "time": 60,
           },
           "end": Object {
-            "point": "80",
+            "point": "80000",
             "time": 80,
           },
         }
       `);
+      expect(console.error).toHaveBeenCalledTimes(1);
 
       // Overlapping alternate
       await dispatch(
@@ -207,15 +170,16 @@ describe("Redux timeline state", () => {
       expect(getFocusWindow(store.getState())).toMatchInlineSnapshot(`
         Object {
           "begin": Object {
-            "point": "60",
+            "point": "60000",
             "time": 60,
           },
           "end": Object {
-            "point": "60",
-            "time": 60,
+            "point": "80000",
+            "time": 80,
           },
         }
       `);
+      expect(console.error).toHaveBeenCalledTimes(2);
     });
 
     it("should stop playback before resizing focusWindow", async () => {
@@ -232,17 +196,17 @@ describe("Redux timeline state", () => {
     });
 
     describe("set start time", () => {
-      it("should focus from the start time to the end of the zoom region if no focus region has been set", async () => {
+      it("should focus from the start time to the end of the recording if no focus region has been set", async () => {
         await dispatch(actions.setFocusWindowBeginTime(65, false));
         expect(getFocusWindow(store.getState())).toMatchInlineSnapshot(`
           Object {
             "begin": Object {
-              "point": "65",
+              "point": "65000",
               "time": 65,
             },
             "end": Object {
-              "point": "100",
-              "time": 100,
+              "point": "1000000",
+              "time": 1000,
             },
           }
         `);
@@ -259,11 +223,11 @@ describe("Redux timeline state", () => {
         expect(getFocusWindow(store.getState())).toMatchInlineSnapshot(`
           Object {
             "begin": Object {
-              "point": "65",
+              "point": "65000",
               "time": 65,
             },
             "end": Object {
-              "point": "70",
+              "point": "70000",
               "time": 70,
             },
           }
@@ -272,16 +236,16 @@ describe("Redux timeline state", () => {
     });
 
     describe("set end time", () => {
-      it("should focus from the beginning of the zoom region to the specified end time if no focus region has been set", async () => {
+      it("should focus from the beginning of the recording to the specified end time if no focus region has been set", async () => {
         await dispatch(actions.setFocusWindowEndTime(65, false));
         expect(getFocusWindow(store.getState())).toMatchInlineSnapshot(`
           Object {
             "begin": Object {
-              "point": "50",
-              "time": 50,
+              "point": "0",
+              "time": 0,
             },
             "end": Object {
-              "point": "65",
+              "point": "65000",
               "time": 65,
             },
           }
@@ -299,11 +263,11 @@ describe("Redux timeline state", () => {
         expect(getFocusWindow(store.getState())).toMatchInlineSnapshot(`
           Object {
             "begin": Object {
-              "point": "50",
+              "point": "50000",
               "time": 50,
             },
             "end": Object {
-              "point": "65",
+              "point": "65000",
               "time": 65,
             },
           }

--- a/src/ui/reducers/timeline.test.ts
+++ b/src/ui/reducers/timeline.test.ts
@@ -54,7 +54,7 @@ describe("Redux timeline state", () => {
 
     it("should not force the currentTime to be within the focusWindow as it moves around", async () => {
       await dispatch(
-        actions.updateFocusWindow({
+        actions.setFocusWindowImprecise({
           begin: 50,
           end: 60,
         })
@@ -62,7 +62,7 @@ describe("Redux timeline state", () => {
       expect(getCurrentTime(store.getState())).toBe(75);
 
       await dispatch(
-        actions.updateFocusWindow({
+        actions.setFocusWindowImprecise({
           begin: 75,
           end: 85,
         })
@@ -70,7 +70,7 @@ describe("Redux timeline state", () => {
       expect(getCurrentTime(store.getState())).toBe(75);
 
       await dispatch(
-        actions.updateFocusWindow({
+        actions.setFocusWindowImprecise({
           begin: 25,
           end: 30,
         })
@@ -81,7 +81,7 @@ describe("Redux timeline state", () => {
     it("should update the hoverTime (and the time displayed in the video player) to match the handle being dragged", async () => {
       // If we are moving the whole focus region, seek to the current time.
       await dispatch(
-        actions.updateFocusWindow({
+        actions.setFocusWindowImprecise({
           begin: 60,
           end: 80,
         })
@@ -90,7 +90,7 @@ describe("Redux timeline state", () => {
 
       // If we are moving the beginTime, seek to that point
       await dispatch(
-        actions.updateFocusWindow({
+        actions.setFocusWindowImprecise({
           begin: 65,
           end: 80,
         })
@@ -99,7 +99,7 @@ describe("Redux timeline state", () => {
 
       // If we are moving the endTime, seek to that point
       await dispatch(
-        actions.updateFocusWindow({
+        actions.setFocusWindowImprecise({
           begin: 65,
           end: 75,
         })
@@ -109,14 +109,14 @@ describe("Redux timeline state", () => {
       // Moving the entire range should not move the hover time,
       // unless the time would otherwise be out of the new focused region.
       await dispatch(
-        actions.updateFocusWindow({
+        actions.setFocusWindowImprecise({
           begin: 68,
           end: 78,
         })
       );
       expect(getHoverTime(store.getState())).toBe(75);
       await dispatch(
-        actions.updateFocusWindow({
+        actions.setFocusWindowImprecise({
           begin: 80,
           end: 90,
         })
@@ -127,7 +127,7 @@ describe("Redux timeline state", () => {
     it("should not allow an invalid focusWindow to be set", async () => {
       // Before the start of the zoom region
       await dispatch(
-        actions.updateFocusWindow({
+        actions.setFocusWindowImprecise({
           begin: 30,
           end: 40,
         })
@@ -147,7 +147,7 @@ describe("Redux timeline state", () => {
 
       // After the end of the zoom region
       await dispatch(
-        actions.updateFocusWindow({
+        actions.setFocusWindowImprecise({
           begin: 110,
           end: 125,
         })
@@ -167,13 +167,13 @@ describe("Redux timeline state", () => {
 
       // Overlapping
       await dispatch(
-        actions.updateFocusWindow({
+        actions.setFocusWindowImprecise({
           begin: 60,
           end: 80,
         })
       );
       await dispatch(
-        actions.updateFocusWindow({
+        actions.setFocusWindowImprecise({
           begin: 90,
           end: 80,
         })
@@ -193,13 +193,13 @@ describe("Redux timeline state", () => {
 
       // Overlapping alternate
       await dispatch(
-        actions.updateFocusWindow({
+        actions.setFocusWindowImprecise({
           begin: 60,
           end: 80,
         })
       );
       await dispatch(
-        actions.updateFocusWindow({
+        actions.setFocusWindowImprecise({
           begin: 60,
           end: 50,
         })
@@ -223,7 +223,7 @@ describe("Redux timeline state", () => {
       expect(getPlayback(store.getState())).not.toBeNull();
 
       await dispatch(
-        actions.updateFocusWindow({
+        actions.setFocusWindowImprecise({
           begin: 50,
           end: 60,
         })
@@ -250,7 +250,7 @@ describe("Redux timeline state", () => {
 
       it("should only update the start time when a region is set", async () => {
         await dispatch(
-          actions.updateFocusWindow({
+          actions.setFocusWindowImprecise({
             begin: 50,
             end: 70,
           })
@@ -290,7 +290,7 @@ describe("Redux timeline state", () => {
 
       it("should only update the end time when a region is set", async () => {
         await dispatch(
-          actions.updateFocusWindow({
+          actions.setFocusWindowImprecise({
             begin: 50,
             end: 70,
           })

--- a/yarn.lock
+++ b/yarn.lock
@@ -15325,7 +15325,7 @@ __metadata:
     ts-node: ^10.7.0
     tsconfig-paths: ^3.14.1
     typescript: ^5.0.4
-    use-context-menu: ^0.4.11
+    use-context-menu: 0.4.10
     utf-8-validate: ^5.0.8
     uuid: ^7.0.3
     v8-to-istanbul: ^9.0.1
@@ -15521,7 +15521,7 @@ __metadata:
     shared: "workspace:*"
     suspense: ^0.0.44
     typescript: 5.0.2
-    use-context-menu: ^0.4.11
+    use-context-menu: 0.4.10
     uuid: ^7.0.3
   languageName: unknown
   linkType: soft
@@ -17712,13 +17712,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-context-menu@npm:^0.4.11":
-  version: 0.4.11
-  resolution: "use-context-menu@npm:0.4.11"
+"use-context-menu@npm:0.4.10":
+  version: 0.4.10
+  resolution: "use-context-menu@npm:0.4.10"
   peerDependencies:
     react: ^16.14.0 || ^17 || ^18
     react-dom: ^16.14.0 || ^17 || ^18
-  checksum: 5ddfc243ae794690a7dc8a3afeff999dacee188bfea1287df31861763ac0c1065aff5d23d7ab9da782100b79cbaa590a2bdcdd8eb073a066cdbcfd1f9c864744
+  checksum: 7d6732b86efe75d164a998ecaaec261d3e73b991de62ba0af68241aef4fe7b6c4e35956a144f71b963f1333e6a53353f947fbeed36016c6ba57f758b2ed6cd5c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3707,10 +3707,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@replayio/protocol@npm:^0.54.0":
-  version: 0.54.0
-  resolution: "@replayio/protocol@npm:0.54.0"
-  checksum: 595a235105492fe47d655c32a2d8318e9ae29e012985dc93ddcaf985dffbebdc26d8ddb0c9221667e2024afab26d429779af3113449dda287324a74d5e886441
+"@replayio/protocol@npm:^0.55.0":
+  version: 0.55.0
+  resolution: "@replayio/protocol@npm:0.55.0"
+  checksum: 287f25a2303920247fc87309f8ad28159e92cc05c22a8902a5fa22e074cbf8da2d591adc96dc7e6c42105cfbe8a56538f6550460699df35f43369850508eff57
   languageName: node
   linkType: hard
 
@@ -15180,7 +15180,7 @@ __metadata:
     "@recordreplay/sourcemap-upload-cli": ^0.1.1
     "@reduxjs/toolkit": ^1.8.4
     "@replayio/overboard": ^0.4.1
-    "@replayio/protocol": ^0.54.0
+    "@replayio/protocol": ^0.55.0
     "@replayio/replay": ^0.12.4
     "@sentry/react": ^7.9.0
     "@sentry/tracing": ^7.9.0
@@ -15499,7 +15499,7 @@ __metadata:
     "@lezer/common_replay_next": "npm:@lezer/common@1.0.1"
     "@lezer/highlight_replay_next": "npm:@lezer/highlight@1.1.1"
     "@playwright/test": ^1.35.0
-    "@replayio/protocol": ^0.54.0
+    "@replayio/protocol": ^0.55.0
     "@testing-library/jest-dom": ^5.16.3
     "@testing-library/react": ^13.2.0
     "@types/uuid": ^7.0.3


### PR DESCRIPTION
### [Loom demo](https://www.loom.com/share/d319cc2c9e9147989ae219961cbb3de9)

### Code changes
- [x] Update `createSession` to pass `focusRequest` rather than `focusWindow`.
- [x] Replace `Session.requestFocusRange` with `Session.requestFocusWindow`.
- [x] Refine focus window using the _currently displayed_ focus window (see comments on [39e26ef4-5697-4fdb-9e8a-28dd2bc1854c](https://app.replay.io/recording/fe-1632-focus-window-expands-when-dragging--39e26ef4-5697-4fdb-9e8a-28dd2bc1854c)); I think this should fix FE-1632.
- [x] Migrate Redux actions (and React components that use them) to set focus using `TimeStampedPoint` when possible.

### Dependencies
- [x] Upgrade `@replayio/protocol` 0.54.0 -> 0.55.0 for new focus method.
- [x] Downgrade `use-context-menu` 0.4.11 -> 0.4.10 because the transition introduced in 0.4.11 caused the context menu not to open sometimes. (I'm not sure why this is, but I noticed it while testing the log point panel focus menu.)