### PR TITLE
Use pre-processing annotation type to show tab

### DIFF
--- a/src/ui/components/SecondaryToolbox/index.tsx
+++ b/src/ui/components/SecondaryToolbox/index.tsx
@@ -17,7 +17,7 @@ import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { SecondaryPanelName, ToolboxLayout } from "ui/state/layout";
 import {
   REACT_ANNOTATIONS_KIND,
-  REDUX_ANNOTATIONS_KIND,
+  REDUX_SETUP_ANNOTATIONS_KIND,
   annotationKindsCache,
 } from "ui/suspense/annotationsCaches";
 import { trackEvent } from "ui/utils/telemetry";
@@ -175,7 +175,7 @@ function SecondaryToolbox({
   const { value: hasReduxAnnotations = false } = useImperativeCacheValue(
     annotationKindsCache,
     replayClient,
-    REDUX_ANNOTATIONS_KIND
+    REDUX_SETUP_ANNOTATIONS_KIND
   );
 
   const chromiumNetMonitorEnabled = useGraphQLUserData("feature_chromiumNetMonitor");

--- a/src/ui/suspense/annotationsCaches.ts
+++ b/src/ui/suspense/annotationsCaches.ts
@@ -32,6 +32,7 @@ export interface ParsedJumpToCodeAnnotation extends TimeStampedPoint {
 }
 
 export const REACT_ANNOTATIONS_KIND = "react-devtools-bridge";
+export const REDUX_SETUP_ANNOTATIONS_KIND = "redux-devtools-setup";
 export const REDUX_ANNOTATIONS_KIND = "redux-devtools-data";
 export const JUMP_ANNOTATION_KIND = "event-listeners-jump-location";
 


### PR DESCRIPTION
Fixes [FE-1697](https://linear.app/replay/issue/FE-1697)
Uses `redux-devtools-setup` annotation kind instead of `redux-devtools-data`