### PR TITLE
Improve Source preview popup error messages

### DIFF
--- a/packages/replay-next/components/Popup.module.css
+++ b/packages/replay-next/components/Popup.module.css
@@ -5,6 +5,11 @@
   flex-direction: column;
   padding: 0;
 }
+.Popup[data-style="error"] {
+  --theme-popup-background-color: var(--background-color-error);
+  --theme-popup-border-color: var(--border-color-error);
+  --theme-popup-color: var(--color-error);
+}
 
 .UpArrow,
 .DownArrow {
@@ -23,8 +28,8 @@
 }
 
 .ArrowBackground {
-  fill: var(--theme-base-80);
+  fill: var(--theme-popup-border-color);
 }
 .ArrowForeground {
-  fill: var(--menu-bgcolor);
+  fill: var(--theme-popup-background-color);
 }

--- a/packages/replay-next/components/Popup.tsx
+++ b/packages/replay-next/components/Popup.tsx
@@ -6,6 +6,8 @@ import styles from "./Popup.module.css";
 const MOUSE_LEAVE_DEBOUNCE_TIMER = 250;
 const RESIZE_DEBOUNCE_TIMER = 100;
 
+export type PopupStyle = "default" | "error";
+
 type Dismiss = () => void;
 
 export default function Popup({
@@ -18,6 +20,7 @@ export default function Popup({
   dismissOnMouseLeave = false,
   horizontalAlignment = "center",
   showTail = false,
+  style = "default",
   target,
 }: {
   children: ReactNode;
@@ -29,6 +32,7 @@ export default function Popup({
   dismissOnMouseLeave?: boolean;
   horizontalAlignment?: "left" | "center" | "right";
   showTail?: boolean;
+  style?: PopupStyle;
   target: HTMLElement;
 }) {
   const arrowRef = useRef<SVGElement>(null);
@@ -215,6 +219,7 @@ export default function Popup({
   return createPortal(
     <div
       className={styles.Popup}
+      data-style={style}
       data-test-id={dataTestId}
       data-test-name={dataTestName}
       onClick={blockEvent}

--- a/packages/replay-next/components/sources/PreviewPopup.module.css
+++ b/packages/replay-next/components/sources/PreviewPopup.module.css
@@ -3,8 +3,8 @@
   max-height: 400px;
   height: auto;
   overflow: hidden;
-  background-color: var(--menu-bgcolor);
-  border: 1px solid var(--theme-base-80);
+  background-color: var(--theme-popup-background-color);
+  border: 1px solid var(--theme-popup-border-color);
   border-radius: 0.25rem;
   filter: drop-shadow(0 1px 2px rgb(0 0 0 / 0.1)) drop-shadow(0 1px 1px rgb(0 0 0 / 0.06));
 }
@@ -12,7 +12,7 @@
 .LoadingMessage,
 .UnavailableMessage {
   padding: 0.5rem;
-  color: var(--color-default);
+  color: var(--theme-popup-color);
   font-family: var(--font-family-default);
   font-size: var(--font-size-regular);
 }

--- a/packages/replay-next/components/sources/PreviewPopup.tsx
+++ b/packages/replay-next/components/sources/PreviewPopup.tsx
@@ -132,12 +132,22 @@ function SuspendingPreviewPopup({
       }
     };
 
+    const onKeyDown = ({ key }: KeyboardEvent) => {
+      switch (key) {
+        case "Escape":
+          dismiss();
+          break;
+      }
+    };
+
     document.body.addEventListener("click", onClick);
     document.body.addEventListener("contextmenu", onClick);
+    document.body.addEventListener("keydown", onKeyDown);
 
     return () => {
       document.body.removeEventListener("click", onClick);
       document.body.removeEventListener("contextmenu", onClick);
+      document.body.removeEventListener("keydown", onKeyDown);
     };
   });
 

--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -395,11 +395,11 @@
 
   /* src/devtools/client/themes/tooltips.css */
 
-  --theme-tooltip-background: var(--theme-popup-background);
+  --theme-tooltip-background: var(--theme-popup-background-color);
   --theme-tooltip-color: var(--theme-text-color-strong);
   --theme-tooltip-shadow: rgba(25, 25, 25, 0.76);
 
-  --theme-arrowpanel-background: var(--theme-popup-background);
+  --theme-arrowpanel-background: var(--theme-popup-background-color);
   --theme-arrowpanel-border-color: var(--theme-popup-border-color);
   --theme-arrowpanel-color: var(--theme-popup-color);
   --theme-arrowpanel-dimmed-further: rgba(249, 249, 250, 0.15);
@@ -607,10 +607,9 @@
   /* Colors used in Graphs, like performance tools. */
 
   /* Common popup styles(used by HTMLTooltip and autocomplete) */
-  --theme-popup-background: var(--grey-60);
-  --theme-popup-border-color: #27272b;
-  --theme-popup-color: rgb(249, 249, 250);
-  --theme-popup-dimmed: rgba(249, 249, 250, 0.1);
+  --theme-popup-background-color: var(--menu-bgcolor);
+  --theme-popup-border-color: var(--theme-base-80);
+  --theme-popup-color: var(--color-default);
 
   /* Styling for devtool buttons */
   --theme-toolbarbutton-active-background: var(--grey-10-a30);
@@ -915,11 +914,11 @@
 
   /* src/devtools/client/themes/tooltips.css */
 
-  --theme-tooltip-background: var(--theme-popup-background);
+  --theme-tooltip-background: var(--theme-popup-background-color);
   --theme-tooltip-color: var(--theme-text-color-strong);
   --theme-tooltip-shadow: rgba(25, 25, 25, 0.76);
 
-  --theme-arrowpanel-background: var(--theme-popup-background);
+  --theme-arrowpanel-background: var(--theme-popup-background-color);
   --theme-arrowpanel-border-color: var(--theme-popup-border-color);
   --theme-arrowpanel-color: var(--theme-popup-color);
   --theme-arrowpanel-dimmed-further: rgba(249, 249, 250, 0.15);
@@ -1125,7 +1124,7 @@
   --theme-focus-outline-color: #000000;
 
   /* Common popup styles(used by HTMLTooltip and autocomplete) */
-  --theme-popup-background: white;
+  --theme-popup-background-color: white;
   --theme-popup-border-color: ThreeDShadow;
   --theme-popup-color: var(--grey-70);
   --theme-popup-dimmed: hsla(0, 0%, 80%, 0.3);

--- a/packages/replay-next/playwright/tests/utils/source.ts
+++ b/packages/replay-next/playwright/tests/utils/source.ts
@@ -580,6 +580,7 @@ export async function hoverOverLine(
     );
 
     await stopHovering(page);
+
     if (withMetaKey) {
       await page.keyboard.up(getCommandKey());
     }
@@ -613,6 +614,9 @@ export async function isSeekOptionEnabled(
     withMetaKey: true,
     withShiftKey: direction === "previous",
   });
+
+  // If there is a preview popup, hide it so it isn't obscuring the hover action
+  await page.keyboard.press("Escape");
 
   const button = lineLocator.locator('[data-test-name="ContinueToButton"]');
   const isHoverButtonEnabled = await button.isEnabled();

--- a/src/devtools/client/themes/common.css
+++ b/src/devtools/client/themes/common.css
@@ -211,7 +211,7 @@ button::selection {
 .CodeMirror-hints,
 .CodeMirror-Tern-tooltip {
   border: 1px solid var(--theme-popup-border-color);
-  background-color: var(--theme-popup-background);
+  background-color: var(--theme-popup-background-color);
   color: var(--theme-popup-color);
 }
 

--- a/src/ui/components/reactjs-popup.css
+++ b/src/ui/components/reactjs-popup.css
@@ -1,6 +1,6 @@
 #popup-root .popup-content {
   background: var(--theme-popup-color);
-  color: var(--theme-popup-background);
+  color: var(--theme-popup-background-color);
   font-family: "Inter", sans-serif;
   font-size: 12px;
   width: auto;


### PR DESCRIPTION
When the user hovers over a value in the source editor that can't be inspected, we used to just show a hard-coded message:
![Screen Shot 2023-09-12 at 9 45 38 AM](https://github.com/replayio/devtools/assets/29597/2e349d95-20d2-44bb-8dd6-58975abea311)

@Andarist shared feedback that it was confusing the Scopes panel showed something different for these same variables:
![Screen Shot 2023-09-12 at 9 46 25 AM](https://github.com/replayio/devtools/assets/29597/301f1e1d-cd21-4b1e-b611-7518cf616013)

@Andarist suggested we show the same thing in both locations, but after thinking about this more– I think it's better if we make the following two changes to the preview popup:

1. Show the specific error reported by the Protocol. (It will have clearer text than just showing "(unavailable)")
2. Style the popup differently when we're displaying a meta error (to differentiate when we're inspecting an `Error` object)

I don't think it makes sense to change what we show in the Scopes panel to match this, since it's more of a passive panel, but this seems subjective and I'm open to discussion.

# Screenshots

| Dark theme | Light theme |
|:---|:---|
| ![Screen Shot 2023-09-12 at 9 41 51 AM](https://github.com/replayio/devtools/assets/29597/8bf71a15-5c7a-4835-8aeb-16735e41a5f7) | ![Screen Shot 2023-09-12 at 9 42 01 AM](https://github.com/replayio/devtools/assets/29597/b739057e-0d45-41e7-ab60-40af3a867f73) |
| ![Screen Shot 2023-09-12 at 9 41 43 AM](https://github.com/replayio/devtools/assets/29597/d74dbd50-5b54-4140-b926-c9937ab138aa) | ![Screen Shot 2023-09-12 at 9 42 08 AM](https://github.com/replayio/devtools/assets/29597/25182684-eae6-42b1-8519-54c67997b937) |

cc @jonbell-lot23 