### PR TITLE
Removing double logo from new team page

### DIFF
--- a/src/ui/components/shared/TeamOnboarding.tsx
+++ b/src/ui/components/shared/TeamOnboarding.tsx
@@ -284,7 +284,7 @@ function TeamOnboarding(props: { organization?: boolean } & PropsFromRedux) {
 
   return (
     <OnboardingModalContainer {...{ randomNumber }} theme="light">
-      <OnboardingContentWrapper>{slide}</OnboardingContentWrapper>
+      <OnboardingContentWrapper noLogo>{slide}</OnboardingContentWrapper>
     </OnboardingModalContainer>
   );
 }


### PR DESCRIPTION
Addresses [DES-813 ](https://linear.app/replay/issue/DES-813/dark-theme-issue-creating-a-team) by adding a simple noLogo prop.