### PR TITLE
Source viewer: Better streaming/loading UX

### DIFF
--- a/packages/replay-next/components/sources/SourceListRow.tsx
+++ b/packages/replay-next/components/sources/SourceListRow.tsx
@@ -64,8 +64,8 @@ if (typeof window !== "undefined") {
 export type ItemData = {
   breakablePositionsByLine: Map<number, SameLineSourceLocations>;
   hitCounts: LineNumberToHitCountMap | null;
-  maxHitCount: number | null;
-  minHitCount: number | null;
+  maxHitCount: number | undefined;
+  minHitCount: number | undefined;
   onLineMouseEnter: (lineIndex: number, lineNumberNode: HTMLElement) => void;
   onLineMouseLeave: (lineIndex: number, lineNumberNode: HTMLElement) => void;
   pointPanelHeight: number;
@@ -176,7 +176,7 @@ const SourceListRow = memo(
     let hitCountBarClassName = styles.LineHitCountBar0;
     let hitCountLabelClassName = styles.LineHitCountLabel0;
     let hitCountIndex = NUM_GRADIENT_COLORS - 1;
-    if (hitCount !== null && minHitCount !== null && maxHitCount !== null) {
+    if (hitCount != null && minHitCount != null && maxHitCount != null) {
       if (minHitCount !== maxHitCount) {
         hitCountIndex = Math.min(
           NUM_GRADIENT_COLORS - 1,

--- a/packages/replay-next/components/sources/StreamingSourceLoadingProgressHeader.tsx
+++ b/packages/replay-next/components/sources/StreamingSourceLoadingProgressHeader.tsx
@@ -5,6 +5,10 @@ import { StreamingParser } from "replay-next/src/suspense/SyntaxParsingCache";
 
 import styles from "./StreamingSourceLoadingProgressHeader.module.css";
 
+// In case the initial source contents request hangs,
+// render some minimal amount of progress so that the source viewer isn't empty
+const STREAMING_IN_PROGRESS_MIN_LOADING_PERCENTAGE = 0.05;
+
 export default function StreamingSourceLoadingProgressHeader({
   streamingParser,
   streamingSourceContents,
@@ -12,7 +16,8 @@ export default function StreamingSourceLoadingProgressHeader({
   streamingParser: StreamingParser;
   streamingSourceContents: StreamingSourceContentsValue;
 }) {
-  const { progress: rawTextPercentage = 0 } = useStreamingValue(streamingSourceContents);
+  const { progress: rawTextPercentage = STREAMING_IN_PROGRESS_MIN_LOADING_PERCENTAGE } =
+    useStreamingValue(streamingSourceContents);
   const { progress: parsedTokensPercentage = 0 } = useStreamingValue(streamingParser);
 
   const loadedProgressBarWidth = Math.round(rawTextPercentage * 100);

--- a/packages/replay-next/src/suspense/SourceHitCountsCache.ts
+++ b/packages/replay-next/src/suspense/SourceHitCountsCache.ts
@@ -120,7 +120,7 @@ export const sourceHitCountsCache = createFocusIntervalCache<
 export function getCachedMinMaxSourceHitCounts(
   sourceId: SourceId,
   focusRange: TimeStampedPointRange | PointRange | null
-): MinMaxHitCountTuple | [null, null] {
+): MinMaxHitCountTuple | [undefined, undefined] {
   const key = getKey(null as any, sourceId, focusRange ? toPointRange(focusRange) : null);
-  return minMaxHitCountsMap.get(key) || [null, null];
+  return minMaxHitCountsMap.get(key) || [undefined, undefined];
 }

--- a/packages/replay-next/src/suspense/SourcesCache.ts
+++ b/packages/replay-next/src/suspense/SourcesCache.ts
@@ -218,6 +218,7 @@ export const streamingSourceContentsCache = createStreamingCache<
         sourceId,
         ({ codeUnitCount, contentType, lineCount }) => {
           data = { codeUnitCount, contentType, lineCount };
+
           update("", 0, data);
         },
         ({ chunk }) => {


### PR DESCRIPTION
### [Loom overview](https://www.loom.com/share/ca4f8f2b98004a61986bbe0a43878714)

- [x] Show loading lines placeholder _immediately_ (even if we don't know the exact number of lines yet)
- [x] Assuming min/max hit count of 1 until data streams in (so the gutter shows initially and jumps less)
- [x] Clamp the source loading progress so that it starts at 5% (so a slow/hung source doesn't look empty)