### PR TITLE
Hide the leave menu if other admins are pending

### DIFF
--- a/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSettingsModal.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSettingsModal.tsx
@@ -37,7 +37,8 @@ export function WorkspaceMembers({
   }, [members]);
 
   const canLeave = members.length > 1;
-  const canAdminLeave = canLeave && members.filter(a => a.roles?.includes("admin")).length > 1;
+  const canAdminLeave =
+    canLeave && members.filter(a => a.roles?.includes("admin") && !a.pending).length > 1;
 
   return (
     <ul className="flex flex-col space-y-2.5">

--- a/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSettingsModal.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSettingsModal.tsx
@@ -39,9 +39,7 @@ export function WorkspaceMembers({
       .sort((a: WorkspaceUser, b: WorkspaceUser) => Number(b.pending) - Number(a.pending));
   }, [members]);
 
-  const canLeave = members.length > 1;
-  const canAdminLeave =
-    canLeave && members.filter(a => a.roles?.includes("admin") && !a.pending).length > 1;
+  const adminCount = members.filter(a => a.roles?.includes("admin") && !a.pending).length;
 
   return (
     <ul className="flex flex-col space-y-2.5">
@@ -57,7 +55,7 @@ export function WorkspaceMembers({
             member={member}
             key={`registered-${member.userId}`}
             isAdmin={isAdmin}
-            canLeave={member.roles?.includes("admin") ? canAdminLeave : canLeave}
+            canLeave={member.roles?.includes("admin") ? adminCount > 1 : members.length > 1}
           />
         )
       )}


### PR DESCRIPTION
The backend prevents leaving a team if you are an admin and there are no other non-pending admins but the frontend still shows the Leave menu option.

This adds a check for pending as well when deciding to show the Leave option.