### PR TITLE
Update GH Action config to run Playwright e2e Test Suite Library tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,7 +141,7 @@ jobs:
         run: npx @replayio/playwright install
       - uses: replayio/action-playwright@main
         with:
-          command: npx playwright test --shard ${{ matrix.shard }}/1 --reporter=@replayio/playwright/reporter,line authenticated/*.ts
+          command: npx playwright test --shard ${{ matrix.shard }}/1 --reporter=@replayio/playwright/reporter,line authenticated/**/*.ts
           working-directory: ./packages/e2e-tests
           api-key: ${{ env.RECORD_REPLAY_API_KEY }}
           public: true

--- a/packages/e2e-tests/authenticated/test-suites/library-tests-list.test.ts
+++ b/packages/e2e-tests/authenticated/test-suites/library-tests-list.test.ts
@@ -33,7 +33,7 @@ test(`authenticated/test-suites/library-tests-list`, async ({ page }) => {
   await expect(await getTestRunAttribute(runSummary, "Branch").textContent()).toBe("main");
   await expect(await getTestRunAttribute(runSummary, "Date").textContent()).toContain("6/14/2023");
   await expect(await getTestRunAttribute(runSummary, "Duration").textContent()).toContain(
-    "4744 sec"
+    "1h 19m 3.6s"
   );
   await expect(await getTestRunAttribute(runSummary, "Username").textContent()).toContain(
     "jazzdan"

--- a/src/ui/components/Library/Team/TeamContextRoot.tsx
+++ b/src/ui/components/Library/Team/TeamContextRoot.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, createContext } from "react";
 
 import { Workspace } from "shared/graphql/types";
+import { hasApiKey } from "shared/utils/environment";
 import { useGetTeamRouteParams } from "ui/components/Library/Team/utils";
 import { TeamNotFound } from "ui/components/Library/Team/View/TeamNotFound";
 import hooks from "ui/hooks";
@@ -22,14 +23,13 @@ export function TeamContextRoot({ children }: { children: ReactNode }) {
   const { workspace, loading: workspaceLoading } = useGetWorkspace(teamId);
   const { pendingWorkspaces, loading: pendingWorkspacesLoading } = hooks.useGetPendingWorkspaces();
 
-  console.log({ workspaceLoading, workspace });
   if (workspaceLoading || pendingWorkspacesLoading || !pendingWorkspaces) {
     return <LibrarySpinner />;
   }
 
   const isPendingTeam = pendingWorkspaces?.some(w => w.id === teamId);
 
-  if (workspace == null && !isPendingTeam) {
+  if (workspace == null && !isPendingTeam && !hasApiKey()) {
     // Either the Workspace ID is invalid or the current user does not have access to this Workspace
     return <TeamNotFound />;
   }


### PR DESCRIPTION
It seems like we were only running these locally because of the bad pattern match 🤡 

Also the recent change to show a team-not-found message (#9620) didn't account for the case of api key authentication.