### PR TITLE
Delta flaky tests

### DIFF
--- a/packages/e2e-tests/helpers/object-inspector.ts
+++ b/packages/e2e-tests/helpers/object-inspector.ts
@@ -25,10 +25,10 @@ export async function getGetterValue(objectInspector: Locator, propertyName: str
   }
 
   const property = objectInspector.locator(
-    `[data-test-name="ExpandableChildren"] [data-test-name="GetterRenderer"]:has([class^="GetterRenderer_Name"]:text-is("${propertyName}"))`
+    `[data-test-name="ExpandableChildren"] [data-test-name="GetterRenderer-Name"]:text-is("${propertyName}"))`
   );
   await property.waitFor();
-  const getterButton = property.locator('[data-test-name="InvokeGetterButton"]');
+  const getterButton = property.locator('[data-test-name="GetterRenderer-LoadValueButton"]');
 
   if (await getterButton.isVisible({ timeout: 250 })) {
     await getterButton.click();

--- a/packages/e2e-tests/tests/object_preview-01.test.ts
+++ b/packages/e2e-tests/tests/object_preview-01.test.ts
@@ -54,7 +54,7 @@ test(`object_preview-01: expressions in the console after time warping`, async (
   await toggleExpandable(page, { scope: objectInspector, targetState: "open" });
   await objectInspector
     .locator(
-      '[data-test-name="GetterRenderer"]:has-text("foo") [data-test-name="InvokeGetterButton"]'
+      '[data-test-name="GetterRenderer"]:has-text("foo") [data-test-name="GetterRenderer-LoadValueButton"]'
     )
     .click();
   await objectInspector

--- a/packages/replay-next/components/inspector/GetterRenderer.tsx
+++ b/packages/replay-next/components/inspector/GetterRenderer.tsx
@@ -87,7 +87,7 @@ export default function GetterRenderer({
   if (getterValue) {
     if (!isExpanded) {
       value = (
-        <span data-test-name="GetterValue">
+        <span data-test-name="GetterRenderer-Value">
           <ValueRenderer
             context="nested"
             layout="vertical"
@@ -101,7 +101,7 @@ export default function GetterRenderer({
     value = (
       <button
         className={styles.InvokeGetterButton}
-        data-test-name="InvokeGetterButton"
+        data-test-name="GetterRenderer-LoadValueButton"
         disabled={isPending}
         onClick={(event: MouseEvent) => {
           event.stopPropagation();
@@ -124,7 +124,9 @@ export default function GetterRenderer({
       )}
       data-test-name="GetterRenderer"
     >
-      <span className={styles.Name}>{name}</span>
+      <span className={styles.Name} data-test-name="GetterRenderer-Name">
+        {name}
+      </span>
       <span className={styles.Separator}>: </span>
       {value}
     </span>

--- a/packages/replay-next/components/inspector/PropertiesRenderer.tsx
+++ b/packages/replay-next/components/inspector/PropertiesRenderer.tsx
@@ -120,11 +120,18 @@ export default function PropertiesRenderer({
 
   switch (object.className) {
     case "Function":
-      specialPropertiesRenderer.push(<FunctionLocationRenderer object={object} />);
+      specialPropertiesRenderer.push(
+        <FunctionLocationRenderer key="FunctionLocation" object={object} />
+      );
     default:
       if (!hidePrototype) {
         specialPropertiesRenderer.push(
-          <PrototypeRenderer object={object} path={path} pauseId={pauseId} />
+          <PrototypeRenderer
+            key="PrototypeRenderer"
+            object={object}
+            path={path}
+            pauseId={pauseId}
+          />
         );
       }
   }

--- a/packages/replay-next/playwright/tests/object-inspector/shared.ts
+++ b/packages/replay-next/playwright/tests/object-inspector/shared.ts
@@ -30,9 +30,9 @@ export async function inspectGetter(page: Page, testInfo: TestInfo, partialText:
     hasText: partialText,
   });
   await takeScreenshot(page, testInfo, getter, `${partialText}-getter-before-inspection`);
-  const invokeGetterButton = getter.locator('[data-test-name="InvokeGetterButton"]');
+  const invokeGetterButton = getter.locator('[data-test-name="GetterRenderer-LoadValueButton"]');
   await invokeGetterButton.click();
-  await getter.locator('[data-test-name="GetterValue"]').waitFor();
+  await getter.locator('[data-test-name="GetterRenderer-Value"]').waitFor();
   await takeScreenshot(page, testInfo, getter, `${partialText}-getter-after-inspection`);
 }
 

--- a/packages/replay-next/playwright/tests/object-inspector/should-render-getters-and-setters-correctly.ts
+++ b/packages/replay-next/playwright/tests/object-inspector/should-render-getters-and-setters-correctly.ts
@@ -1,5 +1,7 @@
 import { test } from "@playwright/test";
 
+import { toggleExpandable } from "replay-next/playwright/tests/utils/inspector";
+
 import { filterByText } from "../utils/console";
 import { takeScreenshot } from "../utils/general";
 import { beforeEach } from "./beforeEach";
@@ -24,15 +26,22 @@ test("should render getters and setters correctly", async ({ page }, testInfo) =
   await inspectGetter(page, testInfo, "array");
 
   // Further inspect object and array
-  const objectRow = await page
-    .locator('[data-test-name="ExpandablePreview"]', { hasText: "objectGetter" })
-    .first();
-  await objectRow.click();
-  await takeScreenshot(page, testInfo, objectRow, "inspect-getter-nested-object");
 
-  const arrayRow = await page
-    .locator('[data-test-name="ExpandablePreview"]', { hasText: "arrayGetter" })
-    .first();
-  await arrayRow.click();
-  await takeScreenshot(page, testInfo, arrayRow, "inspect-getter-nested-array");
+  const objectRow = await toggleExpandable(page, {
+    expanded: true,
+    expandableLocator: page
+      .locator(`[data-test-name="Expandable"] `, { hasText: "objectGetter" })
+      .nth(1),
+    partialText: "objectGetter",
+  });
+  await takeScreenshot(page, testInfo, objectRow.first(), "inspect-getter-nested-object");
+
+  const arrayRow = await toggleExpandable(page, {
+    expanded: true,
+    expandableLocator: page
+      .locator(`[data-test-name="Expandable"]`, { hasText: "arrayGetter" })
+      .nth(1),
+    partialText: "arrayGetter",
+  });
+  await takeScreenshot(page, testInfo, arrayRow.first(), "inspect-getter-nested-array");
 });

--- a/packages/replay-next/playwright/tests/utils/inspector.ts
+++ b/packages/replay-next/playwright/tests/utils/inspector.ts
@@ -47,7 +47,7 @@ export async function toggleExpandable<T>(
     partialText?: string;
     scope?: Locator;
   }
-): Promise<void> {
+): Promise<Locator> {
   const { expanded: nextExpanded = true, scope = page, partialText } = options;
 
   let { expandableLocator } = options;
@@ -87,4 +87,6 @@ export async function toggleExpandable<T>(
       });
     }
   }
+
+  return expandableLocator;
 }


### PR DESCRIPTION
Primary change:
- [x] Updated screenshot test "_should render getters and setters correctly_" to (hopefully) addressing timing related flakiness

Secondary changes:
- [x] Updated `GetterRenderer` `data-test-name` attribute names for consistency
- [x] Fixed missing `key` DEV warning in `PropertiesRenderer`