### PR TITLE
Preview unavailable values

### DIFF
--- a/packages/replay-next/components/sources/PreviewPopup.module.css
+++ b/packages/replay-next/components/sources/PreviewPopup.module.css
@@ -8,3 +8,10 @@
   border-radius: 0.25rem;
   filter: drop-shadow(0 1px 2px rgb(0 0 0 / 0.1)) drop-shadow(0 1px 1px rgb(0 0 0 / 0.06));
 }
+
+.UnavailableMessage {
+  padding: 0.5rem;
+  color: var(--color-default);
+  font-family: var(--font-family-default);
+  font-size: var(--font-size-regular);
+}

--- a/packages/replay-next/components/sources/PreviewPopup.tsx
+++ b/packages/replay-next/components/sources/PreviewPopup.tsx
@@ -67,7 +67,12 @@ function SuspendingPreviewPopup({
             expression,
             undefined
           );
-          value = result.returned || null;
+
+          if (result.failed || result.exception) {
+            valueUnavailableMessage = "Value cannot be inspected";
+          } else {
+            value = result.returned || null;
+          }
         } else {
           valueUnavailableMessage = "Value cannot be inspected";
         }


### PR DESCRIPTION
### [Loom overview](https://www.loom.com/share/335bc4f6c9b84a929062d577b9a19008)

Two new preview popup states added (where we would previously show/do _nothing_):

<img width="316" alt="Screen Shot 2023-07-28 at 11 07 48 AM" src="https://github.com/replayio/devtools/assets/29597/9874c048-41f5-46b4-9d59-1c7bc2201d4a">

<img width="241" alt="Screen Shot 2023-07-28 at 11 07 59 AM" src="https://github.com/replayio/devtools/assets/29597/6309d66c-058d-4975-a7a8-4e65d849ed05">

cc @jonbell-lot23 