### PR TITLE
Add custom error message for Windows+Firefox

### DIFF
--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -95,6 +95,9 @@ const defaultMessaging: UnexpectedError = {
   message: "Our apologies!",
 };
 
+const isWindows = window.navigator.platform.indexOf('Win') > -1;
+const isFirefox = window.navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
+
 // Reported reasons why a session can be destroyed.
 const SessionErrorMessages: Record<number, Partial<UnexpectedError>> = {
   [SessionError.BackendDeploy]: {
@@ -104,7 +107,9 @@ const SessionErrorMessages: Record<number, Partial<UnexpectedError>> = {
     content: "Our servers hiccuped but things should be back to normal soon.",
   },
   [SessionError.UnknownFatalError]: {
-    content: "Refreshing should help.\nIf not, please try recording again.",
+    content: isWindows && isFirefox 
+      ? "Our Windows support is currently in beta and will be improved soon. Thanks for your patience!"
+      : "Refreshing should help.\nIf not, please try recording again.",
   },
   [SessionError.KnownFatalError]: {
     content:


### PR DESCRIPTION
Note: I don't know how to test this. When I'm dealing with other error messages, I can throw this in the console:

```
app.actions.setUnexpectedError({
    message: "Unexpected error",
    content: "This is where an error message will appear",
    action: "refresh",
  })
```

But I'm not sure how to trigger this, which is an UnknownFatalError.   Josh or Brian, any suggestions? This code might work, but until I can test I'm not sure.
