### PR TITLE
Fixing share dialog

### DIFF
--- a/src/ui/components/shared/SharingModal/Collaborators.tsx
+++ b/src/ui/components/shared/SharingModal/Collaborators.tsx
@@ -13,7 +13,7 @@ type CollaboratorsProps = {
 export default function Collaborators({ recordingId }: CollaboratorsProps) {
   const { collaborators, owner, loading } = hooks.useGetOwnersAndCollaborators(recordingId!);
 
-  if (loading || !collaborators || !owner) {
+  if (loading || !collaborators) {
     return null;
   }
 

--- a/src/ui/components/shared/SharingModal/Collaborators.tsx
+++ b/src/ui/components/shared/SharingModal/Collaborators.tsx
@@ -24,7 +24,7 @@ export default function Collaborators({ recordingId }: CollaboratorsProps) {
         <div className="border border-transparent">
           <EmailForm recordingId={recordingId} />
         </div>
-        <CollaboratorsList {...{ owner, collaborators }} />
+        {owner ? <CollaboratorsList owner={owner} collaborators={collaborators} /> : null}
       </section>
     </>
   );


### PR DESCRIPTION
Summary:
We weren't allowing anyone to add collaborators on testsuites replays. (Not even the owner) I removed a check for "is owner" and everything works better now.

Loom explaining how I diagnosed and fixed the issue:
https://www.loom.com/share/bcdfbd0c4bec4c20877deca569ed7352

Here's a second Loom confirming that people without permissions can't make changes:
https://www.loom.com/share/c62a14715a1a4eaa8aed93f675d21017

Here's a third Loom show that logged out users don't get a share button at all:
https://www.loom.com/share/62c44b8b16e84e1dae19a39526bd5e29

--

It's possible my fix is missing some scenarios I didn't test for. I don't think I just opened this functionality to randos on the internet, and the second Loom was me testing that. Feedback welcome!