### PR TITLE
Use ❌ and ✅ in titles to reflect test result

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -110,7 +110,7 @@ function Routing({ Component, pageProps }: AppProps) {
       <Head>
         <meta httpEquiv="Content-Type" content="text/html; charset=utf-8" />
         <link rel="icon" type="image/svg+xml" href="/images/favicon.svg" />
-        <title>Replay</title>
+        <title>⏱️ Loading…</title>
       </Head>
       <ErrorBoundary>
         <_App>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -110,7 +110,7 @@ function Routing({ Component, pageProps }: AppProps) {
       <Head>
         <meta httpEquiv="Content-Type" content="text/html; charset=utf-8" />
         <link rel="icon" type="image/svg+xml" href="/images/favicon.svg" />
-        <title>⏱️ Loading…</title>
+        <title>Replay</title>
       </Head>
       <ErrorBoundary>
         <_App>

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -285,11 +285,13 @@ function _DevTools({
                       <ExpandablesContextRoot>
                         <LayoutContextAdapter>
                           <KeyModifiers>
-                            <Head>
-                              <title>
-                                {emoji} {title}
-                              </title>
-                            </Head>
+                            {title && (
+                              <Head>
+                                <title>
+                                  {emoji} {title}
+                                </title>
+                              </Head>
+                            )}
                             <Header />
                             <Body />
                             {showCommandPalette ? <CommandPaletteModal /> : null}

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -15,6 +15,7 @@ import { PointsContextRoot } from "replay-next/src/contexts/points/PointsContext
 import { SelectedFrameContextRoot } from "replay-next/src/contexts/SelectedFrameContext";
 import usePreferredFontSize from "replay-next/src/hooks/usePreferredFontSize";
 import { setDefaultTags } from "replay-next/src/utils/telemetry";
+import { TestRecording } from "shared/test-suites/RecordingTestMetadata";
 import { getTestEnvironment } from "shared/test-suites/RecordingTestMetadata";
 import { useGraphQLUserData } from "shared/user-data/GraphQL/useGraphQLUserData";
 import { userData } from "shared/user-data/GraphQL/UserData";
@@ -260,6 +261,16 @@ function _DevTools({
   }
 
   const title = recording?.title;
+  const testResult = recording?.metadata?.test?.result;
+  let emoji = "";
+  switch (testResult) {
+    case "passed":
+      emoji = "✅";
+      break;
+    case "failed":
+      emoji = "❌";
+      break;
+  }
 
   return (
     <SessionContextAdapter apiKey={apiKey ?? null}>
@@ -274,11 +285,11 @@ function _DevTools({
                       <ExpandablesContextRoot>
                         <LayoutContextAdapter>
                           <KeyModifiers>
-                            {title && (
-                              <Head>
-                                <title>{title}</title>
-                              </Head>
-                            )}
+                            <Head>
+                              <title>
+                                {emoji} {title}
+                              </title>
+                            </Head>
                             <Header />
                             <Body />
                             {showCommandPalette ? <CommandPaletteModal /> : null}


### PR DESCRIPTION
<img width="540" alt="image" src="https://github.com/replayio/devtools/assets/9154902/1494075d-6cd4-4e85-8636-7a3909a9ed67">

Addresses https://linear.app/replay/issue/DES-847/replay-test-titles-should-include-a-pass-fail-emoji
