### PR TITLE
enable protocol query storage default

### DIFF
--- a/packages/protocol/socket.ts
+++ b/packages/protocol/socket.ts
@@ -135,7 +135,7 @@ export type ExperimentalSettings = {
   keepAllTraces?: boolean;
   disableIncrementalSnapshots?: boolean;
   disableConcurrentControllerLoading?: boolean;
-  enableProtocolQueryCache?: boolean;
+  disableProtocolQueryCache?: boolean;
 };
 
 type SessionCallbacks = {

--- a/packages/shared/user-data/GraphQL/config.ts
+++ b/packages/shared/user-data/GraphQL/config.ts
@@ -43,6 +43,14 @@ export const config = {
     label: "Disable using incremental snapshots",
     legacyKey: "devtools.features.disableIncrementalSnapshots",
   },
+  backend_disableProtocolQueryCache: {
+    defaultValue: Boolean(false),
+    description:
+      "Disable storage of previously generated response for a subset of protocol commands",
+    internalOnly: false,
+    label: "Disable query-level storage for a subset of protocol commands",
+    legacyKey: "devtools.features.disableProtocolQueryCache",
+  },
   backend_disableRecordingAssetsInDatabase: {
     defaultValue: Boolean(false),
     description:
@@ -64,14 +72,6 @@ export const config = {
     internalOnly: Boolean(true),
     label: "Disable query-level caching for stable request types",
     legacyKey: "devtools.features.disableStableQueryCache",
-  },
-  backend_enableProtocolQueryCache: {
-    defaultValue: Boolean(false),
-    description:
-      "Enable storage of previously generated response for a subset of protocol commands",
-    internalOnly: true,
-    label: "Enable query-level storage for a subset of protocol commands",
-    legacyKey: "devtools.hafeatures.enableProtocolQueryCache",
   },
   backend_enableRoutines: {
     defaultValue: Boolean(false),

--- a/packages/shared/user-data/GraphQL/config.ts
+++ b/packages/shared/user-data/GraphQL/config.ts
@@ -46,7 +46,6 @@ export const config = {
   backend_disableProtocolQueryCache: {
     defaultValue: Boolean(false),
     description: "Disable storage of previously generated response for protocol commands",
-    internalOnly: false,
     label: "Disable query-level storage for protocol commands",
     legacyKey: "devtools.features.disableProtocolQueryCache",
   },

--- a/packages/shared/user-data/GraphQL/config.ts
+++ b/packages/shared/user-data/GraphQL/config.ts
@@ -45,10 +45,9 @@ export const config = {
   },
   backend_disableProtocolQueryCache: {
     defaultValue: Boolean(false),
-    description:
-      "Disable storage of previously generated response for a subset of protocol commands",
+    description: "Disable storage of previously generated response for protocol commands",
     internalOnly: false,
-    label: "Disable query-level storage for a subset of protocol commands",
+    label: "Disable query-level storage for protocol commands",
     legacyKey: "devtools.features.disableProtocolQueryCache",
   },
   backend_disableRecordingAssetsInDatabase: {

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -205,7 +205,7 @@ export function createSocket(
         disableConcurrentControllerLoading: userData.get(
           "backend_disableConcurrentControllerLoading"
         ),
-        enableProtocolQueryCache: userData.get("backend_enableProtocolQueryCache"),
+        disableProtocolQueryCache: userData.get("backend_disableProtocolQueryCache"),
       };
       if (userData.get("backend_newControllerOnRefresh")) {
         experimentalSettings.controllerKey = String(Date.now());

--- a/src/ui/components/shared/UserSettingsModal/panels/Experimental.tsx
+++ b/src/ui/components/shared/UserSettingsModal/panels/Experimental.tsx
@@ -18,7 +18,7 @@ export const PREFERENCES: PreferencesKey[] = [
   "feature_reduxDevTools",
   "backend_disableIncrementalSnapshots",
   "backend_disableConcurrentControllerLoading",
-  "backend_enableProtocolQueryCache",
+  "backend_disableProtocolQueryCache",
 ];
 
 export function Experimental() {


### PR DESCRIPTION
it will be simpler to move from using `enableProtocolQueryStorage` to `disableProtocolQueryStorage` in order to be able to enable this by default. probably should have done this to begin with, but I didn't know how fast this project would move.