### PR TITLE
Test Suites: Add filter-by-branch dropdown

### DIFF
--- a/packages/e2e-tests/authenticated/test-suites/library-test-runs.test.ts
+++ b/packages/e2e-tests/authenticated/test-suites/library-test-runs.test.ts
@@ -6,10 +6,15 @@ import {
   filterTestRunsList,
   findTestRunsInList,
   getTestRunAttribute,
+  getVisibleBranchNames,
 } from "../../helpers/test-suites";
 
 test(`authenticated/test-suites/library-test-runs`, async ({ page }) => {
   await startLibraryTest(page, E2E_USER_3_API_KEY, E2E_USER_3_TEAM_ID);
+
+  await filterTestRunsList(page, { branch: "primary" });
+  await expect(await getVisibleBranchNames(page)).toEqual(["main"]);
+  await filterTestRunsList(page, { branch: "all" });
 
   await filterTestRunsList(page, { status: "failed" });
   await expect(await findTestRunsInList(page, { status: "success" }).count()).toBe(0);

--- a/src/ui/components/Library/Team/View/TestRuns/TestRunsPage.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunsPage.tsx
@@ -20,24 +20,45 @@ export function TestRunsPage() {
 
 function TestRunsContent() {
   const {
+    filterByBranch,
     filterByStatus,
     filterByText,
     filterByTextForDisplay,
+    setFilterByBranch,
     setFilterByStatus,
     setFilterByText,
   } = useContext(TestRunsContext);
 
   const {
-    contextMenu,
-    onContextMenu: onClick,
-    onKeyDown,
+    contextMenu: contextMenuStatusFilter,
+    onContextMenu: onClickStatusFilter,
+    onKeyDown: onKeyDownStatusFilter,
   } = useContextMenu(
     <>
       <ContextMenuItem dataTestId="show-all-runs" onSelect={() => setFilterByStatus("all")}>
-        Show all runs
+        All runs
       </ContextMenuItem>
       <ContextMenuItem dataTestId="show-only-failures" onSelect={() => setFilterByStatus("failed")}>
-        Show only failures
+        Only failures
+      </ContextMenuItem>
+    </>,
+    { alignTo: "auto-target" }
+  );
+
+  const {
+    contextMenu: contextMenuBranchFilter,
+    onContextMenu: onClickBranchFilter,
+    onKeyDown: onKeyDownBranchFilter,
+  } = useContextMenu(
+    <>
+      <ContextMenuItem dataTestId="show-all-branches" onSelect={() => setFilterByBranch("all")}>
+        All branches
+      </ContextMenuItem>
+      <ContextMenuItem
+        dataTestId="show-only-primary-branch"
+        onSelect={() => setFilterByBranch("primary")}
+      >
+        Only primary branch
       </ContextMenuItem>
     </>,
     { alignTo: "auto-target" }
@@ -51,19 +72,30 @@ function TestRunsContent() {
             <div className="flex flex-row items-center justify-between gap-2 border-b border-themeBorder bg-bodyBgcolor p-2">
               <div
                 className={styles.dropdownTrigger}
-                data-test-id="TestRunsPage-DropdownTrigger"
-                onClick={onClick}
-                onKeyDown={onKeyDown}
+                data-test-id="TestRunsPage-ResultFilter-DropdownTrigger"
+                onClick={onClickStatusFilter}
+                onKeyDown={onKeyDownStatusFilter}
                 tabIndex={0}
               >
-                {filterByStatus === "all" ? "Show all runs" : "Show only failures"}
+                {filterByStatus === "all" ? "All runs" : "Only failures"}
                 <Icon className="h-5 w-5" type="chevron-down" />
               </div>
-              {contextMenu}
+              {contextMenuStatusFilter}
+              <div
+                className={styles.dropdownTrigger}
+                data-test-id="TestRunsPage-BranchFilter-DropdownTrigger"
+                onClick={onClickBranchFilter}
+                onKeyDown={onKeyDownBranchFilter}
+                tabIndex={0}
+              >
+                {filterByBranch === "all" ? "All branches" : "Only primary branch"}
+                <Icon className="h-5 w-5" type="chevron-down" />
+              </div>
+              {contextMenuBranchFilter}
               <div className={styles.filterContainer}>
                 <input
                   className={styles.filterInput}
-                  data-test-id="TestRunsPage-FilterInput"
+                  data-test-id="TestRunsPage-FilterByText-Input"
                   onChange={event => setFilterByText(event.currentTarget.value)}
                   placeholder="Filter test runs"
                   type="text"


### PR DESCRIPTION
To make room, I shorted the filter-by-status text slightly (by removing the "Show" prefix)

![Screen Shot 2023-09-07 at 2 04 07 PM](https://github.com/replayio/devtools/assets/29597/eca8b63c-d725-481c-a536-3bd1c16676c9)

![Screen Shot 2023-09-07 at 2 04 14 PM](https://github.com/replayio/devtools/assets/29597/15bc8be4-809d-4ac2-93ed-7f6babdf3727)

![Screen Shot 2023-09-07 at 2 04 24 PM](https://github.com/replayio/devtools/assets/29597/d9ef1492-31e7-420d-a4ea-95ba5130f111)

cc @jonbell-lot23 