### PR TITLE
Update all e2e tests to wait for loading+indexing to finish before starting

### DIFF
--- a/packages/e2e-tests/tests/cypress-01_basic-panel.test.ts
+++ b/packages/e2e-tests/tests/cypress-01_basic-panel.test.ts
@@ -18,7 +18,7 @@ import {
   getTestSuiteUser,
   openCypressTestPanel,
 } from "../helpers/testsuites";
-import { waitFor, waitForRecordingToFinishIndexing } from "../helpers/utils";
+import { waitFor } from "../helpers/utils";
 import test, { expect } from "../testFixtureCloneRecording";
 
 test.use({ exampleKey: "flake/adding-spec.ts" });
@@ -28,8 +28,6 @@ test("cypress-01: Basic Test Suites panel functionality", async ({
   exampleKey,
 }) => {
   await startTest(page, exampleKey, recordingId);
-  await waitForRecordingToFinishIndexing(page);
-
   await openDevToolsTab(page);
 
   await openCypressTestPanel(page);

--- a/packages/e2e-tests/tests/cypress-02_test-step-timelines.test.ts
+++ b/packages/e2e-tests/tests/cypress-02_test-step-timelines.test.ts
@@ -7,7 +7,7 @@ import {
   openCypressTestPanel,
 } from "../helpers/testsuites";
 import { getTimelineCurrentHoverPercent, getTimelineCurrentPercent } from "../helpers/timeline";
-import { waitFor, waitForRecordingToFinishIndexing } from "../helpers/utils";
+import { waitFor } from "../helpers/utils";
 import test, { expect } from "../testFixtureCloneRecording";
 
 test.use({ exampleKey: "flake/adding-spec.ts" });
@@ -17,8 +17,6 @@ test("cypress-02: Test Step timeline behavior", async ({
   exampleKey,
 }) => {
   await startTest(page, exampleKey, recordingId);
-  await waitForRecordingToFinishIndexing(page);
-
   await openViewerTab(page);
 
   await openCypressTestPanel(page);

--- a/packages/e2e-tests/tests/cypress-03_test-step-interactions.test.ts
+++ b/packages/e2e-tests/tests/cypress-03_test-step-interactions.test.ts
@@ -11,7 +11,7 @@ import {
   openCypressTestPanel,
 } from "../helpers/testsuites";
 import { waitForTimelineAdvanced } from "../helpers/timeline";
-import { getByTestName, waitFor, waitForRecordingToFinishIndexing } from "../helpers/utils";
+import { getByTestName, waitFor } from "../helpers/utils";
 import test, { expect } from "../testFixtureCloneRecording";
 
 test.use({ exampleKey: "flake/adding-spec.ts" });
@@ -21,8 +21,6 @@ test("cypress-03: Test Step interactions", async ({
   exampleKey,
 }) => {
   await startTest(page, exampleKey, recordingId);
-  await waitForRecordingToFinishIndexing(page);
-
   await openViewerTab(page);
 
   await openCypressTestPanel(page);

--- a/packages/e2e-tests/tests/cypress-04_menu-commands.test.ts
+++ b/packages/e2e-tests/tests/cypress-04_menu-commands.test.ts
@@ -8,7 +8,7 @@ import {
   openCypressTestPanel,
 } from "../helpers/testsuites";
 import { getTimelineCurrentPercent, waitForTimelineAdvanced } from "../helpers/timeline";
-import { getByTestName, waitFor, waitForRecordingToFinishIndexing } from "../helpers/utils";
+import { getByTestName, waitFor } from "../helpers/utils";
 import test, { expect } from "../testFixtureCloneRecording";
 
 test.use({ exampleKey: "cypress-realworld/bankaccounts.spec.js" });
@@ -18,8 +18,6 @@ test("cypress-04: Test Step buttons and menu item", async ({
   exampleKey,
 }) => {
   await startTest(page, exampleKey, recordingId);
-  await waitForRecordingToFinishIndexing(page);
-
   await openViewerTab(page);
 
   await openCypressTestPanel(page);

--- a/packages/e2e-tests/tests/network-02.test.ts
+++ b/packages/e2e-tests/tests/network-02.test.ts
@@ -7,7 +7,6 @@ import {
   verifyNetworkDetailsPanelContains,
   verifyNetworkDetailsTabsVisible,
 } from "../helpers/network-panel";
-import { waitForRecordingToFinishIndexing } from "../helpers/utils";
 import test from "../testFixtureCloneRecording";
 
 test.use({ exampleKey: "flake/adding-spec.ts" });
@@ -19,9 +18,6 @@ test(`network-02: should show details for the selected request`, async ({
   await startTest(page, exampleKey, recordingId);
   await openDevToolsTab(page);
   await openNetworkPanel(page);
-
-  // Fetching Network requests/details can be slow for recordings that aren't fully indexed
-  await waitForRecordingToFinishIndexing(page);
 
   // Select a font element and verify the correct detail headers are shown
   await filterByText(page, "fa-regular-400");

--- a/packages/e2e-tests/tests/network-03.test.ts
+++ b/packages/e2e-tests/tests/network-03.test.ts
@@ -1,5 +1,4 @@
 import { openDevToolsTab, startTest } from "../helpers";
-import { quickOpen } from "../helpers/commands";
 import {
   openNetworkPanel,
   seekToRequestRow,
@@ -7,7 +6,6 @@ import {
   verifyRequestRowTimelineState,
 } from "../helpers/network-panel";
 import { fastForwardToLine, waitForSourceContentsToFinishStreaming } from "../helpers/source-panel";
-import { waitForRecordingToFinishIndexing } from "../helpers/utils";
 import test from "../testFixtureCloneRecording";
 
 test.use({ exampleKey: "flake/adding-spec.ts" });
@@ -19,9 +17,6 @@ test(`network-03: should sync and display the current time in relation to the ne
   await startTest(page, exampleKey, recordingId);
   await openDevToolsTab(page);
   await openNetworkPanel(page);
-
-  // Fetching Source contents can be slow for recordings that aren't fully indexed
-  await waitForRecordingToFinishIndexing(page);
 
   await selectRequestRow(page, {
     name: "cypress_runner.js",


### PR DESCRIPTION
Hopefully this helps offset the recent increase in flakiness seemingly related to cloning recordings before running tests