### PR TITLE
Horizontal panel layout CSS fix

### DIFF
--- a/src/ui/components/Viewer.tsx
+++ b/src/ui/components/Viewer.tsx
@@ -38,7 +38,7 @@ const Vertical = () => {
         </div>
       </Panel>
       <PanelResizeHandle
-        className={videoPanelCollapsed ? "" : "h-2 w-full"}
+        className={videoPanelCollapsed ? "" : "h-2 w-full shrink-0"}
         id="PanelResizeHandle-Video"
       />
       <Panel
@@ -71,13 +71,13 @@ const Horizontal = () => {
         minSize={30}
         order={1}
       >
-        <div className="flex flex-1 flex-row">
+        <div className="flex w-full flex-1 flex-row">
           <SecondaryToolbox
             videoPanelCollapsed={videoPanelCollapsed}
             videoPanelRef={videoPanelRef}
           />
           <PanelResizeHandle
-            className={videoPanelCollapsed ? "" : "w-2"}
+            className={videoPanelCollapsed ? "" : "h-full w-2 shrink-0"}
             id="PanelResizeHandle-Video"
           />
         </div>


### PR DESCRIPTION
## Before

<img width="728" alt="Screen Shot 2023-07-20 at 8 55 35 AM" src="https://github.com/replayio/devtools/assets/29597/7a26506f-c1e8-4da4-8bc8-852af2ddabe3">

## After

<img width="557" alt="Screen Shot 2023-07-20 at 9 02 49 AM" src="https://github.com/replayio/devtools/assets/29597/c56f5a68-2812-40b8-bb61-2228b122f9cb">

Our mix of CSS modules, global CSS, and Tailwind still confuses me.