### PR TITLE
Optimize Log Point panel: Don't run analysis for pending edits

### DIFF
--- a/packages/replay-next/playwright/fixtures/source-and-console.html
+++ b/packages/replay-next/playwright/fixtures/source-and-console.html
@@ -62,6 +62,7 @@
       ReactIs.isAsyncMode({});
 
       // Test hot loop for hit point error statuses
+      // IMPORTANT Keep compatible with MAX_POINTS_TO_RUN_EVALUATION
       let iLoops = 0;
       let xLoops = 0;
       for (let i = 0; i <= 200; i++) {

--- a/packages/replay-next/src/contexts/points/PointsContext.tsx
+++ b/packages/replay-next/src/contexts/points/PointsContext.tsx
@@ -125,24 +125,6 @@ export function PointsContextRoot({ children }: PropsWithChildren<{}>) {
     Map<PointKey, Pick<Point, "condition" | "content">>
   >(new Map());
 
-  // Merge saved points with local edits;
-  // Local edits should take precedence so they're reflected in the Source viewer.
-  const pointForDefaultPriority = useMemo<Point[]>(
-    () =>
-      savedPoints.map(point => {
-        const partialPoint = pendingPointText.get(point.key);
-        if (partialPoint) {
-          return {
-            ...point,
-            ...partialPoint,
-          };
-        } else {
-          return point;
-        }
-      }),
-    [pendingPointText, savedPoints]
-  );
-
   // Track the latest committed values for e.g. the editPointBadge function.
   const committedValuesRef = useRef<CommittedValuesRef["current"]>({
     pendingPointText: new Map(),
@@ -243,7 +225,7 @@ export function PointsContextRoot({ children }: PropsWithChildren<{}>) {
       pointBehaviorsForSuspense: deferredPointBehaviors,
       pointBehaviorsForDefaultPriority: localPointBehaviors,
       pointsForSuspense: deferredPoints,
-      pointsForDefaultPriority: pointForDefaultPriority,
+      pointsForDefaultPriority: savedPoints,
       pointsTransitionPending,
       savePendingPointText,
     }),
@@ -257,8 +239,8 @@ export function PointsContextRoot({ children }: PropsWithChildren<{}>) {
       editPointBadge,
       editPointBehavior,
       localPointBehaviors,
-      pointForDefaultPriority,
       pointsTransitionPending,
+      savedPoints,
       savePendingPointText,
     ]
   );

--- a/packages/replay-next/src/contexts/points/hooks/useSavePendingPointText.ts
+++ b/packages/replay-next/src/contexts/points/hooks/useSavePendingPointText.ts
@@ -1,6 +1,5 @@
 import { Dispatch, SetStateAction, useCallback } from "react";
 
-import { pointEquals } from "protocol/execution-point-utils";
 import { SetLocalPointBehaviors } from "replay-next/src/contexts/points/hooks/useLocalPointBehaviors";
 import { POINT_BEHAVIOR_ENABLED, Point, PointKey } from "shared/client/types";
 

--- a/src/ui/components/ProtocolViewer/components/ProtocolViewerContext.tsx
+++ b/src/ui/components/ProtocolViewer/components/ProtocolViewerContext.tsx
@@ -44,7 +44,6 @@ export function ProtocolViewerContextRoot({
 
   const clearCurrentRequests = useCallback(() => {
     const length = Object.keys(requestMap).length;
-    console.log("clearCurrentRequests", length);
     setClearBeforeIndex(length);
   }, [requestMap]);
 


### PR DESCRIPTION
### [Loom overview](https://www.loom.com/share/24dc47ec634a4677881d005eed49e016)

Replay [a916777c-b2d8-49e8-bbd3-3f95c88e8679](https://app.replay.io/recording/fe-1883-code-complete-plug-in-evaluations--a916777c-b2d8-49e8-bbd3-3f95c88e8679) shows what this is fixing (with comments).

- [x] Don't run analysis for pending log point panel edits

I think this will also allow us to increase the number of max-analysis-points (FE-1701) with minimal performance impact.

---

**Edit** This branch name should be FE-1883, my bad