### PR TITLE
Fix network panel color regression

### DIFF
--- a/packages/design/AddCommentButton/AddCommentButton.module.css
+++ b/packages/design/AddCommentButton/AddCommentButton.module.css
@@ -23,11 +23,11 @@
   height: 26px;
   padding-left: 3px;
   border-radius: 3rem;
-  color: #fff;
   overflow: hidden;
   transition: width 180ms ease-out;
   width: 26px;
   background-color: var(--primary-accent);
+  color: var(--primary-accent-foreground-text);
   position: absolute;
   top: 0;
   right: 0;

--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -34,6 +34,7 @@
 
   --primary-accent: #01acfd;
   --primary-accent-hover: #0194ff;
+  --primary-accent-foreground-text: #fff;
 
   --secondary-accent: #f02d5e;
   --secondary-accent-hover: #d72451;

--- a/src/devtools/client/themes/perf.css
+++ b/src/devtools/client/themes/perf.css
@@ -348,7 +348,7 @@
 
 .perf-photon-button-primary {
   background-color: var(--blue-60);
-  color: #fff;
+  color: var(--primary-accent-foreground-text);
 }
 
 .perf-photon-button-primary:hover:not([disabled]) {

--- a/src/ui/components/NetworkMonitor/NetworkMonitorListRow.module.css
+++ b/src/ui/components/NetworkMonitor/NetworkMonitorListRow.module.css
@@ -37,10 +37,10 @@
 .Row[data-selected]:focus,
 .Row[data-selected]:hover {
   background: var(--primary-accent-hover);
-  color: var(--color-default);
+  color: #fff;
 
-  --status-background-color: var(--color-default);
-  --status-color: var(--color-default);
+  --status-background-color: #fff;
+  --status-color: #fff;
 }
 
 /* These styles should stay in sync with NetworkMonitorListHeader */

--- a/src/ui/components/NetworkMonitor/NetworkMonitorListRow.module.css
+++ b/src/ui/components/NetworkMonitor/NetworkMonitorListRow.module.css
@@ -37,10 +37,9 @@
 .Row[data-selected]:focus,
 .Row[data-selected]:hover {
   background: var(--primary-accent-hover);
-  color: #fff;
+  color: var(--primary-accent-foreground-text);
 
-  --status-background-color: #fff;
-  --status-color: #fff;
+  --status-color: var(--primary-accent-foreground-text);
 }
 
 /* These styles should stay in sync with NetworkMonitorListHeader */

--- a/src/ui/components/Passport/Passport.module.css
+++ b/src/ui/components/Passport/Passport.module.css
@@ -147,7 +147,7 @@
 /* these are made to match the styles of the SidePanel.module.css */
 .TestsuitesPassportWelcome {
   padding: 0.5em;
-  color: #fff;
+  color: var(--primary-accent-foreground-text);
   background: linear-gradient(116.71deg, #ff2f86 21.74%, #ec275d 83.58%),
     linear-gradient(133.71deg, #01acfd 3.31%, #f155ff 106.39%, #f477f8 157.93%, #f33685 212.38%),
     #007aff;

--- a/src/ui/components/SidePanel.module.css
+++ b/src/ui/components/SidePanel.module.css
@@ -1,6 +1,6 @@
 .TourBox {
   padding: 0.5em;
-  color: #fff;
+  color: var(--primary-accent-foreground-text);
   background: linear-gradient(116.71deg, #ff2f86 21.74%, #ec275d 83.58%),
     linear-gradient(133.71deg, #01acfd 3.31%, #f155ff 106.39%, #f477f8 157.93%, #f33685 212.38%),
     #007aff;

--- a/src/ui/components/shared/SharingModal/SharingModal.module.css
+++ b/src/ui/components/shared/SharingModal/SharingModal.module.css
@@ -24,7 +24,7 @@
 .copyURL:hover,
 .downloadVideo:hover {
   background-color: var(--primary-accent);
-  color: #fff;
+  color: var(--primary-accent-foreground-text);
 }
 
 .copyIcon {


### PR DESCRIPTION
Old:
![image](https://github.com/replayio/devtools/assets/9154902/fc3ca5bf-bf70-4092-8fdf-d02c92b1e833)

New:
![image](https://github.com/replayio/devtools/assets/9154902/a864b58c-d6fa-42f3-8a48-466bf9715464)

Another example of a blue background that calls for a white background (similar to our rewind/ff buttons)