### PR TITLE
Improve J2C test stability

### DIFF
--- a/packages/e2e-tests/tests/jump-to-code-01_basic.test.ts
+++ b/packages/e2e-tests/tests/jump-to-code-01_basic.test.ts
@@ -135,18 +135,19 @@ test(`jump-to-code-01: Test basic jumping functionality`, async ({
   await firstValidKeypressJumpButton.click();
   await waitForSelectedSource(page, "Header.tsx");
   // Should highlight the line that ran
-  await waitFor(async () => {
-    const lineNumber = await getSelectedLineNumber(page, false);
-    expect(lineNumber).toBe(12);
-  });
+  await waitFor(
+    async () => {
+      const lineNumber = await getSelectedLineNumber(page, true);
+      expect(lineNumber).toBe(12);
+    },
+    { timeout: 10_000 }
+  );
 
   // Should also have jumped in time
   await waitFor(async () => {
     const timelinePercent = await getTimelineCurrentPercent(page);
     expect(Math.round(timelinePercent)).toBe(32);
   });
-
-  // And should have
 
   // the next clicks were on real buttons, so there is a handler
   debugPrint(page, "Checking for an enabled click 'Jump' button");
@@ -157,10 +158,13 @@ test(`jump-to-code-01: Test basic jumping functionality`, async ({
   await firstValidClickJumpButton.click();
   await waitForSelectedSource(page, "TodoListItem.tsx");
   // Should highlight the line that ran
-  await waitFor(async () => {
-    const lineNumber = await getSelectedLineNumber(page, false);
-    expect(lineNumber).toBe(22);
-  });
+  await waitFor(
+    async () => {
+      const lineNumber = await getSelectedLineNumber(page, true);
+      expect(lineNumber).toBe(22);
+    },
+    { timeout: 10_000 }
+  );
 
   // Should also have jumped in time
   await waitFor(async () => {


### PR DESCRIPTION
The `jump-to-code-01` test is being flaky. It's failing some in CI.  I saw _one_ flake on my own machine, but it passes most of the time.

Tweaking the "selected line" checks to see if that improves things.

**update**

Prior to this PR, the `jump-to-code-01` test was repeatedly flaking or failing on every run.

Two pushes to this branch, and it appears to be passing without any flakes at all.  Should be an improvement.