### PR TITLE
Start removing sources from redux

### DIFF
--- a/packages/replay-next/src/suspense/SourcesCache.ts
+++ b/packages/replay-next/src/suspense/SourcesCache.ts
@@ -11,6 +11,7 @@ import {
   StreamingValue,
   createSingleEntryCache,
   createStreamingCache,
+  useImperativeCacheValue,
 } from "suspense";
 
 import { ArrayMap, assert } from "protocol/utils";
@@ -254,4 +255,22 @@ export function getSourceSuspends(
 ): Source | null {
   const sources = sourcesByIdCache.read(client);
   return sources.get(sourceId) ?? null;
+}
+
+const emptySources: Source[] = [];
+export function useSources(client: ReplayClientInterface) {
+  const cached = useImperativeCacheValue(sourcesCache, client);
+  return cached.status === "resolved" ? cached.value : emptySources;
+}
+
+const emptySourcesById = new Map<SourceId, Source>();
+export function useSourcesById(client: ReplayClientInterface) {
+  const cached = useImperativeCacheValue(sourcesByIdCache, client);
+  return cached.status === "resolved" ? cached.value : emptySourcesById;
+}
+
+const emptySourcesByUrl = new Map<SourceId, Source[]>();
+export function useSourcesByUrl(client: ReplayClientInterface) {
+  const cached = useImperativeCacheValue(sourcesByUrlCache, client);
+  return cached.status === "resolved" ? cached.value : emptySourcesByUrl;
 }

--- a/packages/replay-next/src/utils/sources.ts
+++ b/packages/replay-next/src/utils/sources.ts
@@ -32,6 +32,53 @@ export function getCorrespondingLocations(
   }));
 }
 
