### PR TITLE
Speed up CSS parsing by caching frequently used pieces

### DIFF
--- a/packages/shared/user-data/GraphQL/config.ts
+++ b/packages/shared/user-data/GraphQL/config.ts
@@ -158,10 +158,6 @@ export const config = {
     label: "View protocol requests and responses in the panel",
     legacyKey: "devtools.features.logProtocol",
   },
-  feature_protocolPanelEvents: {
-    defaultValue: Boolean(false),
-    legacyKey: "devtools.features.logProtocolEvents",
-  },
   feature_showPassport: {
     defaultValue: Boolean(false),
     label: "Show Replay Passport",

--- a/packages/shared/utils/quick-lru.d.ts
+++ b/packages/shared/utils/quick-lru.d.ts
@@ -1,0 +1,128 @@
+// Source: https://github.com/sindresorhus/quick-lru/releases/tag/v6.1.2
+
+export interface Options<KeyType, ValueType> {
+  /**
+	The maximum number of milliseconds an item should remain in the cache.
+
+	@default Infinity
+
+	By default, `maxAge` will be `Infinity`, which means that items will never expire.
+	Lazy expiration upon the next write or read call.
+
+	Individual expiration of an item can be specified by the `set(key, value, maxAge)` method.
+	*/
+  readonly maxAge?: number;
+
+  /**
+	The maximum number of items before evicting the least recently used items.
+	*/
+  readonly maxSize: number;
+
+  /**
+	Called right before an item is evicted from the cache.
+
+	Useful for side effects or for items like object URLs that need explicit cleanup (`revokeObjectURL`).
+	*/
+  onEviction?: (key: KeyType, value: ValueType) => void;
+}
+
+export default class QuickLRU<KeyType, ValueType>
+  extends Map
+  implements Iterable<[KeyType, ValueType]>
+{
+  /**
+	The stored item count.
+	*/
+  readonly size: number;
+
+  /**
+	Simple ["Least Recently Used" (LRU) cache](https://en.m.wikipedia.org/wiki/Cache_replacement_policies#Least_Recently_Used_.28LRU.29).
+
+	The instance is an [`Iterable`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Iteration_protocols) of `[key, value]` pairs so you can use it directly in a [`for…of`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Statements/for...of) loop.
+
+	@example
+	```
+	import QuickLRU from 'quick-lru';
+
+	const lru = new QuickLRU({maxSize: 1000});
+
+	lru.set('🦄', '🌈');
+
+	lru.has('🦄');
+	//=> true
+
+	lru.get('🦄');
+	//=> '🌈'
+	```
+	*/
+  constructor(options: Options<KeyType, ValueType>);
+
+  [Symbol.iterator](): IterableIterator<[KeyType, ValueType]>;
+
+  /**
+	Set an item. Returns the instance.
+
+	Individual expiration of an item can be specified with the `maxAge` option. If not specified, the global `maxAge` value will be used in case it is specified in the constructor, otherwise the item will never expire.
+
+	@returns The list instance.
+	*/
+  set(key: KeyType, value: ValueType, options?: { maxAge?: number }): this;
+
+  /**
+	Get an item.
+
+	@returns The stored item or `undefined`.
+	*/
+  get(key: KeyType): ValueType | undefined;
+
+  /**
+	Check if an item exists.
+	*/
+  has(key: KeyType): boolean;
+
+  /**
+	Get an item without marking it as recently used.
+
+	@returns The stored item or `undefined`.
+	*/
+  peek(key: KeyType): ValueType | undefined;
+
+  /**
+	Delete an item.
+
+	@returns `true` if the item is removed or `false` if the item doesn't exist.
+	*/
+  delete(key: KeyType): boolean;
+
+  /**
+	Delete all items.
+	*/
+  clear(): void;
+
+  /**
+	Update the `maxSize` in-place, discarding items as necessary. Insertion order is mostly preserved, though this is not a strong guarantee.
+
+	Useful for on-the-fly tuning of cache sizes in live systems.
+	*/
+  resize(maxSize: number): void;
+
+  /**
+	Iterable for all the keys.
+	*/
+  keys(): IterableIterator<KeyType>;
+
+  /**
+	Iterable for all the values.
+	*/
+  values(): IterableIterator<ValueType>;
+
+  /**
+	Iterable for all entries, starting with the oldest (ascending in recency).
+	*/
+  entriesAscending(): IterableIterator<[KeyType, ValueType]>;
+
+  /**
+	Iterable for all entries, starting with the newest (descending in recency).
+	*/
+  entriesDescending(): IterableIterator<[KeyType, ValueType]>;
+}

--- a/packages/shared/utils/quick-lru.js
+++ b/packages/shared/utils/quick-lru.js
@@ -1,0 +1,285 @@
+// Source: https://github.com/sindresorhus/quick-lru/releases/tag/v6.1.2
+
+export default class QuickLRU extends Map {
+  constructor(options = {}) {
+    super();
+
+    if (!(options.maxSize && options.maxSize > 0)) {
+      throw new TypeError("`maxSize` must be a number greater than 0");
+    }
+
+    if (typeof options.maxAge === "number" && options.maxAge === 0) {
+      throw new TypeError("`maxAge` must be a number greater than 0");
+    }
+
+    // TODO: Use private class fields when ESLint supports them.
+    this.maxSize = options.maxSize;
+    this.maxAge = options.maxAge || Number.POSITIVE_INFINITY;
+    this.onEviction = options.onEviction;
+    this.cache = new Map();
+    this.oldCache = new Map();
+    this._size = 0;
+  }
+
+  // TODO: Use private class methods when targeting Node.js 16.
+  _emitEvictions(cache) {
+    if (typeof this.onEviction !== "function") {
+      return;
+    }
+
+    for (const [key, item] of cache) {
+      this.onEviction(key, item.value);
+    }
+  }
+
+  _deleteIfExpired(key, item) {
+    if (typeof item.expiry === "number" && item.expiry <= Date.now()) {
+      if (typeof this.onEviction === "function") {
+        this.onEviction(key, item.value);
+      }
+
+      return this.delete(key);
+    }
+
+    return false;
+  }
+
+  _getOrDeleteIfExpired(key, item) {
+    const deleted = this._deleteIfExpired(key, item);
+    if (deleted === false) {
+      return item.value;
+    }
+  }
+
+  _getItemValue(key, item) {
+    return item.expiry ? this._getOrDeleteIfExpired(key, item) : item.value;
+  }
+
+  _peek(key, cache) {
+    const item = cache.get(key);
+
+    return this._getItemValue(key, item);
+  }
+
+  _set(key, value) {
+    this.cache.set(key, value);
+    this._size++;
+
+    if (this._size >= this.maxSize) {
+      this._size = 0;
+      this._emitEvictions(this.oldCache);
+      this.oldCache = this.cache;
+      this.cache = new Map();
+    }
+  }
+
+  _moveToRecent(key, item) {
+    this.oldCache.delete(key);
+    this._set(key, item);
+  }
+
+  *_entriesAscending() {
+    for (const item of this.oldCache) {
+      const [key, value] = item;
+      if (!this.cache.has(key)) {
+        const deleted = this._deleteIfExpired(key, value);
+        if (deleted === false) {
+          yield item;
+        }
+      }
+    }
+
+    for (const item of this.cache) {
+      const [key, value] = item;
+      const deleted = this._deleteIfExpired(key, value);
+      if (deleted === false) {
+        yield item;
+      }
+    }
+  }
+
+  get(key) {
+    if (this.cache.has(key)) {
+      const item = this.cache.get(key);
+
+      return this._getItemValue(key, item);
+    }
+
+    if (this.oldCache.has(key)) {
+      const item = this.oldCache.get(key);
+      if (this._deleteIfExpired(key, item) === false) {
+        this._moveToRecent(key, item);
+        return item.value;
+      }
+    }
+  }
+
+  set(key, value, { maxAge = this.maxAge } = {}) {
+    const expiry =
+      typeof maxAge === "number" && maxAge !== Number.POSITIVE_INFINITY
+        ? Date.now() + maxAge
+        : undefined;
+    if (this.cache.has(key)) {
+      this.cache.set(key, {
+        value,
+        expiry,
+      });
+    } else {
+      this._set(key, { value, expiry });
+    }
+
+    return this;
+  }
+
+  has(key) {
+    if (this.cache.has(key)) {
+      return !this._deleteIfExpired(key, this.cache.get(key));
+    }
+
+    if (this.oldCache.has(key)) {
+      return !this._deleteIfExpired(key, this.oldCache.get(key));
+    }
+
+    return false;
+  }
+
+  peek(key) {
+    if (this.cache.has(key)) {
+      return this._peek(key, this.cache);
+    }
+
+    if (this.oldCache.has(key)) {
+      return this._peek(key, this.oldCache);
+    }
+  }
+
+  delete(key) {
+    const deleted = this.cache.delete(key);
+    if (deleted) {
+      this._size--;
+    }
+
+    return this.oldCache.delete(key) || deleted;
+  }
+
+  clear() {
+    this.cache.clear();
+    this.oldCache.clear();
+    this._size = 0;
+  }
+
+  resize(newSize) {
+    if (!(newSize && newSize > 0)) {
+      throw new TypeError("`maxSize` must be a number greater than 0");
+    }
+
+    const items = [...this._entriesAscending()];
+    const removeCount = items.length - newSize;
+    if (removeCount < 0) {
+      this.cache = new Map(items);
+      this.oldCache = new Map();
+      this._size = items.length;
+    } else {
+      if (removeCount > 0) {
+        this._emitEvictions(items.slice(0, removeCount));
+      }
+
+      this.oldCache = new Map(items.slice(removeCount));
+      this.cache = new Map();
+      this._size = 0;
+    }
+
+    this.maxSize = newSize;
+  }
+
+  *keys() {
+    for (const [key] of this) {
+      yield key;
+    }
+  }
+
+  *values() {
+    for (const [, value] of this) {
+      yield value;
+    }
+  }
+
+  *[Symbol.iterator]() {
+    for (const item of this.cache) {
+      const [key, value] = item;
+      const deleted = this._deleteIfExpired(key, value);
+      if (deleted === false) {
+        yield [key, value.value];
+      }
+    }
+
+    for (const item of this.oldCache) {
+      const [key, value] = item;
+      if (!this.cache.has(key)) {
+        const deleted = this._deleteIfExpired(key, value);
+        if (deleted === false) {
+          yield [key, value.value];
+        }
+      }
+    }
+  }
+
+  *entriesDescending() {
+    let items = [...this.cache];
+    for (let i = items.length - 1; i >= 0; --i) {
+      const item = items[i];
+      const [key, value] = item;
+      const deleted = this._deleteIfExpired(key, value);
+      if (deleted === false) {
+        yield [key, value.value];
+      }
+    }
+
+    items = [...this.oldCache];
+    for (let i = items.length - 1; i >= 0; --i) {
+      const item = items[i];
+      const [key, value] = item;
+      if (!this.cache.has(key)) {
+        const deleted = this._deleteIfExpired(key, value);
+        if (deleted === false) {
+          yield [key, value.value];
+        }
+      }
+    }
+  }
+
+  *entriesAscending() {
+    for (const [key, value] of this._entriesAscending()) {
+      yield [key, value.value];
+    }
+  }
+
+  get size() {
+    if (!this._size) {
+      return this.oldCache.size;
+    }
+
+    let oldCacheSize = 0;
+    for (const key of this.oldCache.keys()) {
+      if (!this.cache.has(key)) {
+        oldCacheSize++;
+      }
+    }
+
+    return Math.min(this._size + oldCacheSize, this.maxSize);
+  }
+
+  entries() {
+    return this.entriesAscending();
+  }
+
+  forEach(callbackFunction, thisArgument = this) {
+    for (const [key, value] of this.entriesAscending()) {
+      callbackFunction.call(thisArgument, value, key, this);
+    }
+  }
+
+  get [Symbol.toStringTag]() {
+    return JSON.stringify([...this.entriesAscending()]);
+  }
+}

--- a/packages/third-party/css/lexer.js
+++ b/packages/third-party/css/lexer.js
@@ -14,6 +14,8 @@
 
 "use strict";
 
+import QuickLRU from 'shared/utils/quick-lru';
+
 // White space of any kind.  No value fields are used.  Note that
 // comments do *not* count as white space; comments separate tokens
 // but are not themselves tokens.
@@ -167,7 +169,7 @@ function ensureValidChar(c) {
   return c;
 }
 
-const cachedCodes = new Map();
+const cachedCodes = new QuickLRU({maxSize: 3000});
 
 /**
  * Turn a string into an array of character codes.

--- a/packages/third-party/css/lexer.js
+++ b/packages/third-party/css/lexer.js
@@ -167,6 +167,8 @@ function ensureValidChar(c) {
   return c;
 }
 
+const cachedCodes = new Map();
+
 /**
  * Turn a string into an array of character codes.
  *
@@ -175,7 +177,13 @@ function ensureValidChar(c) {
  *         the input string.
  */
 function stringToCodes(str) {
-  return Array.prototype.map.call(str, c => c.charCodeAt(0));
+  if (cachedCodes.has(str)) {
+    return cachedCodes.get(str);
+  }
+
+  const codes = Array.prototype.map.call(str, c => c.charCodeAt(0));
+  cachedCodes.set(str, codes);
+  return codes;
 }
 
 const IS_HEX_DIGIT = 0x01;

--- a/packages/third-party/css/output-parser.js
+++ b/packages/third-party/css/output-parser.js
@@ -4,6 +4,7 @@
 
 "use strict";
 
+import QuickLRU from "shared/utils/quick-lru";
 import * as angleUtils  from "./css-angle";
 import * as colorUtils from "./color";
 import { getCSSLexer } from "./lexer";
@@ -49,7 +50,9 @@ export const TIMING_FUNCTION = "timing-function";
 export const URI = "url";
 export const VARIABLE_FUNCTION = "variable-function";
 
-const supportsValueMap = new Map();
+const cachedSupportsValue = new QuickLRU({
+  maxSize: 3000,
+});
 
 /**
  * This module is used to process CSS text declarations and output DOM fragments (to be
@@ -548,12 +551,12 @@ OutputParser.prototype = {
   _cssPropertySupportsValue: function (name, value) {
     // Checking pair as a CSS declaration string to account for "!important" in value.
     const declaration = `${name}:${value}`;
-    if (supportsValueMap.has(declaration)) {
-      return supportsValueMap.get(declaration);
+    if (cachedSupportsValue.has(declaration)) {
+      return cachedSupportsValue.get(declaration);
     }
     
     const supportsValue = this.doc.defaultView.CSS.supports(declaration);
-    supportsValueMap.set(declaration, supportsValue);
+    cachedSupportsValue.set(declaration, supportsValue);
 
     return supportsValue;
   },

--- a/packages/third-party/css/output-parser.js
+++ b/packages/third-party/css/output-parser.js
@@ -49,6 +49,8 @@ export const TIMING_FUNCTION = "timing-function";
 export const URI = "url";
 export const VARIABLE_FUNCTION = "variable-function";
 
+const supportsValueMap = new Map();
+
 /**
  * This module is used to process CSS text declarations and output DOM fragments (to be
  * appended to panels in DevTools) for CSS values decorated with additional UI and
@@ -95,7 +97,7 @@ OutputParser.prototype = {
    *         CSS Property value
    * @param  {Object} [options]
    *         Optional options object.
-   * @return {Array<Object|String>}
+   * @return {Array<Record|String>}
    *         An array containing a mix of objects and plain strings. The object contains
    *         parsed information about the type and value.
    */
@@ -540,11 +542,20 @@ OutputParser.prototype = {
    *         CSS Property name to check
    * @param  {String} value
    *         CSS Property value to check
+   * 
+   * @return {boolean}
    */
   _cssPropertySupportsValue: function (name, value) {
     // Checking pair as a CSS declaration string to account for "!important" in value.
     const declaration = `${name}:${value}`;
-    return this.doc.defaultView.CSS.supports(declaration);
+    if (supportsValueMap.has(declaration)) {
+      return supportsValueMap.get(declaration);
+    }
+    
+    const supportsValue = this.doc.defaultView.CSS.supports(declaration);
+    supportsValueMap.set(declaration, supportsValue);
+
+    return supportsValue;
   },
 
   /**

--- a/src/devtools/client/inspector/computed/actions/index.ts
+++ b/src/devtools/client/inspector/computed/actions/index.ts
@@ -1,4 +1,5 @@
 import { Action } from "@reduxjs/toolkit";
+import QuickLRU from "shared/utils/quick-lru";
 
 import CSSProperties from "third-party/css/css-properties";
 import { OutputParser } from "third-party/css/output-parser";
@@ -34,7 +35,9 @@ export function setComputedPropertyExpanded(
   return { type: "set_computed_property_expanded", property, expanded };
 }
 
-const cachedParsedProperties = new Map<string, (string | Record<string, unknown>)[]>();
+const cachedParsedProperties = new QuickLRU<string, (string | Record<string, unknown>)[]>({
+  maxSize: 3000,
+});
 
 export async function createComputedProperties(
   elementStyle: ElementStyle,

--- a/src/devtools/client/inspector/computed/components/ComputedProperties.tsx
+++ b/src/devtools/client/inspector/computed/components/ComputedProperties.tsx
@@ -6,7 +6,7 @@ import { getPauseId } from "devtools/client/debugger/src/selectors";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { processedNodeDataCache } from "ui/suspense/nodeCaches";
-import { cssRulesCache } from "ui/suspense/styleCaches";
+import { computedPropertiesCache, cssRulesCache } from "ui/suspense/styleCaches";
 
 import { getSelectedNodeId } from "../../markup/selectors/markup";
 import { setComputedPropertyExpanded } from "../actions";
@@ -54,14 +54,14 @@ function ComputedProperties() {
 
   const canHaveRules = nodeStatus === "resolved" ? node?.isElement : false;
 
-  const { value: cachedStyles, status } = useImperativeCacheValue(
-    cssRulesCache,
+  const { value: computedProperties, status } = useImperativeCacheValue(
+    computedPropertiesCache,
     replayClient,
     canHaveRules ? pauseId : undefined,
     canHaveRules ? selectedNodeId : undefined
   );
 
-  const properties = status === "resolved" ? cachedStyles?.computedProperties ?? [] : [];
+  const properties = status === "resolved" ? computedProperties ?? [] : [];
 
   let dark = false;
   let allPropertiesHidden = true;

--- a/src/devtools/client/inspector/rules/models/element-style.ts
+++ b/src/devtools/client/inspector/rules/models/element-style.ts
@@ -301,14 +301,6 @@ export default class ElementStyle {
       }
     }
 
-    // Find the CSS variables that have been updated.
-    // const previousVariablesMap = new Map<string, string>(this.variablesMap.get(pseudo) || []);
-    // const changedVariableNamesSet = new Set<string>(
-    //   [...variables.keys(), ...previousVariablesMap.keys()].filter(
-    //     k => variables.get(k) !== previousVariablesMap.get(k)
-    //   )
-    // );
-
     this.variablesMap.set(pseudo, variables);
 
     // For each TextProperty, mark it overridden if all of its computed
@@ -319,40 +311,8 @@ export default class ElementStyle {
     for (const textProp of textProps) {
       // _updatePropertyOverridden will return true if the
       // overridden state has changed for the text property.
-      // _hasUpdatedCSSVariable will return true if the declaration contains any
-      // of the updated CSS variable names.
-      // if (
-      //   this._updatePropertyOverridden(textProp) ||
-      //   this._hasUpdatedCSSVariable(textProp, changedVariableNamesSet)
-      // ) {
-      //   textProp.updateEditor();
-      // }
       this._updatePropertyOverridden(textProp);
-
-      // For each editor show or hide the inactive CSS icon as needed.
-      // if (textProp.editor && this.unusedCssEnabled) {
-      //   textProp.editor.updatePropertyState();
-      // }
     }
-  }
-
-  /**
-   * Returns true if the given declaration's property value contains a CSS variable
-   * matching any of the updated CSS variable names.
-   *
-   * @param {TextProperty} declaration
-   *        A TextProperty of a rule.
-   * @param {Set<String>} variableNamesSet
-   *        A Set of CSS variable names that have been updated.
-   */
-  private _hasUpdatedCSSVariable(declaration: TextProperty, variableNamesSet: Set<string>) {
-    for (const variableName of variableNamesSet) {
-      if (declaration.hasCSSVariable(variableName)) {
-        return true;
-      }
-    }
-
-    return false;
   }
 
   /**

--- a/src/devtools/client/inspector/rules/models/element-style.ts
+++ b/src/devtools/client/inspector/rules/models/element-style.ts
@@ -237,7 +237,7 @@ export default class ElementStyle {
     let computedProps: ComputedProperty[] = [];
     for (const textProp of textProps) {
       assert(textProp.computed, "TextProperty has no computed properties");
-      computedProps = computedProps.concat(textProp.computed);
+      computedProps.push(...textProp.computed);
     }
 
     // CSS Variables inherits from the normal element in case of pseudo element.
@@ -302,12 +302,12 @@ export default class ElementStyle {
     }
 
     // Find the CSS variables that have been updated.
-    const previousVariablesMap = new Map<string, string>(this.variablesMap.get(pseudo) || []);
-    const changedVariableNamesSet = new Set<string>(
-      [...variables.keys(), ...previousVariablesMap.keys()].filter(
-        k => variables.get(k) !== previousVariablesMap.get(k)
-      )
-    );
+    // const previousVariablesMap = new Map<string, string>(this.variablesMap.get(pseudo) || []);
+    // const changedVariableNamesSet = new Set<string>(
+    //   [...variables.keys(), ...previousVariablesMap.keys()].filter(
+    //     k => variables.get(k) !== previousVariablesMap.get(k)
+    //   )
+    // );
 
     this.variablesMap.set(pseudo, variables);
 
@@ -406,11 +406,9 @@ export default class ElementStyle {
 
       // Collect all relevant CSS declarations (aka TextProperty instances).
       if (filterCondition) {
-        for (const textProp of rule.textProps.slice(0).reverse()) {
-          if (textProp.enabled) {
-            textProps.push(textProp);
-          }
-        }
+        const enabledTextProps = rule.textProps.filter(textProp => textProp.enabled);
+        enabledTextProps.reverse();
+        textProps.push(...enabledTextProps);
       }
     }
 

--- a/src/devtools/client/inspector/rules/models/element-style.ts
+++ b/src/devtools/client/inspector/rules/models/element-style.ts
@@ -366,9 +366,14 @@ export default class ElementStyle {
 
       // Collect all relevant CSS declarations (aka TextProperty instances).
       if (filterCondition) {
-        const enabledTextProps = rule.textProps.filter(textProp => textProp.enabled);
-        enabledTextProps.reverse();
-        textProps.push(...enabledTextProps);
+        // Order apparently matters here, so iterate backwards.
+        // Also do this without creating new arrays, for perf reasons.
+        for (let index = rule.textProps.length - 1; index >= 0; index--) {
+          const textProp = rule.textProps[index];
+          if (textProp.enabled) {
+            textProps.push(textProp);
+          }
+        }
       }
     }
 

--- a/src/devtools/client/inspector/rules/models/fronts/rule.ts
+++ b/src/devtools/client/inspector/rules/models/fronts/rule.ts
@@ -6,6 +6,9 @@ import { getCachedObject } from "replay-next/src/suspense/ObjectPreviews";
 import { StyleFront } from "./style";
 import { StyleSheetFront } from "./styleSheet";
 
+const cachedSelectorStrings: Map<string, string[]> = new Map();
+const cachedSelectorText: Map<string, string> = new Map();
+
 // Manages interaction with a CSSRule.
 export class RuleFront {
   private pauseId: string;
@@ -41,12 +44,24 @@ export class RuleFront {
     return this._rule.cssText;
   }
 
-  get selectorText() {
-    return this._rule.selectorText;
+  get cleanedSelectorText() {
+    if (cachedSelectorText.has(this._rule.selectorText!)) {
+      return cachedSelectorText.get(this._rule.selectorText!)!;
+    }
+
+    const selectorText = this.selectors.join(", ");
+    cachedSelectorText.set(this._rule.selectorText!, selectorText);
+    return selectorText;
   }
 
   get selectors() {
-    return this._rule.selectorText!.split(",").map(s => s.trim());
+    if (cachedSelectorStrings.has(this._rule.selectorText!)) {
+      return cachedSelectorStrings.get(this._rule.selectorText!)!;
+    }
+
+    const selectors = this._rule.selectorText!.split(",").map(s => s.trim());
+    cachedSelectorStrings.set(this._rule.selectorText!, selectors);
+    return selectors;
   }
 
   get style() {

--- a/src/devtools/client/inspector/rules/models/fronts/rule.ts
+++ b/src/devtools/client/inspector/rules/models/fronts/rule.ts
@@ -1,4 +1,5 @@
 import { Object as ProtocolObject, Rule } from "@replayio/protocol";
+import QuickLRU from "shared/utils/quick-lru";
 
 import { assert } from "protocol/utils";
 import { getCachedObject } from "replay-next/src/suspense/ObjectPreviews";
@@ -6,8 +7,12 @@ import { getCachedObject } from "replay-next/src/suspense/ObjectPreviews";
 import { StyleFront } from "./style";
 import { StyleSheetFront } from "./styleSheet";
 
-const cachedSelectorStrings: Map<string, string[]> = new Map();
-const cachedSelectorText: Map<string, string> = new Map();
+const cachedSelectorStrings = new QuickLRU<string, string[]>({
+  maxSize: 3000,
+});
+const cachedSelectorText = new QuickLRU<string, string>({
+  maxSize: 3000,
+});
 
 // Manages interaction with a CSSRule.
 export class RuleFront {

--- a/src/devtools/client/inspector/rules/models/rule.ts
+++ b/src/devtools/client/inspector/rules/models/rule.ts
@@ -188,7 +188,7 @@ export default class RuleModel {
   }
 
   get selectorText() {
-    return this.domRule.selectors ? this.domRule.selectors.join(", ") : "element";
+    return this.domRule.selectors ? this.domRule.cleanedSelectorText : "element";
   }
 
   /**
@@ -264,7 +264,7 @@ export default class RuleModel {
 
     if (this.domRule.selectors) {
       // This is a style rule with a selector.
-      selector = this.domRule.selectors.join(", ");
+      selector = this.domRule.cleanedSelectorText;
     }
 
     return selector;


### PR DESCRIPTION
This PR attempts to speed up some of the (very legacy!) CSS parsing logic, which is horribly slow and pathological when you inspect some of our own DOM nodes due to the thousands of Tailwind rules:

- Found a bunch of places where we were repeatedly recalculating strings or similar values, and threw in caches
- Turned some hot path array updates from immutable `concat()` to mutable `push()` (in some cases, 50K array copies were being made, totally unnecessarily)
- Moved the calculation of `ComputedPropertyState[]` from the `cssRulesCache` into its own cache, so that we don't do that calculation until you actually select the "Computed" panel

There's still a _lot_ of slowness here, but I think it's somewhat less bad now.

Here's one local dev perf profile before:

![image](https://github.com/replayio/devtools/assets/1128784/8fbaa386-de8b-4fd5-bd1a-41e64e1fd26d)

(yes, that is 7+ seconds of pure CPU, and 1500ms of GCs)

and what ought to be a couple equivalent parts of a perf profile with these changes applied:

![image](https://github.com/replayio/devtools/assets/1128784/b728d7a8-1c3f-4ffa-8508-4a9338fe3ac9)

![image](https://github.com/replayio/devtools/assets/1128784/0da8ec61-a5bc-4ad2-98ee-ff27aad7c2b3)

500-1000ms still isn't _good_, but it's less _bad_