### PR TITLE
Fixed two places in Redux Timeline actions where we weren't awaiting an async action

### DIFF
--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -547,7 +547,7 @@ export function setFocusWindowImprecise(timeRange: TimeRange | null): UIThunkAct
     const begin = pointsBoundingBegin.before;
     const end = pointsBoundingEnd.after;
 
-    dispatch(setFocusWindow({ begin, end }));
+    await dispatch(setFocusWindow({ begin, end }));
   };
 }
 
@@ -689,13 +689,7 @@ export function syncFocusedRegion(): UIThunkAction {
 
     // If the backend has selected a different focus window, refine our in-memory window to match
     if (begin.point !== window.begin.point || end.point !== window.end.point) {
-      dispatch(
-        setFocusWindow({
-          begin: window.begin,
-          end: window.end,
-        })
-      );
-      dispatch(setFocusWindow(window));
+      await dispatch(setFocusWindow(window));
     }
   };
 }


### PR DESCRIPTION
This was my blunder. [Watch me](https://www.loom.com/share/44a228dbae34492eb55b86aa1eb6db23) fumble my way through it if you're curious. Replay at [b029a9ce-c786-45af-a3a3-27f1c77f8292](https://app.replay.io/recording/cant-set-focus-window--b029a9ce-c786-45af-a3a3-27f1c77f8292)