### PR TITLE
Add E2E test for core event listener Jump to Code functionality

### DIFF
--- a/packages/e2e-tests/helpers/info-event-panel.ts
+++ b/packages/e2e-tests/helpers/info-event-panel.ts
@@ -6,6 +6,16 @@ export function getEventsPanel(page: Page) {
   return getByTestName(page, "EventsList");
 }
 
+export function getEventListItems(page: Page) {
+  const eventsPanel = getEventsPanel(page);
+  const events = getByTestName(eventsPanel, "Event");
+  return events;
+}
+
+export function getEventJumpButton(locator: Locator) {
+  return getByTestName(locator, "JumpToCode");
+}
+
 export async function openEventsPanel(page: Page): Promise<void> {
   const pane = getEventsPanel(page);
 

--- a/packages/e2e-tests/helpers/info-event-panel.ts
+++ b/packages/e2e-tests/helpers/info-event-panel.ts
@@ -1,0 +1,21 @@
+import { Locator, Page, expect } from "@playwright/test";
+
+import { getByTestName, waitFor } from "./utils";
+
+export function getEventsPanel(page: Page) {
+  return getByTestName(page, "EventsList");
+}
+
+export async function openEventsPanel(page: Page): Promise<void> {
+  const pane = getEventsPanel(page);
+
+  const isVisible = await pane.isVisible();
+  if (!isVisible) {
+    const button = page.locator('[data-test-name="ToolbarButton-ReplayInfo"]');
+    await button.click();
+
+    await waitFor(async () => {
+      expect(await pane.isVisible()).toBe(true);
+    });
+  }
+}

--- a/packages/e2e-tests/tests/jump-to-code-01_basic.test.ts
+++ b/packages/e2e-tests/tests/jump-to-code-01_basic.test.ts
@@ -1,0 +1,22 @@
+import { openDevToolsTab, startTest } from "../helpers";
+import { executeAndVerifyTerminalExpression } from "../helpers/console-panel";
+import { openEventsPanel } from "../helpers/info-event-panel";
+import { resumeToLine, rewindToLine } from "../helpers/pause-information-panel";
+import { openSourceExplorerPanel } from "../helpers/source-explorer-panel";
+import { addBreakpoint } from "../helpers/source-panel";
+import { delay } from "../helpers/utils";
+import test from "../testFixtureCloneRecording";
+
+test.use({ exampleKey: "redux-fundamentals/dist/index.html" });
+
+test(`jump-to-code-01: Test basic jumping functionality`, async ({
+  pageWithMeta: { page, recordingId },
+  exampleKey,
+}) => {
+  await startTest(page, exampleKey, recordingId);
+  await openDevToolsTab(page);
+
+  await openSourceExplorerPanel(page);
+  await openEventsPanel(page);
+  await delay(5000);
+});

--- a/packages/e2e-tests/tests/jump-to-code-01_basic.test.ts
+++ b/packages/e2e-tests/tests/jump-to-code-01_basic.test.ts
@@ -1,13 +1,50 @@
+import { expect } from "@playwright/test";
+
 import { openDevToolsTab, startTest } from "../helpers";
 import { executeAndVerifyTerminalExpression } from "../helpers/console-panel";
-import { openEventsPanel } from "../helpers/info-event-panel";
+import {
+  getEventJumpButton,
+  getEventListItems,
+  openEventsPanel,
+} from "../helpers/info-event-panel";
 import { resumeToLine, rewindToLine } from "../helpers/pause-information-panel";
 import { openSourceExplorerPanel } from "../helpers/source-explorer-panel";
 import { addBreakpoint } from "../helpers/source-panel";
-import { delay } from "../helpers/utils";
+import { debugPrint, delay, getByTestName, waitFor } from "../helpers/utils";
 import test from "../testFixtureCloneRecording";
 
 test.use({ exampleKey: "redux-fundamentals/dist/index.html" });
+
+type NavEvent = { type: "navigation"; url: string };
+type KeypressEvent = { type: "keypress"; key: string };
+type ClickEvent = { type: "mousedown" };
+
+type Event = NavEvent | KeypressEvent | ClickEvent;
+
+const makeKeypressEvent = (key: string): KeypressEvent => ({ type: "keypress", key } as const);
+
+const expectedEvents: Event[] = (
+  [
+    { type: "navigation", url: "localhost:8080" },
+    { type: "mousedown" },
+    { type: "mousedown" },
+    [..."test"].map(makeKeypressEvent),
+    [..."Watch Bengals"].map(makeKeypressEvent),
+    { type: "keypress", key: "Enter" },
+    [..."Celebrate"].map(makeKeypressEvent),
+    { type: "keypress", key: "Enter" },
+    { type: "mousedown" },
+    { type: "mousedown" },
+    { type: "mousedown" },
+    { type: "mousedown" },
+    { type: "mousedown" },
+    { type: "mousedown" },
+    { type: "mousedown" },
+    { type: "mousedown" },
+    { type: "mousedown" },
+    { type: "mousedown" },
+  ] as const
+).flat();
 
 test(`jump-to-code-01: Test basic jumping functionality`, async ({
   pageWithMeta: { page, recordingId },
@@ -18,5 +55,62 @@ test(`jump-to-code-01: Test basic jumping functionality`, async ({
 
   await openSourceExplorerPanel(page);
   await openEventsPanel(page);
-  await delay(5000);
+
+  const eventListItems = getEventListItems(page);
+
+  let numListItems = 0;
+  await waitFor(async () => {
+    numListItems = await eventListItems.count();
+    expect(numListItems).toBe(expectedEvents.length);
+  });
+
+  // // Check that all the expected event items are present
+  for (const [index, event] of expectedEvents.entries()) {
+    const eventLocator = eventListItems.nth(index);
+
+    let expectedText = "";
+    switch (event.type) {
+      case "navigation": {
+        expectedText = event.url;
+        break;
+      }
+      case "keypress": {
+        expectedText = `Key Press ${event.key}`;
+        break;
+      }
+      case "mousedown": {
+        expectedText = "Click";
+        break;
+      }
+    }
+
+    debugPrint(page, `Checking event: ${event.type} (text: '${expectedText}')`);
+
+    const type = await eventLocator.getAttribute("data-test-type");
+    expect(type).toBe(event.type);
+    const labelText = await getByTestName(eventLocator, "EventLabel").innerText();
+    expect(labelText).toBe(expectedText);
+  }
+
+  debugPrint(page, "Checking for a disabled 'Jump' button");
+  // The text "test" was typed with no input focused, so no handlers
+  const firstInvalidKeypress = eventListItems.nth(3);
+  const firstInvalidJumpButton = getEventJumpButton(firstInvalidKeypress);
+  expect(await firstInvalidJumpButton.isVisible()).toBe(true);
+  await firstInvalidJumpButton.hover({});
+
+  const firstInvalidButtonText = await getByTestName(
+    firstInvalidJumpButton,
+    "ButtonLabel"
+  ).innerText();
+  expect(firstInvalidButtonText).toBe("No results");
+
+  // the text "Watch Bengals" was typed into an input, so there is a handler
+  debugPrint(page, "Checking for an enabled 'Jump' button");
+  const firstValidKeypress = eventListItems.nth(7);
+  const firstValidJumpButton = getEventJumpButton(firstValidKeypress);
+  expect(await firstValidJumpButton.isVisible()).toBe(true);
+  await firstValidJumpButton.hover();
+  const firstValidButtonText = await getByTestName(firstValidJumpButton, "ButtonLabel").innerText();
+  expect(firstValidButtonText).toBe("Jump to code");
 });

--- a/src/ui/components/Events/Event.tsx
+++ b/src/ui/components/Events/Event.tsx
@@ -127,10 +127,11 @@ export default React.memo(function Event({
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
         data-test-name="Event"
+        data-test-type={event.kind}
       >
         <div className="flex flex-row items-center space-x-2 overflow-hidden">
           <MaterialIcon iconSize="xl">{icon}</MaterialIcon>
-          <Label>{label}</Label>
+          <Label dataTestName="EventLabel">{label}</Label>
         </div>
         <div className="flex space-x-2 opacity-0 group-hover:opacity-100">
           {renderedJumpToCodeButton}
@@ -141,6 +142,11 @@ export default React.memo(function Event({
   );
 });
 
-const Label = ({ children }: { children: ReactNode }) => (
-  <div className="overflow-hidden overflow-ellipsis whitespace-pre font-normal">{children}</div>
+const Label = ({ children, dataTestName }: { children: ReactNode; dataTestName?: string }) => (
+  <div
+    className="overflow-hidden overflow-ellipsis whitespace-pre font-normal"
+    data-test-name={dataTestName}
+  >
+    {children}
+  </div>
 );

--- a/src/ui/components/Events/Events.tsx
+++ b/src/ui/components/Events/Events.tsx
@@ -1,6 +1,6 @@
 import classNames from "classnames";
 import sortedLastIndex from "lodash/sortedLastIndex";
-import { memo, useContext, useMemo } from "react";
+import React, { memo, useContext, useMemo } from "react";
 import { STATUS_PENDING, STATUS_RESOLVED, useImperativeCacheValue } from "suspense";
 
 import { getExecutionPoint } from "devtools/client/debugger/src/reducers/pause";
@@ -95,9 +95,11 @@ function Events() {
     currentTime
   );
 
+  let content: React.ReactNode = null;
+
   if (filteredEvents.length > 0) {
-    return (
-      <div className="bg-bodyBgcolor py-1.5 text-xs">
+    content = (
+      <>
         {filteredEvents.map((event, index) => {
           return (
             <div key={event.point}>
@@ -120,11 +122,15 @@ function Events() {
         <CurrentTimeLine
           isActive={currentEventIndex === filteredEvents.length && !!filteredEvents.length}
         />
-      </div>
+      </>
     );
-  } else {
-    return null;
   }
+
+  return (
+    <div className="bg-bodyBgcolor py-1.5 text-xs" data-test-name="EventsList">
+      {content}
+    </div>
+  );
 }
 
 export default memo(Events);

--- a/src/ui/components/shared/JumpToCodeButton.tsx
+++ b/src/ui/components/shared/JumpToCodeButton.tsx
@@ -85,7 +85,11 @@ export function JumpToCodeButton({
       data-test-name="JumpToCode"
     >
       <div className="flex items-center space-x-1">
-        {isHovered && <span className="truncate text-white ">{jumpButtonText}</span>}
+        {isHovered && (
+          <span className="truncate text-white" data-test-name="ButtonLabel">
+            {jumpButtonText}
+          </span>
+        )}
         <Icon type={timeLabel} className="w-3.5 text-white" />
       </div>
     </div>

--- a/src/ui/components/shared/JumpToCodeButton.tsx
+++ b/src/ui/components/shared/JumpToCodeButton.tsx
@@ -86,7 +86,7 @@ export function JumpToCodeButton({
     >
       <div className="flex items-center space-x-1">
         {isHovered && (
-          <span className="truncate text-white" data-test-name="ButtonLabel">
+          <span className="truncate text-white" data-test-name="JumpToCodeButtonLabel">
             {jumpButtonText}
           </span>
         )}


### PR DESCRIPTION
This PR:

- Currently builds on top of the example app in #9723 (not merged yet)
- Adds an E2E test that exercises the "Events" panel in the left-hand "Info" sidebar, and specifically the "Jump to Code" logic:
  - Checks that we've received and rendered all of the expected event entries
  - Verifies that clicks and keypresses without focus have no J2C results
  - Verifies that clicks and keypresses with valid listeners jump to the correct lines and correct times