+export function getSourceToDisplayById(
+  sourcesById: Map<SourceId, Source>,
+  sourceId: SourceId
+): Source | undefined {
+  const sourceIdToDisplay = getCorrespondingSourceIds(sourcesById, sourceId)[0];
+  return sourcesById.get(sourceIdToDisplay);
+}
+
+export function getSourceIdToDisplayForUrl(
+  sourcesById: Map<SourceId, Source>,
+  sourcesByUrl: Map<string, Source[]>,
+  url: string,
+  preferredGeneratedSourceIds?: SourceId[]
+): SourceId | undefined {
+  const sources = sourcesByUrl.get(url);
+  if (!sources) {
+    return;
+  }
+  const preferred = getPreferredSourceId(
+    sourcesById,
+    sources.map(s => s.sourceId),
+    preferredGeneratedSourceIds
+  );
+  if (!preferred) {
+    return;
+  }
+  return getCorrespondingSourceIds(sourcesById, preferred)[0];
+}
+
+export function getSourceToDisplayForUrl(
+  sourcesById: Map<SourceId, Source>,
+  sourcesByUrl: Map<string, Source[]>,
+  url: string,
+  preferredGeneratedSourceIds?: SourceId[]
+): Source | undefined {
+  const sourceId = getSourceIdToDisplayForUrl(
+    sourcesById,
+    sourcesByUrl,
+    url,
+    preferredGeneratedSourceIds
+  );
+  if (!sourceId) {
+    return;
+  }
+  return sourcesById.get(sourceId);
+}
+
 export function getBestSourceMappedSourceId(
   sourcesById: Map<SourceId, Source>,
   sourceIds: SourceId[]

--- a/src/devtools/client/debugger/src/actions/ui.ts
+++ b/src/devtools/client/debugger/src/actions/ui.ts
@@ -6,9 +6,12 @@
 
 import type { Context } from "devtools/client/debugger/src/reducers/pause";
 import { copyToClipboard as copyTextToClipboard } from "replay-next/components/sources/utils/clipboard";
-import { streamingSourceContentsCache } from "replay-next/src/suspense/SourcesCache";
+import {
+  Source,
+  sourcesByIdCache,
+  streamingSourceContentsCache,
+} from "replay-next/src/suspense/SourcesCache";
 import type { UIThunkAction } from "ui/actions";
-import { SourceDetails, getSourceDetails } from "ui/reducers/sources";
 
 import { closeQuickOpen } from "../reducers/quick-open";
 import {
@@ -67,8 +70,9 @@ export function openSourceLink(sourceId: string, line?: number, column?: number)
 }
 
 export function showSource(cx: Context, sourceId: string, openSource = true): UIThunkAction {
-  return (dispatch, getState) => {
-    const source = getSourceDetails(getState(), sourceId);
+  return (dispatch, getState, { replayClient }) => {
+    const sourcesById = sourcesByIdCache.getValueIfCached(replayClient);
+    const source = sourcesById?.get(sourceId);
 
     if (!source) {
       return;
@@ -87,7 +91,7 @@ export function flashLineRange(location: HighlightedRange): UIThunkAction {
   };
 }
 
-export function copyToClipboard(source: SourceDetails): UIThunkAction {
+export function copyToClipboard(source: Source): UIThunkAction {
   return (dispatch, getState, { replayClient }) => {
     const streaming = streamingSourceContentsCache.stream(replayClient, source.id);
     if (streaming?.complete) {

--- a/src/devtools/client/debugger/src/components/Editor/CommandPaletteButton.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/CommandPaletteButton.tsx
@@ -1,20 +1,20 @@
 import classNames from "classnames";
 import React from "react";
 
-import { getSelectedSource } from "ui/reducers/sources";
+import { getSelectedSourceId } from "ui/reducers/sources";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 
 import { deselectSource } from "../../actions/sources/select";
 
 export default function CommandPaletteButton() {
-  const selectedSource = useAppSelector(getSelectedSource);
+  const selectedSourceId = useAppSelector(getSelectedSourceId);
   const dispatch = useAppDispatch();
 
   const showCommandPalette = () => dispatch(deselectSource());
 
   return (
     <button
-      className={classNames("command-palette cursor-auto", { active: !selectedSource })}
+      className={classNames("command-palette cursor-auto", { active: !selectedSourceId })}
       onClick={showCommandPalette}
     >
       <div className="img replay-logo" style={{ height: "20px", width: "20px" }} />

--- a/src/devtools/client/debugger/src/components/Editor/EditorPane.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/EditorPane.tsx
@@ -5,7 +5,7 @@ import { IndeterminateProgressBar } from "replay-next/components/IndeterminateLo
 import { userData } from "shared/user-data/GraphQL/UserData";
 import { Redacted } from "ui/components/Redacted";
 import { getToolboxLayout } from "ui/reducers/layout";
-import { getSelectedSource, getSourcesUserActionPending } from "ui/reducers/sources";
+import { getSelectedSourceId, getSourcesUserActionPending } from "ui/reducers/sources";
 import { useAppSelector } from "ui/setup/hooks";
 import useWidthObserver from "ui/utils/useWidthObserver";
 
@@ -16,7 +16,7 @@ import EditorTabs from "./Tabs";
 
 export const EditorPane = () => {
   const toolboxLayout = useAppSelector(getToolboxLayout);
-  const selectedSource = useAppSelector(getSelectedSource);
+  const selectedSourceId = useAppSelector(getSelectedSourceId);
   const sourcesUserActionPending = useAppSelector(getSourcesUserActionPending);
   const panelEl = useRef(null);
   const enableLargeText = userData.get("global_enableLargeText");
@@ -44,14 +44,14 @@ export const EditorPane = () => {
       <div className="editor-container relative">
         {sourcesUserActionPending ? <IndeterminateProgressBar /> : null}
         <EditorTabs />
-        {selectedSource ? (
+        {selectedSourceId ? (
           <Redacted className="h-full">
             <NewSourceAdapter />
           </Redacted>
         ) : (
           <WelcomeBox />
         )}
-        {selectedSource && <EditorFooter />}
+        {selectedSourceId && <EditorFooter />}
       </div>
     </div>
   );

--- a/src/devtools/client/debugger/src/components/Editor/SourcemapToggle.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/SourcemapToggle.tsx
@@ -1,8 +1,9 @@
 import React, { useContext } from "react";
 
+import { useSourcesById } from "replay-next/src/suspense/SourcesCache";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { setModal } from "ui/actions/app";
-import { getSelectedSource } from "ui/reducers/sources";
+import { getSelectedSourceId } from "ui/reducers/sources";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 
 import { showAlternateSource } from "../../actions/sources/select";
@@ -44,7 +45,9 @@ export default function SourcemapToggleSuspends({
 }) {
   const dispatch = useAppDispatch();
   const client = useContext(ReplayClientContext);
-  const selectedSource = useAppSelector(getSelectedSource);
+  const selectedSourceId = useAppSelector(getSelectedSourceId);
+  const sourcesById = useSourcesById(client);
+  const selectedSource = selectedSourceId ? sourcesById.get(selectedSourceId) : undefined;
   const selectedFrameId = useAppSelector(getSelectedFrameId);
   const sourcesState = useAppSelector(state => state.sources);
   const alternateSourceIdResult = getAlternateSourceIdSuspense(

--- a/src/devtools/client/debugger/src/components/Editor/SourcemapVisualizerLink.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/SourcemapVisualizerLink.tsx
@@ -1,8 +1,9 @@
 import React, { useContext } from "react";
 
+import { useSourcesById } from "replay-next/src/suspense/SourcesCache";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import Icon from "ui/components/shared/Icon";
-import { getSelectedSource } from "ui/reducers/sources";
+import { getSelectedSourceId } from "ui/reducers/sources";
 import { useAppSelector } from "ui/setup/hooks";
 import { trackEvent } from "ui/utils/telemetry";
 
@@ -16,7 +17,9 @@ export default function SourcemapVisualizerLinkSuspends({
   cursorPosition: CursorPosition;
 }) {
   const client = useContext(ReplayClientContext);
-  const selectedSource = useAppSelector(getSelectedSource);
+  const selectedSourceId = useAppSelector(getSelectedSourceId);
+  const sourcesById = useSourcesById(client);
+  const selectedSource = selectedSourceId ? sourcesById.get(selectedSourceId) : undefined;
   const selectedFrameId = useAppSelector(getSelectedFrameId);
   const sourcesState = useAppSelector(state => state.sources);
   const visualizerURL = getSourcemapVisualizerURLSuspense(

--- a/src/devtools/client/debugger/src/components/Editor/useTabContextMenu.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/useTabContextMenu.tsx
@@ -1,3 +1,4 @@
+import { useContext } from "react";
 import { ContextMenuDivider, ContextMenuItem, useContextMenu } from "use-context-menu";
 
 import { closeTab, closeTabs } from "devtools/client/debugger/src/actions/tabs";
@@ -8,15 +9,20 @@ import {
 import { Tab, getContext, getTabs } from "devtools/client/debugger/src/selectors";
 import { getRawSourceURL } from "devtools/client/debugger/src/utils/source";
 import { copyToClipboard as copyTextToClipboard } from "replay-next/components/sources/utils/clipboard";
+import { useSourcesById } from "replay-next/src/suspense/SourcesCache";
+import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { userData } from "shared/user-data/GraphQL/UserData";
-import { MiniSource, getSelectedSource } from "ui/reducers/sources";
+import { MiniSource, getSelectedSourceId } from "ui/reducers/sources";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 
 export default function useTabContextMenu({ source }: { source: MiniSource }) {
   const dispatch = useAppDispatch();
 
+  const replayClient = useContext(ReplayClientContext);
   const cx = useAppSelector(getContext);
-  const selectedSource = useAppSelector(getSelectedSource);
+  const selectedSourceId = useAppSelector(getSelectedSourceId);
+  const sourcesById = useSourcesById(replayClient);
+  const selectedSource = selectedSourceId ? sourcesById.get(selectedSourceId) : undefined;
   const tabs = useAppSelector(getTabs);
 
   const sourceId = source.id;

--- a/src/devtools/client/debugger/src/components/PrimaryPanes/SourcesTreeItem.tsx
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/SourcesTreeItem.tsx
@@ -12,8 +12,6 @@ import Icon from "replay-next/components/Icon";
 import { copyToClipboard } from "replay-next/components/sources/utils/clipboard";
 import { Redacted } from "ui/components/Redacted";
 import type { SourceDetails } from "ui/reducers/sources";
-import { getHasSiblingOfSameName } from "ui/reducers/sources";
-import { useAppSelector } from "ui/setup/hooks";
 
 import { getSourceQueryString } from "../../utils/source";
 import { getPathWithoutThread, isDirectory } from "../../utils/sources-tree";
@@ -143,8 +141,6 @@ function SourceTreeItem2({
   selectItem,
   setExpanded,
 }: STIProps) {
-  const hasSiblingOfSameName = useAppSelector(state => getHasSiblingOfSameName(state, source));
-
   const { contextMenu, onContextMenu } = useSourceTreeItemContextMenu({
     item,
     source,
@@ -173,13 +169,9 @@ function SourceTreeItem2({
     }
   };
 
-  let querystring;
-  if (hasSiblingOfSameName) {
-    querystring = getSourceQueryString(source);
-  }
+  const querystring = getSourceQueryString(source);
 
-  const query =
-    hasSiblingOfSameName && querystring ? <span className="query">{querystring}</span> : null;
+  const query = querystring ? <span className="query">{querystring}</span> : null;
 
   const tooltip =
     item.type === "source" ? unescape(item.contents.url!) : getPathWithoutThread(item.path);

--- a/src/devtools/client/debugger/src/components/QuickOpenModal.tsx
+++ b/src/devtools/client/debugger/src/components/QuickOpenModal.tsx
@@ -10,18 +10,15 @@ import React, { Component } from "react";
 import { useImperativeCacheValue } from "suspense";
 
 import { sourceOutlineCache } from "replay-next/src/suspense/SourceOutlineCache";
-import { streamingSourceContentsCache } from "replay-next/src/suspense/SourcesCache";
+import {
+  streamingSourceContentsCache,
+  useSourcesById,
+} from "replay-next/src/suspense/SourcesCache";
 import { replayClient } from "shared/client/ReplayClientContext";
 import { ViewMode } from "shared/user-data/GraphQL/config";
 import { setViewMode as setViewModeAction } from "ui/actions/layout";
 import { getViewMode } from "ui/reducers/layout";
-import {
-  SourceDetails,
-  getAllSourceDetails,
-  getSelectedSource,
-  getSourcesLoading,
-  getSourcesToDisplayByUrl,
-} from "ui/reducers/sources";
+import { SourceDetails, getSelectedSourceId, getSourcesToDisplayByUrl } from "ui/reducers/sources";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { trackEvent } from "ui/utils/telemetry";
 
@@ -517,8 +514,9 @@ interface QuickOpenModalProps {
 }
 
 export default function QuickOpenModalWrapper() {
-  const sourceList = useAppSelector(getAllSourceDetails);
-  const selectedSource = useAppSelector(getSelectedSource);
+  const selectedSourceId = useAppSelector(getSelectedSourceId);
+  const sourcesById = useSourcesById(replayClient);
+  const selectedSource = selectedSourceId ? sourcesById.get(selectedSourceId) : undefined;
   const symbolsCacheValue = useImperativeCacheValue(
     sourceOutlineCache,
     replayClient,
@@ -535,9 +533,9 @@ export default function QuickOpenModalWrapper() {
     searchType: useAppSelector(getQuickOpenType),
     selectedSource,
     showOnlyOpenSources: useAppSelector(getShowOnlyOpenSources),
-    sourceCount: sourceList.length,
+    sourceCount: sourcesById.size,
     sourcesForTabs: useAppSelector(getSourcesForTabs),
-    sourcesLoading: useAppSelector(getSourcesLoading),
+    sourcesLoading: sourcesById.size === 0,
     sourcesToDisplayByUrl: useAppSelector(getSourcesToDisplayByUrl),
     symbols:
       symbolsCacheValue.status === "resolved"

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointHeading.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointHeading.tsx
@@ -5,7 +5,7 @@ import { ConnectedProps, connect } from "react-redux";
 import type { Context } from "devtools/client/debugger/src/reducers/pause";
 import { Point } from "shared/client/types";
 import { Redacted } from "ui/components/Redacted";
-import { MiniSource, getHasSiblingOfSameName, getSourceDetails } from "ui/reducers/sources";
+import { MiniSource, getSourceDetails } from "ui/reducers/sources";
 import type { UIState } from "ui/state";
 
 import actions from "../../../actions";
@@ -27,7 +27,6 @@ const mapStateToProps = (state: UIState, { sourceId }: BHExtraProps) => {
   return {
     cx: getContext(state),
     executionPoint: getExecutionPoint(state),
-    hasSiblingOfSameName: getHasSiblingOfSameName(state, source),
     source,
   };
 };
@@ -46,13 +45,13 @@ class BreakpointHeading extends PureComponent<BreakpointsProps> {
   };
 
   getLabel() {
-    const { breakpoint, source, hasSiblingOfSameName } = this.props;
+    const { breakpoint, source } = this.props;
     const { column, line } = breakpoint?.location ?? {};
 
     const columnVal = column != null ? `:${column}` : "";
     const location = `:${line}${columnVal}`;
 
-    const query = hasSiblingOfSameName ? getSourceQueryString(source) : "";
+    const query = getSourceQueryString(source);
     const fileName = getTruncatedFileName(source, query);
 
     return `${fileName}${location}`;
@@ -72,9 +71,9 @@ class BreakpointHeading extends PureComponent<BreakpointsProps> {
   };
 
   render() {
-    const { allBreakpointsAreShared, source, hasSiblingOfSameName } = this.props;
+    const { allBreakpointsAreShared, source } = this.props;
 
-    const query = hasSiblingOfSameName ? getSourceQueryString(source) : "";
+    const query = getSourceQueryString(source);
     const fileName = getTruncatedFileName(source, query);
 
     return (

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/Breakpoints.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/Breakpoints.tsx
@@ -3,9 +3,9 @@ import { ReactNode, useContext, useMemo } from "react";
 
 import { PointsContext } from "replay-next/src/contexts/points/PointsContext";
 import { SessionContext } from "replay-next/src/contexts/SessionContext";
+import { useSourcesById } from "replay-next/src/suspense/SourcesCache";
+import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { POINT_BEHAVIOR_DISABLED, Point } from "shared/client/types";
-import { getSourceDetailsEntities } from "ui/reducers/sources";
-import { useAppSelector } from "ui/setup/hooks";
 
 import Breakpoint from "./Breakpoint";
 import BreakpointHeading from "./BreakpointHeading";
@@ -20,6 +20,7 @@ export default function Breakpoints({
   emptyContent: ReactNode;
   type: "breakpoint" | "logpoint";
 }) {
+  const replayClient = useContext(ReplayClientContext);
   const {
     deletePoints,
     editPointBehavior,
@@ -28,7 +29,7 @@ export default function Breakpoints({
   } = useContext(PointsContext);
   const { currentUserInfo } = useContext(SessionContext);
 
-  const sourceDetailsEntities = useAppSelector(getSourceDetailsEntities);
+  const sourceDetailsEntities = useSourcesById(replayClient);
 
   const filteredAndSortedPoints = useMemo(
     () =>
@@ -38,7 +39,7 @@ export default function Breakpoints({
           // Either we might not have sources fetched yet,
           // or there could be obsolete persisted source IDs for points.
           // Ensure we only show points that have valid sources available.
-          const sourceExists = !!sourceDetailsEntities[point.location.sourceId];
+          const sourceExists = sourceDetailsEntities.has(point.location.sourceId);
 
           const { shouldBreak, shouldLog } = pointBehaviors[point.key] ?? {};
 

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/FrameTimeline.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/FrameTimeline.tsx
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-//
-
 import {
   Location,
   PointDescription,
@@ -17,14 +15,14 @@ import ReactTooltip from "react-tooltip";
 import { locationsInclude } from "protocol/utils";
 import { frameStepsCache } from "replay-next/src/suspense/FrameStepsCache";
 import { sourceOutlineCache } from "replay-next/src/suspense/SourceOutlineCache";
+import { getSourceSuspends } from "replay-next/src/suspense/SourcesCache";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
-import { userData } from "shared/user-data/GraphQL/UserData";
 import { actions } from "ui/actions";
 import {
   SourcesState,
   getPreferredLocation,
   getSelectedLocation,
-  getSelectedSource,
+  getSelectedSourceId,
 } from "ui/reducers/sources";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { trackEvent } from "ui/utils/telemetry";
@@ -232,7 +230,8 @@ function FrameTimeline() {
   const executionPoint = useAppSelector(getExecutionPoint);
   const selectedLocation = useAppSelector(getSelectedLocation);
   const selectedFrame = useAppSelector(state => getSelectedFrameSuspense(replayClient, state));
-  const source = useAppSelector(getSelectedSource);
+  const sourceId = useAppSelector(getSelectedSourceId);
+  const source = sourceId ? getSourceSuspends(replayClient, sourceId) : null;
   const symbols = source ? sourceOutlineCache.read(replayClient, source.id) : null;
   const frameSteps = selectedFrame
     ? frameStepsCache.read(replayClient, selectedFrame.pauseId, selectedFrame.protocolId)

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/NewFrames.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/NewFrames.tsx
@@ -1,5 +1,6 @@
 import { ExecutionPoint, PauseId } from "@replayio/protocol";
 import { Suspense, useContext, useMemo } from "react";
+import { useImperativeCacheValue } from "suspense";
 
 import {
   Context,
@@ -16,10 +17,10 @@ import { FocusContext } from "replay-next/src/contexts/FocusContext";
 import { useCurrentFocusWindow } from "replay-next/src/hooks/useCurrentFocusWindow";
 import { useIsPointWithinFocusWindow } from "replay-next/src/hooks/useIsPointWithinFocusWindow";
 import { getPointAndTimeForPauseId, pauseIdCache } from "replay-next/src/suspense/PauseCache";
+import { sourcesCache } from "replay-next/src/suspense/SourcesCache";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { isPointInRegion } from "shared/utils/time";
 import { enterFocusMode } from "ui/actions/timeline";
-import { getSourcesLoading } from "ui/reducers/sources";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { getPauseFramesSuspense } from "ui/suspense/frameCache";
 import { getAsyncParentPauseIdSuspense } from "ui/suspense/util";
@@ -188,7 +189,8 @@ interface FramesProps {
 
 function Frames({ panel, point, time }: FramesProps) {
   const replayClient = useContext(ReplayClientContext);
-  const sourcesLoading = useAppSelector(getSourcesLoading);
+  const cachedSources = useImperativeCacheValue(sourcesCache, replayClient);
+  const sourcesLoading = cachedSources.status !== "resolved";
   const dispatch = useAppDispatch();
 
   const isInFocusRegion = useIsPointWithinFocusWindow(point);

--- a/src/devtools/client/debugger/src/components/SourceOutline/SourceOutline.tsx
+++ b/src/devtools/client/debugger/src/components/SourceOutline/SourceOutline.tsx
@@ -12,9 +12,10 @@ import {
   SourceOutlineWithHitCounts,
   outlineHitCountsCache,
 } from "replay-next/src/suspense/OutlineHitCountsCache";
+import { useSourcesById } from "replay-next/src/suspense/SourcesCache";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { toPointRange } from "shared/utils/time";
-import { SourceDetails, getSelectedSource } from "ui/reducers/sources";
+import { SourceDetails, getSelectedSourceId } from "ui/reducers/sources";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 
 import { selectLocation } from "../../actions/sources";
@@ -164,9 +165,11 @@ export function SourceOutline({
 
 export default function SourceOutlineWrapper() {
   // This goofy outer selection is so that SourceOutline.stories can inject fake values.
-  const cursorPosition = useAppSelector(getCursorPosition);
-  const selectedSource = useAppSelector(getSelectedSource);
   const replayClient = useContext(ReplayClientContext);
+  const cursorPosition = useAppSelector(getCursorPosition);
+  const selectedSourceId = useAppSelector(getSelectedSourceId);
+  const sourcesById = useSourcesById(replayClient);
+  const selectedSource = selectedSourceId ? sourcesById.get(selectedSourceId) : undefined;
   const { range: focusRange } = useContext(FocusContext);
 
   let symbols: SourceOutlineWithHitCounts | null = null;

--- a/src/devtools/client/debugger/src/reducers/ast.ts
+++ b/src/devtools/client/debugger/src/reducers/ast.ts
@@ -5,8 +5,7 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 
 import { getSourceIDsToSearch } from "devtools/client/debugger/src/utils/sourceVisualizations";
-import { sourcesCache } from "replay-next/src/suspense/SourcesCache";
-import { SourceDetails, getSourceDetailsEntities } from "ui/reducers/sources";
+import { sourcesByIdCache, sourcesCache } from "replay-next/src/suspense/SourcesCache";
 import { UIState } from "ui/state";
 import { LoadingStatus } from "ui/utils/LoadingStatus";
 import { ThunkExtraArgs } from "ui/utils/thunk";
@@ -63,10 +62,10 @@ export const fetchGlobalFunctions = createAsyncThunk<
 
   await sourcesCache.readAsync(replayClient);
 
-  const sourceById = getSourceDetailsEntities(thunkApi.getState());
+  const sourceById = await sourcesByIdCache.readAsync(replayClient);
   // Empty query to grab all of the functions, which we can easily filter later.
   const query = "";
-  const sourceIds = getSourceIDsToSearch(sourceById as Record<string, SourceDetails>);
+  const sourceIds = getSourceIDsToSearch(sourceById);
 
   const globalFns: SearchResult[] = [];
 

--- a/src/devtools/client/debugger/src/utils/quick-open.ts
+++ b/src/devtools/client/debugger/src/utils/quick-open.ts
@@ -11,8 +11,8 @@ import type {
 } from "@replayio/protocol";
 import memoizeOne from "memoize-one";
 
+import { Source } from "replay-next/src/suspense/SourcesCache";
 import { truncate as truncateText } from "replay-next/src/utils/text";
-import { SourceDetails } from "ui/reducers/sources";
 
 import { SearchTypes } from "../reducers/quick-open";
 import { getSourceClassnames, getTruncatedFileName } from "./source";
@@ -65,7 +65,7 @@ export function parseLineColumn(query: string) {
   }
 }
 
-function formatSourceForList(source: SourceDetails, tabUrls: Set<string>) {
+function formatSourceForList(source: Source, tabUrls: Set<string>) {
   const title = getTruncatedFileName(source);
   // `source.url` now includes query strings already
   const subtitle = truncateText(source.url!, { maxLength: 100, position: "start" });
@@ -94,11 +94,11 @@ export function formatSymbol(symbol: FunctionOutline) {
 
 export function formatProjectFunctions(
   functions: FunctionMatch[],
-  displayedSources: Dictionary<SourceDetails>
+  displayedSources: Map<string, Source>
 ) {
   const sourceFunctions = functions
     .map(({ name, loc }) => {
-      const source = displayedSources[loc.sourceId];
+      const source = displayedSources.get(loc.sourceId);
       if (!source?.url) {
         return [];
       }
@@ -151,7 +151,7 @@ export function formatShortcutResults() {
 }
 
 export function formatSources(
-  sourcesToDisplayByUrl: Dictionary<SourceDetails>,
+  sourcesToDisplayByUrl: Dictionary<Source>,
   tabUrls: Set<string>,
   onlySourcesInTabs: boolean
 ) {

--- a/src/ui/actions/event-listeners.ts
+++ b/src/ui/actions/event-listeners.ts
@@ -2,7 +2,6 @@
 
 import { cachePauseData } from "replay-next/src/suspense/PauseCache";
 import { sourcesByIdCache } from "replay-next/src/suspense/SourcesCache";
-import { getSourceDetailsEntities } from "ui/reducers/sources";
 
 import {
   REACT_16_EVENT_LISTENER_PROP_KEY,

--- a/src/ui/components/KeyboardShortcuts.tsx
+++ b/src/ui/components/KeyboardShortcuts.tsx
@@ -14,7 +14,7 @@ import { userData } from "shared/user-data/GraphQL/UserData";
 import { UIThunkAction, actions } from "ui/actions";
 import { useGetRecordingId } from "ui/hooks/recordings";
 import { selectors } from "ui/reducers";
-import { getSelectedSource } from "ui/reducers/sources";
+import { getSelectedSourceId } from "ui/reducers/sources";
 import { useAppSelector } from "ui/setup/hooks";
 import { UIState } from "ui/state";
 import { addGlobalShortcut, isEditableElement, removeGlobalShortcut } from "ui/utils/key-shortcuts";
@@ -63,7 +63,7 @@ function KeyboardShortcuts({
   const { isAuthenticated } = useAuth0();
   const [, dismissFindFileNag] = useNag(Nag.FIND_FILE);
 
-  const selectedSource = useAppSelector(getSelectedSource);
+  const selectedSourceId = useAppSelector(getSelectedSourceId);
 
   const [protocolTimeline] = useGraphQLUserData("feature_protocolTimeline");
   const globalKeyboardShortcuts = useMemo(() => {
@@ -91,7 +91,7 @@ function KeyboardShortcuts({
     };
 
     const toggleGoToLine = (e: KeyboardEvent) => {
-      if (selectedSource) {
+      if (selectedSourceId) {
         toggleQuickOpenModal(e, ":");
       }
     };
@@ -214,7 +214,7 @@ function KeyboardShortcuts({
     jumpToPreviousPause,
     jumpToNextPause,
     dismissFindFileNag,
-    selectedSource,
+    selectedSourceId,
   ]);
 
   useEffect(() => {

--- a/src/ui/components/ProtocolViewer/ProtocolViewerPanel.tsx
+++ b/src/ui/components/ProtocolViewer/ProtocolViewerPanel.tsx
@@ -2,6 +2,7 @@ import { unstable_Offscreen as Offscreen, Suspense, useContext, useMemo, useStat
 
 import Loader from "replay-next/components/Loader";
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
+import { useSources } from "replay-next/src/suspense/SourcesCache";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { ProtocolViewer } from "ui/components/ProtocolViewer/components/ProtocolViewer";
 import { useIsRecordingOfReplay } from "ui/components/ProtocolViewer/hooks/useIsRecordingOfReplay";
@@ -17,7 +18,6 @@ import {
   getProtocolRequestMap,
   getProtocolResponseMap,
 } from "ui/reducers/protocolMessages";
-import { getAllSourceDetails } from "ui/reducers/sources";
 import { useAppSelector } from "ui/setup/hooks";
 
 import styles from "./ProtocolViewerPanel.module.css";
@@ -76,7 +76,7 @@ function RecordedProtocolRequests() {
   const replayClient = useContext(ReplayClientContext);
   const { rangeForSuspense: focusRange } = useContext(FocusContext);
 
-  const sourceDetails = useAppSelector(getAllSourceDetails);
+  const sourceDetails = useSources(replayClient);
   const sources = useAppSelector(state => state.sources);
   const sessionSource = sourceDetails?.find(source => source.url?.includes("ui/actions/session"));
 

--- a/src/ui/components/ProtocolViewer/hooks/useIsRecordingOfReplay.ts
+++ b/src/ui/components/ProtocolViewer/hooks/useIsRecordingOfReplay.ts
@@ -1,10 +1,11 @@
-import { useMemo } from "react";
+import { useContext, useMemo } from "react";
 
-import { getAllSourceDetails } from "ui/reducers/sources";
-import { useAppSelector } from "ui/setup/hooks";
+import { useSources } from "replay-next/src/suspense/SourcesCache";
+import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
 export function useIsRecordingOfReplay() {
-  const sourceDetails = useAppSelector(getAllSourceDetails);
+  const replayClient = useContext(ReplayClientContext);
+  const sourceDetails = useSources(replayClient);
 
   return useMemo(() => {
     const hasKnownReplaySources = sourceDetails.some(source => {

--- a/src/ui/components/ReactPanel.tsx
+++ b/src/ui/components/ReactPanel.tsx
@@ -30,7 +30,12 @@ import { hitPointsForLocationCache } from "replay-next/src/suspense/HitPointsCac
 import { getPointAndTimeForPauseId, pauseIdCache } from "replay-next/src/suspense/PauseCache";
 import { getPointDescriptionForFrame } from "replay-next/src/suspense/PointStackCache";
 import { sourceOutlineCache } from "replay-next/src/suspense/SourceOutlineCache";
-import { streamingSourceContentsCache } from "replay-next/src/suspense/SourcesCache";
+import {
+  streamingSourceContentsCache,
+  useSourcesById,
+  useSourcesByUrl,
+} from "replay-next/src/suspense/SourcesCache";
+import { getSourceToDisplayForUrl } from "replay-next/src/utils/sources";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { ReplayClientInterface } from "shared/client/types";
 import { UIThunkAction } from "ui/actions";
@@ -38,12 +43,7 @@ import { MORE_IGNORABLE_PARTIAL_URLS } from "ui/actions/eventListeners/eventList
 import { findFunctionOutlineForLocation } from "ui/actions/eventListeners/jumpToCode";
 import { seek } from "ui/actions/timeline";
 import { JumpToCodeButton, JumpToCodeStatus } from "ui/components/shared/JumpToCodeButton";
-import {
-  SourceDetails,
-  SourcesState,
-  getSourceIdsByUrl,
-  getSourceToDisplayForUrl,
-} from "ui/reducers/sources";
+import { SourceDetails, SourcesState, getSourceIdsByUrl } from "ui/reducers/sources";
 import { getCurrentTime } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { getPauseFramesAsync } from "ui/suspense/frameCache";
@@ -384,6 +384,8 @@ export function ReactPanel() {
   const executionPoint = useAppSelector(getExecutionPoint);
   const replayClient = useContext(ReplayClientContext);
   const { range: focusRange } = useContext(FocusContext);
+  const sourcesById = useSourcesById(replayClient);
+  const sourcesByUrl = useSourcesByUrl(replayClient);
 
   const reactDomSourceUrl = useAppSelector(getReactDomSourceUrl);
   const sourcesState = useAppSelector(state => state.sources);
@@ -392,7 +394,7 @@ export function ReactPanel() {
       return undefined;
     }
 
-    const reactDomSource = getSourceToDisplayForUrl(state, reactDomSourceUrl);
+    const reactDomSource = getSourceToDisplayForUrl(sourcesById, sourcesByUrl, reactDomSourceUrl);
     if (!reactDomSource || !reactDomSource.url) {
       return;
     }

--- a/src/ui/components/SearchFilesReduxAdapter.tsx
+++ b/src/ui/components/SearchFilesReduxAdapter.tsx
@@ -3,15 +3,13 @@ import { useContext, useLayoutEffect } from "react";
 import { onViewSourceInDebugger } from "devtools/client/webconsole/actions";
 import SearchFiles from "replay-next/components/search-files/SearchFiles";
 import { SourcesContext } from "replay-next/src/contexts/SourcesContext";
-import { getSourceDetailsEntities } from "ui/reducers/sources";
-import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
+import { useAppDispatch } from "ui/setup/hooks";
 
 // Adapter that connects file search to Redux state.
 export default function SearchFilesReduxAdapter() {
   const { focusedSource } = useContext(SourcesContext);
   const { startLineIndex, sourceId } = focusedSource ?? {};
 
-  const sourcesById = useAppSelector(getSourceDetailsEntities);
   const dispatch = useAppDispatch();
 
   // When a user clicks on a search in the file-search panel, open it in Redux as well.
@@ -26,7 +24,7 @@ export default function SearchFilesReduxAdapter() {
         })
       );
     }
-  }, [dispatch, startLineIndex, sourceId, sourcesById]);
+  }, [dispatch, startLineIndex, sourceId]);
 
   return <SearchFiles />;
 }


### PR DESCRIPTION
This PR switches most places that were getting sources from redux to the suspense caches. Most of the remaining places are in `createSelector()` and `connect()` calls, where the switch is slightly more involved.
