### PR TITLE
Bumping up Delta/screenshot test retries to match other e2e tests

### DIFF
--- a/packages/replay-next/playwright/playwright.config.ts
+++ b/packages/replay-next/playwright/playwright.config.ts
@@ -15,7 +15,7 @@ const config: FullConfig = {
   globalSetup: require.resolve("./playwright.globalSetup"),
   // @ts-ignore
   reporter: CI ? "github" : "list",
-  retries: RECORD_VIDEO || VISUAL_DEBUG ? 0 : 2,
+  retries: RECORD_VIDEO || VISUAL_DEBUG ? 0 : 5,
   snapshotDir: "./snapshots",
   use: {
     // Don't allow any one action to take more than 15s


### PR DESCRIPTION
Looking at the past 24 hours of screenshot tests, we have some flakes, but no one test really stands out. I'd like to try increasing our `retries` setting (from 2 to 5) to match the other Playwright tests. I think this might help with the random flakes.