### PR TITLE
Retry failed snapshot uploads

### DIFF
--- a/packages/replay-next/uploadSnapshots.js
+++ b/packages/replay-next/uploadSnapshots.js
@@ -160,7 +160,6 @@ async function uploadSnapshot({ metadata, url, variants }) {
   });
   if (response.status !== 200) {
     const text = await response.text();
-    console.error(`Upload failed (server status ${response.status})\n${text}`);
-    process.exit(1);
+    throw new Error(`Upload failed (server status ${response.status})\n${text}`);
   }
 }


### PR DESCRIPTION
Remove `process.exit(1)` from `uploadSnapshot()` and throw instead - the caller of `uploadSnapshot()` will retry and `process.exit(1)` itself if the second attempt fails.