### PR TITLE
Source search should display errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "reselect": "^4.1.5",
     "shared": "workspace:*",
     "slugify": "^1.6.5",
-    "suspense": "^0.0.45",
+    "suspense": "^0.0.47",
     "use-context-menu": "0.4.13"
   },
   "devDependencies": {

--- a/packages/replay-next/components/search-files/InlineResultsCount.module.css
+++ b/packages/replay-next/components/search-files/InlineResultsCount.module.css
@@ -9,6 +9,12 @@
   opacity: 0.5;
 }
 
+.ErrorIcon {
+  color: var(--color-error);
+  width: 1rem;
+  height: 1rem;
+}
+
 .SpinnerIcon {
   color: var(--color-dim);
   width: 1rem;

--- a/packages/replay-next/components/search-files/SearchFiles.module.css
+++ b/packages/replay-next/components/search-files/SearchFiles.module.css
@@ -36,6 +36,11 @@
 .InputWrapper:focus-within {
   border-color: var(--color-brand);
 }
+.InputWrapper[data-error],
+.InputWrapper[data-error]:focus-within {
+  background-color: var(--background-color-error);
+  border-color: var(--border-color-error);
+}
 
 .Icon {
   flex: 0 0 1.75rem;

--- a/packages/replay-next/components/search-files/SearchFiles.tsx
+++ b/packages/replay-next/components/search-files/SearchFiles.tsx
@@ -2,14 +2,18 @@ import {
   ChangeEvent,
   KeyboardEvent,
   Suspense,
+  startTransition,
+  useContext,
   useEffect,
   useRef,
   useState,
-  useTransition,
 } from "react";
+import { STATUS_REJECTED, useStreamingValue } from "suspense";
 
 import { Checkbox } from "design";
 import { useNag } from "replay-next/src/hooks/useNag";
+import { searchCache } from "replay-next/src/suspense/SearchCache";
+import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { Nag } from "shared/graphql/types";
 
 import Icon from "../Icon";
@@ -20,13 +24,20 @@ import styles from "./SearchFiles.module.css";
 export const SHOW_GLOBAL_SEARCH_EVENT_TYPE = "show-global-search";
 
 export default function SearchFiles({ limit }: { limit?: number }) {
+  const client = useContext(ReplayClientContext);
+
   const [includeNodeModules, setIncludeNodeModules] = useState(false);
   const [queryForDisplay, setQueryForDisplay] = useState("");
   const [queryForSuspense, setQueryForSuspense] = useState("");
-  const [isPending, startTransition] = useTransition();
   const [, dismissSearchSourceTextNag] = useNag(Nag.SEARCH_SOURCE_TEXT);
 
   const inputRef = useRef<HTMLInputElement>(null);
+
+  const streaming = searchCache.stream(client, queryForSuspense, includeNodeModules, limit);
+
+  const { status } = useStreamingValue(streaming);
+
+  const didError = status === STATUS_REJECTED;
 
   const onChange = (event: ChangeEvent<HTMLInputElement>) => {
     setQueryForDisplay(event.target.value);
@@ -61,7 +72,11 @@ export default function SearchFiles({ limit }: { limit?: number }) {
   return (
     <div className={styles.SearchFiles}>
       <div className={styles.Content}>
-        <div className={styles.InputWrapper} data-test-id="SearchFiles-SearchInput">
+        <div
+          className={styles.InputWrapper}
+          data-error={didError || undefined}
+          data-test-id="SearchFiles-SearchInput"
+        >
           <Icon className={styles.Icon} type="search" />
           <input
             autoFocus
@@ -75,12 +90,7 @@ export default function SearchFiles({ limit }: { limit?: number }) {
             value={queryForDisplay}
           />
           <Suspense>
-            <InlineResultsCount
-              includeNodeModules={includeNodeModules}
-              isPending={isPending}
-              limit={limit}
-              query={queryForSuspense}
-            />
+            <InlineResultsCount streaming={streaming} />
           </Suspense>
         </div>
 
@@ -94,12 +104,7 @@ export default function SearchFiles({ limit }: { limit?: number }) {
         </div>
 
         <Suspense>
-          <ResultsList
-            includeNodeModules={includeNodeModules}
-            isPending={isPending}
-            limit={limit}
-            query={queryForSuspense}
-          />
+          <ResultsList query={queryForSuspense} streaming={streaming} />
         </Suspense>
       </div>
     </div>

--- a/packages/replay-next/package.json
+++ b/packages/replay-next/package.json
@@ -25,7 +25,7 @@
     "react-dom": "0.0.0-experimental-e7d0053e6-20220325",
     "react-virtualized-auto-sizer": "^1.0.19",
     "shared": "workspace:*",
-    "suspense": "^0.0.45",
+    "suspense": "^0.0.47",
     "use-context-menu": "0.4.13",
     "uuid": "^7.0.3"
   },

--- a/packages/replay-next/src/suspense/SearchCache.ts
+++ b/packages/replay-next/src/suspense/SearchCache.ts
@@ -1,5 +1,5 @@
 import { Location, SearchSourceContentsMatch, SourceId } from "@replayio/protocol";
-import { Cache, createCache } from "suspense";
+import { StreamingCacheLoadOptions, StreamingValue, createStreamingCache } from "suspense";
 
 import { insert } from "replay-next/src/utils/array";
 import {
@@ -28,13 +28,12 @@ export type SourceSearchResultLocation = {
 export type SourceSearchResultMatch = { match: SearchSourceContentsMatch; type: "match" };
 export type SourceSearchResult = SourceSearchResultLocation | SourceSearchResultMatch;
 
-export type StreamingSourceSearchResults = {
-  complete: boolean;
+export type StreamingSourceMetadata = {
   didOverflow: boolean;
   fetchedCount: number;
-  orderedResults: SourceSearchResult[];
-  subscribe(subscriber: Subscriber): UnsubscribeFunction;
 };
+
+export type StreamingSearchValue = StreamingValue<SourceSearchResult[], StreamingSourceMetadata>;
 
 const MAX_SEARCH_RESULTS_TO_DISPLAY = 1_000;
 
@@ -53,55 +52,47 @@ export function isSourceSearchResultMatch(
   return result.type === "match";
 }
 
-export const searchCache: Cache<
+export const searchCache = createStreamingCache<
   [replayClient: ReplayClientInterface, query: string, includeNodeModules: boolean, limit?: number],
-  StreamingSourceSearchResults
-> = createCache({
-  config: { immutable: true },
-  debugLabel: "Search",
-  getKey: ([replayClient, query, includeNodeModules, limit = MAX_SEARCH_RESULTS_TO_DISPLAY]) =>
-    `${includeNodeModules}:${limit || "-"}:${query}`,
-  load: async ([
+  SourceSearchResult[],
+  StreamingSourceMetadata
+>({
+  debugLabel: "NetworkRequestsCache",
+  getKey: (replayClient, query, includeNodeModules, limit) =>
+    `${limit}-${includeNodeModules}-${query.trim()}`,
+  load: async (
+    options: StreamingCacheLoadOptions<SourceSearchResult[], StreamingSourceMetadata>,
     replayClient,
     query,
     includeNodeModules,
-    limit = MAX_SEARCH_RESULTS_TO_DISPLAY,
-  ]) => {
-    const subscribers: Set<Subscriber> = new Set();
+    limit = MAX_SEARCH_RESULTS_TO_DISPLAY
+  ) => {
+    const { reject, update, resolve } = options;
 
-    const orderedResults: SourceSearchResult[] = [];
+    query = query.trim();
 
-    const result: StreamingSourceSearchResults = {
-      complete: false,
+    const metadata: StreamingSourceMetadata = {
       didOverflow: false,
       fetchedCount: 0,
-      orderedResults,
-      subscribe: (subscriber: Subscriber) => {
-        subscribers.add(subscriber);
-        return () => {
-          subscribers.delete(subscriber);
-        };
-      },
     };
+    const orderedResults: SourceSearchResult[] = [];
 
-    if (sourceIdsWithNodeModules === null) {
-      await initializeSourceIds(replayClient);
+    if (query === "") {
+      update([], undefined, metadata);
+      resolve();
+      return;
     }
 
-    const sourceIds = includeNodeModules ? sourceIdsWithNodeModules! : sourceIdsWithoutNodeModules!;
-
-    const notifySubscribers = () => {
-      subscribers.forEach(subscriber => subscriber());
-    };
+    const sourceIds = await getSourceIds(replayClient, includeNodeModules);
 
     let currentResultLocation: SourceSearchResultLocation | null = null;
 
-    replayClient
-      .searchSources(
+    try {
+      await replayClient.searchSources(
         { limit, query, sourceIds },
         (matches: SearchSourceContentsMatch[], didOverflow: boolean) => {
-          result.didOverflow ||= didOverflow;
-          result.fetchedCount += matches.length;
+          metadata.didOverflow ||= didOverflow;
+          metadata.fetchedCount += matches.length;
 
           for (let index = 0; index < matches.length; index++) {
             const match = matches[index];
@@ -120,65 +111,67 @@ export const searchCache: Cache<
             orderedResults.push({ match, type: "match" });
           }
 
-          notifySubscribers();
+          update(orderedResults, undefined, metadata);
         }
-      )
-      .then(() => {
-        result.complete = true;
+      );
 
-        notifySubscribers();
-      });
-
-    return result;
+      resolve();
+    } catch (error) {
+      reject(error);
+    }
   },
 });
 
-async function initializeSourceIds(client: ReplayClientInterface) {
-  sourceIdsWithNodeModules = [];
-  sourceIdsWithoutNodeModules = [];
+async function getSourceIds(client: ReplayClientInterface, includeNodeModules: boolean) {
+  if (sourceIdsWithNodeModules == null || sourceIdsWithoutNodeModules == null) {
+    sourceIdsWithNodeModules = [];
+    sourceIdsWithoutNodeModules = [];
 
-  const sources = await sourcesByIdCache.readAsync(client);
+    const sources = await sourcesByIdCache.readAsync(client);
 
-  // Insert sources in order so that original sources are first.
-  const compareSources = (a: SourceId, b: SourceId) => {
-    const aIsOriginal = isSourceMappedSource(a, sources);
-    const bIsOriginal = isSourceMappedSource(b, sources);
-    if (aIsOriginal === bIsOriginal) {
-      return 0;
-    } else if (aIsOriginal) {
-      return -1;
-    } else {
-      return 1;
-    }
-  };
+    // Insert sources in order so that original sources are first.
+    const compareSources = (a: SourceId, b: SourceId) => {
+      const aIsOriginal = isSourceMappedSource(a, sources);
+      const bIsOriginal = isSourceMappedSource(b, sources);
+      if (aIsOriginal === bIsOriginal) {
+        return 0;
+      } else if (aIsOriginal) {
+        return -1;
+      } else {
+        return 1;
+      }
+    };
 
-  const minifiedSources = new Set<SourceId>();
-  sources.forEach(source => {
-    if (source.kind === "prettyPrinted" && source.generated.length) {
-      minifiedSources.add(source.generated[0]);
-    }
-  });
+    const minifiedSources = new Set<SourceId>();
+    sources.forEach(source => {
+      if (source.kind === "prettyPrinted" && source.generated.length) {
+        minifiedSources.add(source.generated[0]);
+      }
+    });
 
-  sources.forEach(source => {
-    const sourceId = source.sourceId;
+    sources.forEach(source => {
+      const sourceId = source.sourceId;
 
-    if (minifiedSources.has(sourceId)) {
-      return;
-    }
+      if (minifiedSources.has(sourceId)) {
+        return;
+      }
 
-    const correspondingSourceId = getCorrespondingSourceIds(sources, source.sourceId)[0];
-    if (correspondingSourceId !== sourceId) {
-      return;
-    }
+      const correspondingSourceId = getCorrespondingSourceIds(sources, source.sourceId)[0];
+      if (correspondingSourceId !== sourceId) {
+        return;
+      }
 
-    if (isBowerComponent(source)) {
-      return;
-    }
+      if (isBowerComponent(source)) {
+        return;
+      }
 
-    if (!isNodeModule(source) && !isModuleFromCdn(source)) {
-      insert(sourceIdsWithoutNodeModules!, sourceId, compareSources);
-    }
+      if (!isNodeModule(source) && !isModuleFromCdn(source)) {
+        insert(sourceIdsWithoutNodeModules!, sourceId, compareSources);
+      }
 
-    insert(sourceIdsWithNodeModules!, sourceId, compareSources);
-  });
+      insert(sourceIdsWithNodeModules!, sourceId, compareSources);
+    });
+  }
+
+  return includeNodeModules ? sourceIdsWithNodeModules! : sourceIdsWithoutNodeModules!;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15200,7 +15200,7 @@ __metadata:
     style-loader: ^3.3.1
     stylelint: ^14.16.0
     stylelint-config-prettier: ^9.0.5
-    suspense: ^0.0.45
+    suspense: ^0.0.47
     tailwindcss: ^3.2.4
     ts-node: ^10.7.0
     tsconfig-paths: ^3.14.1
@@ -15399,7 +15399,7 @@ __metadata:
     react-dom: 0.0.0-experimental-e7d0053e6-20220325
     react-virtualized-auto-sizer: ^1.0.19
     shared: "workspace:*"
-    suspense: ^0.0.45
+    suspense: ^0.0.47
     typescript: 5.0.2
     use-context-menu: 0.4.13
     uuid: ^7.0.3
@@ -16731,9 +16731,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"suspense@npm:^0.0.45":
-  version: 0.0.45
-  resolution: "suspense@npm:0.0.45"
+"suspense@npm:^0.0.47":
+  version: 0.0.47
+  resolution: "suspense@npm:0.0.47"
   dependencies:
     "@types/deep-equal": ^1.0.1
     array-sorting-utilities: ^0.0.1
@@ -16744,7 +16744,7 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: ec5997c6d0cf37d15f99103dee3ed8837c5e945738da494da7cda8ccba3bc076ad8892ad8f86029f43a7662bb352bb076a4be32098f060f98f32f279d3066fcc
+  checksum: d3bec377b5d3775779c60332b3313ecebf8ccf3eab7dc267ef2495bced55dc9bbfbf2561172b61d6a7c1777caf19e31c5c347234cbd35a9355c9981c9d3dfcaf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* Update `suspense@0.0.47` ([CHANGELOG](https://github.com/bvaughn/suspense/blob/main/packages/suspense/CHANGELOG.md)) to get streaming `error` value
* Update `searchCache` to use `createStreamingCache` API rather than the earlier approximation we were using
* Update search input and list UI to use the newer/better cache and not to swallow errors

### Successful search
![Kapture 2023-09-26 at 10 57 22](https://github.com/replayio/devtools/assets/29597/cecb3a8b-c4c6-46ec-b202-dce147ecd432)

### Failed search
![Kapture 2023-09-26 at 10 58 17](https://github.com/replayio/devtools/assets/29597/41577154-9468-4e8d-b08a-82061eae0622)

Note that a5709d15-1fd2-4bff-a46a-f8018fd0fd29 is a good test recording for this, as all searches fail for reasons unknown. Maybe it's failing because there are too many sources?