### PR TITLE
Update line numbers based on changed breakpoint/hit count expectations

### DIFF
--- a/packages/e2e-tests/tests/logpoints-07.test.ts
+++ b/packages/e2e-tests/tests/logpoints-07.test.ts
@@ -37,10 +37,13 @@ test(`logpoints-07: should use the correct scope in auto-complete`, async ({
   await verifyConsoleTerminalTypeAheadSuggestions(page, ["setInterval", "setList"]);
 
   // Log point should use generated source (if we're viewing that)
+  // Toggling this will switch from the sourcemapped `App.js` to the minified bundle
+  // that contained it (`main.XYZ.js`).
   await toggleMappedSources(page, "off");
   await delay(1000);
 
-  lineNumber = 19;
+  // We expect that this line in the minified bundle will have hits.
+  lineNumber = 20;
 
   await addLogpoint(page, { lineNumber });
   await editLogPoint(page, { content: "set", lineNumber, saveAfterEdit: false });

--- a/packages/e2e-tests/tests/logpoints-10_too_many_points_to_find.test.ts
+++ b/packages/e2e-tests/tests/logpoints-10_too_many_points_to_find.test.ts
@@ -11,7 +11,7 @@ import test, { expect } from "../testFixtureCloneRecording";
 
 // We need > 10k hits
 const sourceUrl = "react-dom.production.min.js";
-const lineNumber = 36;
+const lineNumber = 38;
 
 // trunk-ignore(gitleaks/generic-api-key)
 test.use({ exampleKey: "breakpoints-01" });

--- a/packages/e2e-tests/tests/logpoints-11_too_many_points_to_run_analysis.test.ts
+++ b/packages/e2e-tests/tests/logpoints-11_too_many_points_to_run_analysis.test.ts
@@ -15,14 +15,14 @@ import {
 import test, { expect } from "../testFixtureCloneRecording";
 
 // We need 500...10k hits
-// Line 43 has 4.9k hits
+// Line 44 has 4.9k hits
 const sourceUrl = "react-dom.production.min.js";
-const lineNumber = 43;
+const lineNumber = 44;
 
 // trunk-ignore(gitleaks/generic-api-key)
 test.use({ exampleKey: "breakpoints-01" });
 
-test(`logpoints-10: too-many-points-to-run-analysis UX`, async ({
+test(`logpoints-11: too-many-points-to-run-analysis UX`, async ({
   pageWithMeta: { page, recordingId },
   exampleKey,
 }) => {

--- a/packages/e2e-tests/tests/stepping-05.test.ts
+++ b/packages/e2e-tests/tests/stepping-05.test.ts
@@ -26,22 +26,22 @@ test(`stepping-05: Test stepping in pretty-printed code`, async ({
 
   await addBreakpoint(page, { url: "bundle_input.js", lineNumber: 4 });
   await rewindToLine(page, 4);
-  await stepInToLine(page, 1);
+  await stepInToLine(page, 2);
 
   // Add a breakpoint in minified.html and resume to there
   await addBreakpoint(page, { url: exampleKey, lineNumber: 8 });
   await resumeToLine(page, 8);
-  await stepOverToLine(page, 8);
   await stepOverToLine(page, 9);
+  await stepOverToLine(page, 10);
 
   await openConsolePanel(page);
   await addEventListenerLogpoints(page, [{ eventType: "event.mouse.click", categoryKey: "mouse" }]);
-  await warpToMessage(page, "click", 14);
+  await warpToMessage(page, "click", 15);
 
   await stepInToLine(page, 2);
   await stepOutToLine(page, 15);
-  await stepInToLine(page, 10);
+  await stepInToLine(page, 11);
   await stepOutToLine(page, 15);
-  await stepInToLine(page, 5);
-  await stepOutToLine(page, 15);
+  await stepInToLine(page, 6);
+  await stepOutToLine(page, 16);
 });

--- a/packages/e2e-tests/tests/stepping-05_chromium.test.ts
+++ b/packages/e2e-tests/tests/stepping-05_chromium.test.ts
@@ -26,7 +26,7 @@ test(`stepping-05_chromium: Test stepping in pretty-printed code`, async ({
 
   await addBreakpoint(page, { url: "bundle_input.js", lineNumber: 4 });
   await rewindToLine(page, 4);
-  await stepInToLine(page, 1);
+  await stepInToLine(page, 2);
 
   // Add a breakpoint in minified.html and resume to there
   await addBreakpoint(page, { url: exampleKey, lineNumber: 8 });
@@ -38,7 +38,7 @@ test(`stepping-05_chromium: Test stepping in pretty-printed code`, async ({
 
   await openConsolePanel(page);
   await addEventListenerLogpoints(page, [{ eventType: "click", categoryKey: "mouse" }]);
-  await warpToMessage(page, "PointerEvent", 14);
+  await warpToMessage(page, "PointerEvent", 15);
 
   await stepInToLine(page, 2);
   await stepOutToLine(page, 15);


### PR DESCRIPTION
This PR:

- Updates several tests that check for specific line numbers, to account for changes in backend breakpoint/hit count values.

Recent backend changes altered the hit count values and breakpoints that get returned, even though the underlying recordings and source files have not changed.

Before, we had breakpoints and hit counts for lines where functions were declared:

![image](https://github.com/replayio/devtools/assets/1128784/025396bb-1efa-42da-b5bb-9eed311a1426)

afterwards, we no longer have hit counts for function declaration lines:

![image](https://github.com/replayio/devtools/assets/1128784/846ab0d0-1bfa-4de5-990c-5f453c5ed5ea)

I've adjusted line numbers in failing tests to account for this.