### PR TITLE
Improve textfield component to work better with themes

### DIFF
--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -705,7 +705,7 @@
   --theme-sidebar-background: var(--theme-base-100);
   --theme-text-field-bgcolor-hover: var(--theme-base-95);
   --theme-text-field-bgcolor: #f6f6f6;
-  --theme-text-field-color: var(--theme-body-color);
+  --theme-text-field-color: var(--body-color);
   --theme-text-field-placeholder-color: #a9a9b1;
   --team-row-active: #3f434a;
   --tooltip-bgcolor: #38383d;

--- a/src/ui/components/shared/Forms/TextInput.module.css
+++ b/src/ui/components/shared/Forms/TextInput.module.css
@@ -29,7 +29,7 @@
 .dark .textInput {
   background-color: #3e434b; /* Dark: --theme-text-field-bgcolor */
   color: #fff; /* --theme-text-field-color: */
-  border-color: var(--theme-base-85); /* --input-border */
+  border-color: #3e434b; /* Dark: --input-border */
 }
 
 .dark .textInput:hover {
@@ -40,7 +40,7 @@
 
 .light .textInput {
   background-color: #f6f6f6; /* --theme-text-field-bgcolor */
-  color: #fff; /* --theme-text-field-color: */
+  color: #38383d; /* Light: var(--body-color); */
   border-color: var(--cool-gray-200); /* --input-border */
 }
 

--- a/src/ui/components/shared/Forms/TextInput.module.css
+++ b/src/ui/components/shared/Forms/TextInput.module.css
@@ -18,6 +18,9 @@
 
 .default .textInput {
   background-color: var(--theme-text-field-bgcolor);
+  color: var(--theme-text-field-color);
+  border-color: var(--input-border);
+  caret-color: var(--theme-text-field-color);
 }
 
 .default .textInput:hover {
@@ -30,6 +33,7 @@
   background-color: #3e434b; /* Dark: --theme-text-field-bgcolor */
   color: #fff; /* --theme-text-field-color: */
   border-color: #3e434b; /* Dark: --input-border */
+  caret-color: #fff;
 }
 
 .dark .textInput:hover {
@@ -42,6 +46,7 @@
   background-color: #f6f6f6; /* --theme-text-field-bgcolor */
   color: #38383d; /* Light: var(--body-color); */
   border-color: var(--cool-gray-200); /* --input-border */
+  caret-color: #38383d;
 }
 
 .light .textInput:hover {

--- a/src/ui/components/shared/Forms/TextInput.module.css
+++ b/src/ui/components/shared/Forms/TextInput.module.css
@@ -16,14 +16,14 @@
   text-align: center;
 }
 
-.default .textInput {
+.system .textInput {
   background-color: var(--theme-text-field-bgcolor);
   color: var(--theme-text-field-color);
   border-color: var(--input-border);
   caret-color: var(--theme-text-field-color);
 }
 
-.default .textInput:hover {
+.system .textInput:hover {
   background-color: var(--theme-text-field-bgcolor-hover);
 }
 

--- a/src/ui/components/shared/Forms/TextInput.module.css
+++ b/src/ui/components/shared/Forms/TextInput.module.css
@@ -1,0 +1,49 @@
+.textInput {
+  text-align: left;
+  display: block;
+  width: 100%;
+  border-radius: 0.375rem;
+  border-color: transparent;
+  padding: 0.5rem;
+  outline: 0;
+}
+
+.textInput:focus {
+  box-shadow: 0 0 0 3px var(--primary-accent);
+}
+
+.textCenter {
+  text-align: center;
+}
+
+.default .textInput {
+  background-color: var(--theme-text-field-bgcolor);
+}
+
+.default .textInput:hover {
+  background-color: var(--theme-text-field-bgcolor-hover);
+}
+
+/* Dark theme */
+
+.dark .textInput {
+  background-color: #3e434b; /* Dark: --theme-text-field-bgcolor */
+  color: #fff; /* --theme-text-field-color: */
+  border-color: var(--theme-base-85); /* --input-border */
+}
+
+.dark .textInput:hover {
+  background-color: #192230; /* Dark: --theme-text-field-bgcolor-hover: */
+}
+
+/* Light theme */
+
+.light .textInput {
+  background-color: #f6f6f6; /* --theme-text-field-bgcolor */
+  color: #fff; /* --theme-text-field-color: */
+  border-color: var(--cool-gray-200); /* --input-border */
+}
+
+.light .textInput:hover {
+  background-color: var(--theme-base-95); /* --theme-text-field-bgcolor-hover: */
+}

--- a/src/ui/components/shared/Forms/TextInput.tsx
+++ b/src/ui/components/shared/Forms/TextInput.tsx
@@ -1,27 +1,28 @@
 import classNames from "classnames";
 import React from "react";
 
+import styles from "./TextInput.module.css";
+
 export default React.forwardRef<
   HTMLInputElement,
   Omit<React.HTMLProps<HTMLInputElement>, "type" | "className"> & {
     textSize?: "base" | "lg" | "2xl";
     center?: boolean;
+    theme?: "light" | "dark";
     className?: string;
   }
 >(function TextInput(props, ref) {
-  const { textSize, center } = props;
+  const { textSize, center, theme, className, ...otherProps } = props;
+
+  const themeClass = theme || "default";
+  const textSizeClass = textSize ? `text-${textSize}` : "text-sm"; // Tailwind class for textSize
+  const centerClass = center ? styles.textCenter : ""; // CSS module class for center
+
+  const inputClass = classNames(styles.textInput, textSizeClass, centerClass, className);
 
   return (
-    <input
-      {...props}
-      ref={ref}
-      type="text"
-      className={classNames(
-        `text-${textSize ? textSize : "sm"}`,
-        center ? "text-center" : "",
-        "block w-full rounded-md border border-transparent border-inputBorder bg-themeTextFieldBgcolor p-2 text-themeTextFieldColor hover:bg-themeTextFieldBgcolorHover focus:border-primaryAccent focus:ring-primaryAccent",
-        props.className
-      )}
-    />
+    <div className={styles[themeClass]}>
+      <input {...otherProps} ref={ref} type="text" className={inputClass} />
+    </div>
   );
 });

--- a/src/ui/components/shared/Forms/TextInput.tsx
+++ b/src/ui/components/shared/Forms/TextInput.tsx
@@ -15,10 +15,27 @@ export default React.forwardRef<
   const { textSize, center, theme, className, ...otherProps } = props;
 
   const themeClass = theme || "default";
-  const textSizeClass = textSize ? `text-${textSize}` : "text-sm"; // Tailwind class for textSize
-  const centerClass = center ? styles.textCenter : ""; // CSS module class for center
+  let textSizeClass = "text-sm"; // Default Tailwind class for textSize
 
-  const inputClass = classNames(styles.textInput, textSizeClass, centerClass, className);
+  // Explicitly map textSize prop to Tailwind classes
+  switch (textSize) {
+    case "base":
+      textSizeClass = "text-base";
+      break;
+    case "lg":
+      textSizeClass = "text-lg";
+      break;
+    case "2xl":
+      textSizeClass = "text-2xl";
+      break;
+  }
+
+  const inputClass = classNames(
+    styles.textInput,
+    textSizeClass,
+    center ? styles.textCenter : "",
+    className
+  );
 
   return (
     <div className={styles[themeClass]}>

--- a/src/ui/components/shared/Forms/TextInput.tsx
+++ b/src/ui/components/shared/Forms/TextInput.tsx
@@ -14,7 +14,7 @@ export default React.forwardRef<
 >(function TextInput(props, ref) {
   const { textSize, center, theme, className, ...otherProps } = props;
 
-  const themeClass = theme || "default";
+  const themeClass = theme || "system";
   let textSizeClass = "text-sm"; // Default Tailwind class for textSize
 
   // Explicitly map textSize prop to Tailwind classes

--- a/src/ui/components/shared/TeamOnboarding.tsx
+++ b/src/ui/components/shared/TeamOnboarding.tsx
@@ -121,7 +121,7 @@ function TeamNamePage({
           onChange={onChange}
           textSize="2xl"
           center={true}
-          theme="dark"
+          theme="dark" // we force onboarding into dark theme
           ref={textInputRef}
         />
         {inputError ? <div className="text-red-500">{inputError}</div> : null}

--- a/src/ui/components/shared/TeamOnboarding.tsx
+++ b/src/ui/components/shared/TeamOnboarding.tsx
@@ -121,6 +121,7 @@ function TeamNamePage({
           onChange={onChange}
           textSize="2xl"
           center={true}
+          theme="dark"
           ref={textInputRef}
         />
         {inputError ? <div className="text-red-500">{inputError}</div> : null}


### PR DESCRIPTION
Addresses [DES-857](https://linear.app/replay/issue/DES-857/fix-new-org-dialog-for-dark-mode)

Old:
![image](https://github.com/replayio/devtools/assets/9154902/1b4f69fa-d40b-4dea-8f9c-dff72d2f5ae6)

New:
![image](https://github.com/replayio/devtools/assets/9154902/1b706c23-c614-456b-b387-fdf2f4ef481b)

--

We force our onboarding into dark theme. But this means you can follow these steps:

1. Go through onboarding
2. Get to our app
3. Change to light theme
4. Go back to an onboarding page (such as the new team page shown here)
5. Result: a light theme textfield in our dark theme onboarding screens

Fixes/changes

1. Passed a "theme" prop so I can force dark or light theme
2. If nothing is passed, it defaults to the system theme, as expected
3. Removed almost all tailwind and used css modules instead

