### PR TITLE
Add restart debugging session

### DIFF
--- a/packages/e2e-tests/helpers/index.ts
+++ b/packages/e2e-tests/helpers/index.ts
@@ -5,7 +5,13 @@ import dotenv from "dotenv";
 import { RecordingTarget } from "replay-next/src/suspense/BuildIdCache";
 
 import exampleRecordings from "../examples.json";
-import { debugPrint, getElementClasses, waitFor, waitForRecordingToFinishIndexing } from "./utils";
+import {
+  debugPrint,
+  getCommandKey,
+  getElementClasses,
+  waitFor,
+  waitForRecordingToFinishIndexing,
+} from "./utils";
 
 dotenv.config({ path: "../../.env" });
 
@@ -75,6 +81,12 @@ export async function startLibraryTest(page: Page, apiKey: string, teamId: strin
 
   await page.locator('[data-test-id="TestRunResults"]').waitFor();
   await page.locator('[data-test-id="TestRunList"]').waitFor();
+}
+
+export async function commandPalette(page: Page, query: string) {
+  await page.keyboard.press(`${getCommandKey()}+K`);
+  await page.keyboard.type(query);
+  await page.keyboard.press("Enter");
 }
 
 export type TestRecordingKey = keyof typeof exampleRecordings;

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -11,6 +11,7 @@
     "test:chromium": "playwright test --project chromium --reporter=@replayio/playwright/reporter,line",
     "test:replay-chromium": "playwright test --project replay-chromium --reporter=@replayio/playwright/reporter,line",
     "test:debug": "playwright test --project chromium --workers 1 --headed",
+    "test:ui": "playwright test --ui",
     "test:install": "playwright install",
     "ts-node": "ts-node --project ../../tsconfig.json"
   },

--- a/packages/e2e-tests/tests/restart-session.test.ts
+++ b/packages/e2e-tests/tests/restart-session.test.ts
@@ -1,0 +1,13 @@
+import { commandPalette, openDevToolsTab, startTest } from "../helpers";
+import { waitForRecordingToFinishIndexing } from "../helpers/utils";
+import test from "../testFixtureCloneRecording";
+
+test.use({ exampleKey: "doc_control_flow.html" });
+
+test(`restart debugging session`, async ({ pageWithMeta: { page, recordingId }, exampleKey }) => {
+  await startTest(page, recordingId);
+  await openDevToolsTab(page);
+  await commandPalette(page, "restart session");
+  await page.waitForNavigation();
+  await waitForRecordingToFinishIndexing(page);
+});

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -252,6 +252,11 @@ export function executeCommand(key: CommandKey): UIThunkAction {
       dispatch(jumpToPreviousPause());
     } else if (key === "jump_to_next_pause") {
       dispatch(jumpToNextPause());
+    } else if (key == "restart_session") {
+      // navigate to the url with an additional search param
+      const url = new URL(window.location.href);
+      url.searchParams.append("restart", "true");
+      window.location.href = url.toString();
     }
     // else if (key === "copy_points") {
     //   dispatch(copyBreakpointsToClipboard());

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -205,7 +205,15 @@ export function createSocket(
         ),
         disableProtocolQueryCache: userData.get("backend_disableProtocolQueryCache"),
       };
-      if (userData.get("backend_newControllerOnRefresh")) {
+
+      const restartParam = new URL(window.location.href).searchParams.get("restart") || undefined;
+      if (restartParam) {
+        const url = new URL(window.location.href);
+        url.searchParams.delete("restart");
+        window.history.replaceState({}, "", url.toString());
+      }
+
+      if (restartParam || userData.get("backend_newControllerOnRefresh")) {
         experimentalSettings.controllerKey = String(Date.now());
       }
 

--- a/src/ui/components/CommandPalette/CommandPalette.tsx
+++ b/src/ui/components/CommandPalette/CommandPalette.tsx
@@ -47,7 +47,8 @@ export type CommandKey =
   | "jump_to_next_pause"
   | "jump_to_previous_pause"
   | "toggle_protocol_panel"
-  | "toggle_protocol_timeline";
+  | "toggle_protocol_timeline"
+  | "restart_session";
 
 const COMMANDS: readonly Command[] = [
   { key: "open_console", label: "Open Console" },
@@ -76,6 +77,7 @@ const COMMANDS: readonly Command[] = [
   { key: "pin_to_bottom", label: "Pin Toolbox To Bottom" },
   { key: "pin_to_left", label: "Pin Toolbox To Left" },
   { key: "pin_to_bottom_right", label: "Pin Toolbox To Bottom Right" },
+  { key: "restart_session", label: "Restart debugging session" },
   { key: "toggle_protocol_panel", label: "Toggle Protocol Panel", internalOnly: true },
   { key: "toggle_protocol_timeline", label: "Toggle Protocol timeline", internalOnly: true },
   // { key: "copy_points", label: "Copy Print Statement Settings to Clipboard" },


### PR DESCRIPTION
fixes FE-1848

This is a small feature that can be useful when a backend debuggions session state is corrupted. We should likely put it in the troubleshooting docs when it lands as well.

