### PR TITLE
Update playwright config

### DIFF
--- a/packages/e2e-tests/README.md
+++ b/packages/e2e-tests/README.md
@@ -33,14 +33,14 @@ yarn test
 # Run a subset of tests by matching filenames
 yarn test some_test_name
 
+# Record tests with Replay.io
+yarn test:replay
+
 # Run tests with a visible browser
 yarn test:debug
-```
 
-And to record replays of the tests.
-
-```bash
-yarn test:replay-chromium
+# Run tests in UI mode
+yarn test:ui
 ```
 
 ### Concepts

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -8,8 +8,8 @@
   },
   "scripts": {
     "test": "playwright test",
-    "test:chromium": "playwright test --project chromium --reporter=@replayio/playwright/reporter,line",
-    "test:replay-chromium": "playwright test --project replay-chromium --reporter=@replayio/playwright/reporter,line",
+    "test:replay": "REPLAYIO=1 playwright test --reporter=@replayio/playwright/reporter,line",
+    "test:ui": "playwright test",
     "test:debug": "playwright test --workers 1 --headed",
     "test:install": "playwright install",
     "ts-node": "ts-node --project ../../tsconfig.json"

--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -1,18 +1,21 @@
 import { PlaywrightTestConfig, devices } from "@playwright/test";
 import { devices as replayDevices } from "@replayio/playwright";
 
-const { CI, SLOW_MO } = process.env;
+const { CI, SLOW_MO, REPLAYIO } = process.env;
 
-const projects = [
-  {
-    name: "replay-chromium",
-    use: { ...(replayDevices["Replay Chromium"] as any) },
-  },
-  {
-    name: "chromium",
-    use: { ...devices["Desktop Chromium"] },
-  },
-];
+const projects = REPLAYIO
+  ? [
+      {
+        name: "replay-chromium",
+        use: { ...(replayDevices["Replay Chromium"] as any) },
+      },
+    ]
+  : [
+      {
+        name: "chromium",
+        use: { ...devices["Desktop Chromium"] },
+      },
+    ];
 
 const config: PlaywrightTestConfig = {
   use: {


### PR DESCRIPTION
* yarn test now defaults to chromium
* yarn test:replay is equivalent to `yarn test` but records with Replay
* yarn test:ui adds playwrights UI mode

NOTE: I replaced `--project` with an environment variable because I could not get the playwright CLI to behave. I'd like to file an issue with the playwright project and see why it is failing.