### PR TITLE
Fix collapsible Sources tab in sidebar

### DIFF
--- a/src/devtools/client/debugger/src/actions/ui.ts
+++ b/src/devtools/client/debugger/src/actions/ui.ts
@@ -18,10 +18,7 @@ import {
   highlightLineRange,
   setCursorPosition,
   setPrimaryPaneTab,
-  sourcesDisplayed,
-  sourcesPanelExpanded,
   toggleActiveSearch,
-  toggleSources,
 } from "../reducers/ui";
 import { getActiveSearch, getContext, getQuickOpenEnabled } from "../selectors";
 import { selectSource } from "./sources/select";
@@ -37,11 +34,8 @@ export {
   setPrimaryPaneTab,
   setShownSource,
   setViewport,
-  sourcesDisplayed,
-  sourcesPanelExpanded,
   toggleActiveSearch,
   toggleFrameworkGrouping,
-  toggleSources,
 } from "../reducers/ui";
 
 export function setActiveSearch(activeSearch: ActiveSearchType): UIThunkAction {
@@ -60,9 +54,6 @@ export function setActiveSearch(activeSearch: ActiveSearchType): UIThunkAction {
 }
 
 // Preserve existing export names
-export const ensureSourcesIsVisible = sourcesDisplayed;
-export const toggleSourcesCollapse = toggleSources;
-export const expandSourcesPane = sourcesPanelExpanded;
 export const updateCursorPosition = setCursorPosition;
 
 export function openSourceLink(sourceId: string, line?: number, column?: number): UIThunkAction {

--- a/src/devtools/client/debugger/src/components/Editor/useTabContextMenu.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/useTabContextMenu.tsx
@@ -3,12 +3,12 @@ import { ContextMenuDivider, ContextMenuItem, useContextMenu } from "use-context
 import { closeTab, closeTabs } from "devtools/client/debugger/src/actions/tabs";
 import {
   copyToClipboard as copySourceToClipboard,
-  ensureSourcesIsVisible,
   showSource,
 } from "devtools/client/debugger/src/actions/ui";
 import { Tab, getContext, getTabs } from "devtools/client/debugger/src/selectors";
 import { getRawSourceURL } from "devtools/client/debugger/src/utils/source";
 import { copyToClipboard as copyTextToClipboard } from "replay-next/components/sources/utils/clipboard";
+import { userData } from "shared/user-data/GraphQL/UserData";
 import { MiniSource, getSelectedSource } from "ui/reducers/sources";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 
@@ -52,8 +52,9 @@ export default function useTabContextMenu({ source }: { source: MiniSource }) {
     }
   };
 
-  const onRevealInTreeClick = () => {
-    dispatch(ensureSourcesIsVisible());
+  const onRevealInTreeClick = async () => {
+    await userData.set("layout_sourcesCollapsed", false);
+
     dispatch(showSource(cx, source.id));
   };
 

--- a/src/devtools/client/debugger/src/components/PrimaryPanes/index.tsx
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/index.tsx
@@ -1,26 +1,22 @@
 import classnames from "classnames";
 import { useEffect } from "react";
-import { ConnectedProps, connect } from "react-redux";
 
 // Add the necessary imports for nag functionality
 import { useNag } from "replay-next/src/hooks/useNag";
 import { Nag } from "shared/graphql/types";
 import { useGraphQLUserData } from "shared/user-data/GraphQL/useGraphQLUserData";
-import { UIState } from "ui/state";
 
-import actions from "../../actions";
-import { getContext, getSelectedPrimaryPaneTab, getSourcesCollapsed } from "../../selectors";
 import Outline from "../SourceOutline/SourceOutline";
 import QuickOpenButton from "./QuickOpenButton";
 import SourcesTree from "./SourcesTree";
 
 import { Accordion, AccordionPane } from "@recordreplay/accordion";
 
-function PrimaryPanes(props: PropsFromRedux) {
+export default function PrimaryPanes() {
   const [outlineExpanded, setOutlineExpanded] = useGraphQLUserData(
     "layout_debuggerOutlineExpanded"
   );
-  const [sourcesCollapsed] = useGraphQLUserData("layout_sourcesCollapsed");
+  const [sourcesCollapsed, setSourcesCollapsed] = useGraphQLUserData("layout_sourcesCollapsed");
   const [enableLargeText] = useGraphQLUserData("global_enableLargeText");
 
   // Add the useNag hook and useEffect block
@@ -37,7 +33,7 @@ function PrimaryPanes(props: PropsFromRedux) {
         // ExperimentFeature: LargeText Logic
         className={classnames("sources-pane", enableLargeText ? "text-base" : "text-xs")}
         expanded={!sourcesCollapsed}
-        onToggle={() => props.toggleSourcesCollapse()}
+        onToggle={() => setSourcesCollapsed(!sourcesCollapsed)}
         initialHeight={400}
         button={<QuickOpenButton />}
       >
@@ -54,22 +50,3 @@ function PrimaryPanes(props: PropsFromRedux) {
     </Accordion>
   );
 }
-
-const mapStateToProps = (state: UIState) => {
-  return {
-    cx: getContext(state),
-    selectedTab: getSelectedPrimaryPaneTab(state),
-    sourcesCollapsed: getSourcesCollapsed(state),
-  };
-};
-
-const connector = connect(mapStateToProps, {
-  setPrimaryPaneTab: actions.setPrimaryPaneTab,
-  setActiveSearch: actions.setActiveSearch,
-  closeActiveSearch: actions.closeActiveSearch,
-  toggleSourcesCollapse: actions.toggleSourcesCollapse,
-});
-
-type PropsFromRedux = ConnectedProps<typeof connector>;
-
-export default connector(PrimaryPanes);

--- a/src/devtools/client/debugger/src/reducers/ui.ts
+++ b/src/devtools/client/debugger/src/reducers/ui.ts
@@ -28,7 +28,6 @@ export interface UISliceState {
   fullTextSearchQuery: string;
   fullTextSearchFocus: boolean;
   shownSource?: SourceDetails | null;
-  sourcesCollapsed: boolean;
   frameworkGroupingOn: boolean;
   viewport?: Range | null;
   cursorPosition?: Location | null;
@@ -41,7 +40,6 @@ export const createUIState = (): UISliceState => ({
   fullTextSearchQuery: "",
   fullTextSearchFocus: false,
   shownSource: null,
-  sourcesCollapsed: userData.get("layout_sourcesCollapsed"),
   frameworkGroupingOn: userData.get("debugger_frameworkGroupingOn"),
   highlightedLineRange: undefined,
   viewport: null,
@@ -60,12 +58,6 @@ const uiSlice = createSlice({
     },
     setShownSource(state, action: PayloadAction<SourceDetails | null>) {
       state.shownSource = action.payload;
-    },
-    toggleSources(state) {
-      state.sourcesCollapsed = !state.sourcesCollapsed;
-    },
-    sourcesPanelExpanded(state) {
-      state.sourcesCollapsed = false;
     },
     highlightLineRange(state, action: PayloadAction<HighlightedRange>) {
       const { start, end, sourceId } = action.payload;
@@ -99,12 +91,6 @@ const uiSlice = createSlice({
     setCursorPosition(state, action: PayloadAction<Location | null>) {
       state.cursorPosition = action.payload;
     },
-    // Need to ensure three pieces of UI are updated:
-    // Here: pause info panel is open, sources are open
-    // Layout reducer: selected primary panel is "explorer"
-    sourcesDisplayed(state) {
-      state.sourcesCollapsed = false;
-    },
   },
   extraReducers: builder => {
     builder.addCase(closeQuickOpen, state => {
@@ -123,11 +109,8 @@ export const {
   setPrimaryPaneTab,
   setShownSource,
   setViewport,
-  sourcesDisplayed,
-  sourcesPanelExpanded,
   toggleActiveSearch,
   toggleFrameworkGrouping,
-  toggleSources,
 } = uiSlice.actions;
 
 export function closeActiveSearch() {
@@ -140,7 +123,6 @@ export const getSelectedPrimaryPaneTab = (state: UIState) => state.ui.selectedPr
 export const getActiveSearch = (state: UIState) => state.ui.activeSearch;
 export const getFrameworkGroupingState = (state: UIState) => state.ui.frameworkGroupingOn;
 export const getShownSource = (state: UIState) => state.ui.shownSource;
-export const getSourcesCollapsed = (state: UIState) => state.ui.sourcesCollapsed;
 export const getHighlightedLineRange = (state: UIState) => state.ui.highlightedLineRange;
 export const getViewport = (state: UIState) => state.ui.viewport;
 export const getCursorPosition = (state: UIState) => state.ui.cursorPosition;

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -214,9 +214,6 @@ export function executeCommand(key: CommandKey): UIThunkAction {
     } else if (key === "open_sources") {
       dispatch(setViewMode("dev"));
       dispatch(setSelectedPrimaryPanel("explorer"));
-      // Someday we'll fix circular dependencies. Today is not that day.
-      const { expandSourcesPane } = await import("devtools/client/debugger/src/actions/ui");
-      dispatch(expandSourcesPane());
     } else if (key === "open_outline") {
       dispatch(setViewMode("dev"));
       dispatch(setSelectedPrimaryPanel("explorer"));

--- a/src/ui/reducers/layout.ts
+++ b/src/ui/reducers/layout.ts
@@ -1,4 +1,3 @@
-import { sourcesDisplayed } from "devtools/client/debugger/src/reducers/ui";
 import { userData } from "shared/user-data/GraphQL/UserData";
 import { LayoutAction } from "ui/actions/layout";
 import { UIState } from "ui/state";
@@ -28,10 +27,6 @@ export default function update(state = syncInitialLayoutState, action: LayoutAct
 
     case "set_selected_primary_panel": {
       return { ...state, selectedPrimaryPanel: action.panel };
-    }
-
-    case sourcesDisplayed.type: {
-      return { ...state, selectedPrimaryPanel: "explorer" };
     }
 
     case "set_view_mode": {


### PR DESCRIPTION
I think this regressed in #9385. We had two places controlling this behavior- a user preference (stored in GraphQL) and a piece of Redux state (that got initialized to the user preference, but then got out of sync). This commit removes the latter since it's redundant.