### PR TITLE
Restrict moving replays to appropriate workspace type

### DIFF
--- a/src/ui/components/Library/Team/View/Recordings/RecordingListItem/MoveRecordingMenu.tsx
+++ b/src/ui/components/Library/Team/View/Recordings/RecordingListItem/MoveRecordingMenu.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 
-import { Workspace } from "shared/graphql/types";
+import { Recording, Workspace } from "shared/graphql/types";
 import { useGetTeamIdFromRoute } from "ui/components/Library/Team/utils";
+import { isTestSuiteReplay } from "ui/components/TestSuite/utils/isTestSuiteReplay";
 import hooks from "ui/hooks";
 import { WorkspaceId } from "ui/state/app";
 import { subscriptionExpired } from "ui/utils/workspace";
@@ -12,17 +13,21 @@ type RecordingOptionsDropdownProps = {
   onMoveRecording: (targetWorkspaceId: WorkspaceId | null) => void;
   workspaces: Workspace[];
   disableLibrary: boolean;
+  isTestSuiteReplay: boolean;
 };
 
 export default function MoveRecordingMenu({
   onMoveRecording,
   workspaces,
   disableLibrary,
+  isTestSuiteReplay = false,
 }: RecordingOptionsDropdownProps) {
   const currentWorkspaceId = useGetTeamIdFromRoute();
   const { workspace, loading } = hooks.useGetWorkspace(currentWorkspaceId || "");
 
-  const availableWorkspaces = workspaces.filter(w => w.id !== currentWorkspaceId);
+  const availableWorkspaces = workspaces.filter(
+    w => w.id !== currentWorkspaceId && isTestSuiteReplay === !!w.isTest
+  );
 
   if (
     availableWorkspaces.length === 0 ||

--- a/src/ui/components/Library/Team/View/Recordings/RecordingListItem/RecordingOptionsDropdown.tsx
+++ b/src/ui/components/Library/Team/View/Recordings/RecordingListItem/RecordingOptionsDropdown.tsx
@@ -5,6 +5,7 @@ import React, { useState } from "react";
 import { Recording } from "shared/graphql/types";
 import { setModal } from "ui/actions/app";
 import { useGetTeamIdFromRoute } from "ui/components/Library/Team/utils";
+import { isTestSuiteReplay } from "ui/components/TestSuite/utils/isTestSuiteReplay";
 import hooks from "ui/hooks";
 import { useGetUserPermissions } from "ui/hooks/users";
 import { useAppDispatch } from "ui/setup/hooks";
@@ -132,6 +133,7 @@ function MoveRecordingOption({
 
   return (
     <MoveRecordingMenu
+      isTestSuiteReplay={isTestSuiteReplay(recording)}
       workspaces={workspaces}
       onMoveRecording={updateRecording}
       disableLibrary={!permissions.moveToLibrary}


### PR DESCRIPTION
## Issue

The bulk edit and per-recording menu in the library allows users to move recordings into unsupported workspaces.

## Resolution

* Restrict the workspace list in the menu to the appropriate type
* Suppress the move option altogether if a user manages to select both types which shouldn't happen because we've prevented this but they might have already and we shouldn't perpetuate it