### PR TITLE
Optimize Log Point panel: Don't run analysis for pending edits

### DIFF
--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -10,7 +10,7 @@
     "test": "playwright test",
     "test:chromium": "playwright test --project chromium --reporter=@replayio/playwright/reporter,line",
     "test:replay-chromium": "playwright test --project replay-chromium --reporter=@replayio/playwright/reporter,line",
-    "test:debug": "playwright test --workers 1 --headed",
+    "test:debug": "playwright test --project chromium --workers 1 --headed",
     "test:install": "playwright install",
     "ts-node": "ts-node --project ../../tsconfig.json"
   },

--- a/packages/replay-next/components/sources/SourceList.tsx
+++ b/packages/replay-next/components/sources/SourceList.tsx
@@ -192,7 +192,13 @@ export default function SourceList({
         pointBehavior?.shouldLog ??
         (point.content ? POINT_BEHAVIOR_ENABLED : POINT_BEHAVIOR_DISABLED);
       if (shouldLog !== POINT_BEHAVIOR_DISABLED) {
-        if (point.condition !== null) {
+        // TRICKY
+        // Refer to comments for "showPendingCondition" in the Point type definition
+        if (
+          point.showPendingCondition !== undefined
+            ? point.showPendingCondition
+            : point.condition !== null
+        ) {
           return lineHeight + pointPanelWithConditionalHeight;
         } else {
           return lineHeight + pointPanelHeight;

--- a/packages/replay-next/components/sources/SourceList.tsx
+++ b/packages/replay-next/components/sources/SourceList.tsx
@@ -69,8 +69,8 @@ export default function SourceList({
   const { range: focusRange } = useContext(FocusContext);
   const {
     pointBehaviorsForDefaultPriority: pointBehaviors,
-    pointsForDefaultPriority,
     pointsForSuspense,
+    pointsWithPendingEdits,
   } = useContext(PointsContext);
   const client = useContext(ReplayClientContext);
   const {
@@ -168,14 +168,14 @@ export default function SourceList({
     if (list) {
       list.resetAfterIndex(0);
     }
-  }, [pointBehaviors, pointsForDefaultPriority]);
+  }, [pointBehaviors, pointsWithPendingEdits]);
 
   const { data: streamingData, value: streamingValue } = useStreamingValue(streamingParser);
 
   const getItemSize = useCallback(
     (index: number) => {
       const lineNumber = index + 1;
-      const point = findPointForLocation(pointsForDefaultPriority, sourceId, lineNumber);
+      const point = findPointForLocation(pointsWithPendingEdits, sourceId, lineNumber);
       if (!point) {
         // If the Point has been removed by some external action,
         // e.g. the Pause Information side panel,
@@ -192,13 +192,7 @@ export default function SourceList({
         pointBehavior?.shouldLog ??
         (point.content ? POINT_BEHAVIOR_ENABLED : POINT_BEHAVIOR_DISABLED);
       if (shouldLog !== POINT_BEHAVIOR_DISABLED) {
-        // TRICKY
-        // Refer to comments for "showPendingCondition" in the Point type definition
-        if (
-          point.showPendingCondition !== undefined
-            ? point.showPendingCondition
-            : point.condition !== null
-        ) {
+        if (point.condition !== null) {
           return lineHeight + pointPanelWithConditionalHeight;
         } else {
           return lineHeight + pointPanelHeight;
@@ -212,7 +206,7 @@ export default function SourceList({
       pointBehaviors,
       pointPanelHeight,
       pointPanelWithConditionalHeight,
-      pointsForDefaultPriority,
+      pointsWithPendingEdits,
       sourceId,
     ]
   );
@@ -253,8 +247,8 @@ export default function SourceList({
     plainText: streamingData?.plainText ?? null,
     parsedTokens: streamingValue ?? null,
     pointBehaviors,
-    pointsForDefaultPriority,
     pointsForSuspense,
+    pointsWithPendingEdits,
     searchResultLineHighlight,
     source,
     viewSourceLineHighlight,

--- a/packages/replay-next/components/sources/SourceListRow.tsx
+++ b/packages/replay-next/components/sources/SourceListRow.tsx
@@ -35,8 +35,8 @@ export type ItemData = {
   minHitCount: number | undefined;
   parsedTokens: ParsedToken[][] | null;
   plainText: string[] | null;
-  pointsForDefaultPriority: Point[];
   pointsForSuspense: Point[];
+  pointsWithPendingEdits: Point[];
   pointBehaviors: PointBehaviorsObject;
   searchResultLineHighlight: SearchResultLineHighlight | null;
   source: Source;
@@ -63,8 +63,8 @@ export default function SourceListRow({
     parsedTokens,
     plainText,
     pointBehaviors,
-    pointsForDefaultPriority,
     pointsForSuspense,
+    pointsWithPendingEdits,
     searchResultLineHighlight,
     source,
     viewSourceLineHighlight,
@@ -96,18 +96,18 @@ export default function SourceListRow({
   }
 
   const pointForSuspense = findPointForLocation(pointsForSuspense, sourceId, lineNumber);
-  const pointsForLine = findPointsForLocation(pointsForDefaultPriority, sourceId, lineNumber);
-  const pointForDefaultPriority = pointsForLine[0] ?? null;
-  const pointBehavior = pointForDefaultPriority
-    ? pointBehaviors[pointForDefaultPriority.key] ?? null
+  const pointsForLine = findPointsForLocation(pointsWithPendingEdits, sourceId, lineNumber);
+  const pointWithPendingEdits = pointsForLine[0] ?? null;
+  const pointBehavior = pointWithPendingEdits
+    ? pointBehaviors[pointWithPendingEdits.key] ?? null
     : null;
 
   let showPointPanel = false;
-  if (pointForDefaultPriority && pointForSuspense) {
+  if (pointWithPendingEdits && pointForSuspense) {
     if (pointBehavior) {
       showPointPanel = pointBehavior.shouldLog !== POINT_BEHAVIOR_DISABLED;
     } else {
-      showPointPanel = !!pointForDefaultPriority.content;
+      showPointPanel = !!pointWithPendingEdits.content;
     }
   }
 
@@ -184,7 +184,7 @@ export default function SourceListRow({
       {showPointPanel && (
         <LogPointPanel
           className={styles.PointPanel}
-          pointForDefaultPriority={pointForDefaultPriority}
+          pointWithPendingEdits={pointWithPendingEdits}
           pointForSuspense={pointForSuspense!}
         />
       )}

--- a/packages/replay-next/components/sources/log-point-panel/LogPointPanel.tsx
+++ b/packages/replay-next/components/sources/log-point-panel/LogPointPanel.tsx
@@ -50,7 +50,7 @@ type EditReason = "condition" | "content";
 
 type ExternalProps = {
   className: string;
-  pointForDefaultPriority: Point;
+  pointWithPendingEdits: Point;
   pointForSuspense: Point;
 };
 
@@ -61,7 +61,7 @@ type InternalProps = ExternalProps & {
 };
 
 export default function PointPanelWrapper(props: ExternalProps) {
-  const { className, pointForDefaultPriority } = props;
+  const { className, pointWithPendingEdits } = props;
 
   const { range: focusRange } = useContext(FocusContext);
   if (!focusRange) {
@@ -74,7 +74,7 @@ export default function PointPanelWrapper(props: ExternalProps) {
         <Loader
           className={`${styles.Loader} ${className}`}
           style={{
-            height: pointForDefaultPriority.condition
+            height: pointWithPendingEdits.condition
               ? "var(--point-panel-with-conditional-height)"
               : "var(--point-panel-height)",
           }}
@@ -89,7 +89,7 @@ export default function PointPanelWrapper(props: ExternalProps) {
 const EMPTY_ARRAY: any[] = [];
 
 function PointPanel(props: ExternalProps & { focusRange: TimeStampedPointRange }) {
-  const { focusRange, pointForDefaultPriority } = props;
+  const { focusRange, pointWithPendingEdits } = props;
 
   const { enterFocusMode } = useContext(FocusContext);
 
@@ -99,8 +99,8 @@ function PointPanel(props: ExternalProps & { focusRange: TimeStampedPointRange }
     hitPointsForLocationCache,
     client,
     { begin: focusRange.begin.point, end: focusRange.end.point },
-    pointForDefaultPriority.location,
-    pointForDefaultPriority.condition
+    pointWithPendingEdits.location,
+    pointWithPendingEdits.condition
   );
 
   const hitPoints = value?.[0] ?? EMPTY_ARRAY;
@@ -121,7 +121,7 @@ function PointPanelWithHitPoints({
   enterFocusMode,
   hitPoints,
   hitPointStatus,
-  pointForDefaultPriority,
+  pointWithPendingEdits,
   pointForSuspense,
 }: InternalProps) {
   const graphQLClient = useContext(GraphQLClientContext);
@@ -139,7 +139,7 @@ function PointPanelWithHitPoints({
 
   // Most of this component should use default priority Point values.
   // Only parts that may suspend should use lower priority values.
-  const { condition, content, key, location, showPendingCondition, user } = pointForDefaultPriority;
+  const { condition, content, key, location, user } = pointWithPendingEdits;
 
   const editable = user?.id === currentUserInfo?.id;
 
@@ -188,10 +188,7 @@ function PointPanelWithHitPoints({
   const pointBehavior = pointBehaviors[key];
   const shouldLog = pointBehavior?.shouldLog === POINT_BEHAVIOR_ENABLED;
 
-  // TRICKY
-  // Refer to comments for "showPendingCondition" in the Point type definition
-  const hasCondition =
-    showPendingCondition !== undefined ? showPendingCondition : condition !== null;
+  const hasCondition = condition !== null;
 
   const toggleCondition = () => {
     if (!editable) {
@@ -414,7 +411,7 @@ function PointPanelWithHitPoints({
             <BadgePicker
               disabled={!editable}
               invalid={!isContentValid}
-              point={pointForDefaultPriority}
+              point={pointWithPendingEdits}
             />
 
             {isEditing ? (

--- a/packages/replay-next/components/sources/log-point-panel/LogPointPanel.tsx
+++ b/packages/replay-next/components/sources/log-point-panel/LogPointPanel.tsx
@@ -139,7 +139,7 @@ function PointPanelWithHitPoints({
 
   // Most of this component should use default priority Point values.
   // Only parts that may suspend should use lower priority values.
-  const { condition, content, key, location, user } = pointForDefaultPriority;
+  const { condition, content, key, location, showPendingCondition, user } = pointForDefaultPriority;
 
   const editable = user?.id === currentUserInfo?.id;
 
@@ -188,7 +188,10 @@ function PointPanelWithHitPoints({
   const pointBehavior = pointBehaviors[key];
   const shouldLog = pointBehavior?.shouldLog === POINT_BEHAVIOR_ENABLED;
 
-  const hasCondition = condition !== null;
+  // TRICKY
+  // Refer to comments for "showPendingCondition" in the Point type definition
+  const hasCondition =
+    showPendingCondition !== undefined ? showPendingCondition : condition !== null;
 
   const toggleCondition = () => {
     if (!editable) {
@@ -197,6 +200,8 @@ function PointPanelWithHitPoints({
 
     if (hasCondition) {
       editPendingPointText(key, { condition: null });
+
+      // TODO [FE-1886] Also save the point; otherwise this change won't be applied on reload
     } else {
       if (!isEditing) {
         startEditing("condition");

--- a/packages/replay-next/playwright/fixtures/source-and-console.html
+++ b/packages/replay-next/playwright/fixtures/source-and-console.html
@@ -62,6 +62,7 @@
       ReactIs.isAsyncMode({});
 
       // Test hot loop for hit point error statuses
+      // IMPORTANT Keep compatible with MAX_POINTS_TO_RUN_EVALUATION
       let iLoops = 0;
       let xLoops = 0;
       for (let i = 0; i <= 200; i++) {

--- a/packages/replay-next/src/contexts/points/hooks/useSavePendingPointText.ts
+++ b/packages/replay-next/src/contexts/points/hooks/useSavePendingPointText.ts
@@ -1,6 +1,5 @@
 import { Dispatch, SetStateAction, useCallback } from "react";
 
-import { pointEquals } from "protocol/execution-point-utils";
 import { SetLocalPointBehaviors } from "replay-next/src/contexts/points/hooks/useLocalPointBehaviors";
 import { POINT_BEHAVIOR_ENABLED, Point, PointKey } from "shared/client/types";
 
@@ -26,23 +25,26 @@ export default function useSavePendingPointText({
       const pendingPoint = pendingPointText.get(key);
       if (pendingPoint) {
         saveLocalAndRemotePoints(key, pendingPoint);
-      }
 
-      setPendingPointText(prev => {
-        const cloned = new Map(prev.entries());
-        cloned.delete(key);
-        return cloned;
-      });
+        // Clear pending edits from the Map once they've been saved
+        setPendingPointText(prev => {
+          const cloned = new Map(prev.entries());
+          cloned.delete(key);
+          return cloned;
+        });
+      }
 
       setPointBehaviors(prev => {
         const pointBehavior = prev[key];
-        return {
-          ...prev,
-          [key]: {
-            ...pointBehavior,
-            shouldLog: POINT_BEHAVIOR_ENABLED,
-          },
-        };
+        return prev[key].shouldLog === POINT_BEHAVIOR_ENABLED
+          ? prev
+          : {
+              ...prev,
+              [key]: {
+                ...pointBehavior,
+                shouldLog: POINT_BEHAVIOR_ENABLED,
+              },
+            };
       });
     },
     [committedValuesRef, saveLocalAndRemotePoints, setPendingPointText, setPointBehaviors]

--- a/packages/replay-next/src/utils/testing.tsx
+++ b/packages/replay-next/src/utils/testing.tsx
@@ -139,6 +139,7 @@ export async function renderFocused(
     pointBehaviorsForDefaultPriority: {},
     pointsForSuspense: [],
     pointsForDefaultPriority: [],
+    pointsWithPendingEdits: [],
     savePendingPointText: jest.fn(),
     ...options?.pointsContext,
   };

--- a/packages/shared/client/types.ts
+++ b/packages/shared/client/types.ts
@@ -122,11 +122,6 @@ export type Point = {
   badge: Badge | null;
   condition: string | null;
   content: string;
-
-  // Local/in-memory only attributes
-  // Whether the condition row should be shown for a point;
-  // If this attribute is defined, it should override the value of the condition attribute
-  showPendingCondition?: boolean;
 };
 
 // Point behaviors are saved to IndexedDB.

--- a/packages/shared/client/types.ts
+++ b/packages/shared/client/types.ts
@@ -122,6 +122,11 @@ export type Point = {
   badge: Badge | null;
   condition: string | null;
   content: string;
+
+  // Local/in-memory only attributes
+  // Whether the condition row should be shown for a point;
+  // If this attribute is defined, it should override the value of the condition attribute
+  showPendingCondition?: boolean;
 };
 
 // Point behaviors are saved to IndexedDB.

--- a/src/ui/components/ProtocolViewer/components/ProtocolViewerContext.tsx
+++ b/src/ui/components/ProtocolViewer/components/ProtocolViewerContext.tsx
@@ -44,7 +44,6 @@ export function ProtocolViewerContextRoot({
 
   const clearCurrentRequests = useCallback(() => {
     const length = Object.keys(requestMap).length;
-    console.log("clearCurrentRequests", length);
     setClearBeforeIndex(length);
   }, [requestMap]);
 


### PR DESCRIPTION
### [Loom overview](https://www.loom.com/share/24dc47ec634a4677881d005eed49e016)

Replay [a916777c-b2d8-49e8-bbd3-3f95c88e8679](https://app.replay.io/recording/fe-1883-code-complete-plug-in-evaluations--a916777c-b2d8-49e8-bbd3-3f95c88e8679) shows what this is fixing (with comments).

- [x] "Remove condition" option now saves log point
- [x] Don't run analysis for pending log point panel edits

I think this will also allow us to increase the number of max-analysis-points (FE-1701) with minimal performance impact.

---

**Edit** This branch name should be FE-1883, my bad