### PR TITLE
Aligning red for testsuites error icons

### DIFF
--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/NetworkRequestEventRow.module.css
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/NetworkRequestEventRow.module.css
@@ -14,7 +14,7 @@
   width: 0.75rem;
 }
 .StatusBadge[data-status-badge="error"] {
-  background-color: var(--testsuites-error-color);
+  background-color: var(--testsuites-error-icon-bgcolor);
 }
 .StatusBadge[data-status-badge="success"] {
   background-color: var(--testsuites-success-color);


### PR DESCRIPTION
Old on left, new on right:

![image](https://github.com/replayio/devtools/assets/9154902/daca70a9-0655-45c4-9ac4-42d75903fdb3)
