### PR TITLE
Fix `breakpoints-07` flakiness

### DIFF
--- a/packages/e2e-tests/helpers/commands.ts
+++ b/packages/e2e-tests/helpers/commands.ts
@@ -2,7 +2,7 @@ import { Page, expect } from "@playwright/test";
 import chalk from "chalk";
 
 import { waitForSourceContentsToFinishStreaming } from "./source-panel";
-import { debugPrint, getCommandKey, waitFor } from "./utils";
+import { debugPrint, delay, getCommandKey, waitFor } from "./utils";
 
 export async function quickOpen(page: Page, url: string): Promise<void> {
   await debugPrint(page, "Opening quick-open dialog", "quickOpen");
@@ -12,10 +12,13 @@ export async function quickOpen(page: Page, url: string): Promise<void> {
   await debugPrint(page, `Filtering files by "${chalk.bold(url)}"`, "quickOpen");
   await page.keyboard.type(url);
 
+  await page.getByText("Loading results...").waitFor({ state: "hidden" });
+
   await debugPrint(page, `Opening file "${chalk.bold(url)}"`, "quickOpen");
   const sourceRow = await page.waitForSelector(
-    `[data-test-name="QuickOpenResultsList-Row"]:has-text("${url}")`
+    `[data-test-name="QuickOpenResultsList-Row"].selected:has-text("${url}")`
   );
+
   const sourceId = await sourceRow.getAttribute("data-test-id");
 
   await page.keyboard.press("Enter");

--- a/packages/e2e-tests/helpers/index.ts
+++ b/packages/e2e-tests/helpers/index.ts
@@ -1,11 +1,11 @@
-import { Page } from "@playwright/test";
+import { Page, expect } from "@playwright/test";
 import chalk from "chalk";
 import dotenv from "dotenv";
 
 import { RecordingTarget } from "replay-next/src/suspense/BuildIdCache";
 
 import exampleRecordings from "../examples.json";
-import { debugPrint, getElementClasses, waitForRecordingToFinishIndexing } from "./utils";
+import { debugPrint, getElementClasses, waitFor, waitForRecordingToFinishIndexing } from "./utils";
 
 dotenv.config({ path: "../../.env" });
 
@@ -23,7 +23,15 @@ export async function openDevToolsTab(page: Page) {
   // The DevTools tab won't exist if it's a Node recording.
   const tab = getDevToolsTab(page);
   if (await tab.isVisible()) {
+    const isAlreadyActive = await isDevToolsTabActive(page);
+    if (isAlreadyActive) {
+      return;
+    }
     await tab.click();
+    await waitFor(async () => {
+      const isActive = await isDevToolsTabActive(page);
+      expect(isActive).toBe(true);
+    });
   }
 }
 
@@ -38,6 +46,10 @@ export async function openViewerTab(page: Page) {
 
   const tab = getViewerTab(page);
   await tab.click();
+  await waitFor(async () => {
+    const isActive = await isViewerTabActive(page);
+    expect(isActive).toBe(true);
+  });
 }
 
 export async function isViewerTabActive(page: Page) {

--- a/packages/e2e-tests/tests/breakpoints-07.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-07.test.ts
@@ -15,6 +15,7 @@ import {
   waitForBreakpoint,
   waitForLogpoint,
 } from "../helpers/source-panel";
+import { debugPrint } from "../helpers/utils";
 import test from "../testFixtureCloneRecording";
 
 test.use({ exampleKey: "doc_navigate.html" });
@@ -56,6 +57,7 @@ test(`breakpoints-07: rewind and seek using command bar and console messages`, a
   await sourceTab.waitFor({ state: "visible" });
 
   // Verify that the active source and breakpoints/logpoints are restored after a reload.
+  debugPrint(page, "Reloading page to check that breakpoints/logpoints are restored");
   await page.reload();
   await openDevToolsTab(page); // Should be unnecessary but sometimes "Viewer" tab is selected
   await quickOpen(page, "bundle_input.js"); // Should be unnecessary


### PR DESCRIPTION
Per https://app.replay.io/recording/breakpoints-07-rewind-and-seek-using-command-bar-and-console-messages--c129861e-7a6b-410e-a79e-fb02e4f4b207 , `breakpoints-07` sometimes gets stuck because it tries to click on the "DevTools" button to ensure we're on the right tab, but then continues on and shows the "Quick Open" modal immediately without waiting.  

I think there's a couple issues that have been happening:

- The logic for typing into the "Quick Open" modal and selecting a filename wasn't waiting to make sure that the list was loaded and that the _right_ filename was selected
- It was also trying to click on the "DevTools" tab without waiting for the modal to go away (and related to that, it didn't even _need_ to click on the tab in this case)

Updated the logic to more specifically wait for the _selected_ source row with the right text, and `openDevTools/Viewer` to skip clicking if the right tab is already active.