### PR TITLE
Add NUX/Passport messaging for testsuites users

### DIFF
--- a/packages/shared/user-data/GraphQL/config.ts
+++ b/packages/shared/user-data/GraphQL/config.ts
@@ -280,6 +280,10 @@ export const config = {
     defaultValue: Boolean(false),
     legacyKey: "devtools.debugger.sources-collapsed",
   },
+  layout_testsuitesPassportFirstRun: {
+    defaultValue: Boolean(true),
+    legacyKey: null,
+  },
 
   protocol_chromiumRepaints: {
     defaultValue: Boolean(true),

--- a/src/ui/components/Passport/Passport.module.css
+++ b/src/ui/components/Passport/Passport.module.css
@@ -142,3 +142,28 @@
 .blurbContainer a:hover {
   color: #2257a7;
 }
+
+/* these are made to match the styles of the SidePanel.module.css */
+.TestsuitesPassportWelcome {
+  padding: 0.5em;
+  color: #fff;
+  background: linear-gradient(116.71deg, #ff2f86 21.74%, #ec275d 83.58%),
+    linear-gradient(133.71deg, #01acfd 3.31%, #f155ff 106.39%, #f477f8 157.93%, #f33685 212.38%),
+    #007aff;
+  border-radius: 4px;
+}
+
+.TestsuitesPassportWelcome h2 {
+  font-size: var(--font-size-large);
+  margin-bottom: 0.25em;
+  font-weight: bold;
+}
+
+.TestsuitesPassportWelcome p {
+  font-size: var(--font-size-regular);
+}
+
+.TestsuitesPassportWelcome {
+  padding: 1rem;
+  border-radius: 4px 4px 0 0;
+}

--- a/src/ui/components/Passport/Passport.tsx
+++ b/src/ui/components/Passport/Passport.tsx
@@ -29,6 +29,8 @@ type PrimaryPanelName = "events" | "cypress" | string;
 const stepNames = ["step-one", "step-two", "step-three", "step-four"] as const;
 
 const Passport = (props: PropsFromRedux) => {
+  const [showWelcome, setShowWelcome] = useState(localStorage.getItem("passportNUX") !== "true");
+
   const recordingId = useGetRecordingId();
   const { recording } = useGetRecording(recordingId);
   const [selectedIndices, setSelectedIndices] = useState({ sectionIndex: 0, itemIndex: 0 });
@@ -51,6 +53,12 @@ const Passport = (props: PropsFromRedux) => {
   type StepNames = (typeof stepNames)[number];
   const videoExampleRef = useRef<HTMLImageElement>(null);
   const [videoHeight, setVideoHeight] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (showWelcome) {
+      localStorage.setItem("passportNUX", "true");
+    }
+  }, [showWelcome]);
 
   useLayoutEffect(() => {
     const videoExample = videoExampleRef.current;
@@ -308,12 +316,23 @@ const Passport = (props: PropsFromRedux) => {
           }}
         />
       )}
-      <div className={styles.ToolbarHeader}>
-        Passport
-        <button className={styles.close} onClick={hideFeatureShowPassport}>
-          <Icon type="close" />
-        </button>
-      </div>
+
+      {showWelcome ? (
+        <div className={styles.TestsuitesPassportWelcome}>
+          <h2>Passport</h2>
+          <p>
+            This sidebar shows some of our most helpful features alongside a little video. Try
+            clicking around to learn more!
+          </p>
+        </div>
+      ) : (
+        <div className={styles.ToolbarHeader}>
+          Passport
+          <button className={styles.close} onClick={hideFeatureShowPassport}>
+            <Icon type="close" />
+          </button>
+        </div>
+      )}
 
       <div className="flex-grow overflow-auto">
         <div className="p-2">

--- a/src/ui/components/Passport/Passport.tsx
+++ b/src/ui/components/Passport/Passport.tsx
@@ -3,6 +3,8 @@ import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { ConnectedProps, connect } from "react-redux";
 
 import Icon from "replay-next/components/Icon";
+import { useGraphQLUserData } from "shared/user-data/GraphQL/useGraphQLUserData";
+import { userData } from "shared/user-data/GraphQL/UserData";
 import * as actions from "ui/actions/app";
 import { isTestSuiteReplay } from "ui/components/TestSuite/utils/isTestSuiteReplay";
 import hooks from "ui/hooks";
@@ -30,8 +32,8 @@ type PrimaryPanelName = "events" | "cypress" | string;
 const stepNames = ["step-one", "step-two", "step-three", "step-four"] as const;
 
 const Passport = (props: PropsFromRedux) => {
-  const [showTestsuitesPassportWelcome, setshowTestsuitesPassportWelcome] = useState(
-    localStorage.getItem("TestsuitesPassportWelcome") !== "true"
+  const [showTestsuitesPassportFirstRun, setShowTestsuitesPassportFirstRun] = useState(
+    userData.get("layout_testsuitesPassportFirstRun") !== false
   );
 
   const recordingId = useGetRecordingId();
@@ -58,10 +60,10 @@ const Passport = (props: PropsFromRedux) => {
   const [videoHeight, setVideoHeight] = useState<number | null>(null);
 
   useEffect(() => {
-    if (showTestsuitesPassportWelcome) {
-      localStorage.setItem("TestsuitesPassportWelcome", "true");
+    if (showTestsuitesPassportFirstRun) {
+      userData.set("layout_testsuitesPassportFirstRun", false);
     }
-  }, [showTestsuitesPassportWelcome]);
+  }, [showTestsuitesPassportFirstRun]);
 
   useLayoutEffect(() => {
     const videoExample = videoExampleRef.current;
@@ -320,7 +322,7 @@ const Passport = (props: PropsFromRedux) => {
         />
       )}
 
-      {showTestsuitesPassportWelcome && recording && isTestSuiteReplay(recording) ? (
+      {showTestsuitesPassportFirstRun && recording && isTestSuiteReplay(recording) ? (
         <div className={styles.TestsuitesPassportWelcome}>
           <h2>Passport</h2>
           <p>

--- a/src/ui/components/Passport/Passport.tsx
+++ b/src/ui/components/Passport/Passport.tsx
@@ -30,7 +30,9 @@ type PrimaryPanelName = "events" | "cypress" | string;
 const stepNames = ["step-one", "step-two", "step-three", "step-four"] as const;
 
 const Passport = (props: PropsFromRedux) => {
-  const [showWelcome, setShowWelcome] = useState(localStorage.getItem("passportNUX") !== "true");
+  const [showTestsuitesPassportWelcome, setshowTestsuitesPassportWelcome] = useState(
+    localStorage.getItem("TestsuitesPassportWelcome") !== "true"
+  );
 
   const recordingId = useGetRecordingId();
   const { recording } = useGetRecording(recordingId);
@@ -56,10 +58,10 @@ const Passport = (props: PropsFromRedux) => {
   const [videoHeight, setVideoHeight] = useState<number | null>(null);
 
   useEffect(() => {
-    if (showWelcome) {
-      localStorage.setItem("passportNUX", "true");
+    if (showTestsuitesPassportWelcome) {
+      localStorage.setItem("TestsuitesPassportWelcome", "true");
     }
-  }, [showWelcome]);
+  }, [showTestsuitesPassportWelcome]);
 
   useLayoutEffect(() => {
     const videoExample = videoExampleRef.current;
@@ -318,7 +320,7 @@ const Passport = (props: PropsFromRedux) => {
         />
       )}
 
-      {showWelcome && recording && isTestSuiteReplay(recording) ? (
+      {showTestsuitesPassportWelcome && recording && isTestSuiteReplay(recording) ? (
         <div className={styles.TestsuitesPassportWelcome}>
           <h2>Passport</h2>
           <p>

--- a/src/ui/components/Passport/Passport.tsx
+++ b/src/ui/components/Passport/Passport.tsx
@@ -4,6 +4,7 @@ import { ConnectedProps, connect } from "react-redux";
 
 import Icon from "replay-next/components/Icon";
 import * as actions from "ui/actions/app";
+import { isTestSuiteReplay } from "ui/components/TestSuite/utils/isTestSuiteReplay";
 import hooks from "ui/hooks";
 import { useGetRecording, useGetRecordingId } from "ui/hooks/recordings";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
@@ -317,7 +318,7 @@ const Passport = (props: PropsFromRedux) => {
         />
       )}
 
-      {showWelcome ? (
+      {showWelcome && recording && isTestSuiteReplay(recording) ? (
         <div className={styles.TestsuitesPassportWelcome}>
           <h2>Passport</h2>
           <p>


### PR DESCRIPTION
**Background**

We've long had a NUX flow for traditional replays that starts with "Larry" waving at you and walking you through some steps. Testsuites is a bit different, because we don't want to take over the Cypress/Playwright pane on the side.

**Summary**

![image](https://github.com/replayio/devtools/assets/9154902/8e6eb066-436d-4341-abea-d5f43954b47c)

This explains what the passport is with a little banner that dismisses as soon as you click away.

Loom walkthrough of me testing a few scenarios:
https://www.loom.com/share/dc2730266e064ea3a203cd4c14eaa5f7