### PR TITLE
Layout options should not auto-close dropdown menu

### DIFF
--- a/packages/e2e-tests/helpers/layout.ts
+++ b/packages/e2e-tests/helpers/layout.ts
@@ -1,5 +1,7 @@
 import { Page, expect } from "@playwright/test";
 
+import { waitFor } from "./utils";
+
 type ToolboxLayout = "bottom" | "full" | "ide" | "left";
 
 export async function getToolboxLayout(page: Page): Promise<ToolboxLayout | null> {
@@ -11,6 +13,19 @@ export async function getToolboxLayout(page: Page): Promise<ToolboxLayout | null
   expect(layout).not.toBeNull();
 
   return layout as ToolboxLayout;
+}
+
+export async function hideUserOptionsDropdown(page: Page) {
+  const button = await page.waitForSelector('[data-test-id="UserOptions-DropdownButton"]');
+  const state = await button.getAttribute("data-dropdown-state");
+  if (state !== "closed") {
+    await page.keyboard.press("Escape");
+
+    await waitFor(async () => {
+      const state = await button.getAttribute("data-dropdown-state");
+      expect(state).toBe("closed");
+    });
+  }
 }
 
 export async function showUserOptionsDropdown(page: Page) {
@@ -28,6 +43,9 @@ export async function toggleToolboxLayout(page: Page, layout: ToolboxLayout): Pr
 
   const element = await page.waitForSelector(`[data-layout-option="${layout}"]`);
   await element.click();
+
+  // Changing layout options will not close the menu
+  await hideUserOptionsDropdown(page);
 }
 
 export async function verifyToolboxLayout(page: Page, expected: ToolboxLayout): Promise<void> {

--- a/src/ui/components/Header/UserOptions.tsx
+++ b/src/ui/components/Header/UserOptions.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useContext, useState } from "react";
+import React, { ReactNode, useContext, useEffect, useState } from "react";
 
 import { recordingCapabilitiesCache } from "replay-next/src/suspense/BuildIdCache";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
@@ -26,6 +26,22 @@ export default function UserOptions() {
   const [videoPanelCollapsed, setVideoPanelCollapsed] = useLocalStorageUserData(
     "replayVideoPanelCollapsed"
   );
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      switch (event.key) {
+        case "Escape":
+          setExpanded(false);
+          break;
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, []);
 
   // only show layout options in devtools
   let devLayoutOptions: ReactNode = null;
@@ -153,13 +169,11 @@ export default function UserOptions() {
   const onLayoutChange = (orientation: "bottom" | "full" | "ide" | "left") => {
     dispatch(setToolboxLayout(orientation));
     trackEvent(`layout.settings.set_${orientation}`);
-    setExpanded(false);
   };
 
   const onVideoPanelCollapseChange = (collapsed: boolean) => {
     setVideoPanelCollapsed(collapsed);
     trackEvent(collapsed ? "video.settings.set_collapsed" : "video.settings.set_expanded");
-    setExpanded(false);
   };
 
   return (


### PR DESCRIPTION
This change on its own would break the stacking tests, but I updated the layout helper to avoid that. (Didn't touch the stacking tests themselves since Mark has moved and rewritten some of them in another open PR.)