### PR TITLE
Test Suites: Re-apply fix for FE-1833

### DIFF
--- a/packages/e2e-tests/tests/cypress-03_test-step-interactions.test.ts
+++ b/packages/e2e-tests/tests/cypress-03_test-step-interactions.test.ts
@@ -145,17 +145,16 @@ test("cypress-03: Test Step interactions", async ({
   await steps.nth(4).click();
   await waitFor(async () => {
     const detailsPane = getUserActionEventDetails(page);
-    expect(await detailsPane.isVisible()).toBe(false);
-    const message = getByTestName(page, "TestEventDetailsMessage");
-    const messageContents = await message.textContent();
-    expect(messageContents).toMatch("Select an action above to view its details");
+    const detailsPaneContents = await getDetailsPaneContents(detailsPane);
+    expect(detailsPaneContents["Command"]).toBe(`"type"`);
+    expect(detailsPaneContents["Typed"]).toMatch("{enter}");
   });
 
   await steps.nth(5).click();
   await waitFor(async () => {
     const detailsPane = getUserActionEventDetails(page);
     const detailsPaneContents = await getDetailsPaneContents(detailsPane);
-    expect(detailsPaneContents["Command"]).toBe(`"type"`);
-    expect(detailsPaneContents["Typed"]).toMatch("{enter}");
+    expect(detailsPaneContents["Command"]).toBe(`"get"`);
+    expect(detailsPaneContents["Selector"]).toBe(`".todo-list li"`);
   });
 });

--- a/packages/shared/test-suites/RecordingTestMetadata.ts
+++ b/packages/shared/test-suites/RecordingTestMetadata.ts
@@ -558,9 +558,6 @@ export async function processCypressTestRecording(
             assert(stepStartPoint !== null, `Missing "step:start" annotation for test event`, {
               id,
             });
-            assert(stepEnqueuePoint !== null, `Missing "step:enqueue" annotation for test event`, {
-              id,
-            });
             assert(viewSourcePoint !== null, `Missing annotation for test event`, {
               annotationType: isChaiAssertion ? "step:start" : "step:enqueue",
               id,
@@ -585,7 +582,7 @@ export async function processCypressTestRecording(
                 },
               },
               timeStampedPointRange: {
-                begin: stepEnqueuePoint,
+                begin: stepEnqueuePoint ?? stepStartPoint,
                 end: stepEndPoint ?? stepStartPoint,
               },
               type: "user-action",

--- a/src/ui/components/TestSuite/hooks/useShowUserActionEventBoundary.ts
+++ b/src/ui/components/TestSuite/hooks/useShowUserActionEventBoundary.ts
@@ -12,20 +12,23 @@ export function useShowUserActionEventBoundary({
   boundary: "before" | "after";
   userActionEvent: UserActionEvent;
 }) {
-  const { timeStampedPointRange } = userActionEvent;
+  const {
+    data: {
+      timeStampedPoints: { afterStep, beforeStep },
+    },
+  } = userActionEvent;
   const { executionPoint: currentPoint } = useContext(TimelineContext);
 
   const dispatch = useAppDispatch();
 
-  if (timeStampedPointRange === null) {
+  if (afterStep == null || beforeStep == null) {
     return {
       disabled: true,
       onClick: () => {},
     };
   }
 
-  const timeStampedPoint =
-    boundary === "before" ? timeStampedPointRange.begin : timeStampedPointRange.end;
+  const timeStampedPoint = boundary === "before" ? beforeStep : afterStep;
 
   const disabled = timeStampedPoint.point === currentPoint;
 

--- a/src/ui/components/TestSuite/suspense/TestStepSourceLocationCache.ts
+++ b/src/ui/components/TestSuite/suspense/TestStepSourceLocationCache.ts
@@ -20,14 +20,10 @@ export const TestStepSourceLocationCache = createCacheWithTelemetry<
     const runnerVersion = groupedTestCases.environment.testRunner.version;
 
     if (runner === "cypress" && runnerVersion) {
-      const { viewSourceTimeStampedPoint } = testEvent.data;
-      assert(viewSourceTimeStampedPoint !== null);
+      const { viewSource } = testEvent.data.timeStampedPoints;
+      assert(viewSource !== null);
 
-      const pauseId = await pauseIdCache.readAsync(
-        client,
-        viewSourceTimeStampedPoint.point,
-        viewSourceTimeStampedPoint.time
-      );
+      const pauseId = await pauseIdCache.readAsync(client, viewSource.point, viewSource.time);
       const frames = await framesCache.readAsync(client, pauseId);
 
       if (frames) {

--- a/src/ui/components/TestSuite/views/TestRecording/TestEventDetails.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestEventDetails.tsx
@@ -32,15 +32,15 @@ export default function TestEventDetails({ collapsed }: { collapsed: boolean }) 
         stack={testEvent.data.testSourceCallStack}
       />
     );
-  } else if (testEvent.data.result == null) {
+  } else if (!testEvent.data.resultVariable || !testEvent.data.timeStampedPoints.result) {
     return <LoadingFailedMessage />;
   }
 
   return (
     <ErrorBoundary name="TestEventDetails">
       <UserActionEventDetails
-        timeStampedPoint={testEvent.data.result.timeStampedPoint}
-        variable={testEvent.data.result.variable}
+        timeStampedPoint={testEvent.data.timeStampedPoints.result}
+        variable={testEvent.data.resultVariable}
       />
     </ErrorBoundary>
   );

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
@@ -50,7 +50,8 @@ export default memo(function UserActionEventRow({
   userActionEvent: UserActionEvent;
 }) {
   const { data, timeStampedPointRange } = userActionEvent;
-  const { command, error, parentId, result } = data;
+  const { command, error, parentId, timeStampedPoints, resultVariable } = data;
+  const { result: resultTimeStampedPoint } = timeStampedPoints;
 
   const replayClient = useContext(ReplayClientContext);
 
@@ -105,7 +106,11 @@ export default memo(function UserActionEventRow({
     dispatch(jumpToKnownEventListenerHit(onSeek, jumpToCodeAnnotation));
   };
 
-  const showBadge = isSelected && command.name === "get" && result != null;
+  const showBadge =
+    isSelected &&
+    command.name === "get" &&
+    resultVariable != null &&
+    resultTimeStampedPoint !== null;
   const showJumpToCode = (isHovered || isSelected) && canShowJumpToCode;
 
   let jumpToCodeStatus: JumpToCodeStatus = "loading";
@@ -163,8 +168,8 @@ export default memo(function UserActionEventRow({
         <Suspense fallback={<Loader />}>
           <Badge
             isSelected={isSelected}
-            timeStampedPoint={result!.timeStampedPoint}
-            variable={result!.variable}
+            timeStampedPoint={resultTimeStampedPoint}
+            variable={resultVariable}
           />
         </Suspense>
       )}

--- a/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
@@ -133,7 +133,7 @@ export function TestSectionRow({
     let time: number | null = null;
 
     if (isUserActionTestEvent(testEvent)) {
-      const timeStampedPoint = testEvent.timeStampedPointRange?.begin ?? null;
+      const timeStampedPoint = testEvent.data.timeStampedPoints.beforeStep ?? null;
       if (timeStampedPoint) {
         executionPoint = timeStampedPoint.point;
         time = timeStampedPoint.time;


### PR DESCRIPTION
Fixes FE-1833 (which got reverted) and FE-1875

Refactors the user-action type so that we're tracking three times of time stamped points now:
* One range to set focus so that we can view the test code source (`"step:enqueue"` … `"step:end"`)
* One range to show the before and after action in the UI (`"step:start"` … `"step:end"`)
* One point to view the test code source (`"step:enqueue"` or `"step:end"`, depending on the value of `command.name`)

I used recording 1a098592-1330-4e81-9391-dce178fc1ce2 as a test case for comparing this branch to production. I used recording b6ded8cf-f4b5-4844-a3d6-d311a981d2f3 to verify that this change still addresses the original bug report from FE-1833.