### PR TITLE
Fix sidebar gear icon clipping with long team names

### DIFF
--- a/src/ui/components/Library/Navigation/TeamButton.tsx
+++ b/src/ui/components/Library/Navigation/TeamButton.tsx
@@ -81,7 +81,7 @@ export function SettingsButton() {
   return (
     <button
       onClick={onClick}
-      className="material-icons w-5 text-sm text-gray-200 transition duration-200"
+      className="material-icons w-5 flex-shrink-0 text-sm text-gray-200 transition duration-200"
     >
       settings
     </button>


### PR DESCRIPTION
Was
<img width="282" alt="image" src="https://github.com/replayio/devtools/assets/788456/8a9f746f-2c2f-490c-9816-231f89470eaa">

Now
<img width="293" alt="image" src="https://github.com/replayio/devtools/assets/788456/f53aa060-d597-422b-bd3b-a8ff4a2c8152">
