### PR TITLE
Rewrite "Recorded Protocol Viewer" to use runEvaluation for perf

### DIFF
--- a/packages/e2e-tests/helpers/react-devtools-panel.ts
+++ b/packages/e2e-tests/helpers/react-devtools-panel.ts
@@ -117,7 +117,6 @@ export async function getComponentName(componentLocator: Locator): Promise<strin
       let name = "";
       for (const child of childNodes) {
         if (child.nodeName === "SPAN" || child.nodeName === "MARK") {
-          console.log("Found partial name: ", (child as HTMLElement).textContent, child.nodeName);
           name += (child as HTMLElement).textContent ?? "";
         }
       }

--- a/packages/replay-next/src/suspense/HitPointsCache.ts
+++ b/packages/replay-next/src/suspense/HitPointsCache.ts
@@ -66,7 +66,10 @@ export const hitPointsCache = createFocusIntervalCacheForExecutionPoints<
         { kind: "locations", locations },
         { begin, end }
       );
-      hitPoints = pointDescriptions.map(({ point, time }) => ({ point, time }));
+      // Note that PointDescriptions include the current frame.
+      // Type-wise we're going to return `TimeStampedPoint`s,
+      // but the extra frame data is there in this case.
+      hitPoints = pointDescriptions;
     }
 
     return hitPoints;

--- a/packages/replay-next/src/suspense/HitPointsCache.ts
+++ b/packages/replay-next/src/suspense/HitPointsCache.ts
@@ -1,4 +1,4 @@
-import { Location, PointRange, TimeStampedPoint } from "@replayio/protocol";
+import { Location, PointDescription, PointRange, TimeStampedPoint } from "@replayio/protocol";
 import { createCache } from "suspense";
 
 import { breakpointPositionsCache } from "replay-next/src/suspense/BreakpointPositionsCache";
@@ -14,12 +14,12 @@ import { ProtocolError, isCommandError } from "shared/utils/error";
 import { getCorrespondingLocations } from "../utils/sources";
 import { createFocusIntervalCacheForExecutionPoints } from "./FocusIntervalCache";
 import { mappedExpressionCache } from "./MappedExpressionCache";
-import { cachePauseData, setPointAndTimeForPauseId } from "./PauseCache";
+import { cachePauseData, setPointAndTimeForPauseId, updateMappedLocation } from "./PauseCache";
 import { sourcesByIdCache } from "./SourcesCache";
 
 export const hitPointsCache = createFocusIntervalCacheForExecutionPoints<
   [replayClient: ReplayClientInterface, location: Location, condition: string | null],
