### PR TITLE
Improved video loader

### DIFF
--- a/src/ui/components/Video.tsx
+++ b/src/ui/components/Video.tsx
@@ -43,7 +43,7 @@ export default function Video() {
   const [showDelayedSpinner, setShowDelayedSpinner] = useState(false);
 
   useEffect(() => {
-    let timerId;
+    let timerId: NodeJS.Timeout | undefined;
     if (highlightedNodesLoading || (isNodePickerActive && mouseTargetsLoading) || stalled) {
       timerId = setTimeout(() => {
         setShowDelayedSpinner(true);

--- a/src/ui/components/Video.tsx
+++ b/src/ui/components/Video.tsx
@@ -98,7 +98,6 @@ export default function Video() {
 
   const showCommentTool =
     isPaused && !isNodeTarget && !isNodePickerActive && !isNodePickerInitializing;
-  const showSpinner = showDelayedSpinner;
 
   return (
     <div id="video" className="relative bg-toolbarBackground">
@@ -117,7 +116,7 @@ export default function Video() {
       {contextMenu}
       {showCommentTool ? (
         <CommentsOverlay>
-          {showSpinner && (
+          {showDelayedSpinner && (
             <div className="absolute bottom-5 right-5 z-20 flex opacity-100">
               <Spinner className="w-5 animate-spin text-black" />
             </div>


### PR DESCRIPTION
Old on top, new on bottom:
![image](https://github.com/replayio/devtools/assets/9154902/cbc1e8e2-be5a-4c85-974b-031854644ec8)

Changes:
* brighter blue for the foreground
* modified background color
* larger
* 700ms delay to reduce flickering

[Loom explaining changes](https://www.loom.com/share/beb1676fab3a46e89232e48daf642d0b) 

Time to design/develop/test/record Loom: 18 minutes

Addresses https://linear.app/replay/issue/DES-808/the-video-loading-indicator-should-be-more-obvious and is part of DES-814 work.

FAQ:

Q: Did we try making the background contrast more?
A: Yes, but video backgrounds can be any color from black to white, so you can't count on that. This design will have very high contrast on a white background (a dark circle with a bright blue spinner) and works well on a dark background (the dark circle fades away, but the size and brightness make it much clearer, as shown above)

Q: What about putting it in the middle of the screen, or larger?
A: Both are reasonable options, but this is larger and more clear without being garish. We can always make it bigger in a further iteration, but I think this will work well.