### PR TITLE
Fix source viewer copy/paste format

### DIFF
--- a/packages/replay-next/components/sources/SourceList.module.css
+++ b/packages/replay-next/components/sources/SourceList.module.css
@@ -1,3 +1,12 @@
 .List {
   overscroll-behavior: none;
 }
+
+.List > div {
+  /**
+  * Each row should grow as much as needed to fit its code/content.
+  * The parent list will measure rows after render and adjust the min-width of the list.
+  * This prevents horizontal scrolling from jumping as new rows are rendered.
+  */
+  width: var(--longest-line-width) !important;
+}

--- a/packages/replay-next/components/sources/SourceListRow.module.css
+++ b/packages/replay-next/components/sources/SourceListRow.module.css
@@ -1,13 +1,4 @@
 .Row {
-  /**
-  * Each row should grow as much as needed to fit its code/content.
-  * The parent list will measure rows after render and adjust the min-width of the list.
-  * This prevents horizontal scrolling from jumping as new rows are rendered.
-  */
-  min-width: var(--longest-line-width);
-  width: unset !important;
-
-  white-space: pre;
   font-family: var(--font-family-monospace);
   font-size: var(--font-size-regular);
   display: flex;

--- a/packages/replay-next/components/sources/SourceListRowFormattedText.module.css
+++ b/packages/replay-next/components/sources/SourceListRowFormattedText.module.css
@@ -1,0 +1,4 @@
+.Text {
+  display: block;
+  white-space: pre;
+}

--- a/packages/replay-next/components/sources/SourceListRowFormattedText.tsx
+++ b/packages/replay-next/components/sources/SourceListRowFormattedText.tsx
@@ -3,6 +3,8 @@ import { ReactNode, memo } from "react";
 import { getClassNames, isTokenInspectable } from "replay-next/components/sources/utils/tokens";
 import { ParsedToken } from "replay-next/src/utils/syntax-parser";
 
+import styles from "./SourceListRowFormattedText.module.css";
+
 // Primarily exists as a way for e2e tests to disable syntax highlighting
 // to simulate large files that aren't fully parsed.
 let disableSyntaxHighlighting = false;
@@ -29,7 +31,7 @@ export const SourceListRowFormattedText = memo(
     plainText: string | null;
   }) => {
     if (plainText === null || parsedTokens === null || disableSyntaxHighlighting) {
-      return plainText;
+      return <div className={styles.Text}>{plainText}</div>;
     }
 
     let renderedTextLength = 0;
@@ -59,7 +61,7 @@ export const SourceListRowFormattedText = memo(
       renderedTextLength += token.value.length;
     }
 
-    return renderedTokens as any;
+    return <div className={styles.Text}>{renderedTokens}</div>;
   }
 );
 

--- a/packages/replay-next/components/sources/SourceListRowLineHighlight.module.css
+++ b/packages/replay-next/components/sources/SourceListRowLineHighlight.module.css
@@ -3,7 +3,7 @@
 .ViewSourceHighlight {
   position: absolute;
   left: var(--source-line-number-offset);
-  right: 0;
+  width: calc(var(--longest-line-width) - var(--source-line-number-offset));
   top: 0;
   height: var(--line-height);
   z-index: -1;

--- a/packages/replay-next/components/sources/hooks/useSourceListCssVariables.ts
+++ b/packages/replay-next/components/sources/hooks/useSourceListCssVariables.ts
@@ -60,7 +60,7 @@ export function useSourceListCssVariables({
         let longestLineWidth = 0;
         for (let index = 0; index < innerElement.children.length; index++) {
           const child = innerElement.children[index];
-          longestLineWidth = Math.max(longestLineWidth, child.clientWidth);
+          longestLineWidth = Math.max(longestLineWidth, child.clientWidth, child.scrollWidth);
         }
 
         if (longestLineWidth > longestLineWidthRef.current) {

--- a/packages/replay-next/playwright/tests/utils/source.ts
+++ b/packages/replay-next/playwright/tests/utils/source.ts
@@ -136,7 +136,11 @@ export async function continueTo(
 
   switch (use) {
     case "context-menu": {
-      await showContextMenu(page, lineLocator);
+      // It's safer to hover over this locator to avoid accidentally triggering a preview popup
+      // (which might block a context-menu click)
+      const hitCountLocator = lineLocator.locator(`[data-test-name="SourceLine-HitCount"]`);
+
+      await showContextMenu(page, hitCountLocator);
       const menuItem = await findContextMenuItem(
         page,
         direction === "next" ? "Fast forward" : "Rewind"


### PR DESCRIPTION
Seems like the extra wrapper element is unavoidable because of the parent using `display: flex`

I tried using `display: block` on the parent instead, but for some reason that resulted in no line breaks being copied at all, even when selecting multiple lines.