### PR TITLE
Playwright annotations

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -26,6 +26,14 @@ const baseNextConfig = {
   },
   productionBrowserSourceMaps: true,
 
+  typescript: {
+    // !! WARN !!
+    // Dangerously allow production builds to successfully complete even if
+    // your project has type errors.
+    // !! WARN !!
+    ignoreBuildErrors: true,
+  },
+
   async redirects() {
     return [
       {

--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -1,36 +1,30 @@
 import { PlaywrightTestConfig, devices } from "@playwright/test";
 import { devices as replayDevices } from "@replayio/playwright";
 
-const { CHROMIUM_ONLY, CI, SLOW_MO } = process.env;
+const { CI, SLOW_MO, TRACE, HEADLESS } = process.env;
 
-let projects;
-if (!CHROMIUM_ONLY) {
-  if (CI) {
-    projects = [
-      {
-        name: "replay-chromium",
-        use: { ...(replayDevices["Replay Chromium"] as any) },
-      },
-      {
-        name: "chromium",
-        use: { ...devices["Desktop Chromium"] },
-      },
-    ];
-  } else {
-    projects = [
-      {
-        name: "chromium",
-        use: { ...devices["Desktop Chromium"] },
-      },
-    ];
-  }
+function isTruthy(value) {
+  return value === "true" || value == "1";
 }
+
+const projects = [
+  {
+    name: "replay-chromium",
+    use: { ...(replayDevices["Replay Chromium"] as any) },
+  },
+  {
+    name: "chromium",
+    use: { ...devices["Desktop Chromium"] },
+  },
+];
 
 const config: PlaywrightTestConfig = {
   use: {
     launchOptions: {
+      headless: isTruthy(HEADLESS),
       slowMo: SLOW_MO ? parseInt(SLOW_MO, 10) : 0,
     },
+    trace: isTruthy(TRACE) ? "on" : "off",
     viewport: {
       width: 1280,
       height: 1024,

--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -3,7 +3,7 @@ import { devices as replayDevices } from "@replayio/playwright";
 
 const { CI, SLOW_MO, TRACE, HEADLESS } = process.env;
 
-function isTruthy(value) {
+function isTruthy(value: any) {
   return value === "true" || value == "1";
 }
 

--- a/packages/e2e-tests/testFixtureCloneRecording.ts
+++ b/packages/e2e-tests/testFixtureCloneRecording.ts
@@ -73,7 +73,10 @@ const testWithCloneRecording = base.extend<TestIsolatedRecordingFixture>({
                   apiName,
                 });
                 // @ts-ignore
-                window.top.__RECORD_REPLAY_ANNOTATION__?.("replay-playwright");
+                window.__RECORD_REPLAY_ANNOTATION_HOOK__?.("replay-playwright", {
+                  event: "step:start",
+                  id,
+                });
               },
               [id, apiName]
             )
@@ -98,7 +101,10 @@ const testWithCloneRecording = base.extend<TestIsolatedRecordingFixture>({
             .evaluate(() => {
               console.log("Page:: onApiCallEnd");
               // @ts-ignore
-              window.top.__RECORD_REPLAY_ANNOTATION__?.("replay-playwright");
+              window.__RECORD_REPLAY_ANNOTATION_HOOK__?.("replay-playwright", {
+                event: "step:end",
+                id,
+              });
             })
             .then()
             .catch(e => console.error);

--- a/packages/e2e-tests/testFixtureCloneRecording.ts
+++ b/packages/e2e-tests/testFixtureCloneRecording.ts
@@ -9,6 +9,7 @@ type TestIsolatedRecordingFixture = {
     page: Page;
     recordingId: string;
   };
+  _replay: any;
 };
 
 const testWithCloneRecording = base.extend<TestIsolatedRecordingFixture>({
@@ -28,7 +29,93 @@ const testWithCloneRecording = base.extend<TestIsolatedRecordingFixture>({
 
     await deleteTestRecording(newRecordingId);
   },
+
+  _replay: [
+    async ({ playwright, page }, use, testInfo) => {
+      page.on("console", async msg => {
+        const values = [];
+        for (const arg of msg.args()) {
+          //   values.push(await arg?.jsonValue?.());
+        }
+        // console.log(...values);
+      });
+
+      const csiListener = {
+        onApiCallBegin: (apiName, params, stackTrace, wallTime, userData) => {
+          if (
+            ["Object.onApiCallBegin", "Object.onApiCallEnd"].includes(stackTrace.frames[0].function)
+          ) {
+            return;
+          }
+
+          if ("Page.<anonymous>" === stackTrace.frames[0].function) {
+            return;
+          }
+
+          const args = JSON.stringify({ apiName, params });
+          const id = userData?.userObject?.stepId;
+          console.log(
+            "onApiCallBegin",
+            id,
+            apiName,
+            stackTrace.frames
+              .map(f => f.function)
+              .filter(Boolean)
+              .join(" -> ")
+          );
+
+          page
+            .evaluate(
+              ([id, apiName]) => {
+                console.log(`Page:: onApiCallBegin`, {
+                  event: "step:start",
+                  id,
+                  apiName,
+                });
+                // @ts-ignore
+                window.top.__RECORD_REPLAY_ANNOTATION__?.("replay-playwright");
+              },
+              [id, apiName]
+            )
+            .then()
+            .catch(e => console.error);
+        },
+
+        onApiCallEnd: (userData, error) => {
+          const functionName = userData.userObject?.location?.function;
+          if (
+            ["Object.onApiCallBegin", "Page.<anonymous>", "Object.onApiCallEnd"].includes(
+              functionName
+            )
+          ) {
+            return;
+          }
+
+          const id = userData?.userObject?.stepId;
+
+          console.log("onApiCallEnd", id);
+          page
+            .evaluate(() => {
+              console.log("Page:: onApiCallEnd");
+              // @ts-ignore
+              window.top.__RECORD_REPLAY_ANNOTATION__?.("replay-playwright");
+            })
+            .then()
+            .catch(e => console.error);
+        },
+      };
+
+      const clientInstrumentation = playwright._instrumentation;
+      clientInstrumentation.addListener(csiListener);
+
+      await use();
+
+      clientInstrumentation.removeListener(csiListener);
+    },
+    { auto: "all-hooks-included", _title: "trace recording" },
+  ],
 });
+
 export default testWithCloneRecording;
 export { testWithCloneRecording as test };
 export { expect } from "@playwright/test";

--- a/packages/protocol/socket.ts
+++ b/packages/protocol/socket.ts
@@ -238,7 +238,7 @@ export async function sendMessage<M extends CommandMethods>(
     gMessageWaiters.set(id, { method, resolve })
   );
 
-  console.log("sendMessage", id, msg, params, pauseId, response);
+  // console.log("sendMessage", id, msg, params, pauseId, response);
   if (response.error) {
     gSessionCallbacks?.onResponseError(response);
 
@@ -249,7 +249,7 @@ export async function sendMessage<M extends CommandMethods>(
       return {};
     }
 
-    console.warn("Message failed", method, { code, id, message }, data);
+    // console.warn("Message failed", method, { code, id, message }, data);
 
     let finalMessage = message;
     if (process.env.NODE_ENV === "development") {

--- a/packages/protocol/socket.ts
+++ b/packages/protocol/socket.ts
@@ -238,6 +238,7 @@ export async function sendMessage<M extends CommandMethods>(
     gMessageWaiters.set(id, { method, resolve })
   );
 
+  console.log("sendMessage", id, msg, params, pauseId, response);
   if (response.error) {
     gSessionCallbacks?.onResponseError(response);
 

--- a/packages/protocol/socket.ts
+++ b/packages/protocol/socket.ts
@@ -11,6 +11,7 @@ import {
 } from "@replayio/protocol";
 import { captureException } from "@sentry/react";
 
+import { isDevelopment } from "shared/utils/environment";
 import { ProtocolError, commandError } from "shared/utils/error";
 
 import { makeInfallible } from "./utils";

--- a/packages/shared/client/ReplayClient.ts
+++ b/packages/shared/client/ReplayClient.ts
@@ -694,13 +694,17 @@ export class ReplayClient implements ReplayClientInterface {
     locations: SameLineSourceLocations[],
     focusRange: PointRange | null
   ) {
-    const sessionId = this.getSessionIdThrows();
-    await this.waitForRangeToBeInFocusRange(focusRange);
-    const { hits } = await client.Debugger.getHitCounts(
-      { sourceId, locations, maxHits: TOO_MANY_POINTS_TO_FIND, range: focusRange || undefined },
-      sessionId
-    );
-    return hits;
+    try {
+      const sessionId = this.getSessionIdThrows();
+      await this.waitForRangeToBeInFocusRange(focusRange);
+      const { hits } = await client.Debugger.getHitCounts(
+        { sourceId, locations, maxHits: TOO_MANY_POINTS_TO_FIND, range: focusRange || undefined },
+        sessionId
+      );
+      return hits;
+    } catch (e) {
+      return [];
+    }
   }
 
   getSourceOutline(sourceId: SourceId) {

--- a/packages/shared/test-suites/RecordingTestMetadata.ts
+++ b/packages/shared/test-suites/RecordingTestMetadata.ts
@@ -824,7 +824,8 @@ export async function processPlaywrightTestRecording(
           rrId,
         } = partialTestEvent.data as any;
 
-        const [_, name, args] = partialTestEvent.data.command.name.match(/(.*)\((.*)\)/) || [];
+        const commandName = partialTestEvent.data.command.name;
+        const [_, name, args] = commandName.match(/^(.+?)\((.+)\)$/) || [];
 
         const command = {
           name: name || partialTestEvent.data.command.name,
@@ -1156,6 +1157,12 @@ export function isUserActionTestEvent(
   value: TestEvent
 ): value is RecordingTestMetadataV3.UserActionEvent {
   return value.type === "user-action";
+}
+
+export function isFunctionEvent(
+  value: TestEvent
+): value is RecordingTestMetadataV3.UserActionEvent {
+  return value.type === "function";
 }
 
 export function compareTestEventExecutionPoints(

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -231,6 +231,9 @@ export function createSocket(
         }
       }
 
+      console.log("pausePointParams", getPausePointParams());
+      console.log("experimentalSettings", experimentalSettings);
+
       const focusWindowFromParams = getPausePointParams().focusWindow;
 
       const sessionId = await createSession(

--- a/src/ui/components/TestSuite/suspense/AnnotationsCache.ts
+++ b/src/ui/components/TestSuite/suspense/AnnotationsCache.ts
@@ -48,8 +48,6 @@ export const PlaywrightAnnotationsCache = createSingleEntryCacheWithTelemetry<
       );
     });
 
-    console.log("playwright", sortedAnnotations);
-
     return sortedAnnotations;
   },
 });

--- a/src/ui/components/TestSuite/suspense/AnnotationsCache.ts
+++ b/src/ui/components/TestSuite/suspense/AnnotationsCache.ts
@@ -48,6 +48,8 @@ export const PlaywrightAnnotationsCache = createSingleEntryCacheWithTelemetry<
       );
     });
 
+    console.log("playwright", sortedAnnotations);
+
     return sortedAnnotations;
   },
 });

--- a/src/ui/components/TestSuite/suspense/AnnotationsCache.ts
+++ b/src/ui/components/TestSuite/suspense/AnnotationsCache.ts
@@ -28,6 +28,30 @@ export const AnnotationsCache = createSingleEntryCacheWithTelemetry<
   },
 });
 
