### PR TITLE
Improve RDT component inspection and avoid timeouts

### DIFF
--- a/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
+++ b/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
@@ -72,7 +72,6 @@ class ReplayWall implements Wall {
   private _listener?: (msg: any) => void;
   private inspectedElements = new Set();
   private highlightedElementId?: number;
-  private recordingTarget: RecordingTarget | null = null;
   store?: StoreWithInternals;
   pauseId?: string;
 
@@ -239,11 +238,9 @@ class ReplayWall implements Wall {
   }
 
   public async ensureReactDevtoolsBackendLoaded() {
-    if (this.recordingTarget === null) {
-      this.recordingTarget = await recordingTargetCache.readAsync(this.replayClient);
-    }
+    const recordingTarget = await recordingTargetCache.readAsync(this.replayClient);
 
-    if (this.recordingTarget === "chromium") {
+    if (recordingTarget === "chromium") {
       const pauseId = await ThreadFront.getCurrentPauseId(this.replayClient);
       await injectReactDevtoolsBackend(this.replayClient, pauseId);
     }
@@ -634,7 +631,6 @@ export function ReactDevtoolsPanel() {
 
   useEffect(() => {
     if (wall && currentPoint !== null) {
-      console.log("Starting RDT injection from effect");
       wall.ensureReactDevtoolsBackendLoaded();
     }
   }, [currentPoint, wall]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -14786,11 +14786,11 @@ __metadata:
 
 "react-devtools-inline@patch:react-devtools-inline@npm:4.24.7#.yarn/patches/react-devtools-inline-npm-4.24.7-9582a0f8d6.patch::locator=recordreplay-devtools%40workspace%3A.":
   version: 4.24.7
-  resolution: "react-devtools-inline@patch:react-devtools-inline@npm%3A4.24.7#.yarn/patches/react-devtools-inline-npm-4.24.7-9582a0f8d6.patch::version=4.24.7&hash=16cfed&locator=recordreplay-devtools%40workspace%3A."
+  resolution: "react-devtools-inline@patch:react-devtools-inline@npm%3A4.24.7#.yarn/patches/react-devtools-inline-npm-4.24.7-9582a0f8d6.patch::version=4.24.7&hash=b2b58f&locator=recordreplay-devtools%40workspace%3A."
   dependencies:
     source-map-js: ^0.6.2
     sourcemap-codec: ^1.4.8
-  checksum: 619eef6d9027c231daeb18a7229153d01b3e7e5c0a8881411a861c18f19703aac1cf56209683eed54411c0f93bda46effab96c30b47a20c11ecbf21886909624
+  checksum: 459c911eb486b5f0f654bca557ea3d12c1d88c57c0f1e0488ea34b596a87c7cd0f864fed7bd8188a0d1a93acd0bdb159b2f7b3ca16942b3ecf6b68ad88abaa03
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Updated the RDT panel to inject the backend eval earlier (as soon as it pauses, rather than waiting for the first request attempt)
- Added check to avoid passing on messages to the RDT UI if the pause has changed since the request started
- Patched RDT `frontend.js` to increase timeout from 5s -> 15s

This doesn't completely eliminate the chance of an inspection timeout, but given that it looked like inspection results _usually_ come back within a few seconds (and in some cases, less than 500ms after the UI had timed out), I think this should significantly reduce the chances of us hitting a timeout.

(the RDT `.patch` file is ginormous because I hand-edited the sourcemap to match, for completeness, and that's all one giant line.  all I actually changed was `const TIMEOUT = 5000` => `15000`.)