### PR TITLE
Add loading emoji to our loading screen title

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -110,7 +110,7 @@ function Routing({ Component, pageProps }: AppProps) {
       <Head>
         <meta httpEquiv="Content-Type" content="text/html; charset=utf-8" />
         <link rel="icon" type="image/svg+xml" href="/images/favicon.svg" />
-        <title>Replay</title>
+        <title>⏱️ Loading…</title>
       </Head>
       <ErrorBoundary>
         <_App>


### PR DESCRIPTION
![image](https://github.com/replayio/devtools/assets/9154902/7f3ef60b-f0ca-46a9-930e-4bc13f9ef865)

This is one of several tickets around helping our tabs be more expressive. Other PRs coming are:

* An emoji for showing the timed out "ready when you are!" state
* Emojis for showing tests that have failed or succeeded ([Linear](https://linear.app/replay/issue/DES-847/replay-test-titles-should-include-a-pass-fail-emoji))

It may also go hand-in-hand with https://linear.app/replay/issue/DES-812/[explore]-add-a-browser-notification-when-loading-is-complete