### PR TITLE
Fix text input sizing in settings modal

### DIFF
--- a/src/ui/components/shared/Forms/TextInput.module.css
+++ b/src/ui/components/shared/Forms/TextInput.module.css
@@ -16,39 +16,39 @@
   text-align: center;
 }
 
-.system .textInput {
+.system.textInput {
   background-color: var(--theme-text-field-bgcolor);
   color: var(--theme-text-field-color);
   border-color: var(--input-border);
   caret-color: var(--theme-text-field-color);
 }
 
-.system .textInput:hover {
+.system.textInput:hover {
   background-color: var(--theme-text-field-bgcolor-hover);
 }
 
 /* Dark theme */
 
-.dark .textInput {
+.dark.textInput {
   background-color: #3e434b; /* Dark: --theme-text-field-bgcolor */
   color: #fff; /* --theme-text-field-color: */
   border-color: #3e434b; /* Dark: --input-border */
   caret-color: #fff;
 }
 
-.dark .textInput:hover {
+.dark.textInput:hover {
   background-color: #192230; /* Dark: --theme-text-field-bgcolor-hover: */
 }
 
 /* Light theme */
 
-.light .textInput {
+.light.textInput {
   background-color: #f6f6f6; /* --theme-text-field-bgcolor */
   color: #38383d; /* Light: var(--body-color); */
   border-color: var(--cool-gray-200); /* --input-border */
   caret-color: #38383d;
 }
 
-.light .textInput:hover {
+.light.textInput:hover {
   background-color: var(--theme-base-95); /* --theme-text-field-bgcolor-hover: */
 }

--- a/src/ui/components/shared/Forms/TextInput.tsx
+++ b/src/ui/components/shared/Forms/TextInput.tsx
@@ -31,15 +31,12 @@ export default React.forwardRef<
   }
 
   const inputClass = classNames(
+    styles[themeClass],
     styles.textInput,
     textSizeClass,
     center ? styles.textCenter : "",
     className
   );
 
-  return (
-    <div className={styles[themeClass]}>
-      <input {...otherProps} ref={ref} type="text" className={inputClass} />
-    </div>
-  );
+  return <input {...otherProps} ref={ref} type="text" className={inputClass} />;
 });


### PR DESCRIPTION
## Issue

Several text boxes in the settings modal were short instead of taking the whole width. This was a regression from #9624 which added an extra DOM layer that broke some of the existing layout

## Fix

Remove the layer and fix up the associated CSS

Was:
![image](https://github.com/replayio/devtools/assets/788456/9b599bf0-cc1e-4884-a37d-0c618948f22a)

Now:
<img width="513" alt="image" src="https://github.com/replayio/devtools/assets/788456/cc36cd69-5d22-4c8e-954f-7f0651e2127f">

