### PR TITLE
Show default UI for test replays in a non-test workspace

### DIFF
--- a/packages/shared/graphql/generated/GetMyRecordings.ts
+++ b/packages/shared/graphql/generated/GetMyRecordings.ts
@@ -60,7 +60,6 @@ export interface GetMyRecordings_viewer_recordings_edges_node {
   createdAt: any;
   private: boolean;
   isInitialized: boolean;
-  isProcessed: boolean;
   userRole: string;
   owner: GetMyRecordings_viewer_recordings_edges_node_owner | null;
   comments: GetMyRecordings_viewer_recordings_edges_node_comments[];

--- a/packages/shared/graphql/generated/GetRecording.ts
+++ b/packages/shared/graphql/generated/GetRecording.ts
@@ -145,13 +145,14 @@ export interface GetRecording_recording {
   createdAt: any;
   private: boolean;
   isInitialized: boolean;
-  isProcessed: boolean;
   ownerNeedsInvite: boolean;
   userRole: string;
   operations: any | null;
   resolution: any | null;
   metadata: any | null;
   isTest: boolean;
+  isProcessed: boolean | null;
+  isInTestWorkspace: boolean;
   comments: GetRecording_recording_comments[];
   activeSessions: GetRecording_recording_activeSessions[] | null;
   owner: GetRecording_recording_owner | null;

--- a/packages/shared/graphql/generated/GetTestsRun.ts
+++ b/packages/shared/graphql/generated/GetTestsRun.ts
@@ -11,13 +11,6 @@ export interface GetTestsRun_node_Recording {
   __typename: "Recording";
 }
 
-export interface GetTestsRun_node_Workspace_testRuns_edges_node_results_counts {
-  __typename: "TestRunStats";
-  failed: number;
-  flaky: number;
-  passed: number;
-}
-
 export interface GetTestsRun_node_Workspace_testRuns_edges_node_results_recordings_comments_user {
   __typename: "User";
   id: string;
@@ -32,6 +25,7 @@ export interface GetTestsRun_node_Workspace_testRuns_edges_node_results_recordin
   __typename: "Recording";
   uuid: any;
   duration: number | null;
+  isProcessed: boolean | null;
   createdAt: any;
   metadata: any | null;
   comments: GetTestsRun_node_Workspace_testRuns_edges_node_results_recordings_comments[];
@@ -39,31 +33,12 @@ export interface GetTestsRun_node_Workspace_testRuns_edges_node_results_recordin
 
 export interface GetTestsRun_node_Workspace_testRuns_edges_node_results {
   __typename: "TestRunResults";
-  counts: GetTestsRun_node_Workspace_testRuns_edges_node_results_counts;
   recordings: GetTestsRun_node_Workspace_testRuns_edges_node_results_recordings[];
-}
-
-export interface GetTestsRun_node_Workspace_testRuns_edges_node_source {
-  __typename: "TestRunSource";
-  commitId: string;
-  commitTitle: string | null;
-  groupLabel: string | null;
-  isPrimaryBranch: boolean;
-  branchName: string | null;
-  prNumber: number | null;
-  prTitle: string | null;
-  repository: string | null;
-  triggerUrl: string | null;
-  user: string | null;
 }
 
 export interface GetTestsRun_node_Workspace_testRuns_edges_node {
   __typename: "TestRun";
-  id: string;
-  date: any;
-  mode: string | null;
   results: GetTestsRun_node_Workspace_testRuns_edges_node_results;
-  source: GetTestsRun_node_Workspace_testRuns_edges_node_source | null;
 }
 
 export interface GetTestsRun_node_Workspace_testRuns_edges {

--- a/packages/shared/graphql/generated/GetTestsRunsForWorkspace.ts
+++ b/packages/shared/graphql/generated/GetTestsRunsForWorkspace.ts
@@ -41,7 +41,6 @@ export interface GetTestsRunsForWorkspace_node_Workspace_testRuns_edges_node {
   __typename: "TestRun";
   id: string;
   date: any;
-  isProcessed: boolean;
   mode: string | null;
   results: GetTestsRunsForWorkspace_node_Workspace_testRuns_edges_node_results;
   source: GetTestsRunsForWorkspace_node_Workspace_testRuns_edges_node_source | null;

--- a/packages/shared/graphql/types.ts
+++ b/packages/shared/graphql/types.ts
@@ -213,6 +213,7 @@ export interface Recording {
   isInitialized?: boolean;
   isProcessed?: boolean;
   isTest?: boolean;
+  isInTestWorkspace?: boolean;
   metadata?: RecordingMetadata | null;
   operations?: OperationsData;
   ownerNeedsInvite?: boolean;

--- a/src/ui/components/Events/ReplayInfo.tsx
+++ b/src/ui/components/Events/ReplayInfo.tsx
@@ -17,6 +17,7 @@ import MaterialIcon from "../shared/MaterialIcon";
 import { getPrivacySummaryAndIcon } from "../shared/SharingModal/PrivacyDropdown";
 import PrivacyDropdown from "../shared/SharingModal/PrivacyDropdown";
 import LabeledIcon from "../TestSuite/components/LabeledIcon";
+import { isTestSuiteReplay } from "../TestSuite/utils/isTestSuiteReplay";
 import { getUniqueDomains } from "../UploadScreen/Privacy";
 import styles from "./ReplayInfo.module.css";
 
@@ -53,7 +54,7 @@ function ReplayInfo({ setModal }: PropsFromRedux) {
     setModal("privacy");
   };
 
-  const isTest = recording.metadata?.test;
+  const isTest = isTestSuiteReplay(recording);
   return (
     <div className="flex-column flex items-center overflow-hidden border-splitter bg-bodyBgcolor">
       <div className="mt-.5 mb-2 flex w-full cursor-default flex-col self-stretch overflow-hidden px-1.5 pb-0 text-xs">

--- a/src/ui/components/Header/Header.tsx
+++ b/src/ui/components/Header/Header.tsx
@@ -19,6 +19,7 @@ import { useAppSelector } from "ui/setup/hooks";
 import { trackEvent } from "ui/utils/telemetry";
 import useAuth0 from "ui/utils/useAuth0";
 
+import { isTestSuiteReplay } from "../TestSuite/utils/isTestSuiteReplay";
 import { RecordingTrialEnd } from "./RecordingTrialEnd";
 import ShareButton from "./ShareButton";
 import styles from "./Header.module.css";
@@ -181,7 +182,7 @@ export default function Header() {
   if (recording.workspace !== null) {
     dashboardUrl = `/team/${recording.workspace?.id}`;
 
-    if (recording.isTest && recording.metadata?.test !== undefined) {
+    if (isTestSuiteReplay(recording) && recording.metadata?.test) {
       const runId = getTestRunId(recording.metadata.test);
       if (runId != null) {
         dashboardUrl += `/runs/${runId}`;

--- a/src/ui/components/RecordingDocumentTitle.tsx
+++ b/src/ui/components/RecordingDocumentTitle.tsx
@@ -5,6 +5,8 @@ import { useIsRecordingProcessed } from "replay-next/src/hooks/useIsRecordingPro
 import { useRecordingProcessingProgress } from "replay-next/src/hooks/useRecordingProcessingProgress";
 import { useGetRecording, useGetRecordingId } from "ui/hooks/recordings";
 
+import { isTestSuiteReplay } from "./TestSuite/utils/isTestSuiteReplay";
+
 const ANIMATION_INTERVAL = 100;
 const ANIMATION_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
@@ -19,7 +21,7 @@ export function RecordingDocumentTitle() {
 
   const { metadata, title = "" } = recording ?? {};
 
-  const testResult = metadata?.test?.result;
+  const testResult = recording && isTestSuiteReplay(recording) ? metadata?.test?.result : undefined;
 
   // Track the animation counter with a ref so that it doesn't reset to 0 when the effect re-runs
   // (The effect will re-run when the processing progress changes, for example)

--- a/src/ui/components/TestSuite/utils/isTestSuiteReplay.ts
+++ b/src/ui/components/TestSuite/utils/isTestSuiteReplay.ts
@@ -7,6 +7,7 @@ import {
 export function isTestSuiteReplay(recording: Recording): boolean {
   const testMetadata = recording?.metadata?.test;
   return (
+    !!recording.isInTestWorkspace &&
     testMetadata != null &&
     (isGroupedTestCasesV2(testMetadata) || isGroupedTestCasesV3(testMetadata))
   );

--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -18,6 +18,7 @@ import { trackEvent } from "ui/utils/telemetry";
 
 import { actions } from "../actions";
 import { selectors } from "../reducers";
+import { isTestSuiteReplay } from "./TestSuite/utils/isTestSuiteReplay";
 import styles from "./Toolbar.module.css";
 
 function CypressIcon() {
@@ -425,11 +426,12 @@ export default function Toolbar() {
     }
   };
 
-  const testMetadata = recording?.metadata?.test;
-
   let testRunner = null;
-  if (testMetadata && !isGroupedTestCasesV1(testMetadata)) {
-    testRunner = testMetadata.environment.testRunner.name;
+  if (recording && isTestSuiteReplay(recording)) {
+    const testMetadata = recording.metadata?.test;
+    if (testMetadata && !isGroupedTestCasesV1(testMetadata)) {
+      testRunner = testMetadata.environment.testRunner.name;
+    }
   }
 
   return (

--- a/src/ui/graphql/recordings.ts
+++ b/src/ui/graphql/recordings.ts
@@ -28,6 +28,7 @@ export const GET_RECORDING = gql`
       metadata
       isTest
       isProcessed
+      isInTestWorkspace
       comments {
         id
         isPublished

--- a/src/ui/hooks/recordings.ts
+++ b/src/ui/hooks/recordings.ts
@@ -286,12 +286,13 @@ export function convertRecording(
     title: "title" in rec ? rec.title : undefined,
     duration: rec.duration,
     private: "private" in rec ? rec.private : undefined,
-    isProcessed: "isProcessed" in rec ? rec.isProcessed : undefined,
+    isProcessed: "isProcessed" in rec ? rec.isProcessed ?? undefined : undefined,
     isInitialized: "isInitialized" in rec ? rec.isInitialized : undefined,
     date: rec.createdAt,
     comments: rec.comments,
     userRole: "userRole" in rec ? (rec.userRole as RecordingRole) : undefined,
     isTest: "isTest" in rec ? rec.isTest : undefined,
+    isInTestWorkspace: "isInTestWorkspace" in rec ? rec.isInTestWorkspace : undefined,
   };
 
   if ("workspace" in rec) {


### PR DESCRIPTION
- update the generated GraphQL types
- add `isInTestWorkspace` to the `GET_RECORDING` query
- check `isInTestWorkspace` in `isTestSuiteReplay()`
- consistently use `isTestSuiteReplay()` to check for test recordings