### PR TITLE
[WIP] show protocol viewer in the loading screen

### DIFF
--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -128,6 +128,25 @@ function InfoIcon() {
   );
 }
 
+function ProtocolIcon() {
+  return (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M8.00033 7L1.70716 13.2929C1.31661 13.6834 1.31661 14.3166 1.70716 14.7071L8.00033 21"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+      <path
+        d="M16 21L22.2929 14.7071C22.6834 14.3166 22.6834 13.6834 22.2929 13.2929L16 7"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
 function CommentIcon() {
   return (
     <svg
@@ -291,8 +310,8 @@ function ToolbarButton({
       break;
     }
 
-    case "info": {
-      iconContents = <InfoIcon />;
+    case "protocol": {
+      iconContents = <ProtocolIcon />;
       break;
     }
 
@@ -483,8 +502,13 @@ export default function Toolbar() {
             )}
           </>
         ) : null}
-        {logProtocolExperimentEnabled && viewMode === "dev" ? (
-          <ToolbarButton icon="code" label="Protocol" name="protocol" onClick={handleButtonClick} />
+        {logProtocolExperimentEnabled ? (
+          <ToolbarButton
+            icon="protocol"
+            label="Protocol"
+            name="protocol"
+            onClick={handleButtonClick}
+          />
         ) : null}
 
         <div className="flex-grow"></div>

--- a/src/ui/components/shared/LoadingScreen.tsx
+++ b/src/ui/components/shared/LoadingScreen.tsx
@@ -5,6 +5,7 @@ import { ConnectedProps, connect } from "react-redux";
 import { getAwaitingSourcemaps, getUploading } from "ui/reducers/app";
 import { UIState } from "ui/state";
 
+import ProtocolViewer from "../ProtocolViewer";
 import { DefaultViewportWrapper } from "./Viewport";
 import styles from "./LoadingScreen.module.css";
 
@@ -31,6 +32,10 @@ export function LoadingScreenTemplate({ children }: { children?: ReactNode }) {
   return (
     <div className={styles.loadingScreenWrapper}>
       <DefaultViewportWrapper>
+        <div className="fixed top-0 left-0 h-full bg-black p-2 text-sm">
+          <ProtocolViewer />
+        </div>
+
         <div className={styles.loadingScreenWrapper}>
           <div className="flex flex-col items-center space-y-2">
             <div className={styles.hoverboardWrapper} onClick={changeHoverboardColor}>


### PR DESCRIPTION
i wonder if we want to let internal users view the protocol timeline in the loading screen

<img width="1440" alt="Screenshot 2023-07-28 at 11 35 46 PM" src="https://github.com/replayio/devtools/assets/254562/b53b1981-d5c9-4800-a742-ad2ca771db85">
