### PR TITLE
Link to function definition in preview (FE-1825)

### DIFF
--- a/packages/replay-next/components/inspector/KeyValueRenderer.tsx
+++ b/packages/replay-next/components/inspector/KeyValueRenderer.tsx
@@ -24,6 +24,47 @@ export type Props = {
   protocolValue: ProtocolValue;
 };
 
+export function KeyValueHeader({
+  before,
+  showExpandableView,
+  layout,
+  onContextMenu,
+  nameClass,
+  name,
+  value,
+}: {
+  before?: ReactNode;
+  layout?: "horizontal" | "vertical";
+  onContextMenu?: (event: MouseEvent) => void;
+  showExpandableView?: boolean;
+  nameClass?: string;
+  name?: string | null;
+  value: ReactNode;
+}) {
+  return (
+    <span
+      className={classNames(
+        styles.KeyValue,
+        !showExpandableView && layout === "vertical" ? styles.ToggleAlignmentPadding : null
+      )}
+      data-test-name="KeyValue"
+      onContextMenu={onContextMenu}
+    >
+      {before}
+      {name != null ? (
+        <>
+          <span className={nameClass} data-test-name="KeyValue-Header">
+            {name}
+          </span>
+          <span className={styles.Separator}>: </span>
+        </>
+      ) : null}
+
+      {value}
+    </span>
+  );
+}
+
 // Renders a protocol Object/ObjectPreview as a key+value pair.
 //
 // This renderer supports two layouts: "horizontal" and "vertical".
@@ -148,26 +189,15 @@ export default function KeyValueRenderer({
   }
 
   const header = (
-    <span
-      className={classNames(
-        styles.KeyValue,
-        !showExpandableView && layout === "vertical" ? styles.ToggleAlignmentPadding : null
-      )}
-      data-test-name="KeyValue"
+    <KeyValueHeader
+      value={value}
+      before={before}
+      showExpandableView={showExpandableView}
+      layout={layout}
       onContextMenu={onContextMenu}
-    >
-      {before}
-      {name != null ? (
-        <>
-          <span className={nameClass} data-test-name="KeyValue-Header">
-            {name}
-          </span>
-          <span className={styles.Separator}>: </span>
-        </>
-      ) : null}
-
-      {value}
-    </span>
+      nameClass={nameClass}
+      name={name}
+    />
   );
 
   if (showExpandableView) {

--- a/packages/replay-next/components/inspector/PropertiesRenderer.module.css
+++ b/packages/replay-next/components/inspector/PropertiesRenderer.module.css
@@ -27,3 +27,23 @@
 .Separator {
   color: var(--object-inspector-separator-color);
 }
+
+.KeyValue {
+  display: inline;
+  text-align: start;
+  vertical-align: top;
+}
+
+.ToggleAlignmentPadding {
+  margin-left: 1.25rem;
+}
+
+.SourceLocationLink {
+  color: var(--link-color);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.SourceLocationLink:hover {
+  color: var(--link-color-active);
+}


### PR DESCRIPTION
Adds a link to function location similar to the one in Chrome devtools in the value preview.

Chrome DevTools:
![image](https://github.com/replayio/devtools/assets/50412128/1f901637-84b8-4502-b9b5-82fd30f63f60)

Replay DevTools:
<img width="400" alt="Screenshot 2023-08-19 at 12 35 52 AM" src="https://github.com/replayio/devtools/assets/50412128/398723ff-7f88-48b5-973a-ca02d8b006c3">

This does not modify any logic in `KeyValueRenderer`, just extracts the header of it out to a separate component to be used by `PropertiesRenderer` to render the clickable value.