### PR TITLE
Add Tour to Testsuites

### DIFF
--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -650,6 +650,10 @@
   --loading-background: var(--theme-base-100);
   --loading-boxes: var(--chrome);
 
+  /* Tour */
+  --tour-body-color: #fff;
+  --tour-callout-body-color: #ff0;
+
   /* Focus mode editor (dark) */
   --focus-mode-capsule-bgcolor-hover: #232938;
   --focus-mode-capsule-bgcolor: var(--theme-base-90);
@@ -1172,6 +1176,10 @@
   /* Loading screen */
   --loading-background: var(--chrome);
   --loading-boxes: white;
+
+  /* Tour */
+  --tour-body-color: #fff;
+  --tour-callout-body-color: #ff0;
 
   /* Focus mode editor (light) */
   --focus-mode-capsule-bgcolor-hover: #d8d8d8;

--- a/src/ui/components/Passport/Passport.tsx
+++ b/src/ui/components/Passport/Passport.tsx
@@ -323,22 +323,12 @@ const Passport = (props: PropsFromRedux) => {
         />
       )}
 
-      {showTestsuitesPassportFirstRun && recording && isTestSuiteReplay(recording) ? (
-        <div className={styles.TestsuitesPassportWelcome}>
-          <h2>Passport</h2>
-          <p>
-            This sidebar shows some of our most helpful features alongside a little video. Try
-            clicking around to learn more!
-          </p>
-        </div>
-      ) : (
-        <div className={styles.ToolbarHeader}>
-          Time Traveller Passport
-          <button className={styles.close} onClick={hideFeatureShowPassport}>
-            <Icon type="close" />
-          </button>
-        </div>
-      )}
+      <div className={styles.ToolbarHeader}>
+        Time Traveller Passport
+        <button className={styles.close} onClick={hideFeatureShowPassport}>
+          <Icon type="close" />
+        </button>
+      </div>
 
       <div className="flex-grow overflow-auto">
         <div className="p-2">

