### PR TITLE
Open the source for the initial pause point

### DIFF
--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -128,7 +128,7 @@ export function jumpToInitialPausePoint(): UIThunkAction<Promise<void>> {
     if (initialPausePoint?.time) {
       time = initialPausePoint.time;
     }
-    ThreadFront.timeWarp(point, time, false);
+    ThreadFront.timeWarp(point, time, true);
   };
 }
 


### PR DESCRIPTION
It may have been a conscious decision to not open that source: it can take quite some time to get the top frame for the initial pause point, by that time the user may already be interacting with the recording and it could feel disruptive if the UI then suddenly opens a source. Furthermore, opening the source manually is easy, just click on the top frame in the frames panel.
@jasonLaster what do you think, should we land this change?