### PR TITLE
Adjust Passport visuals

### DIFF
--- a/src/ui/components/Passport/Passport.module.css
+++ b/src/ui/components/Passport/Passport.module.css
@@ -11,9 +11,21 @@
   overflow-x: hidden;
 }
 
+.ToolbarHeader {
+  font-size: 14px;
+  line-height: 1.25rem;
+  font-weight: 600;
+  color: #4584e1;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid #4583e184;
+}
+
 .checklist {
   padding: 6px 0 12px;
-  font-size: 16px;
+  font-size: 14px;
   height: 100%;
   flex: 1;
   overflow-y: auto;
@@ -24,9 +36,7 @@
 .headerItem {
   display: flex;
   align-items: center;
-  padding: 0.2rem;
   padding-left: 0.4rem;
-  border-radius: 3rem;
   margin-bottom: 1px;
   z-index: var(--z-index-1);
   white-space: nowrap;
@@ -48,7 +58,7 @@
 
 .headerItem {
   font-weight: 600;
-  font-size: 16px;
+  font-size: 14px;
   display: flex;
   align-items: center;
   position: relative;
@@ -56,7 +66,7 @@
 
 .checklistItem.selectedItem,
 .checklistItem.selectedItem:hover {
-  background-color: rgba(63, 150, 238, 0.4);
+  background-color: rgba(63, 150, 238, 0.3);
   z-index: var(--z-index-1);
 }
 
@@ -70,7 +80,7 @@
   border-bottom-right-radius: 6px;
   z-index: var(--z-index-1);
   width: 100%;
-  margin-bottom: 115px;
+  margin-bottom: 105px;
 }
 
 .largeCompletedImage {
@@ -93,8 +103,8 @@
   vertical-align: middle;
 }
 
-.ml2 {
-  margin-left: 0.5rem;
+.title {
+  margin-left: 0.25rem;
 }
 
 .checklist div:hover {

--- a/src/ui/components/Passport/Passport.tsx
+++ b/src/ui/components/Passport/Passport.tsx
@@ -40,7 +40,7 @@ const Passport = () => {
   const showShareNag = shouldShowShareNag(nags);
   const showUseFocusMode = shouldShowUseFocusMode(nags);
 
-  type StepNames = typeof stepNames[number];
+  type StepNames = (typeof stepNames)[number];
   const videoExampleRef = useRef<HTMLImageElement>(null);
   const [videoHeight, setVideoHeight] = useState<number | null>(null);
 
@@ -255,7 +255,7 @@ const Passport = () => {
       <div className={styles.section}>
         <div className={classnames("flex", styles.headerItem)}>
           <Icon className={styles.stepIcon} type={stepNames[sectionIndex]} />
-          <span className={`${styles.ml2}`}>{section.title}</span>
+          <span className={`${styles.title}`}>{section.title}</span>
         </div>
         <div className={styles.checklist}>
           {section.items.map((item: ItemType, itemIndex: number) => (
@@ -268,7 +268,7 @@ const Passport = () => {
               data-test-completed={item.completed}
             >
               <Icon className={styles.stepIcon} type={renderCheckmarkIcon(item.completed)} />
-              <span className={styles.ml2}>{item.label}</span>
+              <span className={styles.title}>{item.label}</span>
             </div>
           ))}
         </div>
@@ -296,9 +296,8 @@ const Passport = () => {
           }}
         />
       )}
-      <div className="my-2 p-2">
-        <img src={`/images/passport/passportHeader.svg`} className={`w-full px-1`} />
-      </div>
+      <div className={styles.ToolbarHeader}>Passport</div>
+
       <div className="flex-grow overflow-auto">
         <div className="p-2">
           <div className={styles.sectionsContainer}>


### PR DESCRIPTION
Done:

* Tightened each line
* Standardized header
* Fixed margin issue on the bottom of the animated gif

This adjustment allows me to add these features:

* Welcome to passport banner
* Dismiss button

Once we have those features live, we'll have addressed the NUX Testsuites->Passport without Larry flow

Old on left, new on right:
![image](https://github.com/replayio/devtools/assets/9154902/ca59f765-db43-4e32-a87d-605b250e6ef7)

Part of https://linear.app/replay/issue/DES-733/[explore]-tour-passport-for-testsuites