### PR TITLE
Ensure the focus window is valid

### DIFF
--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -76,6 +76,7 @@ import type { UIStore, UIThunkAction } from "./index";
 
 const DEFAULT_FOCUS_WINDOW_PERCENTAGE = 0.3;
 export const MAX_FOCUS_REGION_DURATION = 60_000;
+export const MIN_FOCUS_REGION_DURATION = 10;
 
 export async function setupTimeline(store: UIStore) {
   const dispatch = store.dispatch;

--- a/src/ui/components/Timeline/Focuser.tsx
+++ b/src/ui/components/Timeline/Focuser.tsx
@@ -1,7 +1,8 @@
 import classNames from "classnames";
+import clamp from "lodash/clamp";
 import React, { useEffect, useRef, useState } from "react";
 
-import { MAX_FOCUS_REGION_DURATION } from "ui/actions/timeline";
+import { MAX_FOCUS_REGION_DURATION, MIN_FOCUS_REGION_DURATION } from "ui/actions/timeline";
 import { selectors } from "ui/reducers";
 import { AppDispatch } from "ui/setup";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
@@ -125,19 +126,23 @@ function Focuser({ editMode, setEditMode, updateFocusWindowThrottled }: Props) {
             break;
           }
           case "resize-end": {
-            // If we're resizing the window, make sure we honor the max focus window size
-            if (mouseTime - beginTime > MAX_FOCUS_REGION_DURATION) {
-              beginTime = mouseTime - MAX_FOCUS_REGION_DURATION;
-            }
+            // If we're resizing the window, make sure we honor the min and max focus window size
+            beginTime = clamp(
+              beginTime,
+              mouseTime - MAX_FOCUS_REGION_DURATION,
+              mouseTime - MIN_FOCUS_REGION_DURATION
+            );
 
             updateDisplayedFocusWindow(beginTime, mouseTime);
             break;
           }
           case "resize-start": {
-            // If we're resizing the window, make sure we honor the max focus window size
-            if (endTime - mouseTime > MAX_FOCUS_REGION_DURATION) {
-              endTime = mouseTime + MAX_FOCUS_REGION_DURATION;
-            }
+            // If we're resizing the window, make sure we honor the min and max focus window size
+            endTime = clamp(
+              endTime,
+              mouseTime + MIN_FOCUS_REGION_DURATION,
+              mouseTime + MAX_FOCUS_REGION_DURATION
+            );
 
             updateDisplayedFocusWindow(mouseTime, endTime);
             break;


### PR DESCRIPTION
When the end of the focus window was dragged beyond the start (or the start beyond the end), we set an invalid focus window (i.e. start > end).