### PR TITLE
Add 4 UI polish improvements

### DIFF
--- a/pages/recording/[[...id]].tsx
+++ b/pages/recording/[[...id]].tsx
@@ -66,11 +66,13 @@ function RecordingHead({ metadata }: MetadataProps) {
     description = "";
   }
 
+  const pageTitle = title ? `⏱️ ${title}` : "⏱️";
+
   const image = `${process.env.NEXT_PUBLIC_IMAGE_URL}${metadata.id}.png`;
 
   return (
     <Head>
-      <title>{title}</title>
+      <title>{pageTitle}</title>
       {/* nosemgrep typescript.react.security.audit.react-http-leak.react-http-leak */}
       <meta property="og:title" content={title} />
       <meta property="og:type" content="website" />

--- a/src/ui/components/Library/Team/View/TestRuns/TestRunsPage.module.css
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunsPage.module.css
@@ -1,0 +1,52 @@
+.dropdownTrigger {
+  display: flex;
+  cursor: pointer;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 0.375rem;
+  border: 1px solid var(--input-border);
+  background-color: var(--theme-text-field-bgcolor);
+  padding: 0.375rem 0.625rem;
+  font-size: 0.875rem;
+  color: var(--theme-text-field-color);
+  outline: none;
+  --ring-width: 3px;
+  --ring-color: var(--primary-accent);
+  white-space: nowrap;
+}
+
+.dropdownTrigger:focus {
+  box-shadow: 0 0 0 var(--ring-width) var(--ring-color);
+}
+
+.filterContainer {
+  position: relative;
+  flex-grow: 1;
+}
+
+.filterInput {
+  width: 100%;
+  padding: 0.3rem 0.625rem;
+  appearance: none;
+  border-radius: 0.25rem;
+  border: none;
+  background-color: rgba(0, 0, 0, 0.1);
+  font-size: 0.75rem; /* Equivalent to text-xs */
+  outline: none;
+  padding-right: 1.55rem;
+}
+
+.filterInput:focus {
+  box-shadow: 0 0 0 2px var(--primary-accent); /* Equivalent to focus:ring-primaryAccent */
+}
+
+.searchIcon {
+  position: absolute;
+  right: 0.5rem;
+  top: 50%;
+  height: 1rem;
+  width: 1rem;
+  transform: translateY(-50%);
+  opacity: 0.5;
+}

--- a/src/ui/components/Library/Team/View/TestRuns/TestRunsPage.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunsPage.tsx
@@ -8,6 +8,7 @@ import { LibrarySpinner } from "ui/components/Library/LibrarySpinner";
 import { TestRunOverviewPage } from "./Overview/TestRunOverviewContextRoot";
 import { TestRunList } from "./TestRunList";
 import { TestRunsContext, TestRunsContextRoot } from "./TestRunsContextRoot";
+import styles from "./TestRunsPage.module.css";
 
 export function TestRunsPage() {
   return (
@@ -48,9 +49,9 @@ function TestRunsContent() {
       <PanelGroup autoSaveId="Library:TestRuns" direction="horizontal">
         <Panel minSize={20} order={1}>
           <div className="flex h-full w-full flex-col overflow-hidden rounded-xl bg-bodyBgcolor">
-            <div className="flex flex-row items-center justify-between gap-4 border-b border-themeBorder bg-bodyBgcolor p-2">
+            <div className="flex flex-row items-center justify-between gap-2 border-b border-themeBorder bg-bodyBgcolor p-2">
               <div
-                className="flex cursor-pointer flex-row items-center gap-2 rounded-md border-inputBorder bg-themeTextFieldBgcolor px-2.5 py-1.5 text-sm text-themeTextFieldColor focus:outline-none focus:ring focus:ring-primaryAccent"
+                className={styles.dropdownTrigger}
                 data-test-id="TestRunsPage-DropdownTrigger"
                 onClick={onClick}
                 onKeyDown={onKeyDown}
@@ -60,20 +61,16 @@ function TestRunsContent() {
                 <Icon className="h-5 w-5" type="chevron-down" />
               </div>
               {contextMenu}
-              <div className="relative max-w-sm grow">
+              <div className={styles.filterContainer}>
                 <input
-                  className="w-full appearance-none rounded border-none bg-black bg-opacity-10 text-xs focus:outline-none focus:ring focus:ring-primaryAccent"
+                  className={styles.filterInput}
                   data-test-id="TestRunsPage-FilterInput"
                   onChange={event => setFilterByText(event.currentTarget.value)}
                   placeholder="Filter test runs"
                   type="text"
                   value={filterByTextForDisplay}
                 />
-
-                <Icon
-                  className="absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 opacity-50"
-                  type="search"
-                />
+                <Icon className={styles.searchIcon} type="search" />
               </div>
             </div>
             <div

--- a/src/ui/components/shared/LaunchBrowserModal.tsx
+++ b/src/ui/components/shared/LaunchBrowserModal.tsx
@@ -20,23 +20,18 @@ function LaunchBrowser({
   }, [path]);
 
   return (
-    <section className="relative m-auto w-full max-w-xl overflow-hidden rounded-lg bg-modalBgcolor text-sm text-bodyColor shadow-lg">
+    <section className="relative m-auto w-full max-w-xl overflow-hidden rounded-lg border border-inputBorder bg-modalBgcolor text-sm text-bodyColor shadow-lg">
       <div className="flex flex-col items-center space-y-9 p-6">
         <div className="place-content-center space-y-3">
           <img className="mx-auto h-12 w-12" src="/images/logo.svg" />
         </div>
         <div className="flex flex-col items-center space-y-4 text-center">
-          <div className="text-lg font-bold">Launching Replay ...</div>
-          <div className="space-y-6">
-            <p>
-              Click <strong>Open Replay</strong> in the dialog shown by your browser
-            </p>
-            {children}
-          </div>
+          <div className="text-lg font-bold">Launching Replay...</div>
+          <div className="space-y-6">{children}</div>
           <div className="w-full" />
-          <div className="flex flex-row text-xs text-gray-500">
+          <div className="flex flex-row text-xs text-gray-400">
             <p>
-              {`Don't have Replay yet? Download it on `}
+              {`Download it for `}
               <a
                 href="https://static.replay.io/downloads/replay.dmg"
                 onClick={() => trackEvent("launch.download_replay", { OS: "mac" })}
@@ -54,7 +49,7 @@ function LaunchBrowser({
               >
                 Linux
               </a>
-              {`, and `}
+              {`, or `}
               <a
                 href="https://static.replay.io/downloads/windows-replay.zip"
                 onClick={() => trackEvent("launch.download_replay", { OS: "windows" })}

--- a/src/ui/components/shared/PrivacyModal.tsx
+++ b/src/ui/components/shared/PrivacyModal.tsx
@@ -10,7 +10,7 @@ function PrivacyModal({ hideModal }: PropsFromRedux) {
   return (
     <Modal options={{ maskTransparency: "translucent" }} onMaskClick={hideModal}>
       <div
-        className="relative flex overflow-hidden rounded-xl border bg-themeBase-100"
+        className="relative flex overflow-hidden rounded-xl border border-inputBorder bg-themeBase-100"
         style={{ width: "440px", height: "480px" }}
       >
         <Privacy />

--- a/src/ui/components/shared/SharingModal/SharingModal.tsx
+++ b/src/ui/components/shared/SharingModal/SharingModal.tsx
@@ -108,7 +108,7 @@ function CollaboratorsSection({
           <div>
             <div className="mb-2 font-bold">Team</div>
 
-            <div className="rounded-md border border border-inputBorder bg-themeTextFieldBgcolor p-2 hover:bg-themeTextFieldBgcolorHover">
+            <div className="rounded-md border border-inputBorder bg-themeTextFieldBgcolor p-2 hover:bg-themeTextFieldBgcolorHover">
               <PrivacyDropdown recording={recording} />
             </div>
 
@@ -167,7 +167,7 @@ function SharingSection({
         showPrivacy={showPrivacy}
         setShowPrivacy={setShowPrivacy}
       />
-      <section className="flex flex-col bg-menuHoverBgcolor px-4 pb-5 pt-3">
+      <section className="flex flex-col bg-menuHoverBgcolor px-4 pt-3 pb-5">
         <div className="mb-2 font-bold">Sharing Options</div>
 
         <div className="flex">
@@ -290,7 +290,7 @@ function SharingModal({ recording, hideModal }: SharingModalProps) {
   return (
     <Modal options={{ maskTransparency: "translucent" }} onMaskClick={hideModal}>
       <div
-        className="sharing-modal relative flex flex-row overflow-hidden rounded-lg text-sm shadow-xl"
+        className="sharing-modal relative flex flex-row overflow-hidden rounded-lg border border-inputBorder text-sm shadow-xl"
         style={{ width: showPrivacy ? 720 : 390 }}
       >
         <div className="flex flex-col space-y-0" style={{ width: 390 }}>


### PR DESCRIPTION
[DES-843](https://linear.app/replay/issue/DES-843/testsuites-button-shouldnt-wrap) addresses our testsuites button wrapping awkwardly. Here's a video of the before and after:
https://github.com/replayio/devtools/assets/9154902/9c55a24e-b308-4875-b120-ee098f2f5658

[DES-840](https://linear.app/replay/issue/DES-840/replay-launcher-dialog-is-low-contrast) addresses our low contrast Replay launcher dialog:
![image](https://github.com/replayio/devtools/assets/9154902/b2f6d065-d6d9-4270-9c3d-4852a027ca4d)

[DES-841](https://linear.app/replay/issue/DES-841/privacy-modal-has-ugly-white-border) addresses our broken border on our privacy modal:
![image](https://github.com/replayio/devtools/assets/9154902/2026ee4f-918e-460f-8c48-92ee3c2c9d57)

[DES-839](https://linear.app/replay/issue/DES-839/the-share-dialog-is-hard-to-see-in-dark-theme) addresses our share dialog border:
![image](https://github.com/replayio/devtools/assets/9154902/a6e25f3f-fc22-4c26-b544-9f9fd8b065ea)


