### PR TITLE
Test Suites: Clicking on any test action type will update timeline

### DIFF
--- a/src/ui/components/TestSuite/hooks/useJumpToSource.ts
+++ b/src/ui/components/TestSuite/hooks/useJumpToSource.ts
@@ -78,11 +78,6 @@ export function useJumpToSource({
       if (location) {
         dispatch(selectLocation(context, location, openSourceAutomatically));
       }
-
-      const timeStampedPoint = timeStampedPointRange.begin;
-      if (timeStampedPoint.point && timeStampedPoint.time) {
-        dispatch(seek(timeStampedPoint.point, timeStampedPoint.time, false));
-      }
     }
 
     dispatch(setSourcesUserActionPending(false));


### PR DESCRIPTION
### [Loom video](https://www.loom.com/share/e59a695374e9474cb226b9cd150d696a)

Previous–
* In `UserActionEventRow`, the `useJumpToSource` hook opens the source code for user action events only ([see here](https://app.replay.io/recording/fe-1731--bb420e7e-652e-4ba5-b48e-9f7df7dd889c?point=56466228347560090264771817990258763&time=22614.982750359366)) because those are the only types that have meaningful source code? This handler also seeks to the test step's execution point.
* In `TestSectionRow`, the inline click handler sets the selected test event ([see here](https://app.replay.io/recording/fe-1731--bb420e7e-652e-4ba5-b48e-9f7df7dd889c?point=56466228347560197486471746427027523&time=22615.094154288454)) but does not seek to that time/point.

This PR moves the timeline logic into `TestSectionRow` so that it will work for all event types <sup>1</sup> but leaves the selected source location logic in `UserActionEventRow`.

<sup>1</sup> Note that Playwright user action test steps have no execution points so the timeline will not advance for them.