### PR TITLE
Add ErrorBoundary around Library dashboard page

### DIFF
--- a/src/ui/components/Library/Library.tsx
+++ b/src/ui/components/Library/Library.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from "next/router";
 import { useEffect } from "react";
 
+import ErrorBoundary from "replay-next/components/ErrorBoundary";
 import { UserSettings } from "shared/graphql/types";
 import { LibrarySpinner } from "ui/components/Library/LibrarySpinner";
 import {
@@ -100,7 +101,9 @@ function Library({ userSettings, userInfo }: { userSettings: UserSettings; userI
   return (
     <div className="flex h-screen w-screen flex-row">
       <Navigation />
-      <TeamPage />
+      <ErrorBoundary key={teamId} name="Library">
+        <TeamPage />
+      </ErrorBoundary>
       <LibraryNags />
     </div>
   );


### PR DESCRIPTION
Using DevTools to manually trigger an error on the Library page

Before:
<img width="991" alt="Screen Shot 2023-09-22 at 2 22 12 PM" src="https://github.com/replayio/devtools/assets/29597/1e7f9ad9-6b7e-44e2-8702-07c3270d8cc9">

After:
<img width="993" alt="Screen Shot 2023-09-22 at 2 20 24 PM" src="https://github.com/replayio/devtools/assets/29597/d58895c2-a55a-498a-8e73-8b2ed1044f38">
