### PR TITLE
Fix the way we track whether a session is for a test recording

### DIFF
--- a/pages/recording/[[...id]].tsx
+++ b/pages/recording/[[...id]].tsx
@@ -169,10 +169,6 @@ function RecordingPage({
 
       setRecording(rec);
 
-      if (rec.isTest) {
-        trackEvent("session_start.test");
-      }
-
       if (Array.isArray(query.id) && query.id[query.id.length - 1] === "share") {
         dispatch(setModal("sharing", { recordingId }));
       }

--- a/src/ui/setup/index.ts
+++ b/src/ui/setup/index.ts
@@ -183,12 +183,15 @@ export async function bootstrapApp() {
 
     const userInfo = await getUserInfo();
     if (userInfo) {
+      const recordingId = getRecordingId();
+      const rec = recordingId ? await getRecording(recordingId) : null;
+
       const userSettings = await getUserSettings();
       const workspaceId = userSettings.defaultWorkspaceId;
       const role = userData.get("global_role");
 
       setTelemetryContext(userInfo);
-      maybeSetMixpanelContext({ ...userInfo, workspaceId, role });
+      maybeSetMixpanelContext({ ...userInfo, workspaceId, role, isTest: rec?.isTest });
     }
 
     initLaunchDarkly();

--- a/src/ui/utils/mixpanel.ts
+++ b/src/ui/utils/mixpanel.ts
@@ -143,9 +143,9 @@ export function initializeMixpanel() {
 }
 
 export function maybeSetMixpanelContext(
-  userInfo: TelemetryUser & { workspaceId: string | null; role: string | null }
+  userInfo: TelemetryUser & { workspaceId: string | null; role: string | null; isTest?: boolean }
 ) {
-  const { internal: isInternal } = userInfo;
+  const { internal: isInternal, isTest } = userInfo;
   const forceEnableMixpanel = userData.get("global_logTelemetryEvent");
   const shouldEnableMixpanel = (!isInternal && !skipTelemetry()) || forceEnableMixpanel;
 
@@ -154,6 +154,11 @@ export function maybeSetMixpanelContext(
     enableMixpanel();
     trackMixpanelEvent("session_start", { workspaceId: userInfo.workspaceId });
     timeMixpanelEvent("session.devtools_start");
+
+    if (isTest) {
+      trackMixpanelEvent("session_start.test");
+    }
+
     setupSessionEndListener();
   }
 }


### PR DESCRIPTION
There's currently a race condition where it's possible for us to try to send an event to Mixpanel before Mixpanel is "initialized" (has the user info for event metadata). In those cases, we end up dropping the event.

This moves one of those events (`session_start.test`) so that it only ever fires once Mixpanel has been initialized.