### PR TITLE
Run updateMappedLocation before RDT view source

### DIFF
--- a/packages/replay-next/src/suspense/PauseCache.ts
+++ b/packages/replay-next/src/suspense/PauseCache.ts
@@ -80,7 +80,7 @@ export function cachePauseData(
   stack?: CallStack
 ) {
   if (pauseData.objects) {
-    preCacheObjects(pauseId, pauseData.objects);
+    preCacheObjects(sources, pauseId, pauseData.objects);
   }
   if (stack) {
     const frames = sortFramesAndUpdateLocations(sources, pauseData.frames || [], stack);

--- a/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
+++ b/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
@@ -21,6 +21,8 @@ import { useIsPointWithinFocusWindow } from "replay-next/src/hooks/useIsPointWit
 import { useNag } from "replay-next/src/hooks/useNag";
 import { RecordingTarget, recordingTargetCache } from "replay-next/src/suspense/BuildIdCache";
 import { objectCache } from "replay-next/src/suspense/ObjectPreviews";
+import { updateMappedLocation } from "replay-next/src/suspense/PauseCache";
+import { sourcesByIdCache } from "replay-next/src/suspense/SourcesCache";
 import { evaluate } from "replay-next/src/utils/evaluate";
 import { recordData } from "replay-next/src/utils/telemetry";
 import { isExecutionPointsLessThan } from "replay-next/src/utils/time";
@@ -355,6 +357,12 @@ class ReplayWall implements Wall {
           res.returned.object,
           "canOverflow"
         );
+        const sources = await sourcesByIdCache.readAsync(this.replayClient);
+
+        if (componentFunctionPreview.preview?.functionLocation) {
+          updateMappedLocation(sources, componentFunctionPreview.preview.functionLocation);
+        }
+
         return componentFunctionPreview;
       }
     }

--- a/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
+++ b/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
@@ -21,8 +21,6 @@ import { useIsPointWithinFocusWindow } from "replay-next/src/hooks/useIsPointWit
 import { useNag } from "replay-next/src/hooks/useNag";
 import { RecordingTarget, recordingTargetCache } from "replay-next/src/suspense/BuildIdCache";
 import { objectCache } from "replay-next/src/suspense/ObjectPreviews";
-import { updateMappedLocation } from "replay-next/src/suspense/PauseCache";
-import { sourcesByIdCache } from "replay-next/src/suspense/SourcesCache";
 import { evaluate } from "replay-next/src/utils/evaluate";
 import { recordData } from "replay-next/src/utils/telemetry";
 import { isExecutionPointsLessThan } from "replay-next/src/utils/time";
@@ -357,11 +355,6 @@ class ReplayWall implements Wall {
           res.returned.object,
           "canOverflow"
         );
-        const sources = await sourcesByIdCache.readAsync(this.replayClient);
-
-        if (componentFunctionPreview.preview?.functionLocation) {
-          updateMappedLocation(sources, componentFunctionPreview.preview.functionLocation);
-        }
 
         return componentFunctionPreview;
       }


### PR DESCRIPTION
Note: Creating another PR because #9726 was created from a fork.

The current RDT view source behaviour sometimes doesn't run updateMappedLocation to the list of possible locations to mutate them which leads to the following error:
```
utils.ts:69 Uncaught (in promise) Error: location.sourceId should be updated to the first corresponding sourceId: {"preferredLocation":{"line":36,"column":24,"sourceId":"o58-240-df24f5-31ec2e"},"correspondingSources":["o65-26-df24f5-6c77dd","o58-240-df24f5-31ec2e","o77-354-df24f5-fd421c"]}
    at a (utils.ts:69:18)
    at A (sources.ts:268:3)
    at ReactDevTools.tsx:368:22
    at index.js:16:1
    at Object.dispatch (index.ts:458:18)
    at dispatch (<anonymous>:1:54884)
    at viewElementSourceFunction (ReactDevTools.tsx:711:13)
```
This should fix that