### PR TITLE
Fix timing issue in breakpoints-04 test

### DIFF
--- a/packages/replay-next/components/sources/SourceListRow.tsx
+++ b/packages/replay-next/components/sources/SourceListRow.tsx
@@ -131,6 +131,7 @@ export default function SourceListRow({
       data-test-line-has-hits={lineHitCounts != null ? hitCount > 0 : undefined}
       data-test-line-number={lineNumber}
       data-test-id={`SourceLine-${lineNumber}`}
+      data-test-is-scrolling={isScrolling || undefined}
       data-test-name="SourceLine"
       style={style}
     >


### PR DESCRIPTION
Here is a recent [test suite run](https://app.replay.io/team/dzowNDAyOGMwYS05ZjM1LTQ2ZjktYTkwYi1jNzJkMTIzNzUxOTI=/runs/beebe762-77a7-4a1e-b211-413ee43dae63) with all four attempts of `breakpoints-04` failing. Zooming in on [one particular failing test](https://app.replay.io/recording/breakpoints-04-catch-finally-generators-and-asyncawait--53952ed9-40fb-4e81-8ac9-bc8400238055), the test runner says that it's stuck waiting for the breakpoint on line 54 to be set, but the last "click" event showing up in the Replay info panel is the click on line 50. (The other recordings all look the same.)

I think that means that Playwright isn't actually issuing the click through to the browser? (The React "click" event handler doesn't seem to be triggered either, which this might explain.)

Evaluating the following in the Replay console finds the line number element:
```js
document.querySelectorAll('[data-test-id="SourceLine-54"] [data-test-name="SourceLine-LineNumber"]')
// <div class="SourceListRow_LineNumber__TbrqD" data-test-name="SourceLine-LineNumber">54</div>
```

But I can't resolve the breakpoint toggle element:
```js
document.querySelectorAll('[data-test-id="SourceLine-54"] [data-test-name="BreakpointToggle"]')
// empty NodeList
```

I think this means we're trying to click prematurely, and we need to pause and wait for the locator to actually match things before we proceed.

I think is logical, because line 54 is only visible after scrolling– and the breakpoint toggle is rendered by `SourceListRowMouseEvents`, which is skipped while the list is actively scrolling (for performance reasons):
```jsx
{/**
 * Certain user interactions don't occur while scrolling,
 * so we can avoid rendering them so that we scrolls more smoothly.
 * This includes interactions like the hover button (used to add log points or to seek),
 * as well as right-click context menu action.
 */}
{isScrolling || (
  <SourceListRowMouseEvents
    lineHasLogPoint={showPointPanel}
    lineHitCounts={lineHitCounts}
    lineNumber={lineNumber}
    pointBehavior={pointBehavior}
    pointsForLine={pointsForLine}
    source={source}
  />
)}
```

I can see how this would manifest as a "flaky" test because sometimes React might have time to get the extra render in (and sometimes not).