### PR TITLE
Show spinner when playback is stalled

### DIFF
--- a/src/ui/components/Comments/VideoComments/CommentsOverlay.tsx
+++ b/src/ui/components/Comments/VideoComments/CommentsOverlay.tsx
@@ -20,7 +20,8 @@ function CommentsOverlay({
   canvas,
   currentTime,
   children,
-}: PropsFromRedux & { children: React.ReactNode }) {
+  showComments,
+}: PropsFromRedux & { children: React.ReactNode; showComments: boolean }) {
   const recordingId = hooks.useGetRecordingId();
   const { comments: allComments } = hooks.useGetComments(recordingId);
 
@@ -45,17 +46,19 @@ function CommentsOverlay({
         height: height * scale - 2,
       }}
     >
-      <div className="canvas-comments">
-        {commentsAtTime.map(comment => {
-          return (
-            <VideoComment
-              comment={comment}
-              isHighlighted={hoveredCommentId === comment.id || selectedCommentId === comment.id}
-              key={comment.id}
-            />
-          );
-        })}
-      </div>
+      {showComments && (
+        <div className="canvas-comments">
+          {commentsAtTime.map(comment => {
+            return (
+              <VideoComment
+                comment={comment}
+                isHighlighted={hoveredCommentId === comment.id || selectedCommentId === comment.id}
+                key={comment.id}
+              />
+            );
+          })}
+        </div>
+      )}
       {children}
     </div>
   );

--- a/src/ui/components/Video.tsx
+++ b/src/ui/components/Video.tsx
@@ -49,7 +49,7 @@ export default function Video() {
   const [showDelayedSpinner, setShowDelayedSpinner] = useState(false);
 
   useEffect(() => {
-    if ((isNodePickerActive && mouseTargetsLoading) || stalled) {
+    if (isNodePickerActive && mouseTargetsLoading) {
       const timerId = setTimeout(() => {
         setShowDelayedSpinner(true);
       }, 700);
@@ -100,7 +100,7 @@ export default function Video() {
     addComment();
   };
 
-  const showCommentTool =
+  const showComments =
     isPaused && !isNodeTarget && !isNodePickerActive && !isNodePickerInitializing;
 
   return (
@@ -118,15 +118,13 @@ export default function Video() {
         ref={canvasRef}
       />
       {contextMenu}
-      {showCommentTool ? (
-        <CommentsOverlay>
-          {showDelayedSpinner && (
-            <div className="absolute bottom-5 right-5 z-20 flex opacity-100">
-              <Spinner className="w-5 animate-spin text-black" />
-            </div>
-          )}
-        </CommentsOverlay>
-      ) : null}
+      <CommentsOverlay showComments={showComments}>
+        {(showDelayedSpinner || stalled) && (
+          <div className="absolute bottom-5 right-5 z-20 flex opacity-100">
+            <Spinner className="w-5 animate-spin text-black" />
+          </div>
+        )}
+      </CommentsOverlay>
       {isNodePickerInitializing ? <Tooltip label="Loading…" targetID="video" /> : null}
       {panel === "cypress" && <ToggleButton />}
       <div id="highlighter-root">


### PR DESCRIPTION
- the spinner is shown in the `CommentsOverlay`, but that was hidden during playback - now it's always shown and only the comments are hidden during playback
- the spinner is shown with a delay of 700ms - that makes sense when the data for the node picker is being fetched but not for stalled playback, so I took that part out of the delay