### PR TITLE
Reverting loading title

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -110,7 +110,7 @@ function Routing({ Component, pageProps }: AppProps) {
       <Head>
         <meta httpEquiv="Content-Type" content="text/html; charset=utf-8" />
         <link rel="icon" type="image/svg+xml" href="/images/favicon.svg" />
-        <title>⏱️ Loading…</title>
+        <title>Replay</title>
       </Head>
       <ErrorBoundary>
         <_App>


### PR DESCRIPTION
We added ⏱️ to the loading title, but it's also showing up in other screens such as the 'ready when you are" screen. 