+export const PlaywrightAnnotationsCache = createSingleEntryCacheWithTelemetry<
+  [client: ReplayClientInterface],
+  Annotation[]
+>({
+  debugLabel: "PlaywrightAnnotationsCache",
+  load: async ([client]) => {
+    const sortedAnnotations: Annotation[] = [];
+
+    await client.findAnnotations("replay-playwright", annotation => {
+      const processedAnnotation = {
+        point: annotation.point,
+        time: annotation.time,
+        message: JSON.parse(annotation.contents).message,
+      };
+
+      insert(sortedAnnotations, processedAnnotation, (a, b) =>
+        compareNumericStrings(a.point, b.point)
+      );
+    });
+
+    return sortedAnnotations;
+  },
+});
+
 function parseContents(contents: string) {
   const parsed = JSON.parse(contents);
 

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/HelperFunctionEvent.module.css
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/HelperFunctionEvent.module.css
@@ -6,9 +6,9 @@
   position: relative;
 }
 
-.Text {
+.FunctionRow {
   flex: 1;
-  /* color: var(--color-dim); */
+  width: 100%;
 }
 
 .Name {
@@ -16,5 +16,6 @@
   overflow: hidden;
   text-overflow: ellipsis;
   word-break: break-all;
-  /* color: var(--color-link); */
+  font-weight: 600;
+  color: var(--color-dim);
 }

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/HelperFunctionEvent.module.css
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/HelperFunctionEvent.module.css
@@ -1,0 +1,20 @@
+.Row {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  position: relative;
+}
+
+.Text {
+  flex: 1;
+  /* color: var(--color-dim); */
+}
+
+.Name {
+  flex: 0 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-break: break-all;
+  /* color: var(--color-link); */
+}

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/HelperFunctionEventRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/HelperFunctionEventRow.tsx
@@ -10,21 +10,22 @@ export default memo(function HelperFunctionEventRow({
   functionEvent,
   testRunnerName,
   testSectionName,
+  nestingLevel,
 }: {
   functionEvent: FunctionEvent;
   testRunnerName: string | null;
   testSectionName: string;
+  nestingLevel: number;
 }) {
   const [collapsed, toggleCollapsed] = useState(true);
   const formattedName = truncateMiddle(functionEvent.function, 150);
   const events = functionEvent.events;
-  console.log(`>>>`, functionEvent, events);
 
   return (
     <div className={styles.Row}>
       <div
         style={{}}
-        className={styles.Text}
+        className={styles.FunctionRow}
         onClick={e => {
           e.stopPropagation();
           e.preventDefault();
@@ -33,15 +34,27 @@ export default memo(function HelperFunctionEventRow({
       >
         <span className={styles.Name}>{formattedName || "Outer function"}</span>
       </div>
-      {!collapsed &&
-        events.map((testEvent, index) => (
-          <TestSectionRow
-            key={index}
-            testEvent={testEvent}
-            testRunnerName={testRunnerName}
-            testSectionName={testSectionName}
-          />
-        ))}
+      <div
+        style={{
+          display: "flex",
+          flex: 1,
+          flexDirection: "column",
+          justifyContent: "space-between",
+          width: "100%",
+          marginTop: collapsed ? 0 : "1rem",
+        }}
+      >
+        {!collapsed &&
+          events.map((testEvent, index) => (
+            <TestSectionRow
+              key={index}
+              testEvent={testEvent}
+              testRunnerName={testRunnerName}
+              testSectionName={testSectionName}
+              nestingLevel={nestingLevel + 1}
+            />
+          ))}
+      </div>
     </div>
   );
 });

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/HelperFunctionEventRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/HelperFunctionEventRow.tsx
@@ -1,0 +1,47 @@
+import { memo, useState } from "react";
+
+import { truncateMiddle } from "replay-next/src/utils/string";
+import { FunctionEvent } from "shared/test-suites/RecordingTestMetadata";
+
+import { TestSectionRow } from "../TestSectionRow";
+import styles from "./HelperFunctionEvent.module.css";
+
+export default memo(function HelperFunctionEventRow({
+  functionEvent,
+  testRunnerName,
+  testSectionName,
+}: {
+  functionEvent: FunctionEvent;
+  testRunnerName: string | null;
+  testSectionName: string;
+}) {
+  const [collapsed, toggleCollapsed] = useState(true);
+  const formattedName = truncateMiddle(functionEvent.function, 150);
+  const events = functionEvent.events;
+  console.log(`>>>`, functionEvent, events);
+
+  return (
+    <div className={styles.Row}>
+      <div
+        style={{}}
+        className={styles.Text}
+        onClick={e => {
+          e.stopPropagation();
+          e.preventDefault();
+          toggleCollapsed(!collapsed);
+        }}
+      >
+        <span className={styles.Name}>{formattedName || "Outer function"}</span>
+      </div>
+      {!collapsed &&
+        events.map((testEvent, index) => (
+          <TestSectionRow
+            key={index}
+            testEvent={testEvent}
+            testRunnerName={testRunnerName}
+            testSectionName={testSectionName}
+          />
+        ))}
+    </div>
+  );
+});

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
@@ -51,7 +51,6 @@ export default memo(function UserActionEventRow({
 }) {
   const { data, timeStampedPointRange } = userActionEvent;
   const { command, error, parentId, result, testSourceCallStack } = data;
-  console.log(testSourceCallStack)
 
   const replayClient = useContext(ReplayClientContext);
 
@@ -250,13 +249,12 @@ function findJumpToCodeDetailsIfAvailable(
 
     if (timeStampedPointRange !== null) {
       canShowJumpToCode =
-        category === "command" && (
-          name.startsWith("locator.click") ||
+        category === "command" &&
+        (name.startsWith("locator.click") ||
           name.startsWith("locator.type") ||
           name.startsWith("keyboard.down") ||
           name.startsWith("keyboard.press") ||
-          name.startsWith("keyboard.type")
-        );
+          name.startsWith("keyboard.type"));
 
       if (canShowJumpToCode) {
         jumpToCodeAnnotation = jumpToCodeAnnotations.find(a =>

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
@@ -242,6 +242,31 @@ function findJumpToCodeDetailsIfAvailable(
         }
       }
     }
+  } else if (groupedTestCases.environment.testRunner.name === "playwright") {
+    const { data, timeStampedPointRange } = userActionEvent;
+    const { category, command } = data;
+    const { name } = command;
+
+    if (timeStampedPointRange !== null) {
+      canShowJumpToCode =
+        category === "command" && (
+          name.startsWith("locator.click") ||
+          name.startsWith("locator.type") ||
+          name.startsWith("keyboard.down") ||
+          name.startsWith("keyboard.press") ||
+          name.startsWith("keyboard.type")
+        );
+
+      if (canShowJumpToCode) {
+        jumpToCodeAnnotation = jumpToCodeAnnotations.find(a =>
+          isExecutionPointsWithinRange(
+            a.point,
+            timeStampedPointRange.begin.point,
+            timeStampedPointRange.end.point
+          )
+        );
+      }
+    }
   }
 
   return [canShowJumpToCode, jumpToCodeAnnotation] as const;

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
@@ -50,7 +50,8 @@ export default memo(function UserActionEventRow({
   userActionEvent: UserActionEvent;
 }) {
   const { data, timeStampedPointRange } = userActionEvent;
-  const { command, error, parentId, result } = data;
+  const { command, error, parentId, result, testSourceCallStack } = data;
+  console.log(testSourceCallStack)
 
   const replayClient = useContext(ReplayClientContext);
 

--- a/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.module.css
+++ b/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.module.css
@@ -31,15 +31,34 @@
 }
 .Row[data-status="success"][data-position="before"],
 .Row[data-type="navigation"][data-position="before"],
-.Row[data-type="network-request"][data-position="before"] {
+.Row[data-type="network-request"][data-position="before"],
+.Row[data-type="function"][data-position="before"] {
   --border-left-color: var(--primary-accent);
 }
+
+.Row[data-position="before"]:not([data-nesting-level="2"]) {
+  --border-left-color: transparent;
+}
+
 .Row[data-status="success"][data-selected],
 .Row[data-type="navigation"][data-selected],
 .Row[data-type="network-request"][data-selected] {
-  --border-left-color: var(--primary-accent);
   --row-background-color: var(--testsuites-active-bgcolor);
   --row-background-color-hover: var(--testsuites-active-bgcolor);
+}
+
+.Row[data-status="success"][data-selected]:not([data-nesting-level="2"]),
+.Row[data-type="navigation"][data-selected]:not([data-nesting-level="2"]),
+.Row[data-type="network-request"][data-selected]:not([data-nesting-level="2"]) {
+  --border-left-color: transparent;
+}
+
+.Row[data-type="function"] {
+  --row-background-color-hover: "blue";
+}
+
+.Row[data-nesting-level="0"][data-status="success"] {
+  --border-left-color: transparent;
 }
 
 .Row[data-position="before"] {

--- a/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
@@ -25,6 +25,7 @@ import { useTestEventContextMenu } from "ui/components/TestSuite/views/TestRecor
 import { TestSuiteContext } from "ui/components/TestSuite/views/TestSuiteContext";
 import { useAppDispatch } from "ui/setup/hooks";
 
+import HelperFunctionEventRow from "./TestRecordingEvents/HelperFunctionEventRow";
 import NavigationEventRow from "./TestRecordingEvents/NavigationEventRow";
 import NetworkRequestEventRow from "./TestRecordingEvents/NetworkRequestEventRow";
 import UserActionEventRow from "./TestRecordingEvents/UserActionEventRow";
@@ -109,6 +110,15 @@ export function TestSectionRow({
     case "network-request":
       child = <NetworkRequestEventRow networkRequestEvent={testEvent} />;
       break;
+    case "function":
+      child = (
+        <HelperFunctionEventRow
+          functionEvent={testEvent}
+          testRunnerName={testRunnerName}
+          testSectionName={testSectionName}
+        />
+      );
+      break;
     case "user-action":
       child = (
         <UserActionEventRow
@@ -125,6 +135,10 @@ export function TestSectionRow({
   }
 
   const onClick = async () => {
+    if (testEvent.type === "function") {
+      return false;
+    }
+
     startTransition(() => {
       setTestEvent(testEvent);
     });

--- a/src/ui/suspense/nodeCaches.ts
+++ b/src/ui/suspense/nodeCaches.ts
@@ -222,14 +222,16 @@ export const boxModelCache: Cache<
   debugLabel: "BoxModel",
   getKey: ([protocolClient, sessionId, pauseId, nodeId]) => `${pauseId}:${nodeId}`,
   load: async ([protocolClient, sessionId, pauseId, nodeId]) => {
-    const { model: nodeBoxModel } = await protocolClient.DOM.getBoxModel(
-      {
-        node: nodeId,
-      },
-      sessionId,
-      pauseId
-    );
-    return nodeBoxModel;
+    try {
+      const { model: nodeBoxModel } = await protocolClient.DOM.getBoxModel(
+        {
+          node: nodeId,
+        },
+        sessionId,
+        pauseId
+      );
+      return nodeBoxModel;
+    } catch (e) {}
   },
 });
 


### PR DESCRIPTION
extends @hbenl's two PRs

1. https://github.com/replayio/devtools/pull/9594/files
2. https://github.com/replayio/playwright-stacks/pull/1/files#diff-841ff7831cd3c0b7ab2f1b287034c13d04afa2a309a09e34e90a2cf5d6cd6444

To show how you can use a Fixture to wrap the instrumentation API similar to what [playwright-test](https://github.com/microsoft/playwright/blob/main/packages/playwright-test/src/index.ts#L273) does and get `onApiBegin` and `onApiCallEnd` events.

We'll never land this PR, but it's a good proof of concept for what we will likely need to do in the playwright plugin side.

What are the next questions
1. What is the role of the reporter if we can get all of the information (stack traces, call params, ...) here and have one ID?
2. How will we setup the fixture? Do we need to tell users to use our test command? ...


Here's a [replay](http://localhost:8080/recording/breakpoints-02-test-unhandled-divergence-while-evaluating-at-a-breakpoint--a17fa476-423f-48a3-afb6-1db7d42af2e8?point=29855706958035288958493902227111936&time=11593) with annotations from the fixture.

Here's a [replay](https://app.replay.io/recording/replay-of-localhost8080--041b414b-3ffe-4c6a-b803-eed1479d85b2?point=28882151300558176690227923302481920&time=12543) of the replay that shows the annotations.