### PR TITLE
Conditionally fetch Network request/response bodies

### DIFF
--- a/src/ui/components/NetworkMonitor/RequestBody.tsx
+++ b/src/ui/components/NetworkMonitor/RequestBody.tsx
@@ -5,7 +5,7 @@ import HttpBody from "./HttpBody";
 import { RequestSummary, findHeader } from "./utils";
 
 export default function RequestBodyWrapper({ request }: { request: RequestSummary | undefined }) {
-  if (!request) {
+  if (!request || !request.hasRequestBody) {
     return null;
   }
 

--- a/src/ui/components/NetworkMonitor/ResponseBody.tsx
+++ b/src/ui/components/NetworkMonitor/ResponseBody.tsx
@@ -1,31 +1,15 @@
-import { ResponseBodyData } from "@replayio/protocol";
-
 import { useNetworkResponseBody } from "replay-next/src/hooks/useNetworkResponseBody";
 
 import LoadingProgressBar from "../shared/LoadingProgressBar";
 import HttpBody from "./HttpBody";
 import { RequestSummary, findHeader } from "./utils";
 
-// Keep the internal implementation separate so we can mock it easily in storybook.
-export function _ResponseBody({
-  request,
-  responseBodyParts,
-}: {
-  request: RequestSummary;
-  responseBodyParts: ResponseBodyData[];
-}) {
-  return (
-    <>
-      <div className="flex items-center justify-between px-4 py-2 font-bold">Response body:</div>
-      <div className="pl-4">
-        <HttpBody
-          bodyParts={responseBodyParts}
-          contentType={findHeader(request.responseHeaders, "content-type") || "unknown"}
-          filename={request.name}
-        />
-      </div>
-    </>
-  );
+export default function ResponseBodyWrapper({ request }: { request: RequestSummary | undefined }) {
+  if (!request || !request.hasResponseBody) {
+    return null;
+  }
+
+  return <ResponseBody request={request} />;
 }
 
 function ResponseBody({ request }: { request: RequestSummary }) {
@@ -34,7 +18,16 @@ function ResponseBody({ request }: { request: RequestSummary }) {
     return <LoadingProgressBar />;
   }
 
-  return <_ResponseBody request={request} responseBodyParts={responseBody} />;
+  return (
+    <>
+      <div className="flex items-center justify-between px-4 py-2 font-bold">Response body:</div>
+      <div className="pl-4">
+        <HttpBody
+          bodyParts={responseBody}
+          contentType={findHeader(request.responseHeaders, "content-type") || "unknown"}
+          filename={request.name}
+        />
+      </div>
+    </>
+  );
 }
-
-export default ResponseBody;

--- a/src/ui/components/NetworkMonitor/useCopyAsCURL.ts
+++ b/src/ui/components/NetworkMonitor/useCopyAsCURL.ts
@@ -18,12 +18,16 @@ export default function useCopyAsCURL(
   requestSummary: RequestSummary,
   resetAfterDelay: number = 2_500
 ): {
-  copy: () => void;
+  copy: (() => void) | null;
   state: State;
 } {
   const replayClient = useContext(ReplayClientContext);
 
   const [state, setState] = useState<State>("ready");
+
+  if (!requestSummary.hasRequestBody) {
+    return { copy: null, state };
+  }
 
   const copy = async () => {
     try {

--- a/src/ui/components/NetworkMonitor/useNetworkContextMenu.tsx
+++ b/src/ui/components/NetworkMonitor/useNetworkContextMenu.tsx
@@ -102,12 +102,14 @@ export default function useNetworkContextMenu({
           </ContextMenuItem>
         </>
       )}
-      <ContextMenuItem disabled={state !== "ready"} onSelect={copyAsCURL}>
-        <>
-          <Icon type="copy" />
-          Copy as CURL
-        </>
-      </ContextMenuItem>
+      {copyAsCURL && (
+        <ContextMenuItem disabled={state !== "ready"} onSelect={copyAsCURL}>
+          <>
+            <Icon type="copy" />
+            Copy as CURL
+          </>
+        </ContextMenuItem>
+      )}
     </>,
     {
       dataTestName: "ContextMenu-NetworkRequest",


### PR DESCRIPTION
Ideally I'd prefer the use-data hooks to do the checks here but the format our Network data is in doesn't make that easy. The React components in `ui/components` use a _different_ data format (`RequestSummary`) from what the Protocol returns, and this type can't be imported by the hooks in replay-next because of how our Webpack config is setup.

I don't think we should be manipulating formats from what Suspense caches return. These changes are mostly subjective anyway:

https://github.com/replayio/devtools/blob/0ef83c84333519940a71a7686f65d44a35bcb40c/src/ui/components/NetworkMonitor/utils.ts#L151-L172