### PR TITLE
Update playwright timeouts + retries

### DIFF
--- a/packages/e2e-tests/helpers/utils.ts
+++ b/packages/e2e-tests/helpers/utils.ts
@@ -98,7 +98,7 @@ export async function waitForRecordingToFinishIndexing(page: Page): Promise<void
     },
     {
       retryInterval: 1_000,
-      timeout: 30_000,
+      timeout: 60_000,
     }
   );
 }

--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -27,8 +27,12 @@ const config: PlaywrightTestConfig = {
     actionTimeout: 15_000,
   },
 
+  expect: {
+    timeout: 10_000,
+  },
+
   // Retry failed tests on CI to account for some basic flakiness.
-  retries: CI ? 5 : 0,
+  retries: CI ? 3 : 0,
 
   // Give individual tests a while to complete instead of default 30s
   timeout: 120_000,

--- a/packages/replay-next/playwright/tests/utils/general.ts
+++ b/packages/replay-next/playwright/tests/utils/general.ts
@@ -237,7 +237,7 @@ export async function waitFor(
     timeout?: number;
   } = {}
 ): Promise<void> {
-  const { retryInterval = 250, timeout = 5_000 } = options;
+  const { retryInterval = 250, timeout = 10_000 } = options;
 
   const startTime = performance.now();
 


### PR DESCRIPTION
I think it would be helpful to see if extending our timeouts would let us use fewer retries.

How will this impact test run times? I don't think it will slow down run times because Playwright will still retry at the same interval. It will help us reduce the instances of backend performance issues causing tests to fail.