--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -435,7 +435,7 @@ export default function Toolbar() {
   return (
     <div className={styles.toolboxToolbarContainer}>
       <div className={styles.toolboxToolbar}>
-        {testRunner !== "cypress" && showTour ? (
+        {showTour ? (
           <ToolbarButton icon="tour" name="tour" label="Replay Tour" onClick={handleButtonClick} />
         ) : null}
         {showPassport ? (

--- a/src/ui/components/Tour/Tour.module.css
+++ b/src/ui/components/Tour/Tour.module.css
@@ -21,16 +21,24 @@
 }
 
 .stepCallout {
-  border: 1px solid #fff;
-  background-color: rgba(255, 255, 255, 0.05);
-  padding: 0.5em 0.5em;
-  border-radius: 4px;
+  display: flex;
+  align-items: top;
+  color: #ff0;
+}
+
+.stepCallout .Icon {
+  width: 16px;
+  color: #ff0;
+}
+
+.stepCalloutText {
+  padding-top: 1px;
 }
 
 .h1 {
   color: #fff;
   margin-bottom: 20px;
-  font-size: 22px;
+  font-size: 18px;
   font-weight: 500;
   border-bottom: 1px solid rgba(255, 255, 255, 0.3);
   padding-bottom: 1rem;
@@ -40,7 +48,7 @@
 
 .intro {
   color: #fff;
-  font-size: 18px;
+  font-size: 14px;
   font-weight: 300;
   margin-bottom: 1rem;
   height: 100%;

--- a/src/ui/components/Tour/Tour.module.css
+++ b/src/ui/components/Tour/Tour.module.css
@@ -15,7 +15,7 @@
 }
 
 .TourBox {
-  color: #fff;
+  color: var(--tour-body-color);
   padding: 0.5rem;
   height: 100vh;
 }
@@ -23,12 +23,12 @@
 .stepCallout {
   display: flex;
   align-items: top;
-  color: #ff0;
+  color: var(--tour-callout-body-color);
 }
 
 .stepCallout .Icon {
   width: 16px;
-  color: #ff0;
+  color: var(--tour-callout-body-color);
 }
 
 .stepCalloutText {
@@ -36,7 +36,7 @@
 }
 
 .h1 {
-  color: #fff;
+  color: var(--tour-body-color);
   margin-bottom: 20px;
   font-size: 18px;
   font-weight: 500;
@@ -47,7 +47,7 @@
 }
 
 .intro {
-  color: #fff;
+  color: var(--tour-body-color);
   font-size: 14px;
   font-weight: 300;
   margin-bottom: 1rem;

--- a/src/ui/components/Tour/Tour.tsx
+++ b/src/ui/components/Tour/Tour.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 
+import Icon from "replay-next/components/Icon";
 import { userData } from "shared/user-data/GraphQL/UserData";
 import { setSelectedPrimaryPanel } from "ui/actions/layout";
 import { shouldShowDevToolsNag } from "ui/components/Header/ViewToggle";
@@ -63,15 +64,31 @@ const Tour: React.FC = () => {
 
   const intro = (
     <div className={styles.intro}>
-      <p className={styles.h1}>Hello and welcome!</p>
+      <p className={styles.h1}>Welcome!</p>
       {typeOfReplay === "events" ? (
         <>
           <p>Replay is the first time-travel enabled DevTools. Let's get started!</p>
+          <div className={styles.stepCallout}>
+            <Icon className={styles.Icon} type="error" />
+
+            <div className={styles.stepCalloutText}>Click on DevTools in the top right</div>
+          </div>
+        </>
+      ) : (
+        <>
           <p>
-            <div className={styles.stepCallout}>Click on DevTools in the top right.</div>
+            Replay lets you debug flaky tests in a familiar DevTools environment. When you’re ready
+            to see our best feature, please click DevTools at the top right.
+          </p>
+          <p>
+            <div className={styles.stepCallout}>
+              <Icon className={styles.Icon} type="error" />
+
+              <div className={styles.stepCalloutText}>Click on DevTools in the top right</div>
+            </div>
           </p>
         </>
-      ) : null}
+      )}
     </div>
   );
 
@@ -82,17 +99,39 @@ const Tour: React.FC = () => {
     </div>
   );
 
-  const timeTravel = (
-    <div className={styles.intro}>
-      <div className={styles.h1}>Time travel 🚀</div>
-      <p>In DevTools, look underneath the video to find the Replay console.</p>
-      <p>
-        <div className={styles.stepCallout}>
-          Hover in the console and click a button to time travel!
-        </div>
-      </p>
-    </div>
-  );
+  const timeTravel =
+    typeOfReplay === "events" ? (
+      <div className={styles.intro}>
+        <div className={styles.h1}>Time travel 🚀</div>
+        <p>In DevTools, look underneath the video to find the Replay console.</p>
+        <p>
+          <div className={styles.stepCallout}>
+            <Icon className={styles.Icon} type="error" />
+            <div className={styles.stepCalloutText}>
+              Hover in the console and click a button to time travel!
+            </div>
+          </div>
+        </p>
+      </div>
+    ) : (
+      <div className={styles.intro}>
+        <div className={styles.h1}>Time travel 🚀</div>
+
+        <p>
+          Now look underneath the video to find the Replay console, which should have messages you
+          can time travel to.
+        </p>
+
+        <p>If your console is empty, open the console menu to enable a mouse event to track.</p>
+
+        <p>
+          <div className={styles.stepCallout}>
+            <Icon className={styles.Icon} type="error" />
+            <div className={styles.stepCalloutText}>Click a time travel button in the console</div>
+          </div>
+        </p>
+      </div>
+    );
 
   const TimeTravelGif = () => (
     <img src="https://vercel.replay.io/tour/fast-forward.gif" className={styles.videoExample} />
@@ -110,11 +149,14 @@ const Tour: React.FC = () => {
 
       <p>
         Now a file should be open in the Source Viewer. (If not, you can open a file by pressing
-        command-P or clicking Sources Explorer from the left-nav)
+        command-P or clicking Sources Explorer from the left nav)
       </p>
       <p>
         <div className={styles.stepCallout}>
-          Click the plus button on a line of code to set a print statement.
+          <Icon className={styles.Icon} type="error" />
+          <div className={styles.stepCalloutText}>
+            Click the plus button on a line of code to set a print statement.
+          </div>
         </div>
       </p>
     </div>
@@ -130,7 +172,8 @@ const Tour: React.FC = () => {
       <p>You can pass anything you want into print statements, including objects and variables.</p>
       <p>
         <div className={styles.stepCallout}>
-          Type something, then hit enter or click the check button.
+          <Icon className={styles.Icon} type="error" />
+          <div className={styles.stepCalloutText}>Type something and hit enter to save</div>
         </div>
       </p>
     </div>
@@ -219,7 +262,7 @@ const Tour: React.FC = () => {
       </div>
       <div className="absolute bottom-28 p-3">
         {(isNewUser || viewMode === "non-dev") && (
-          <div className="relative -bottom-3">
+          <div className="relative -bottom-6">
             <img src="/images/illustrations/larry_wave.png" className="z-1 w-full" />
           </div>
         )}


### PR DESCRIPTION
**Background**

This adds our Tour flow to the Testsuites experience, but with different copy to handle the differences with the standard Tour.

**How testsuites will look:**
![image](https://github.com/replayio/devtools/assets/9154902/cf247429-bc30-48b0-b6f7-689ff368e051)

**How standard replays will look:**
![image](https://github.com/replayio/devtools/assets/9154902/06098268-37bf-4a69-8b41-9bf40c24bb4f)

And as comparison, here's how standard replays looked before these visual adjustments. The most notable change is how I'm making a more clear yellow callout rather than using a single pixel border that looks like a button:
![image](https://github.com/replayio/devtools/assets/9154902/59cb4345-8c54-4ee8-b79f-f3f133965c61)

I am tracking the text differences in [this Notion document](https://www.notion.so/replayio/Testsuites-Tour-Copy-9aeb9b921b49415b81a739bd0e0f0829?pvs=4). I'm doing Figma work [here](https://www.figma.com/file/mAotNZRv6M5X0zHIFKPzFY/Replay-Design-Doc?type=design&node-id=18482-63785&mode=design).

**Status**

~~I have a few more edgecases I need to track down. First, I don't think we should default to Larry for testsuites users, so I'll need to special-case that. Second, I need to make sure our other paths aren't adversely affected by this change. Stay tuned for that.~~ Ok, I've done my due diligence and this is ready for review.