### PR TITLE
Address margins for source viewer search

### DIFF
--- a/packages/replay-next/components/sources/SourceSearch.module.css
+++ b/packages/replay-next/components/sources/SourceSearch.module.css
@@ -1,14 +1,14 @@
 .Outer {
-  width: 100%;
   padding: 0.25rem 0;
   background-color: var(--color-contrast);
+  margin: 1px 5px 4px 5px;
 }
 
 .Container,
 .ContainerFocused {
   width: 100%;
   height: 1.75rem;
-  border: 2px solid var(--background-color-contrast-2);
+  border: 1px solid var(--background-color-contrast-2);
   overflow: hidden;
   border-radius: 0.5rem;
   display: flex;


### PR DESCRIPTION
**Description**

I'm improving the balance for our search box. It was originally [filed](https://linear.app/replay/issue/FE-1828/find-bar-should-not-have-a-border-radius) with a suggestion to remove the border radius. But that would cause its own composition issues. Better is to give the component its own space, with consistent margins.

Old on left, new on right:
<img width="1318" alt="image" src="https://github.com/replayio/devtools/assets/9154902/6073db2a-943d-46d7-a4a7-064b564e91e4">

Zoomed out view:
<img width="1186" alt="image" src="https://github.com/replayio/devtools/assets/9154902/1533412f-3e17-402b-b1b1-b7720aedc931">

rem vs px note: we frequently default to .25rem increments, which is great. But there are cases like these where we need more precise than that approach offers.