### PR TITLE
Remove points from the displayed focus window

### DIFF
--- a/packages/replay-next/components/console/Focuser.test.tsx
+++ b/packages/replay-next/components/console/Focuser.test.tsx
@@ -34,14 +34,8 @@ describe("Focuser", () => {
           },
         },
         rangeForDisplay: {
-          begin: {
-            point: "0",
-            time: 0,
-          },
-          end: {
-            time: 30_000,
-            point: "30000",
-          },
+          begin: 0,
+          end: 30_000,
         },
       },
       sessionContext: {

--- a/packages/replay-next/components/console/Focuser.tsx
+++ b/packages/replay-next/components/console/Focuser.tsx
@@ -12,8 +12,8 @@ export default function Focuser() {
   const { duration } = useContext(SessionContext);
   const { rangeForDisplay, updateForTimelineImprecise: update } = useContext(FocusContext);
 
-  const begin = rangeForDisplay === null ? 0 : rangeForDisplay.begin.time / duration;
-  const end = rangeForDisplay === null ? 1 : rangeForDisplay.end.time / duration;
+  const begin = rangeForDisplay === null ? 0 : rangeForDisplay.begin / duration;
+  const end = rangeForDisplay === null ? 1 : rangeForDisplay.end / duration;
 
   const toggleFocus = () => {
     if (rangeForDisplay === null) {

--- a/packages/replay-next/src/utils/testing.tsx
+++ b/packages/replay-next/src/utils/testing.tsx
@@ -181,7 +181,10 @@ function timeToFakeExecutionPoint(time: number): string {
 // This mock client is mostly useless by itself,
 // but its methods can be overridden individually (or observed/inspected) by test code.
 export function createMockReplayClient() {
-  let focusWindow: TimeStampedPointRange | null = null;
+  let focusWindow: TimeStampedPointRange = {
+    begin: { time: 0, point: "0" },
+    end: { time: 1_000, point: timeToFakeExecutionPoint(1_000) },
+  };
   const mockClient = mock<ReplayClientInterface>();
   mockClient.addEventListener.mockImplementation(() => {});
   mockClient.createPause.mockImplementation(async () => ({

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/useStackFrameContextMenu.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/useStackFrameContextMenu.tsx
@@ -6,7 +6,7 @@ import Icon from "replay-next/components/Icon";
 import { copyToClipboard } from "replay-next/components/sources/utils/clipboard";
 import { getFrameStepForFrameLocation } from "replay-next/src/suspense/FrameStepsCache";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
-import { seek, setFocusWindowBegin, setFocusWindowEnd } from "ui/actions/timeline";
+import { requestFocusWindow, seek } from "ui/actions/timeline";
 import { useAppDispatch } from "ui/setup/hooks";
 
 interface StackFrameContextMenuOptions {
@@ -50,10 +50,11 @@ export function useStackFrameContextMenu({
 
       if (matchingFrameStep) {
         dispatch(
-          setFocusWindowBegin({
-            executionPoint: matchingFrameStep.point,
-            time: matchingFrameStep.time,
-            sync: true,
+          requestFocusWindow({
+            begin: {
+              point: matchingFrameStep.point,
+              time: matchingFrameStep.time,
+            },
           })
         );
       }
@@ -64,10 +65,11 @@ export function useStackFrameContextMenu({
 
       if (matchingFrameStep) {
         dispatch(
-          setFocusWindowEnd({
-            executionPoint: matchingFrameStep.point,
-            time: matchingFrameStep.time,
-            sync: true,
+          requestFocusWindow({
+            end: {
+              point: matchingFrameStep.point,
+              time: matchingFrameStep.time,
+            },
           })
         );
       }

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -353,10 +353,10 @@ export function createSocket(
       assert(focusWindow !== null); // replayClient.configure() sets this value
       if (
         !focusWindowFromParams ||
-        focusWindowFromParams.begin.point !== focusWindow.begin.point ||
-        focusWindowFromParams.end.point !== focusWindow.end.point
+        focusWindowFromParams.begin.time !== focusWindow.begin.time ||
+        focusWindowFromParams.end.time !== focusWindow.end.time
       ) {
-        dispatch(setFocusWindow(focusWindow));
+        dispatch(setFocusWindow({ begin: focusWindow.begin.time, end: focusWindow.end.time }));
       }
     } catch (e: any) {
       const currentError = getUnexpectedError(getState());

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -33,11 +33,6 @@ import {
   sessionEndPointCache,
 } from "replay-next/src/suspense/ExecutionPointsCache";
 import { screenshotCache } from "replay-next/src/suspense/ScreenshotCache";
-import { isExecutionPointsLessThan } from "replay-next/src/utils/time";
-import {
-  isTimeStampedPointRangeGreaterThan,
-  isTimeStampedPointRangeLessThan,
-} from "replay-next/src/utils/timeStampedPoints";
 import { ReplayClientInterface } from "shared/client/types";
 import {
   encodeObjectToURL,
@@ -49,7 +44,6 @@ import { getFirstComment } from "ui/hooks/comments/comments";
 import {
   getCurrentTime,
   getFocusWindow,
-  getFocusWindowBackup,
   getHoverTime,
   getHoveredItem,
   getPlayback,
@@ -61,7 +55,7 @@ import {
   pointsReceived,
   setPlaybackPrecachedTime,
 } from "ui/reducers/timeline";
-import { FocusWindow, HoveredItem, PlaybackOptions, TimeRange } from "ui/state/timeline";
+import { HoveredItem, PlaybackOptions, TimeRange } from "ui/state/timeline";
 import KeyShortcuts, { isEditableElement } from "ui/utils/key-shortcuts";
 import { trackEvent } from "ui/utils/telemetry";
 import { rangeForFocusWindow } from "ui/utils/timeline";
@@ -154,7 +148,9 @@ export async function getInitialPausePoint(recordingId: string) {
 function onPaused({ point, time }: PauseEventArgs): UIThunkAction {
   return async (dispatch, getState, { replayClient }) => {
     const focusWindow = replayClient.getCurrentFocusWindow();
-    const params: Omit<PauseEventArgs, "openSource"> & { focusWindow: FocusWindow | null } = {
+    const params: Omit<PauseEventArgs, "openSource"> & {
+      focusWindow: TimeStampedPointRange | null;
+    } = {
       focusWindow,
       point,
       time,
@@ -220,7 +216,7 @@ export function getUrlParams({
   point,
   time,
 }: {
-  focusWindow: FocusWindow | null;
+  focusWindow: TimeStampedPointRange | null;
   point: ExecutionPoint;
   time: number;
 }) {
@@ -238,20 +234,13 @@ export function updatePausePointParams({
 }: {
   point: ExecutionPoint;
   time: number;
-  focusWindow: FocusWindow | null;
+  focusWindow: TimeStampedPointRange | null;
 }) {
   const params = getUrlParams({ focusWindow, point, time });
   updateUrlWithParams(params);
 }
 
-export function updateFocusWindowParam(): UIThunkAction<void> {
-  return (dispatch, getState, { replayClient }) => {
-    const focusWindow = replayClient.getCurrentFocusWindow();
-    updateUrlWithParams({ focusWindow: encodeFocusWindow(focusWindow) });
-  };
-}
-
-function encodeFocusWindow(focusWindow: FocusWindow | null) {
+function encodeFocusWindow(focusWindow: TimeStampedPointRange | null) {
   return focusWindow ? encodeObjectToURL(rangeForFocusWindow(focusWindow)) : undefined;
 }
 
@@ -544,28 +533,10 @@ export function clearHoveredItem(): UIThunkAction {
   };
 }
 
-export function setFocusWindowImprecise(timeRange: TimeRange | null): UIThunkAction<Promise<void>> {
-  return async (dispatch, getState, { replayClient }) => {
-    if (timeRange === null) {
-      dispatch(newFocusWindow(null));
-      return;
-    }
-
-    const [pointsBoundingBegin, pointsBoundingEnd] = await Promise.all([
-      pointsBoundingTimeCache.readAsync(replayClient, timeRange.begin),
-      pointsBoundingTimeCache.readAsync(replayClient, timeRange.end),
-    ]);
-    const begin = pointsBoundingBegin.before;
-    const end = pointsBoundingEnd.after;
-
-    await dispatch(setFocusWindow({ begin, end }));
-  };
-}
-
-export function setFocusWindow(
-  focusWindow: TimeStampedPointRange | null
+export function setDisplayedFocusWindow(
+  focusWindow: TimeRange | null
 ): UIThunkAction<Promise<void>> {
-  return async (dispatch, getState, { replayClient }) => {
+  return async (dispatch, getState) => {
     const state = getState();
     const currentTime = getCurrentTime(state);
 
@@ -576,151 +547,105 @@ export function setFocusWindow(
     }
 
     if (focusWindow === null) {
-      dispatch(setTimelineState({ focusWindow: null }));
+      dispatch(newFocusWindow(null));
       return;
     }
 
     let { begin, end } = focusWindow;
 
     const prevFocusWindow = getFocusWindow(state);
-    const prevBeginTime = prevFocusWindow?.begin.time;
-    const prevEndTime = prevFocusWindow?.end.time;
+    const prevBeginTime = prevFocusWindow?.begin;
+    const prevEndTime = prevFocusWindow?.end;
 
     // Ignore invalid requested focus windows.
     try {
-      assert(isExecutionPointsLessThan(begin.point, end.point), "Invalid focus window");
+      assert(begin <= end, "Invalid focus window");
     } catch (error) {
       console.error(error);
       return;
     }
 
     // Update the paint preview to match the handle that's being dragged.
-    if (begin.time !== prevBeginTime && end.time === prevEndTime) {
-      dispatch(setTimelineToTime(begin.time));
-    } else if (begin.time === prevBeginTime && end.time !== prevEndTime) {
-      dispatch(setTimelineToTime(end.time));
+    if (begin !== prevBeginTime && end === prevEndTime) {
+      dispatch(setTimelineToTime(begin));
+    } else if (begin === prevBeginTime && end !== prevEndTime) {
+      dispatch(setTimelineToTime(end));
     } else {
       // Else just make sure the preview time stays within the moving window.
       const hoverTime = getHoverTime(state);
       if (hoverTime !== null) {
-        if (hoverTime < begin.time) {
-          dispatch(setTimelineToTime(begin.time));
-        } else if (hoverTime > end.time) {
-          dispatch(setTimelineToTime(end.time));
+        if (hoverTime < begin) {
+          dispatch(setTimelineToTime(begin));
+        } else if (hoverTime > end) {
+          dispatch(setTimelineToTime(end));
         }
       } else {
         dispatch(setTimelineToTime(currentTime));
       }
     }
 
-    await dispatch(newFocusWindow({ begin, end }));
+    dispatch(newFocusWindow({ begin, end }));
   };
 }
 
-export function setFocusWindowEnd({
-  executionPoint,
-  sync,
-  time,
-}: {
-  executionPoint?: string;
-  sync: boolean;
-  time: number;
-}): UIThunkAction<Promise<void>> {
-  return async (dispatch, getState, { replayClient }) => {
-    const state = getState();
-
-    let end: TimeStampedPoint;
-    if (executionPoint != null) {
-      end = { point: executionPoint, time };
-    } else {
-      const timeStampedPoint = await pointsBoundingTimeCache.readAsync(replayClient, time);
-      end = timeStampedPoint.after;
-    }
-
-    // If this is the first time the user is focusing, begin at the beginning of the recording
-    const focusWindow = replayClient.getCurrentFocusWindow();
-    const begin = focusWindow?.begin ?? {
-      point: "0",
-      time: 0,
-    };
-
-    await dispatch(
-      setFocusWindow({
-        begin,
-        end,
-      })
-    );
-
-    if (sync) {
-      await dispatch(syncFocusedRegion("end"));
-
-      dispatch(updateFocusWindowParam());
-    }
+export interface PartialFocusWindow {
+  begin?: {
+    point?: ExecutionPoint;
+    time: number;
+  };
+  end?: {
+    point?: ExecutionPoint;
+    time: number;
   };
 }
 
-export function setFocusWindowBegin({
-  executionPoint,
-  sync,
-  time,
-}: {
-  executionPoint?: string;
-  sync: boolean;
-  time: number;
-}): UIThunkAction<Promise<void>> {
+export function requestFocusWindow(
+  focusWindow: PartialFocusWindow,
+  bias?: FocusWindowRequestBias
+): UIThunkAction<Promise<void>> {
   return async (dispatch, getState, { replayClient }) => {
-    const state = getState();
+    const currentFocusWindow = replayClient.getCurrentFocusWindow();
+    assert(currentFocusWindow);
 
     let begin: TimeStampedPoint;
-    if (executionPoint != null) {
-      begin = { point: executionPoint, time };
+    if (focusWindow.begin) {
+      if (focusWindow.begin.point) {
+        begin = focusWindow.begin as TimeStampedPoint;
+      } else {
+        const pointsBoundingTime = await pointsBoundingTimeCache.readAsync(
+          replayClient,
+          focusWindow.begin.time
+        );
+        begin = pointsBoundingTime.before;
+      }
     } else {
-      const timeStampedPoint = await pointsBoundingTimeCache.readAsync(replayClient, time);
-      begin = timeStampedPoint.before;
+      begin = currentFocusWindow.begin;
     }
 
-    // If this is the first time the user is focusing, extend to the end of the recording
-    const focusWindow = replayClient.getCurrentFocusWindow();
-    const end = focusWindow?.end ?? (await sessionEndPointCache.readAsync(replayClient));
-
-    await dispatch(setFocusWindow({ begin, end }));
-
-    if (sync) {
-      await dispatch(syncFocusedRegion("begin"));
-
-      dispatch(updateFocusWindowParam());
+    let end: TimeStampedPoint;
+    if (focusWindow.end) {
+      if (focusWindow.end.point) {
+        end = focusWindow.end as TimeStampedPoint;
+      } else {
+        const pointsBoundingTime = await pointsBoundingTimeCache.readAsync(
+          replayClient,
+          focusWindow.end.time
+        );
+        end = pointsBoundingTime.after;
+      }
+    } else {
+      end = currentFocusWindow.end;
     }
-  };
-}
-
-export function syncFocusedRegion(bias?: FocusWindowRequestBias): UIThunkAction {
-  return async (dispatch, getState, { replayClient }) => {
-    const state = getState();
-
-    // Note that we should use the displayed focus window here because the deferred one may still have a pending update.
-    const focusWindow = getFocusWindow(state);
-    if (focusWindow === null) {
-      return;
-    }
-
-    const focusWindowBackup = getFocusWindowBackup(state);
-
-    const zoomTime = getZoomRegion(state);
-
-    const begin = focusWindow
-      ? focusWindow.begin
-      : {
-          point: "0",
-          time: zoomTime.beginTime,
-        };
-    const end = focusWindow ? focusWindow.end : await sessionEndPointCache.readAsync(replayClient);
 
     // Compare the new focus range to the previous one to infer user intent.
     // This helps when a focus range can't be loaded in full.
-    if (bias == null && focusWindowBackup != null) {
-      if (isTimeStampedPointRangeLessThan(focusWindowBackup, focusWindow)) {
+    if (!bias) {
+      if (begin.time < currentFocusWindow.begin.time && end.time <= currentFocusWindow.end.time) {
         bias = "begin";
-      } else if (isTimeStampedPointRangeGreaterThan(focusWindowBackup, focusWindow)) {
+      } else if (
+        begin.time >= currentFocusWindow.begin.time &&
+        end.time > currentFocusWindow.end.time
+      ) {
         bias = "end";
       }
     }
@@ -730,11 +655,8 @@ export function syncFocusedRegion(bias?: FocusWindowRequestBias): UIThunkAction 
       bias,
       end,
     });
-
-    // If the backend has selected a different focus window, refine our in-memory window to match
-    if (begin.point !== window.begin.point || end.point !== window.end.point) {
-      await dispatch(setFocusWindow(window));
-    }
+    dispatch(newFocusWindow({ begin: window.begin.time, end: window.end.time }));
+    updateUrlWithParams({ focusWindow: encodeFocusWindow(window) });
   };
 }
 
@@ -751,8 +673,7 @@ export function enterFocusMode(): UIThunkAction {
     // shrink it to ~30% of the overall recording and center it around the current time.
     if (
       prevFocusWindow == null ||
-      (prevFocusWindow.begin.time === zoomRegion.beginTime &&
-        prevFocusWindow.end.time === zoomRegion.endTime)
+      (prevFocusWindow.begin === zoomRegion.beginTime && prevFocusWindow.end === zoomRegion.endTime)
     ) {
       const focusWindowSize =
         (zoomRegion.endTime - zoomRegion.beginTime) * DEFAULT_FOCUS_WINDOW_PERCENTAGE;
@@ -762,12 +683,11 @@ export function enterFocusMode(): UIThunkAction {
         end: Math.min(zoomRegion.endTime, currentTime + focusWindowSize / 2),
       };
 
-      await dispatch(setFocusWindowImprecise(initialFocusWindow));
+      await dispatch(setDisplayedFocusWindow(initialFocusWindow));
     }
 
     await dispatch(
       setTimelineState({
-        focusWindowBackup: prevFocusWindow,
         showFocusModeControls: true,
       })
     );
@@ -779,7 +699,6 @@ export function exitFocusMode(): UIThunkAction {
     trackEvent("timeline.exit_focus_edit");
     dispatch(
       setTimelineState({
-        focusWindowBackup: null,
         showFocusModeControls: false,
       })
     );

--- a/src/ui/components/Comments/useCommentContextMenu.tsx
+++ b/src/ui/components/Comments/useCommentContextMenu.tsx
@@ -4,7 +4,7 @@ import { ContextMenuDivider, ContextMenuItem, useContextMenu } from "use-context
 
 import Icon from "replay-next/components/Icon";
 import { SessionContext } from "replay-next/src/contexts/SessionContext";
-import { setFocusWindowBegin, setFocusWindowEnd } from "ui/actions/timeline";
+import { requestFocusWindow } from "ui/actions/timeline";
 import { useAppDispatch } from "ui/setup/hooks";
 import type { Remark } from "ui/state/comments";
 import { trackEvent } from "ui/utils/telemetry";
@@ -59,20 +59,22 @@ export default function useCommentContextMenu({
 
   const setFocusEnd = () => {
     dispatch(
-      setFocusWindowEnd({
-        executionPoint: remark.point,
-        time: remark.time,
-        sync: true,
+      requestFocusWindow({
+        end: {
+          point: remark.point,
+          time: remark.time,
+        },
       })
     );
   };
 
   const setFocusStart = () => {
     dispatch(
-      setFocusWindowBegin({
-        executionPoint: remark.point,
-        time: remark.time,
-        sync: true,
+      requestFocusWindow({
+        begin: {
+          point: remark.point,
+          time: remark.time,
+        },
       })
     );
   };

--- a/src/ui/components/Events/useEventContextMenu.tsx
+++ b/src/ui/components/Events/useEventContextMenu.tsx
@@ -2,7 +2,7 @@ import { ContextMenuDivider, ContextMenuItem, useContextMenu } from "use-context
 
 import Icon from "replay-next/components/Icon";
 import { copyToClipboard as copyTextToClipboard } from "replay-next/components/sources/utils/clipboard";
-import { setFocusWindowBegin, setFocusWindowEnd } from "ui/actions/timeline";
+import { requestFocusWindow } from "ui/actions/timeline";
 import { useAppDispatch } from "ui/setup/hooks";
 import { ReplayEvent } from "ui/state/app";
 
@@ -11,20 +11,22 @@ export default function useEventContextMenu(event: ReplayEvent) {
 
   const setFocusEnd = () => {
     dispatch(
-      setFocusWindowEnd({
-        executionPoint: event.point,
-        time: event.time,
-        sync: true,
+      requestFocusWindow({
+        end: {
+          point: event.point,
+          time: event.time,
+        },
       })
     );
   };
 
   const setFocusStart = () => {
     dispatch(
-      setFocusWindowBegin({
-        executionPoint: event.point,
-        time: event.time,
-        sync: true,
+      requestFocusWindow({
+        begin: {
+          point: event.point,
+          time: event.time,
+        },
       })
     );
   };

--- a/src/ui/components/NetworkMonitor/useNetworkContextMenu.tsx
+++ b/src/ui/components/NetworkMonitor/useNetworkContextMenu.tsx
@@ -10,7 +10,7 @@ import { GraphQLClientContext } from "replay-next/src/contexts/GraphQLClientCont
 import { InspectorContext } from "replay-next/src/contexts/InspectorContext";
 import { SessionContext } from "replay-next/src/contexts/SessionContext";
 import { addComment as addCommentGraphQL } from "shared/graphql/Comments";
-import { setFocusWindowBegin, setFocusWindowEnd } from "ui/actions/timeline";
+import { requestFocusWindow } from "ui/actions/timeline";
 import useCopyAsCURL from "ui/components/NetworkMonitor/useCopyAsCURL";
 import { useAppDispatch } from "ui/setup/hooks";
 
@@ -37,11 +37,11 @@ export default function useNetworkContextMenu({
   const endTime = requestSummary.end!;
 
   const setFocusEnd = () => {
-    dispatch(setFocusWindowEnd({ time: endTime, sync: true }));
+    dispatch(requestFocusWindow({ end: { time: endTime } }));
   };
 
   const setFocusStart = () => {
-    dispatch(setFocusWindowBegin({ time: beginTime, sync: true }));
+    dispatch(requestFocusWindow({ begin: { time: beginTime } }));
   };
 
   const addComment = () => {

--- a/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
@@ -19,7 +19,7 @@ import {
   isUserActionTestEvent,
 } from "shared/test-suites/RecordingTestMetadata";
 import { isPointInRegion } from "shared/utils/time";
-import { seek, setFocusWindow, setTimelineToTime, syncFocusedRegion } from "ui/actions/timeline";
+import { requestFocusWindow, seek, setTimelineToTime } from "ui/actions/timeline";
 import { TestSuiteCache } from "ui/components/TestSuite/suspense/TestSuiteCache";
 import { useTestEventContextMenu } from "ui/components/TestSuite/views/TestRecording/useTestEventContextMenu";
 import { TestSuiteContext } from "ui/components/TestSuite/views/TestSuiteContext";
@@ -151,20 +151,24 @@ export function TestSectionRow({
         const timeStampedPoint = { point: executionPoint, time };
         if (isExecutionPointsLessThan(executionPoint, focusWindow.begin.point)) {
           await dispatch(
-            setFocusWindow({
-              begin: timeStampedPoint,
-              end: focusWindow.end,
-            })
+            requestFocusWindow(
+              {
+                begin: timeStampedPoint,
+                end: focusWindow.end,
+              },
+              "begin"
+            )
           );
-          await dispatch(syncFocusedRegion("begin"));
         } else {
           await dispatch(
-            setFocusWindow({
-              begin: focusWindow.begin,
-              end: timeStampedPoint,
-            })
+            requestFocusWindow(
+              {
+                begin: focusWindow.begin,
+                end: timeStampedPoint,
+              },
+              "end"
+            )
           );
-          await dispatch(syncFocusedRegion("end"));
         }
       }
 

--- a/src/ui/components/Timeline/FocusInputs.tsx
+++ b/src/ui/components/Timeline/FocusInputs.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { getFormattedTime } from "shared/utils/time";
-import { setFocusWindowImprecise } from "ui/actions/timeline";
+import { setDisplayedFocusWindow } from "ui/actions/timeline";
 import { selectors } from "ui/reducers";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { getSecondsFromFormattedTime } from "ui/utils/timeline";
@@ -23,8 +23,8 @@ export default function FocusInputs() {
   const inputSize = formattedDuration.length;
 
   if (showFocusModeControls && focusWindow !== null) {
-    const formattedEndTime = getFormattedTime(focusWindow.end.time);
-    const formattedBeginTime = getFormattedTime(focusWindow.begin.time);
+    const formattedEndTime = getFormattedTime(focusWindow.end);
+    const formattedBeginTime = getFormattedTime(focusWindow.begin);
 
     const validateAndSaveBeginTime = async (pending: string) => {
       try {
@@ -32,11 +32,10 @@ export default function FocusInputs() {
         if (!isNaN(newBeginTime)) {
           // If the new end time is less than the current start time, the user is probably trying to move the whole range.
           // We can simplify this operation by resetting both the start and end time to the same value.
-          const newEndTime =
-            newBeginTime <= focusWindow.end.time ? focusWindow.end.time : newBeginTime;
+          const newEndTime = newBeginTime <= focusWindow.end ? focusWindow.end : newBeginTime;
 
           await dispatch(
-            setFocusWindowImprecise({
+            setDisplayedFocusWindow({
               begin: newBeginTime,
               end: newEndTime,
             })
@@ -52,11 +51,10 @@ export default function FocusInputs() {
         if (!isNaN(newEndTime)) {
           // If the new start time is greater than the current end time, the user is probably trying to move the whole range.
           // We can simplify this operation by resetting both the start and end time to the same value.
-          const newBeginTime =
-            newEndTime >= focusWindow.begin.time ? focusWindow.begin.time : newEndTime;
+          const newBeginTime = newEndTime >= focusWindow.begin ? focusWindow.begin : newEndTime;
 
           await dispatch(
-            setFocusWindowImprecise({
+            setDisplayedFocusWindow({
               begin: newBeginTime,
               end: newEndTime,
             })

--- a/src/ui/components/Timeline/Focuser.tsx
+++ b/src/ui/components/Timeline/Focuser.tsx
@@ -49,8 +49,8 @@ function Focuser({ editMode, setEditMode, updateFocusWindowThrottled }: Props) {
 
   // Mirror focus state so we can re-render immediately and dispatch throttled Redux updates
   const [displayedFocusWindow, setDisplayedFocusWindow] = useState({
-    beginTime: focusWindow?.begin.time ?? zoomRegion.beginTime,
-    endTime: focusWindow?.end.time ?? zoomRegion.endTime,
+    beginTime: focusWindow?.begin ?? zoomRegion.beginTime,
+    endTime: focusWindow?.end ?? zoomRegion.endTime,
   });
   const displayedFocusWindowRef = useRef(displayedFocusWindow);
   useEffect(() => {

--- a/src/ui/components/Timeline/PlaybackControls.tsx
+++ b/src/ui/components/Timeline/PlaybackControls.tsx
@@ -12,9 +12,7 @@ export default function PlayPauseButton() {
   const playback = useAppSelector(selectors.getPlayback);
   const recordingDuration = useAppSelector(selectors.getRecordingDuration);
 
-  const isAtEnd = focusWindow
-    ? currentTime === focusWindow.end.time
-    : currentTime == recordingDuration;
+  const isAtEnd = focusWindow ? currentTime === focusWindow.end : currentTime == recordingDuration;
 
   let onClick;
   let icon;

--- a/src/ui/components/Timeline/Timeline.tsx
+++ b/src/ui/components/Timeline/Timeline.tsx
@@ -4,7 +4,7 @@ import { FocusContext } from "replay-next/src/contexts/FocusContext";
 import { throttle } from "shared/utils/function";
 import {
   seek,
-  setFocusWindowImprecise,
+  setDisplayedFocusWindow,
   setTimelineToTime,
   stopPlayback,
 } from "ui/actions/timeline";
@@ -135,8 +135,8 @@ export default function Timeline() {
       <div
         className="timeline"
         data-test-id="Timeline"
-        data-test-focus-begin-time={rangeForDisplay?.begin?.time}
-        data-test-focus-end-time={rangeForDisplay?.end?.time}
+        data-test-focus-begin-time={rangeForDisplay?.begin}
+        data-test-focus-end-time={rangeForDisplay?.end}
       >
         <div className="commands">
           <PlayPauseButton />
@@ -181,5 +181,5 @@ export default function Timeline() {
 }
 
 const updateFocusWindowThrottled = throttle((dispatch: AppDispatch, begin: number, end: number) => {
-  return dispatch(setFocusWindowImprecise({ begin, end }));
+  return dispatch(setDisplayedFocusWindow({ begin, end }));
 }, 250);

--- a/src/ui/components/Timeline/Tooltip.tsx
+++ b/src/ui/components/Timeline/Tooltip.tsx
@@ -30,7 +30,7 @@ export default function Tooltip({ timelineWidth }: { timelineWidth: number }) {
   );
 
   const isHoveredOnUnFocusedRegion =
-    focusWindow && (focusWindow.begin.time > hoverTime || focusWindow.end.time < hoverTime);
+    focusWindow && (focusWindow.begin > hoverTime || focusWindow.end < hoverTime);
 
   const timestamp = getFormattedTime(hoverTime);
   const message =

--- a/src/ui/components/Timeline/UnfocusedRegion.tsx
+++ b/src/ui/components/Timeline/UnfocusedRegion.tsx
@@ -12,8 +12,8 @@ export default function UnfocusedRegion() {
     return null;
   }
 
-  const beginTime = focusWindow!.begin.time;
-  const endTime = focusWindow!.end.time;
+  const beginTime = focusWindow!.begin;
+  const endTime = focusWindow!.end;
   const duration = zoomRegion.endTime - zoomRegion.beginTime;
 
   const start = getVisiblePosition({ time: beginTime, zoom: zoomRegion }) * 100;

--- a/src/ui/components/Timeline/useTimelineContextMenu.tsx
+++ b/src/ui/components/Timeline/useTimelineContextMenu.tsx
@@ -18,16 +18,15 @@ import { createFrameComment } from "ui/actions/comments";
 import {
   MAX_FOCUS_REGION_DURATION,
   getUrlParams,
+  requestFocusWindow,
   seek,
-  setFocusWindowImprecise,
-  syncFocusedRegion,
 } from "ui/actions/timeline";
 import { useAppDispatch } from "ui/setup/hooks";
 
 import styles from "./ContextMenu.module.css";
 
 export default function useTimelineContextMenu() {
-  const { rangeForDisplay: focusWindow } = useContext(FocusContext);
+  const { range: focusWindow } = useContext(FocusContext);
   const { showCommentsPanel } = useContext(InspectorContext);
   const replayClient = useContext(ReplayClientContext);
   const { accessToken, duration, recordingId } = useContext(SessionContext);
@@ -72,16 +71,14 @@ export default function useTimelineContextMenu() {
     let end = focusEndTime ?? duration;
     end = Math.min(end, currentTime + MAX_FOCUS_REGION_DURATION);
 
-    await dispatch(setFocusWindowImprecise({ begin: currentTime, end }));
-    dispatch(syncFocusedRegion());
+    await dispatch(requestFocusWindow({ begin: { time: currentTime }, end: { time: end } }));
   };
 
   const setFocusEnd = async () => {
     let begin = focusBeginTime ?? 0;
     begin = Math.max(begin, currentTime - MAX_FOCUS_REGION_DURATION);
 
-    await dispatch(setFocusWindowImprecise({ begin, end: currentTime }));
-    dispatch(syncFocusedRegion());
+    await dispatch(requestFocusWindow({ begin: { time: begin }, end: { time: currentTime } }));
   };
 
   const shareReplay = async () => {

--- a/src/ui/state/timeline.ts
+++ b/src/ui/state/timeline.ts
@@ -11,17 +11,11 @@ export interface ZoomRegion {
   scale: number;
 }
 
-export interface FocusWindow {
-  end: TimeStampedPoint;
-  begin: TimeStampedPoint;
-}
-
 export interface TimelineState {
   allPaintsReceived: boolean;
   currentTime: number;
   dragging: boolean;
-  focusWindow: FocusWindow | null;
-  focusWindowBackup: FocusWindow | null;
+  focusWindow: TimeRange | null;
   hoveredItem: HoveredItem | null;
   hoverTime: number | null;
   markTimeStampedPoint: TimeStampedPoint | null;

--- a/src/ui/suspense/util.ts
+++ b/src/ui/suspense/util.ts
@@ -1,11 +1,10 @@
-import { PauseId } from "@replayio/protocol";
+import { PauseId, TimeStampedPointRange } from "@replayio/protocol";
 
 import { framesCache } from "replay-next/src/suspense/FrameCache";
 import { frameStepsCache } from "replay-next/src/suspense/FrameStepsCache";
 import { pauseIdCache } from "replay-next/src/suspense/PauseCache";
 import { isExecutionPointsWithinRange } from "replay-next/src/utils/time";
 import { ReplayClientInterface } from "shared/client/types";
-import { FocusWindow } from "ui/state/timeline";
 
 // returns undefined if the async parent pause doesn't exist
 // or null if it is not in a loaded region
@@ -13,7 +12,7 @@ export function getAsyncParentPauseIdSuspense(
   replayClient: ReplayClientInterface,
   pauseId: PauseId,
   asyncIndex: number,
-  focusWindow: FocusWindow
+  focusWindow: TimeStampedPointRange
 ): PauseId | null {
   while (asyncIndex > 0) {
     const frames = framesCache.read(replayClient, pauseId)!;

--- a/src/ui/utils/timeline.test.ts
+++ b/src/ui/utils/timeline.test.ts
@@ -1,20 +1,13 @@
-import { FocusWindow, ZoomRegion } from "ui/state/timeline";
+import { ZoomRegion } from "ui/state/timeline";
 
 import {
-  filterToFocusWindow,
   getSecondsFromFormattedTime,
   getTimeFromPosition,
-  isFocusWindowSubset,
   isValidTimeString,
   mergeSortedPointLists,
-  overlap,
 } from "./timeline";
 
 const point = (time: number) => ({ time, point: `${time}` });
-const focusWindow = (from: number, to: number): FocusWindow => ({
-  begin: point(from),
-  end: point(to),
-});
 
 describe("getSecondsFromFormattedTime", () => {
   it("should parse standalone seconds", () => {
@@ -100,30 +93,6 @@ describe("getTimeFromPosition", () => {
   });
 });
 
-describe("isFocusWindowSubset", () => {
-  it("should always be true when previous focus region was null", () => {
-    expect(isFocusWindowSubset(null, null)).toBe(true);
-    expect(isFocusWindowSubset(null, focusWindow(0, 0))).toBe(true);
-    expect(isFocusWindowSubset(null, focusWindow(0, 1000))).toBe(true);
-    expect(isFocusWindowSubset(null, focusWindow(1000, 1000))).toBe(true);
-  });
-
-  it("should never be true when new focus region was null (unless previous one was also)", () => {
-    expect(isFocusWindowSubset(focusWindow(0, 0), null)).toBe(false);
-    expect(isFocusWindowSubset(focusWindow(0, 1000), null)).toBe(false);
-    expect(isFocusWindowSubset(focusWindow(1000, 1000), null)).toBe(false);
-  });
-
-  it("should correctly differentiate between overlapping and non-overlapping focus regions", () => {
-    expect(isFocusWindowSubset(focusWindow(0, 0), focusWindow(0, 0))).toBe(true);
-    expect(isFocusWindowSubset(focusWindow(100, 200), focusWindow(0, 50))).toBe(false);
-    expect(isFocusWindowSubset(focusWindow(100, 200), focusWindow(50, 150))).toBe(false);
-    expect(isFocusWindowSubset(focusWindow(100, 200), focusWindow(100, 200))).toBe(true);
-    expect(isFocusWindowSubset(focusWindow(100, 200), focusWindow(125, 175))).toBe(true);
-    expect(isFocusWindowSubset(focusWindow(100, 200), focusWindow(150, 250))).toBe(false);
-    expect(isFocusWindowSubset(focusWindow(100, 200), focusWindow(200, 300))).toBe(false);
-  });
-});
 describe("isValidTimeString", () => {
   it("should recognized valid time strings", () => {
     expect(isValidTimeString("0")).toBe(true);
@@ -151,59 +120,6 @@ describe("isValidTimeString", () => {
     expect(isValidTimeString("a:1")).toBe(false);
     expect(isValidTimeString("a:b")).toBe(false);
     expect(isValidTimeString("1:b")).toBe(false);
-  });
-});
-
-describe("overlap", () => {
-  const point = (time: number) => {
-    return { point: "", time };
-  };
-
-  const range = (begin: number, end: number) => {
-    return {
-      begin: point(begin),
-      end: point(end),
-    };
-  };
-
-  it("correctly merges overlapping regions when the second begins during the first", () => {
-    expect(overlap([range(0, 5)], [range(2, 7)])).toStrictEqual([range(2, 5)]);
-  });
-
-  it("correctly merges overlapping regions when the first begins during the second", () => {
-    expect(overlap([range(2, 7)], [range(0, 5)])).toStrictEqual([range(2, 5)]);
-  });
-
-  it("leaves non-overlapping regions alone", () => {
-    expect(overlap([range(0, 2)], [range(3, 5)])).toStrictEqual([]);
-  });
-
-  it("does not blow up with empty inputs", () => {
-    expect(overlap([range(0, 2)], [])).toStrictEqual([]);
-    expect(overlap([], [range(0, 2)])).toStrictEqual([]);
-  });
-});
-
-describe("filterToFocusWindow", () => {
-  it("will not include points before the region", () => {
-    expect(filterToFocusWindow([point(5)], focusWindow(10, 20))).toEqual([[], 1, 0]);
-  });
-  it("will not include points after the region", () => {
-    expect(filterToFocusWindow([point(25)], focusWindow(10, 20))).toEqual([[], 0, 1]);
-  });
-  it("will include points inside the region", () => {
-    expect(filterToFocusWindow([point(5), point(15), point(25)], focusWindow(10, 20))).toEqual([
-      [point(15)],
-      1,
-      1,
-    ]);
-  });
-  it("will include points on the boundaries the region", () => {
-    expect(filterToFocusWindow([point(10), point(15), point(20)], focusWindow(10, 20))).toEqual([
-      [point(10), point(15), point(20)],
-      0,
-      0,
-    ]);
   });
 });
 


### PR DESCRIPTION
- the displayed focus window only needs `time`, so I removed `point`
- I also removed `focusWindowBackup` and use the active focus window instead
- instead of setting the displayed focus window and then syncing the active focus window to it you can now set the active focus window directly with `requestFocusWindow()`, you can use it to set the beginning or the end of the window or both and you can specify the `point`s if you have them or leave them out if not