### PR TITLE
Source preview popup shows "Loading..." immediately

### DIFF
--- a/packages/replay-next/components/Popup.tsx
+++ b/packages/replay-next/components/Popup.tsx
@@ -186,6 +186,10 @@ export default function Popup({
     observer.observe(popover);
     observer.observe(target);
 
+    // Call this synchronously to avoid a flash of the popover in the wrong position.
+    // ResizeObserver will automatically call the method, but seemingly only after paint.
+    reposition();
+
     return () => {
       scrollTargets.forEach(target => {
         target.removeEventListener("scroll", onScroll);

--- a/packages/replay-next/components/sources/PreviewPopup.module.css
+++ b/packages/replay-next/components/sources/PreviewPopup.module.css
@@ -9,6 +9,7 @@
   filter: drop-shadow(0 1px 2px rgb(0 0 0 / 0.1)) drop-shadow(0 1px 1px rgb(0 0 0 / 0.06));
 }
 
+.LoadingMessage,
 .UnavailableMessage {
   padding: 0.5rem;
   color: var(--color-default);

--- a/packages/replay-next/components/sources/PreviewPopup.tsx
+++ b/packages/replay-next/components/sources/PreviewPopup.tsx
@@ -1,5 +1,13 @@
 import { Value as ProtocolValue, SourceId } from "@replayio/protocol";
-import { ReactNode, RefObject, Suspense, useContext, useEffect, useRef } from "react";
+import {
+  PropsWithChildren,
+  ReactNode,
+  RefObject,
+  Suspense,
+  useContext,
+  useEffect,
+  useRef,
+} from "react";
 
 import { SelectedFrameContext } from "replay-next/src/contexts/SelectedFrameContext";
 import { useCurrentFocusWindow } from "replay-next/src/hooks/useCurrentFocusWindow";
@@ -28,7 +36,15 @@ type Props = {
 export default function PreviewPopup(props: Props) {
   return (
     <ErrorBoundary name="PreviewPopup">
-      <Suspense fallback={null}>
+      <Suspense
+        fallback={
+          <PopupWithChildren {...props}>
+            <div className={styles.Popup}>
+              <div className={styles.LoadingMessage}>Loading...</div>
+            </div>
+          </PopupWithChildren>
+        }
+      >
         <SuspendingPreviewPopup {...props} />
       </Suspense>
     </ErrorBoundary>
@@ -108,26 +124,24 @@ function SuspendingPreviewPopup({
   let children: ReactNode = null;
   if (valueUnavailableMessage !== null) {
     return (
-      <Popup
+      <PopupWithChildren
         clientX={clientX}
         containerRef={containerRef}
         dismiss={dismiss}
         target={target}
-        showTail={true}
       >
         <div className={styles.Popup}>
           <div className={styles.UnavailableMessage}>{valueUnavailableMessage}</div>
         </div>
-      </Popup>
+      </PopupWithChildren>
     );
   } else if (pauseId !== null && value !== null) {
     return (
-      <Popup
+      <PopupWithChildren
         clientX={clientX}
         containerRef={containerRef}
         dismiss={dismiss}
         target={target}
-        showTail={true}
       >
         <SourcePreviewInspector
           className={styles.Popup}
@@ -135,19 +149,41 @@ function SuspendingPreviewPopup({
           protocolValue={value}
           ref={popupRef}
         />
-      </Popup>
+      </PopupWithChildren>
     );
   }
 
   return children !== null ? (
+    <PopupWithChildren
+      children={children}
+      clientX={clientX}
+      containerRef={containerRef}
+      dismiss={dismiss}
+      target={target}
+    />
+  ) : null;
+}
+
+function PopupWithChildren({
+  children,
+  clientX,
+  containerRef,
+  dismiss,
+  target,
+}: PropsWithChildren & {
+  clientX?: number | null;
+  containerRef: RefObject<HTMLElement>;
+  dismiss: () => void;
+  target: HTMLElement;
+}) {
+  return (
     <Popup
+      children={children}
       clientX={clientX}
       containerRef={containerRef}
       dismiss={dismiss}
       target={target}
       showTail={true}
-    >
-      {children}
-    </Popup>
-  ) : null;
+    />
+  );
 }


### PR DESCRIPTION
### [Loom overview](https://www.loom.com/share/c2f13b9c15d044b5916f94419cafef18)

- [x] Show source preview popup immediately when hovering over an inspectable token. (We used to render a null fallback; now we'll show a "Loading..." popup.)
- [x] Update `Popup` repositioning logic to run synchronously on mount. (We used to rely on `ResizeObserver` only, but it seems not to call our reposition method until after paint– which causes a small layout shift/flicker. This fix is important to land even if we decided not to land the other one for some reason.)

cc @jonbell-lot23 