### PR TITLE
Fixed Console rewind/fast-forward regression

### DIFF
--- a/src/ui/components/LayoutContextAdapter.tsx
+++ b/src/ui/components/LayoutContextAdapter.tsx
@@ -1,18 +1,34 @@
-import React, { PropsWithChildren, useMemo } from "react";
+import { PropsWithChildren, useContext, useMemo } from "react";
+import { useImperativeCacheValue } from "suspense";
 
 import { LayoutContext, LayoutContextType } from "replay-next/src/contexts/LayoutContext";
+import { recordingCapabilitiesCache } from "replay-next/src/suspense/BuildIdCache";
+import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { getToolboxLayout } from "ui/reducers/layout";
 import { useAppSelector } from "ui/setup/hooks";
 
 export default function LayoutContextAdapter({ children }: PropsWithChildren) {
+  const replayClient = useContext(ReplayClientContext);
+
   const layout = useAppSelector(getToolboxLayout);
 
-  const context = useMemo<LayoutContextType>(
-    () => ({
-      canShowConsoleAndSources: layout === "ide",
-    }),
-    [layout]
+  const { value: recordingCapabilities } = useImperativeCacheValue(
+    recordingCapabilitiesCache,
+    replayClient
   );
+
+  const context = useMemo<LayoutContextType>(() => {
+    let canShowConsoleAndSources = false;
+    if (recordingCapabilities) {
+      if (recordingCapabilities.supportsRepaintingGraphics) {
+        canShowConsoleAndSources = layout === "ide";
+      } else {
+        canShowConsoleAndSources = layout === "left";
+      }
+    }
+
+    return { canShowConsoleAndSources };
+  }, [layout, recordingCapabilities]);
 
   return <LayoutContext.Provider value={context}>{children}</LayoutContext.Provider>;
 }


### PR DESCRIPTION
This regression had manifested in causing `node_logpoint-02` but we missed that because Test Suites was ignoring failures in that test (see SCS-1413).