### PR TITLE
Harden scrollUntilLineIsVisible() helper to avoid false positives

### DIFF
--- a/packages/e2e-tests/helpers/source-panel.ts
+++ b/packages/e2e-tests/helpers/source-panel.ts
@@ -163,10 +163,12 @@ export async function jumpToLogPointHit(
 
 async function scrollUntilLineIsVisible(page: Page, lineNumber: number) {
   const lineLocator = await getSourceLine(page, lineNumber);
-  const lineIsVisible = await lineLocator.isVisible();
-  if (lineIsVisible) {
-    return;
-  }
+
+  // Don't rely on lineLocator.isVisible() because it can give false positives for partially visible rows
+  // const lineIsVisible = await lineLocator.isVisible();
+  // if (lineIsVisible) {
+  //   return;
+  // }
 
   await debugPrint(page, `Scrolling to source line ${chalk.bold(lineNumber)}`, "goToLine");
 

--- a/packages/e2e-tests/helpers/source-panel.ts
+++ b/packages/e2e-tests/helpers/source-panel.ts
@@ -165,10 +165,6 @@ async function scrollUntilLineIsVisible(page: Page, lineNumber: number) {
   const lineLocator = await getSourceLine(page, lineNumber);
 
   // Don't rely on lineLocator.isVisible() because it can give false positives for partially visible rows
-  // const lineIsVisible = await lineLocator.isVisible();
-  // if (lineIsVisible) {
-  //   return;
-  // }
 
   await debugPrint(page, `Scrolling to source line ${chalk.bold(lineNumber)}`, "goToLine");
 


### PR DESCRIPTION
Building on @markerikson's insight on [b5ba8725-0bb1-41c4-9877-48a7d1be289a](https://app.replay.io/recording/breakpoints-04-catch-finally-generators-and-asyncawait--b5ba8725-0bb1-41c4-9877-48a7d1be289a), this PR updates our `scrollUntilLineIsVisible` to avoid potential false positives for partially-visible rows.