-  TimeStampedPoint
+  PointDescription
 >({
   debugLabel: "HitPointsCache",
   getKey: (replayClient, location, condition) =>
@@ -32,7 +32,7 @@ export const hitPointsCache = createFocusIntervalCacheForExecutionPoints<
       locations.map(location => breakpointPositionsCache.readAsync(replayClient, location.sourceId))
     );
 
-    let hitPoints: TimeStampedPoint[] = [];
+    let hitPoints: PointDescription[] = [];
 
     if (condition) {
       const mappedCondition = await mappedExpressionCache.readAsync(
@@ -70,6 +70,12 @@ export const hitPointsCache = createFocusIntervalCacheForExecutionPoints<
       // Type-wise we're going to return `TimeStampedPoint`s,
       // but the extra frame data is there in this case.
       hitPoints = pointDescriptions;
+    }
+
+    for (const point of hitPoints) {
+      if (point.frame) {
+        updateMappedLocation(sources, point.frame);
+      }
     }
 
     return hitPoints;

--- a/packages/shared/client/ReplayClient.ts
+++ b/packages/shared/client/ReplayClient.ts
@@ -891,6 +891,7 @@ export class ReplayClient implements ReplayClientInterface {
       frameIndex?: number;
       fullPropertyPreview?: boolean;
       limits?: PointPageLimits;
+      shareProcesses?: boolean;
     },
     onResults: (results: RunEvaluationResult[]) => void
   ): Promise<void> {
@@ -925,6 +926,7 @@ export class ReplayClient implements ReplayClientInterface {
           pointLimits,
           pointSelector: opts.selector,
           runEvaluationId,
+          shareProcesses: opts.shareProcesses,
         },
         sessionId
       );

--- a/packages/shared/client/types.ts
+++ b/packages/shared/client/types.ts
@@ -22,6 +22,7 @@ import {
   PauseId,
   PointDescription,
   PointLimits,
+  PointPageLimits,
   PointRange,
   PointRangeFocusRequest,
   PointSelector,
@@ -244,7 +245,8 @@ export interface ReplayClientInterface {
       expression: string;
       frameIndex?: number;
       fullPropertyPreview?: boolean;
-      limits?: PointLimits;
+      limits?: PointPageLimits;
+      shareProcesses?: boolean;
     },
     onResults: (results: RunEvaluationResult[]) => void
   ): Promise<void>;

--- a/src/ui/components/ProtocolViewer/ProtocolViewerPanel.tsx
+++ b/src/ui/components/ProtocolViewer/ProtocolViewerPanel.tsx
@@ -1,12 +1,18 @@
-import { unstable_Offscreen as Offscreen, Suspense, useContext, useState } from "react";
+import { unstable_Offscreen as Offscreen, Suspense, useContext, useMemo, useState } from "react";
 
 import Loader from "replay-next/components/Loader";
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { ProtocolViewer } from "ui/components/ProtocolViewer/components/ProtocolViewer";
 import { useIsRecordingOfReplay } from "ui/components/ProtocolViewer/hooks/useIsRecordingOfReplay";
-import { recordedProtocolMessagesCache } from "ui/components/ProtocolViewer/suspense/recordedProtocolMessagesCache";
 import {
+  RecordedProtocolData,
+  recordedProtocolMessagesCache,
+} from "ui/components/ProtocolViewer/suspense/recordedProtocolMessagesCache";
+import {
+  ProtocolErrorMap,
+  ProtocolRequestMap,
+  ProtocolResponseMap,
   getProtocolErrorMap,
   getProtocolRequestMap,
   getProtocolResponseMap,
@@ -64,18 +70,57 @@ export function LiveProtocolRequests() {
   return <ProtocolViewer errorMap={errorMap} requestMap={requestMap} responseMap={responseMap} />;
 }
 
+const NO_MESSAGES: RecordedProtocolData[] = [];
+
 function RecordedProtocolRequests() {
   const replayClient = useContext(ReplayClientContext);
   const { range: focusRange } = useContext(FocusContext);
 
   const sourceDetails = useAppSelector(getAllSourceDetails);
+  const sources = useAppSelector(state => state.sources);
+  const sessionSource = sourceDetails?.find(source => source.url?.includes("ui/actions/session"));
 
-  const { errorMap, requestMap, responseMap } = focusRange
-    ? recordedProtocolMessagesCache.read(replayClient, sourceDetails, {
-        begin: focusRange.begin.point,
-        end: focusRange.end.point,
-      })
-    : { errorMap: {}, requestMap: {}, responseMap: {} };
+  const allProtocolMessagesForRange =
+    sessionSource && focusRange
+      ? recordedProtocolMessagesCache.read(
+          BigInt(focusRange.begin.point),
+          BigInt(focusRange.end.point),
+          replayClient,
+          sessionSource,
+          sources
+        )
+      : NO_MESSAGES;
+
+  // The cache gave us the data as a flat array. Regroup it by request ID.
+  const groupedMessageData = useMemo(() => {
+    const errorMap: ProtocolErrorMap = {};
+    const requestMap: ProtocolRequestMap = {};
+    const responseMap: ProtocolResponseMap = {};
+
+    for (const messageData of allProtocolMessagesForRange) {
+      switch (messageData.type) {
+        case "error": {
+          errorMap[messageData.id] = messageData.value;
+          break;
+        }
+        case "request": {
+          requestMap[messageData.id] = messageData.value;
+          break;
+        }
+        case "response": {
+          responseMap[messageData.id] = messageData.value;
+          break;
+        }
+      }
+    }
+    return { requestMap, responseMap, errorMap } as const;
+  }, [allProtocolMessagesForRange]);
+
+  if (!sessionSource) {
+    return null;
+  }
+
+  const { requestMap, responseMap, errorMap } = groupedMessageData;
 
   return <ProtocolViewer errorMap={errorMap} requestMap={requestMap} responseMap={responseMap} />;
 }

--- a/src/ui/components/ProtocolViewer/ProtocolViewerPanel.tsx
+++ b/src/ui/components/ProtocolViewer/ProtocolViewerPanel.tsx
@@ -46,11 +46,11 @@ export function ProtocolViewerPanel() {
         <Offscreen mode={tab === "live" ? "visible" : "hidden"}>
           <LiveProtocolRequests />
         </Offscreen>
-        <Offscreen mode={tab === "recorded" ? "visible" : "hidden"}>
+        {isRecordingOfReplay && tab === "recorded" ? (
           <Suspense fallback={<Loader />}>
             <RecordedProtocolRequests />
           </Suspense>
-        </Offscreen>
+        ) : null}
       </div>
     </div>
   );

--- a/src/ui/components/ProtocolViewer/components/RequestDetails.tsx
+++ b/src/ui/components/ProtocolViewer/components/RequestDetails.tsx
@@ -19,17 +19,27 @@ export function RequestDetails() {
   const bugReportLink = useBugReportLink();
   const honeycombQueryLink = useHoneycombQueryLink();
 
+  const nothingSelected = (
+    <div className={styles.Details}>
+      <div className={styles.NoSelection}>Select a request to view its details</div>
+    </div>
+  );
+
   if (selectedRequestId === null) {
-    return (
-      <div className={styles.Details}>
-        <div className={styles.NoSelection}>Select a request to view its details</div>
-      </div>
-    );
+    return nothingSelected;
   }
 
   const error = errorMap[selectedRequestId];
   const request = requestMap[selectedRequestId];
   const response = responseMap[selectedRequestId];
+
+  // Every entry must have a request.
+  // But, if the focus window has slide around, the selected
+  // request ID may be out of date and we don't have anything
+  // available to show for the focus range.
+  if (!request) {
+    return nothingSelected;
+  }
 
   return (
     <div className={styles.Details}>

--- a/src/ui/components/ProtocolViewer/suspense/recordedProtocolMessagesCache.ts
+++ b/src/ui/components/ProtocolViewer/suspense/recordedProtocolMessagesCache.ts
@@ -1,61 +1,66 @@
-import { Location, PointRange, Value as ProtocolValue } from "@replayio/protocol";
+import {
+  Location,
+  PointDescription,
+  PointRange,
+  Property,
+  RunEvaluationResult,
+  TimeStampedPoint,
+} from "@replayio/protocol";
 import { Cache, createCache } from "suspense";
 
 import { breakpointPositionsCache } from "replay-next/src/suspense/BreakpointPositionsCache";
+import { recordingTargetCache } from "replay-next/src/suspense/BuildIdCache";
+import { createFocusIntervalCacheForExecutionPoints } from "replay-next/src/suspense/FocusIntervalCache";
 import { hitPointsForLocationCache } from "replay-next/src/suspense/HitPointsCache";
-import {
-  LogPointAnalysisResult,
-  getLogPointAnalysisResultAsync,
-} from "replay-next/src/suspense/LogPointAnalysisCache";
+import { mappedExpressionCache } from "replay-next/src/suspense/MappedExpressionCache";
 import { sourceOutlineCache } from "replay-next/src/suspense/SourceOutlineCache";
+import { compareExecutionPoints } from "replay-next/src/utils/time";
 import { ReplayClientInterface } from "shared/client/types";
 import {
+  ProtocolError,
   ProtocolErrorMap,
+  ProtocolRequest,
   ProtocolRequestMap,
+  ProtocolResponse,
   ProtocolResponseMap,
 } from "ui/reducers/protocolMessages";
-import { SourceDetails } from "ui/reducers/sources";
-import { getJSON } from "ui/utils/objectFetching";
+import { SourceDetails, SourcesState, getPreferredLocation } from "ui/reducers/sources";
 
-export const recordedProtocolMessagesCache: Cache<
-  [replayClient: ReplayClientInterface, sourceDetails: SourceDetails[], range: PointRange],
-  {
-    errorMap: ProtocolErrorMap;
-    requestMap: ProtocolRequestMap;
-    responseMap: ProtocolResponseMap;
-  }
-> = createCache({
-  config: { immutable: true },
-  debugLabel: "RecordedPotocolMessages",
-  getKey: ([replayClient, sourceDetails, range]) => `${range.begin}-${range.end}`,
-  load: async ([replayClient, sourceDetails, range]) => {
-    const sessionSource = sourceDetails.find(source => source.url?.includes("ui/actions/session"));
+export type RecordedProtocolData = {
+  id: number;
+  point: TimeStampedPoint;
+  recordedAt: number;
+} & (
+  | { type: "error"; value: ProtocolError }
+  | { type: "request"; value: ProtocolRequest }
+  | { type: "response"; value: ProtocolResponse }
+);
 
-    if (!sessionSource) {
-      return {
-        errorMap: {},
-        requestMap: {},
-        responseMap: {},
-      };
-    }
-
+export const recordedProtocolMessagesCache = createFocusIntervalCacheForExecutionPoints<
+  [replayClient: ReplayClientInterface, sessionSource: SourceDetails, sourcesState: SourcesState],
+  RecordedProtocolData
+>({
+  debugLabel: "RecordedProtocolMessages",
+  getPointForValue: data => data.point.point,
+  async load(rangeStart, rangeEnd, replayClient, sessionSource, sourcesState) {
     const [breakablePositionsSorted] = await breakpointPositionsCache.readAsync(
       replayClient,
       sessionSource.id
     );
     const symbols = await sourceOutlineCache.readAsync(replayClient, sessionSource.id);
+    const recordingTarget = await recordingTargetCache.readAsync(replayClient);
 
     const mapNamesToCallbackNames = {
       requestMap: "onRequest",
       responseMap: "onResponse",
       errorMap: "onResponseError",
-    };
+    } as const;
 
-    const results = {
-      errorMap: {},
-      requestMap: {},
-      responseMap: {},
-    };
+    const argNames = {
+      onRequest: "request",
+      onResponse: "response",
+      onResponseError: "error",
+    } as const;
 
     const promises = Object.entries(mapNamesToCallbackNames).map(
       async ([fieldName, functionName]) => {
@@ -63,7 +68,7 @@ export const recordedProtocolMessagesCache: Cache<
         const functionEntry = symbols?.functions.find(entry => entry.name === functionName);
 
         if (!functionEntry) {
-          return;
+          return [];
         }
 
         const { begin, end } = functionEntry.location;
@@ -74,8 +79,9 @@ export const recordedProtocolMessagesCache: Cache<
         );
 
         if (!firstBreakablePosition) {
-          return;
+          return [];
         }
+
         const position: Location = {
           sourceId: sessionSource.id,
           line: firstBreakablePosition.line,
@@ -85,69 +91,172 @@ export const recordedProtocolMessagesCache: Cache<
         // Get all the times that first line was hit
         const [hitPoints] = await hitPointsForLocationCache.readAsync(
           replayClient,
-          range,
+          {
+            begin: rangeStart,
+            end: rangeEnd,
+          },
           position,
           null
         );
 
-        // For every hit, grab the first arg, which should be the `event`
-        // that is either the request, response, or error data
-        const hitPointsWithResults = (
-          await Promise.all(
-            hitPoints.map(hp =>
-              getLogPointAnalysisResultAsync(
-                replayClient,
-                range,
-                hp,
-                position,
-                "[...arguments][0]",
-                null
-              )
-            )
-          )
-        ).filter(b => !!b) as LogPointAnalysisResult[];
+        const pointDescriptions = hitPoints as PointDescription[];
 
-        // For every analysis result, download the entire event object
-        // as a real JS object, and add the relevant timestamp
-        const events = await Promise.all(
-          hitPointsWithResults.map(async analysisResult => {
-            const values: ProtocolValue[] = analysisResult.values;
-            const [eventValue] = values;
+        if (pointDescriptions.length === 0) {
+          return [];
+        }
 
-            // @ts-ignore
-            let parsedObject: {
-              id: number;
-              recordedAt: number;
-            } = {};
-
-            if (eventValue?.object) {
-              parsedObject = (await getJSON(
-                replayClient,
-                analysisResult.pauseId!,
-                eventValue
-              )) as any;
-            }
-
-            parsedObject.recordedAt = analysisResult.time;
-
-            return parsedObject;
-          })
+        const preferredLocation = getPreferredLocation(
+          sourcesState,
+          pointDescriptions[0].frame ?? []
         );
 
-        const eventsById: Record<string, Object> = {};
+        if (!preferredLocation) {
+          return [];
+        }
 
-        // The `<ProtocolViewer>` wants these normalized by ID
-        events.forEach(event => {
-          eventsById[event.id] = event;
-        });
+        // Make sure we use the in-scope variable name here.
+        // Note that the expression often has `;` appended,
+        // so remove that.
+        const mappedExpression = (
+          await mappedExpressionCache.readAsync(
+            replayClient,
+            argNames[functionName],
+            preferredLocation
+          )
+        ).replace(";", "");
 
-        // @ts-ignore it wants specific field names, not `string`
-        results[fieldName] = eventsById;
+        // Now the ugly part. We need to serialize a potentially large
+        // JS object representing the protocol req/res/err.
+        // However, `runEvaluation` only returns a single level of
+        // object previews, as I found out while working on routines.
+        // The workaround is to call `JSON.stringify()` in the eval.
+        // BUT, Chromium has a 10K-character limit for strings.
+        // So, we break the string into 9999-char chunks, and stuff
+        // all those into a single array, and return _that_ from the eval.
+        // `serializeArgument` will be evaluated in the paused browser.
+        type ChunksArray = (string | number)[];
+        function serializeArgument(arg: any) {
+          // Gotta define this inline, since this whole function
+          // will be evaluated
+          function splitStringIntoChunks(allChunks: ChunksArray, str: string) {
+            // Split the stringified data into chunks
+            const stringChunks: string[] = [];
+            for (let i = 0; i < str.length; i += 9999) {
+              stringChunks.push(str.slice(i, i + 9999));
+            }
+
+            // If there's more than one string chunk, save its size
+            if (stringChunks.length > 1) {
+              allChunks.push(stringChunks.length);
+            }
+
+            for (const chunk of stringChunks) {
+              allChunks.push(chunk);
+            }
+            return stringChunks.length;
+          }
+
+          const stringifiedArg = JSON.stringify(arg);
+          const chunks: ChunksArray = [];
+          splitStringIntoChunks(chunks, stringifiedArg);
+
+          return chunks;
+        }
+
+        // The counterpart will run locally on the eval result data.
+        function deserializeChunkedString(chunks: Property[]): string {
+          let numStringChunks = 1;
+          if (typeof chunks[0].value === "number") {
+            const numChunksProp = chunks.shift()!;
+            numStringChunks = numChunksProp.value;
+          }
+          const stringChunks = chunks.splice(0, numStringChunks);
+
+          let str = "";
+          for (const stringChunkProp of stringChunks) {
+            str += stringChunkProp.value;
+          }
+
+          return str;
+        }
+
+        const evalResults: RunEvaluationResult[] = [];
+        await replayClient.runEvaluation(
+          {
+            // Run `serializeArgument` in an eval, and pass in the local variable
+            // as the argument to serialize
+            expression: `(${serializeArgument})(${mappedExpression})`,
+            limits: {
+              begin: rangeStart,
+              end: rangeEnd,
+              maxCount: 1000,
+            },
+            frameIndex: 0,
+            fullPropertyPreview: true,
+            selector: {
+              kind: "points",
+              points: pointDescriptions.map(hp => hp.point),
+            },
+            shareProcesses: recordingTarget === "chromium",
+          },
+          results => {
+            evalResults.push(...results);
+          }
+        );
+
+        evalResults.sort((a, b) => compareExecutionPoints(a.point.point, b.point.point));
+
+        const allProtocolData = evalResults
+          .map(evalResult => {
+            const { pauseId, data, returned, point } = evalResult;
+            if (!returned?.object) {
+              return undefined;
+            }
+
+            const obj = data.objects?.find(o => o.objectId === returned.object);
+            if (!obj) {
+              return;
+            }
+
+            const properties = obj.preview?.properties ?? [];
+            const remainingProperties = properties.filter(prop => {
+              const expectedIndex = Number.parseInt(prop.name);
+
+              if (prop.isSymbol || !Number.isInteger(expectedIndex)) {
+                // Array preview won't normally hit this case, but since this code is
+                // currently running on the user's actual page content, they may have
+                // overloaded properties on Array.prototype that could show up here.
+                return false;
+              }
+
+              return true;
+            });
+
+            const fullString = deserializeChunkedString(remainingProperties);
+            const parsedObject: ProtocolRequest | ProtocolResponse | ProtocolError =
+              JSON.parse(fullString);
+
+            parsedObject.recordedAt = point.time;
+
+            // @ts-ignore doesn't like the unioned `value` field
+            const recordedProtocolData: RecordedProtocolData = {
+              id: parsedObject.id,
+              point,
+              recordedAt: point.time,
+              type: argNames[functionName],
+              value: parsedObject,
+            };
+
+            return recordedProtocolData;
+          })
+          .filter(b => !!b) as RecordedProtocolData[];
+
+        return allProtocolData;
       }
     );
 
-    await Promise.all(promises);
-
+    const results = (await Promise.all(promises)).flat();
+    results.sort((a, b) => compareExecutionPoints(a.point.point, b.point.point));
     return results;
   },
 });


### PR DESCRIPTION
This PR:

- Makes a few small tweaks
  - Removed a console log from an E2E test helper
  - Updated `hitPointsCache` to stop stripping `frame` info out of hit points
  - Updated `ReplayClient.runEvaluation` options to match what the protocol currently allows
- Rewrites the "Recorded Protocol Viewer" panel to use `runEvaluation` and an interval cache for better perf

The "Recorded Protocol Viewer" panel was _really_ slow, largely because it was trying to make dozens or hundreds of calls to the `logPointAnalysisCache` to extract the arguments to our protocol `onRequest/onResponse/onRequestError` callbacks.  That's the use case `runEvaluation` is meant to solve.  Also, it was rerunning all the requests every time you changed the focus range.

I've rewritten it to use an interval cache, and the body now uses `runEvaluation` to fetch the data.

This did get tricky, because `runEvaluation` still only lets you return 1 depth of object previews, and the response objects can be arbitrarily large.  So, I've resorted to the same trick Logan and I used in the routines: `JSON.stringify()` the actual value in the evaluation, split it into 9999-character chunks to work around our Chromium 10K-character limit, stick all those chunks into one array as the final eval result, then reconstruct the large string and run it through `JSON.parse()` on the other end (whew!).

This actually works!  It can still take a few seconds for it to process several hundred protocol requests, but the data looks good in the UI, and it should now only fetch a given range's protocol requests once.