### PR TITLE
Show team-not-found message

### DIFF
--- a/src/ui/components/Library/Team/TeamContextRoot.tsx
+++ b/src/ui/components/Library/Team/TeamContextRoot.tsx
@@ -2,6 +2,7 @@ import { ReactNode, createContext } from "react";
 
 import { Workspace } from "shared/graphql/types";
 import { useGetTeamRouteParams } from "ui/components/Library/Team/utils";
+import { TeamNotFound } from "ui/components/Library/Team/View/TeamNotFound";
 import hooks from "ui/hooks";
 import { useGetWorkspace } from "ui/hooks/workspaces";
 
@@ -21,11 +22,17 @@ export function TeamContextRoot({ children }: { children: ReactNode }) {
   const { workspace, loading: workspaceLoading } = useGetWorkspace(teamId);
   const { pendingWorkspaces, loading: pendingWorkspacesLoading } = hooks.useGetPendingWorkspaces();
 
+  console.log({ workspaceLoading, workspace });
   if (workspaceLoading || pendingWorkspacesLoading || !pendingWorkspaces) {
     return <LibrarySpinner />;
   }
 
   const isPendingTeam = pendingWorkspaces?.some(w => w.id === teamId);
+
+  if (workspace == null && !isPendingTeam) {
+    // Either the Workspace ID is invalid or the current user does not have access to this Workspace
+    return <TeamNotFound />;
+  }
 
   return (
     <TeamContext.Provider value={{ teamId, team: workspace, isPendingTeam }}>

--- a/src/ui/components/Library/Team/View/TeamNotFound.tsx
+++ b/src/ui/components/Library/Team/View/TeamNotFound.tsx
@@ -1,0 +1,3 @@
+export function TeamNotFound() {
+  return <div className="flex justify-center p-4">Team not found.</div>;
+}

--- a/src/ui/components/Library/Team/View/TestRuns/TestRunsPage.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunsPage.tsx
@@ -24,7 +24,6 @@ function TestRunsContent() {
     filterByTextForDisplay,
     setFilterByStatus,
     setFilterByText,
-    testRunId,
   } = useContext(TestRunsContext);
 
   const {


### PR DESCRIPTION
Trying to view a team you didn't have access to (or using an invalid team id)

### Before: Library
<img width="963" alt="Screen Shot 2023-08-14 at 3 05 03 PM" src="https://github.com/replayio/devtools/assets/29597/30c7b095-f4fa-49d8-be53-b549beb0aeb8">

### Before: Test Suites
<img width="1017" alt="Screen Shot 2023-08-14 at 3 12 04 PM" src="https://github.com/replayio/devtools/assets/29597/2e19c377-c31c-47d4-a31a-5feec9f3f7e1">

### After (both)
<img width="955" alt="Screen Shot 2023-08-14 at 3 16 58 PM" src="https://github.com/replayio/devtools/assets/29597/ea5d595b-5025-4b8e-ae07-bd153ed6df58">

This is just a placeholder UI to address the bad UX. @jonbell-lot23 can make it prettier.