### PR TITLE
Revert "React Test Suites beginPoint from step:enqueue (#9646)"

### DIFF
--- a/packages/e2e-tests/tests/cypress-03_test-step-interactions.test.ts
+++ b/packages/e2e-tests/tests/cypress-03_test-step-interactions.test.ts
@@ -145,16 +145,17 @@ test("cypress-03: Test Step interactions", async ({
   await steps.nth(4).click();
   await waitFor(async () => {
     const detailsPane = getUserActionEventDetails(page);
-    const detailsPaneContents = await getDetailsPaneContents(detailsPane);
-    expect(detailsPaneContents["Command"]).toBe(`"type"`);
-    expect(detailsPaneContents["Typed"]).toMatch("{enter}");
+    expect(await detailsPane.isVisible()).toBe(false);
+    const message = getByTestName(page, "TestEventDetailsMessage");
+    const messageContents = await message.textContent();
+    expect(messageContents).toMatch("Select an action above to view its details");
   });
 
   await steps.nth(5).click();
   await waitFor(async () => {
     const detailsPane = getUserActionEventDetails(page);
     const detailsPaneContents = await getDetailsPaneContents(detailsPane);
-    expect(detailsPaneContents["Command"]).toBe(`"get"`);
-    expect(detailsPaneContents["Selector"]).toBe(`".todo-list li"`);
+    expect(detailsPaneContents["Command"]).toBe(`"type"`);
+    expect(detailsPaneContents["Typed"]).toMatch("{enter}");
   });
 });

--- a/packages/shared/test-suites/RecordingTestMetadata.ts
+++ b/packages/shared/test-suites/RecordingTestMetadata.ts
@@ -517,13 +517,6 @@ export async function processCypressTestRecording(
                   break;
                 }
                 case "step:enqueue": {
-                  if (!beginPoint || comparePoints(beginPoint.point, annotation.point) > 0) {
-                    beginPoint = {
-                      point: annotation.point,
-                      time: annotation.time,
-                    };
-                  }
-
                   if (!isChaiAssertion) {
                     viewSourceTimeStampedPoint = {
                       point: annotation.point,
@@ -533,12 +526,10 @@ export async function processCypressTestRecording(
                   break;
                 }
                 case "step:start": {
-                  if (!beginPoint || comparePoints(beginPoint.point, annotation.point) > 0) {
-                    beginPoint = {
-                      point: annotation.point,
-                      time: annotation.time,
-                    };
-                  }
+                  beginPoint = {
+                    point: annotation.point,
+                    time: annotation.time,
+                  };
 
                   if (isChaiAssertion) {
                     viewSourceTimeStampedPoint = {


### PR DESCRIPTION
This reverts this change https://github.com/replayio/devtools/pull/9646 because of https://linear.app/replay/issue/FE-1875/react-hook-form-cypress-steps-jump-to-the-wrong-time-and-point

FE-1875 did two things. It changed the behavior and made the tests more stable. This change preserves the test improvements, but changes the behavior.  FYI I dont think a straight revert would not work...