### PR TITLE
Fix potential overflow on Test Suite library page

### DIFF
--- a/src/ui/components/Library/Team/View/TestRuns/TestRunsPage.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunsPage.tsx
@@ -44,7 +44,7 @@ function TestRunsContent() {
   );
 
   return (
-    <div className="flex flex-grow flex-row p-2">
+    <div className="flex w-full flex-grow flex-row p-2">
       <PanelGroup autoSaveId="Library:TestRuns" direction="horizontal">
         <Panel minSize={20} order={1}>
           <div className="flex h-full w-full flex-col overflow-hidden rounded-xl bg-bodyBgcolor">


### PR DESCRIPTION
## Before
<img width="1323" alt="Screen Shot 2023-08-14 at 3 40 54 PM" src="https://github.com/replayio/devtools/assets/29597/22339ca5-d466-4561-8a5b-97e74069f33c">

## After
<img width="1323" alt="Screen Shot 2023-08-14 at 3 41 06 PM" src="https://github.com/replayio/devtools/assets/29597/02b9d969-4db4-4099-b6ce-6492cc6843ee">
