### PR TITLE
Remove "Download replay" from NUX flow

### DIFF
--- a/pages/recording/[[...id]].tsx
+++ b/pages/recording/[[...id]].tsx
@@ -66,11 +66,13 @@ function RecordingHead({ metadata }: MetadataProps) {
     description = "";
   }
 
+  const pageTitle = title ? `⏱️ ${title}` : "⏱️";
+
   const image = `${process.env.NEXT_PUBLIC_IMAGE_URL}${metadata.id}.png`;
 
   return (
     <Head>
-      <title>{title}</title>
+      <title>{pageTitle}</title>
       {/* nosemgrep typescript.react.security.audit.react-http-leak.react-http-leak */}
       <meta property="og:title" content={title} />
       <meta property="og:type" content="website" />

--- a/pages/recording/[[...id]].tsx
+++ b/pages/recording/[[...id]].tsx
@@ -66,13 +66,11 @@ function RecordingHead({ metadata }: MetadataProps) {
     description = "";
   }
 
-  const pageTitle = title ? `⏱️ ${title}` : "⏱️";
-
   const image = `${process.env.NEXT_PUBLIC_IMAGE_URL}${metadata.id}.png`;
 
   return (
     <Head>
-      <title>{pageTitle}</title>
+      <title>{title}</title>
       {/* nosemgrep typescript.react.security.audit.react-http-leak.react-http-leak */}
       <meta property="og:title" content={title} />
       <meta property="og:type" content="website" />

--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -90,9 +90,6 @@ function AppModal({ hideModal, modal }: { hideModal: () => void; modal: ModalTyp
     case "first-replay": {
       return <FirstReplayModal />;
     }
-    case "download-replay": {
-      return <DownloadReplayPromptModal />;
-    }
     case "privacy": {
       return <PrivacyModal />;
     }

--- a/src/ui/components/Library/LibraryNags.tsx
+++ b/src/ui/components/Library/LibraryNags.tsx
@@ -36,9 +36,6 @@ function NagSwitcher({
     if (singleInvitation(pendingWorkspaces?.length || 0, workspaces.length)) {
       trackEvent("onboarding.team_invite");
       dispatch(setModal("single-invite"));
-    } else if (downloadReplay(userInfo.nags, dismissNag)) {
-      trackEvent("onboarding.download_replay_prompt");
-      dispatch(setModal("download-replay"));
     } else if (firstReplay(userInfo.nags)) {
       trackEvent("onboarding.demo_replay_prompt");
       dispatch(setModal("first-replay"));


### PR DESCRIPTION
**Background**

Several years ago we built a screen that said "To start making recordings, please download the Replay browser." This was designed for a world where we wanted nearly 100% of new users to download the browser manually.

With testsuites, our product focus has shifted, which has made this screen less relevant. Plenty of invited users go through a flow (sometimes referred to as "New Guest Experience," or NGX) that doesn't require the browser. In fact, the screen is a bit misleading because it implies that the browser is the preferred entry point to recording replays. But for testsuites users, it's not.

This PR removes this screen outright. If someone wants to run the browser, there's an obvious "Launch Replay" button in the top-right corner. But for the vast majority of people, getting dropped into their library directly is the best way to get started. Follow-up: [DES-782](https://linear.app/replay/issue/DES-796/better-library-onboarding)