### PR TITLE
Update settings

### DIFF
--- a/packages/shared/user-data/GraphQL/UserData.test.ts
+++ b/packages/shared/user-data/GraphQL/UserData.test.ts
@@ -133,7 +133,7 @@ describe("UserData", () => {
       switch (key) {
         case LOCAL_STORAGE_KEY:
           return JSON.stringify({
-            feature_brokenSourcemapWorkaround: false,
+            debugger_frameworkGroupingOn: false,
             console_showFiltersByDefault: true,
           });
         default:
@@ -156,7 +156,7 @@ describe("UserData", () => {
 
     const userData = require("./UserData").userData;
 
-    expect(userData.get("feature_brokenSourcemapWorkaround")).toBe(false);
+    expect(userData.get("debugger_frameworkGroupingOn")).toBe(false);
     expect(userData.get("console_showFiltersByDefault")).toBe(true);
     expect(userData.get("layout_breakpointsPanelExpanded")).toBe(true);
 
@@ -166,7 +166,7 @@ describe("UserData", () => {
     expect(localStorageMock.setItem).toHaveBeenCalledTimes(1);
 
     // GraphQL should be called after initialization and preferences should be merged with localStorage
-    expect(userData.get("feature_brokenSourcemapWorkaround")).toBe(false);
+    expect(userData.get("debugger_frameworkGroupingOn")).toBe(false);
     expect(userData.get("console_showFiltersByDefault")).toBe(false);
     expect(userData.get("layout_breakpointsPanelExpanded")).toBe(false);
 

--- a/packages/shared/user-data/GraphQL/config.ts
+++ b/packages/shared/user-data/GraphQL/config.ts
@@ -39,12 +39,14 @@ export const config = {
   },
   backend_disableIncrementalSnapshots: {
     defaultValue: Boolean(false),
+    internalOnly: Boolean(true),
     description: "Disable using diffs between snapshots",
     label: "Disable using incremental snapshots",
     legacyKey: "devtools.features.disableIncrementalSnapshots",
   },
   backend_disableProtocolQueryCache: {
     defaultValue: Boolean(false),
+    internalOnly: Boolean(true),
     description: "Disable storage of previously generated response for protocol commands",
     label: "Disable query-level storage for protocol commands",
     legacyKey: "devtools.features.disableProtocolQueryCache",
@@ -66,16 +68,19 @@ export const config = {
   },
   backend_enableRoutines: {
     defaultValue: Boolean(false),
+    internalOnly: Boolean(true),
     description: "Enable backend support for running processing routines (like React DevTools)",
     label: "Enable backend processing routines",
     legacyKey: "devtools.features.enableRoutines",
   },
   backend_keepAllTraces: {
     defaultValue: Boolean(false),
+    internalOnly: Boolean(true),
     legacyKey: "devtools.features.keepAllTraces",
   },
   backend_listenForMetrics: {
     defaultValue: Boolean(false),
+    internalOnly: Boolean(true),
     legacyKey: "devtools.listenForMetrics",
   },
   backend_newControllerOnRefresh: {
@@ -122,8 +127,6 @@ export const config = {
   },
   console_showFiltersByDefault: {
     defaultValue: Boolean(false),
-    description:
-      "Open the console filter settings by default when opening a Replay for the first time",
     internalOnly: Boolean(false),
     label: "Console filter drawer defaults to open",
     legacyKey: "devtools.features.consoleFilterDrawerDefaultsToOpen",
@@ -141,12 +144,7 @@ export const config = {
     label: "Detailed loading bar",
     legacyKey: "devtools.features.basicProcessingLoadingBar",
   },
-  feature_brokenSourcemapWorkaround: {
-    defaultValue: Boolean(true),
-    description: "Skip locations that are mapped to the beginning of a function body",
-    label: "Enable workaround for broken sourcemaps",
-    legacyKey: "devtools.features.brokenSourcemapWorkaround",
-  },
+
   feature_chromiumNetMonitor: {
     defaultValue: Boolean(true),
     legacyKey: "devtools.features.chromiumNetMonitor",
@@ -278,7 +276,6 @@ export const config = {
     defaultValue: Boolean(true),
     legacyKey: null,
   },
-
   protocol_chromiumRepaints: {
     defaultValue: Boolean(true),
     label: "Enable repaintGraphics for Chrome.",

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/FrameTimeline.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/FrameTimeline.tsx
@@ -111,7 +111,7 @@ class FrameTimelineRenderer extends Component<FrameTimelineProps, FrameTimelineS
     // skip over steps that are mapped to the beginning of a function body
     // see SCS-172
     const bodyLocations = symbols?.functions.map(f => f.body).filter(Boolean) as SourceLocation[];
-    if (userData.get("feature_brokenSourcemapWorkaround") && bodyLocations) {
+    if (bodyLocations) {
       while (adjustedDisplayIndex < numberOfPositions - 2) {
         const location = frameSteps[adjustedDisplayIndex].frame?.find(
           location => location.sourceId === selectedLocation?.sourceId

--- a/src/devtools/client/debugger/src/reducers/pause.ts
+++ b/src/devtools/client/debugger/src/reducers/pause.ts
@@ -137,8 +137,7 @@ export const executeCommandOperation = createAsyncThunk<
     locationsToSkip:
       // skip over points that are mapped to the beginning of a function body
       // see SCS-172
-      userData.get("feature_brokenSourcemapWorkaround") &&
-      (command === "stepOver" || command === "reverseStepOver")
+      command === "stepOver" || command === "reverseStepOver"
         ? (symbols?.functions.map(f => f.body).filter(Boolean) as SourceLocation[])
         : undefined,
   });

--- a/src/ui/components/shared/UserSettingsModal/components/BooleanPreference.tsx
+++ b/src/ui/components/shared/UserSettingsModal/components/BooleanPreference.tsx
@@ -37,18 +37,15 @@ export function BooleanPreference({
       style={{ gridTemplateColumns: "auto minmax(0, 1fr)", gap: "0 0.5rem" }}
       data-private
       htmlFor={preferencesKey}
-    >
-      <Checkbox
-        id={`BooleanPreference-${preferencesKey}`}
-        checked={checked as boolean}
-        onChange={() => {
-          setChecked(!checked);
+      onClick={() => {
+        setChecked(!checked);
 
-          if (onChange) {
-            onChange(!checked);
-          }
-        }}
-      />
+        if (onChange) {
+          onChange(!checked);
+        }
+      }}
+    >
+      <Checkbox id={`BooleanPreference-${preferencesKey}`} checked={checked as boolean} />
       <div>{label}</div>
       {description ? (
         <div className="mb-1 text-xs text-bodySubColor" style={{ gridColumnStart: "2" }}>

--- a/src/ui/components/shared/UserSettingsModal/panels/Advanced.tsx
+++ b/src/ui/components/shared/UserSettingsModal/panels/Advanced.tsx
@@ -8,11 +8,20 @@ export const PREFERENCES: PreferencesKey[] = [
   "feature_logProtocol",
   "backend_newControllerOnRefresh",
   "protocol_chromiumRepaints",
+  "backend_profileWorkerThreads",
+  "feature_basicProcessingLoadingBar",
+  "backend_disableScanDataCache",
+  "backend_enableRoutines",
+  "backend_rerunRoutines",
+  "backend_disableRecordingAssetsInDatabase",
+  "backend_disableIncrementalSnapshots",
+  "backend_disableConcurrentControllerLoading",
+  "backend_disableProtocolQueryCache",
 ];
 
 export function Advanced() {
   return (
-    <div className="flex flex-col space-y-2 p-1">
+    <div className="flex flex-col space-y-2 overflow-y-auto p-1">
       {PREFERENCES.map(key => (
         <BooleanPreference key={key} preference={config[key]} preferencesKey={key} />
       ))}

--- a/src/ui/components/shared/UserSettingsModal/panels/Experimental.tsx
+++ b/src/ui/components/shared/UserSettingsModal/panels/Experimental.tsx
@@ -2,21 +2,7 @@ import { config } from "shared/user-data/GraphQL/config";
 import { PreferencesKey } from "shared/user-data/GraphQL/types";
 import { BooleanPreference } from "ui/components/shared/UserSettingsModal/components/BooleanPreference";
 
-export const PREFERENCES: PreferencesKey[] = [
-  "backend_profileWorkerThreads",
-  "feature_basicProcessingLoadingBar",
-  "console_showFiltersByDefault",
-  "backend_disableScanDataCache",
-  "feature_brokenSourcemapWorkaround",
-  "backend_enableRoutines",
-  "backend_rerunRoutines",
-  "backend_disableRecordingAssetsInDatabase",
-  "feature_reactPanel",
-  "feature_reduxDevTools",
-  "backend_disableIncrementalSnapshots",
-  "backend_disableConcurrentControllerLoading",
-  "backend_disableProtocolQueryCache",
-];
+export const PREFERENCES: PreferencesKey[] = ["feature_reactPanel", "feature_reduxDevTools"];
 
 export function Experimental() {
   return (

--- a/src/ui/components/shared/UserSettingsModal/panels/Preferences.tsx
+++ b/src/ui/components/shared/UserSettingsModal/panels/Preferences.tsx
@@ -36,6 +36,10 @@ export function Preferences() {
           preference={config.feature_showPassport}
           preferencesKey="feature_showPassport"
         />
+        <BooleanPreference
+          preference={config.console_showFiltersByDefault}
+          preferencesKey="console_showFiltersByDefault"
+        />
       </div>
 
       <div className="space-y-4">


### PR DESCRIPTION
1. Moves a bunch of advanced settings to the advanced panel so that experimental settings really are experimental
2. Moves the show console filters to preferences
3. ~Adds toggle protocol panel and timeline to the command palette~
4. fixes a bug so that clicking a boolean pref description toggles the value as well
5. ~re-writes the command palette code to be a switch statement~
6. deleted this setting because it should always be available `feature_brokenSourcemapWorkaround`
7. ~add the ability to restart the session with a new controller~

fixes FE-1800

<img width="776" alt="Screenshot 2023-08-19 at 11 31 06 PM" src="https://github.com/replayio/devtools/assets/254562/fd48efc1-b111-4043-9f15-d3ab52411e6a">

