### PR TITLE
Load workspaces before showing the UploadScreen

### DIFF
--- a/pages/recording/upload.tsx
+++ b/pages/recording/upload.tsx
@@ -5,12 +5,14 @@ import { BlankViewportWrapper } from "ui/components/shared/Viewport";
 import UploadScreen from "ui/components/UploadScreen";
 import { useGetRecording, useGetRecordingId } from "ui/hooks/recordings";
 import { useGetUserSettings } from "ui/hooks/settings";
+import { useGetNonPendingWorkspaces } from "ui/hooks/workspaces";
 
 function UploadScreenWrapper({ onUpload }: { onUpload: () => void }) {
   const recordingId = useGetRecordingId();
   const { recording } = useGetRecording(recordingId);
-  // Make sure to get the user's settings before showing the upload screen.
+  // Make sure to get the user's settings and workspaces before showing the upload screen.
   const { userSettings, loading } = useGetUserSettings();
+  const { workspaces, loading: loading2 } = useGetNonPendingWorkspaces();
 
   useEffect(() => {
     if (recording?.isInitialized) {
@@ -21,9 +23,17 @@ function UploadScreenWrapper({ onUpload }: { onUpload: () => void }) {
   if (loading) {
     return <LoadingScreen message="Loading settings..." />;
   }
+  if (loading2) {
+    return <LoadingScreen message="Loading team info..." />;
+  }
 
   return recording ? (
-    <UploadScreen userSettings={userSettings} recording={recording} onUpload={onUpload} />
+    <UploadScreen
+      userSettings={userSettings}
+      workspaces={workspaces}
+      recording={recording}
+      onUpload={onUpload}
+    />
   ) : (
     <BlankViewportWrapper />
   );

--- a/pages/recording/upload.tsx
+++ b/pages/recording/upload.tsx
@@ -11,8 +11,8 @@ function UploadScreenWrapper({ onUpload }: { onUpload: () => void }) {
   const recordingId = useGetRecordingId();
   const { recording } = useGetRecording(recordingId);
   // Make sure to get the user's settings and workspaces before showing the upload screen.
-  const { userSettings, loading } = useGetUserSettings();
-  const { workspaces, loading: loading2 } = useGetNonPendingWorkspaces();
+  const { userSettings, loading: userSettingsLoading } = useGetUserSettings();
+  const { workspaces, loading: pendingWorkspacesLoading } = useGetNonPendingWorkspaces();
 
   useEffect(() => {
     if (recording?.isInitialized) {
@@ -20,11 +20,8 @@ function UploadScreenWrapper({ onUpload }: { onUpload: () => void }) {
     }
   });
 
-  if (loading) {
-    return <LoadingScreen message="Loading settings..." />;
-  }
-  if (loading2) {
-    return <LoadingScreen message="Loading team info..." />;
+  if (userSettingsLoading || pendingWorkspacesLoading) {
+    return <LoadingScreen message="Loading..." />;
   }
 
   return recording ? (

--- a/src/ui/components/UploadScreen/UploadScreen.tsx
+++ b/src/ui/components/UploadScreen/UploadScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 
-import { Recording, UserSettings } from "shared/graphql/types";
+import { Recording, UserSettings, Workspace } from "shared/graphql/types";
 import Modal from "ui/components/shared/NewModal";
 import hooks from "ui/hooks";
 import { useGetRecordingId } from "ui/hooks/recordings";
@@ -20,6 +20,7 @@ import { UploadRecordingTrialEnd } from "./UploadRecordingTrialEnd";
 
 type UploadScreenProps = {
   recording: Recording;
+  workspaces: Workspace[];
   userSettings: UserSettings;
   onUpload: () => void;
 };
@@ -108,11 +109,15 @@ function ReplayScreenshot({
   );
 }
 
-export default function UploadScreen({ recording, userSettings, onUpload }: UploadScreenProps) {
+export default function UploadScreen({
+  recording,
+  userSettings,
+  workspaces: allWorkspaces,
+  onUpload,
+}: UploadScreenProps) {
   const recordingId = useGetRecordingId();
   // This is pre-loaded in the parent component.
   const { screenData, loading: loading1 } = hooks.useGetRecordingPhoto(recordingId!);
-  const { workspaces: allWorkspaces, loading: loading2 } = hooks.useGetNonPendingWorkspaces();
 
   const workspaces = allWorkspaces.filter(workspace => workspace.isTest === recording.isTest);
 
@@ -174,9 +179,6 @@ export default function UploadScreen({ recording, userSettings, onUpload }: Uplo
 
   if (loading1) {
     return <LoadingScreen message="Loading recording metadata..." />;
-  }
-  if (loading2) {
-    return <LoadingScreen message="Loading team info..." />;
   }
 
   if (status === "deleted") {


### PR DESCRIPTION
We need to ensure workspaces are loaded before showing the `UploadScreen`, otherwise `selectedWorkspaceId` will be initialized to `MY_LIBRARY`.