### PR TITLE
Upload screen should hide Workspaces with non-matching "test" chriteria

### DIFF
--- a/src/ui/components/UploadScreen/SettingsPreview.tsx
+++ b/src/ui/components/UploadScreen/SettingsPreview.tsx
@@ -46,11 +46,11 @@ export default function SettingsPreview({
       onClick={canEdit ? onClick : undefined}
       style={{ minHeight: "38px" }}
     >
-      <div className="flex flex-row items-center space-x-2.5">
+      <div className="flex flex-row items-center space-x-2.5 truncate">
         <span className="material-icons" style={{ fontSize: "24px" }}>
           {icon}
         </span>
-        <div className="font-medium">{text}</div>
+        <div className="truncate font-medium">{text}</div>
       </div>
       {canEdit ? (
         <div className="flex flex-row items-center space-x-2">

--- a/src/ui/components/UploadScreen/SettingsPreview.tsx
+++ b/src/ui/components/UploadScreen/SettingsPreview.tsx
@@ -1,52 +1,21 @@
 import classNames from "classnames";
-import React from "react";
 
 import { Workspace } from "shared/graphql/types";
 import { getOrganizationSettings } from "ui/utils/org";
 
 import { MY_LIBRARY, personalWorkspace } from "./libraryConstants";
 
-const getIconAndText = (
-  isPublic: boolean,
-  selectedWorkspaceId: string,
-  workspaceName?: string
-): {
-  text: string;
-  icon: string;
-} => {
-  if (isPublic) {
-    return {
-      text: "This replay can be viewed by anyone with the link",
-      icon: "public",
-    };
-  }
-
-  if (selectedWorkspaceId === MY_LIBRARY) {
-    return {
-      text: `Only you can view this`,
-      icon: "person",
-    };
-  }
-
-  return {
-    text: `Shared privately with ${workspaceName}`,
-    icon: "groups",
-  };
-};
-
-type SettingsPreviewProps = {
-  onClick: () => void;
-  isPublic: boolean;
-  workspaces: Workspace[];
-  selectedWorkspaceId: string;
-};
-
 export default function SettingsPreview({
-  onClick,
   isPublic,
-  workspaces,
+  onClick,
   selectedWorkspaceId,
-}: SettingsPreviewProps) {
+  workspaces,
+}: {
+  isPublic: boolean;
+  onClick: () => void;
+  selectedWorkspaceId: string;
+  workspaces: Workspace[];
+}) {
   const { features } = getOrganizationSettings(workspaces);
   const canEdit = workspaces.length > 1 || features.user.library || features.recording.public;
 
@@ -54,7 +23,18 @@ export default function SettingsPreview({
     ? [...workspaces, personalWorkspace].find(w => w.id === selectedWorkspaceId)!.name
     : workspaces[0]!.name;
 
-  const { icon, text } = getIconAndText(isPublic, selectedWorkspaceId, workspaceName);
+  let icon: string;
+  let text: string;
+  if (isPublic) {
+    text = "This replay can be viewed by anyone with the link";
+    icon = "public";
+  } else if (selectedWorkspaceId === MY_LIBRARY) {
+    text = `Only you can view this`;
+    icon = "person";
+  } else {
+    text = `Shared privately with ${workspaceName}`;
+    icon = "groups";
+  }
 
   return (
     <button

--- a/src/ui/components/UploadScreen/Sharing.tsx
+++ b/src/ui/components/UploadScreen/Sharing.tsx
@@ -1,8 +1,8 @@
 import classNames from "classnames";
-import React, { Dispatch, SetStateAction, useEffect, useState } from "react";
+import { Dispatch, SetStateAction, useState } from "react";
 
 import { Workspace } from "shared/graphql/types";
-import hooks from "ui/hooks";
+import { useUpdateDefaultWorkspace } from "ui/hooks/settings";
 import { isPublicDisabled } from "ui/utils/org";
 
 import { Toggle } from "../shared/Forms";
@@ -10,22 +10,35 @@ import { MY_LIBRARY } from "./libraryConstants";
 import SettingsPreview from "./SettingsPreview";
 import TeamSelect from "./TeamSelect";
 
-type SharingProps = {
-  workspaces: Workspace[];
-  selectedWorkspaceId: string;
-  setSelectedWorkspaceId: Dispatch<SetStateAction<string>>;
-  isPublic: boolean;
-  setIsPublic: Dispatch<SetStateAction<boolean>>;
-};
-
-function EditableSettings({
-  workspaces,
-  selectedWorkspaceId,
-  setSelectedWorkspaceId,
+export default function EditableSettings({
   isPublic,
+  selectedWorkspaceId,
   setIsPublic,
-}: Omit<SharingProps, "showSharingSettings">) {
-  const updateDefaultWorkspace = hooks.useUpdateDefaultWorkspace();
+  setSelectedWorkspaceId,
+  workspaces,
+}: {
+  isPublic: boolean;
+  selectedWorkspaceId: string;
+  setIsPublic: Dispatch<SetStateAction<boolean>>;
+  setSelectedWorkspaceId: Dispatch<SetStateAction<string>>;
+  workspaces: Workspace[];
+}) {
+  const updateDefaultWorkspace = useUpdateDefaultWorkspace();
+
+  const [isEditing, setIsEditing] = useState(false);
+  if (!isEditing) {
+    return (
+      <div className="relative">
+        <SettingsPreview
+          isPublic={isPublic}
+          onClick={() => setIsEditing(!isEditing)}
+          selectedWorkspaceId={selectedWorkspaceId}
+          workspaces={workspaces}
+        />
+      </div>
+    );
+  }
+
   const publicDisabled = isPublicDisabled(workspaces, selectedWorkspaceId);
 
   const handleWorkspaceSelect = (id: string) => {
@@ -36,35 +49,23 @@ function EditableSettings({
   };
 
   return (
-    <div className="grid w-full grid-cols-2 gap-5 text-base">
-      <TeamSelect {...{ handleWorkspaceSelect, selectedWorkspaceId, workspaces }} />
-      <div
-        className={classNames(
-          publicDisabled ? "opacity-60" : undefined,
-          "flex w-full cursor-default select-none flex-row items-center justify-between space-x-2 rounded-md border border-inputBorder bg-jellyfishBgcolor px-2.5 py-1.5 text-left shadow-sm focus:border-primaryAccentHover focus:outline-none focus:ring-1 focus:ring-primaryAccent"
-        )}
-        onClick={() => !publicDisabled && setIsPublic(!isPublic)}
-      >
-        <div>Public Access</div>
-        <Toggle
-          enabled={isPublic && !publicDisabled}
-          setEnabled={publicDisabled ? () => {} : setIsPublic}
-        />
-      </div>
-    </div>
-  );
-}
-
-export default function Sharing(props: SharingProps) {
-  const [isEditing, setIsEditing] = useState(false);
-
-  return (
     <div className="relative">
-      {isEditing ? (
-        <EditableSettings {...props} />
-      ) : (
-        <SettingsPreview {...props} onClick={() => setIsEditing(!isEditing)} />
-      )}
+      <div className="grid w-full grid-cols-2 gap-5 text-base">
+        <TeamSelect {...{ handleWorkspaceSelect, selectedWorkspaceId, workspaces }} />
+        <div
+          className={classNames(
+            publicDisabled ? "opacity-60" : undefined,
+            "flex w-full cursor-default select-none flex-row items-center justify-between space-x-2 rounded-md border border-inputBorder bg-jellyfishBgcolor px-2.5 py-1.5 text-left shadow-sm focus:border-primaryAccentHover focus:outline-none focus:ring-1 focus:ring-primaryAccent"
+          )}
+          onClick={() => !publicDisabled && setIsPublic(!isPublic)}
+        >
+          <div>Public Access</div>
+          <Toggle
+            enabled={isPublic && !publicDisabled}
+            setEnabled={publicDisabled ? () => {} : setIsPublic}
+          />
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/ui/components/UploadScreen/UploadScreen.tsx
+++ b/src/ui/components/UploadScreen/UploadScreen.tsx
@@ -112,7 +112,10 @@ export default function UploadScreen({ recording, userSettings, onUpload }: Uplo
   const recordingId = useGetRecordingId();
   // This is pre-loaded in the parent component.
   const { screenData, loading: loading1 } = hooks.useGetRecordingPhoto(recordingId!);
-  const { workspaces, loading: loading2 } = hooks.useGetNonPendingWorkspaces();
+  const { workspaces: allWorkspaces, loading: loading2 } = hooks.useGetNonPendingWorkspaces();
+
+  const workspaces = allWorkspaces.filter(workspace => workspace.isTest === recording.isTest);
+
   const [showPrivacy, setShowPrivacy] = useState(false);
 
   const [status, setStatus] = useState<Status>(null);
@@ -121,9 +124,15 @@ export default function UploadScreen({ recording, userSettings, onUpload }: Uplo
   // Before being initialized, public/private behaves similarly since non-authors
   // can't view the replay.
   const [isPublic, setIsPublic] = useState(false);
-  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string>(
-    userSettings?.defaultWorkspaceId || MY_LIBRARY
-  );
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string>(() => {
+    let workspaceId = userSettings?.defaultWorkspaceId;
+
+    if (workspaceId && workspaces.find(workspace => workspace.id === workspaceId)) {
+      return workspaceId;
+    }
+
+    return workspaces[0]?.id ?? MY_LIBRARY;
+  });
 
   const initializeRecording = hooks.useInitializeRecording();
   const updateIsPrivate = hooks.useUpdateIsPrivate();


### PR DESCRIPTION
This prevents people from uploading invalid combos of test recording in a non-test workspace (or vice versa).

For example, using a new _non test_ recording dce15ba7-be76-482c-ab09-59fbce7e06a8 as a control, here is the before and after upload prompt showing that both the _default_ workspace and the dropdown list have been filtered correctly:

| before | after |
| :---: | :---: |
| <img width="653" alt="Screen Shot 2023-08-04 at 8 44 51 AM" src="https://github.com/replayio/devtools/assets/29597/1857680b-e383-4872-8cc4-66e7c4ebbd3f"> | <img width="660" alt="Screen Shot 2023-08-04 at 8 45 09 AM" src="https://github.com/replayio/devtools/assets/29597/c2d90e4c-e679-4485-93e7-5111609088fe"> |
| <img width="652" alt="Screen Shot 2023-08-04 at 8 44 58 AM" src="https://github.com/replayio/devtools/assets/29597/a00f4690-ca10-48f0-8663-603e0e76640d"> | <img width="657" alt="Screen Shot 2023-08-04 at 8 45 14 AM" src="https://github.com/replayio/devtools/assets/29597/b76feaea-d24e-4b57-8f2f-c161c77fb6ff"> |

I also fixed a text truncation issue on the share dialog while I was in that code (compare to above **before** case):

<img width="650" alt="Screen Shot 2023-08-04 at 8 53 33 AM" src="https://github.com/replayio/devtools/assets/29597/cad452ec-74f6-43d6-b3f3-2e209dff74f4">
