### PR TITLE
Restored Protocol viewer's Admin app session link

### DIFF
--- a/src/ui/components/ProtocolViewer/components/ProtocolViewerList.tsx
+++ b/src/ui/components/ProtocolViewer/components/ProtocolViewerList.tsx
@@ -9,7 +9,7 @@ import { useGetUserInfo } from "ui/hooks/users";
 
 import styles from "./ProtocolViewerList.module.css";
 
-const ADMIN_APP_BASE_URL = "http://admin.replay.prod/controllers";
+const ADMIN_APP_BASE_URL = "http://admin.replay.prod/sessions";
 
 export function ProtocolViewerList() {
   const { clearCurrentRequests, filteredRequestIds, filterText, updateFilterText } =
@@ -20,12 +20,7 @@ export function ProtocolViewerList() {
   let viewLogLink = null;
   if (isInternalUser) {
     const sessionId = ThreadFront.sessionId;
-    const sessionIdPieces = sessionId?.split("/");
-    if (sessionIdPieces?.length === 2) {
-      const controllerId = sessionIdPieces[0];
-
-      viewLogLink = `${ADMIN_APP_BASE_URL}/${controllerId}`;
-    }
+    viewLogLink = `${ADMIN_APP_BASE_URL}/${sessionId}`;
   }
 
   return (


### PR DESCRIPTION
The (recent?) change to the session id from the "session/controller" format broke the previous link in the protocol viewer.

Maybe also worth noting that when I link to a session, it says:
> ## Summary
> Could not read report

Maybe this is expected? 🤷🏼  I don't know.