### PR TITLE
Fix mock test GitHub action

### DIFF
--- a/packages/shared/graphql/types.ts
+++ b/packages/shared/graphql/types.ts
@@ -212,7 +212,7 @@ export interface Recording {
   isInitialized?: boolean;
   isProcessed?: boolean;
   isTest?: boolean;
-  metadata?: RecordingMetadata;
+  metadata?: RecordingMetadata | null;
   operations?: OperationsData;
   ownerNeedsInvite?: boolean;
   private?: boolean;

--- a/src/ui/components/RecordingDocumentTitle.tsx
+++ b/src/ui/components/RecordingDocumentTitle.tsx
@@ -17,9 +17,9 @@ export function RecordingDocumentTitle() {
   const isProcessed = useIsRecordingProcessed(recording);
   const processingProgress = useRecordingProcessingProgress();
 
-  const { metadata = {}, title = "" } = recording ?? {};
+  const { metadata, title = "" } = recording ?? {};
 
-  const testResult = metadata.test?.result;
+  const testResult = metadata?.test?.result;
 
   // Track the animation counter with a ref so that it doesn't reset to 0 when the effect re-runs
   // (The effect will re-run when the processing progress changes, for example)


### PR DESCRIPTION
Looks like mock tests were passing consistently until #9625.

Running those tests locally I saw this error:
https://uploads.linear.app/253b2bcd-e9cf-41f8-ad4f-b0276e3ff7fc/8d82adbc-13a2-47bc-bb9e-7d813205076d/20250ac9-73e2-4e01-85ed-5742b898c420

This disagrees with the TypeScript definition for `Recording`, which says that `recording.metadata` will always either be an object or undefined. Looks like `metadata: null` got added to the mock recording back in PR #7052.

I've updated the type def to be looser, so we're forced to handle `null` _and_ `undefined`. I don't know if `null` will ever exist outside of the mock data @jaril added though.