### PR TITLE
Fix error handling in loadNodeSubTree/loadNodePathToRoot

### DIFF
--- a/packages/replay-next/components/elements/utils/loadNodePathToRoot.ts
+++ b/packages/replay-next/components/elements/utils/loadNodePathToRoot.ts
@@ -1,6 +1,6 @@
 import { ObjectId, PauseId } from "@replayio/protocol";
 
-import { elementCache } from "replay-next/components/elements/suspense/ElementCache";
+import { Element, elementCache } from "replay-next/components/elements/suspense/ElementCache";
 import { ReplayClientInterface } from "shared/client/types";
 
 export function loadNodePathToRoot(
@@ -17,14 +17,12 @@ export function loadNodePathToRoot(
   ) => {
     ids.unshift(id);
 
-    let element = await elementCache.readAsync(replayClient, pauseId, id);
-    if (element == null) {
-      try {
-        element = await elementCache.readAsync(replayClient, pauseId, id);
-      } catch (error) {
-        reject(error);
-        return;
-      }
+    let element: Element;
+    try {
+      element = await elementCache.readAsync(replayClient, pauseId, id);
+    } catch (error) {
+      reject(error);
+      return;
     }
 
     if (element.node.parentNode == null) {

--- a/packages/replay-next/components/elements/utils/loadNodeSubTree.ts
+++ b/packages/replay-next/components/elements/utils/loadNodeSubTree.ts
@@ -1,6 +1,6 @@
 import { ObjectId, PauseId } from "@replayio/protocol";
 
-import { elementCache } from "replay-next/components/elements/suspense/ElementCache";
+import { Element, elementCache } from "replay-next/components/elements/suspense/ElementCache";
 import { getDistanceFromRoot } from "replay-next/components/elements/utils/getDistanceFromRoot";
 import { ReplayClientInterface } from "shared/client/types";
 
@@ -27,14 +27,12 @@ export function loadNodeSubTree(
     // Also add before loading non-cached results to preserve the order of the tree
     loadedIds.add(id);
 
-    let element = await elementCache.readAsync(replayClient, pauseId, id);
-    if (element == null) {
-      try {
-        element = await elementCache.readAsync(replayClient, pauseId, id);
-      } catch (error) {
-        reject(error);
-        return;
-      }
+    let element: Element;
+    try {
+      element = await elementCache.readAsync(replayClient, pauseId, id);
+    } catch (error) {
+      reject(error);
+      return;
     }
 
     const childNodes = element.filteredChildNodeIds;


### PR DESCRIPTION
I noticed the failing unit tests for `ElementsListData` error handling.