### PR TITLE
Align Secondary Panel filter styles

### DIFF
--- a/packages/replay-next/components/elements/ElementsPanel.tsx
+++ b/packages/replay-next/components/elements/ElementsPanel.tsx
@@ -123,7 +123,7 @@ export function ElementsPanel({
             onKeyDown={onSearchInputKeyDown}
             placeholder="Search DOM"
             ref={searchInputRef}
-            type="search"
+            type="text"
             value={query}
           />
         </label>

--- a/src/ui/components/NetworkMonitor/TestFilterRow.module.css
+++ b/src/ui/components/NetworkMonitor/TestFilterRow.module.css
@@ -1,20 +1,26 @@
-.Panel {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  background-color: var(--body-bgcolor);
-}
-
-.SearchRow {
-  flex: 0 0 auto;
+.Row {
   display: flex;
   flex-direction: row;
   align-items: center;
   gap: 0.25rem;
   padding: 0.25rem;
-  border-bottom: 1px solid var(--theme-splitter-color);
+  background-color: var(--body-bgcolor);
+}
+
+.FilterButton {
+  flex: 0 0 1.25rem;
+  background: none;
+  border: none;
+  outline: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.FilterIcon,
+.SearchIcon {
+  width: 1rem;
+  height: 1rem;
 }
 
 .SearchIconAndInput {
@@ -34,36 +40,16 @@
   border-color: var(--color-brand);
 }
 
-.SearchIcon {
-  width: 1rem;
-  height: 1rem;
-  margin: 0.25rem;
-}
-
 .SearchInput {
   flex: 1;
   background: none;
   border: none;
   outline: none;
   padding: 0;
-  transition: 200ms opacity;
   font-size: var(--font-size-regular);
-}
-.SearchInput[data-search-in-progress] {
-  opacity: 0.5;
 }
 .SearchInput:focus {
   outline: none;
   border: none;
   box-shadow: none;
-}
-
-.SearchResults {
-  line-height: 1.5rem;
-  font-size: var(--font-size-small);
-}
-
-.ListRow {
-  flex: 1 1 auto;
-  padding-bottom: 0.25rem;
 }

--- a/src/ui/components/NetworkMonitor/TextFilterRow.tsx
+++ b/src/ui/components/NetworkMonitor/TextFilterRow.tsx
@@ -1,7 +1,7 @@
-import classNames from "classnames";
+import Icon from "replay-next/components/Icon";
 
-import MaterialIcon from "../shared/MaterialIcon";
 import { CanonicalRequestType } from "./utils";
+import styles from "./TestFilterRow.module.css";
 
 export function TextFilterRow({
   filterByText,
@@ -18,34 +18,26 @@ export function TextFilterRow({
 }) {
   return (
     <>
-      <div className="flex items-center bg-bodyBgcolor p-1 pl-0">
-        <div className={classNames("pl-1", showTypeFilters && "basis-32")}>
-          <button
-            onClick={() => setShowTypeFilters(!showTypeFilters)}
-            className={classNames("flex items-center", {
-              "mr-1": !showTypeFilters,
-              "text-primaryAccent hover:text-primaryAccentHover focus:text-primaryAccentHover":
-                types.size > 0,
-            })}
-            data-test-id="Network-ToggleFilterByTypePanelButton"
-            data-test-state={showTypeFilters ? "open" : "closed"}
-          >
-            <MaterialIcon iconSize="lg" outlined={true}>
-              filter_alt
-            </MaterialIcon>
-          </button>
-        </div>
-        <div className="flex flex-1 items-center rounded-md bg-themeTextFieldBgcolor p-1">
-          <MaterialIcon iconSize="lg">search</MaterialIcon>
+      <div className={styles.Row}>
+        <button
+          onClick={() => setShowTypeFilters(!showTypeFilters)}
+          className={styles.FilterButton}
+          data-test-id="Network-ToggleFilterByTypePanelButton"
+          data-test-state={showTypeFilters ? "open" : "closed"}
+        >
+          <Icon className={styles.FilterIcon} type="filter" />
+        </button>
+        <label className={styles.SearchIconAndInput}>
+          <Icon className={styles.SearchIcon} type="search" />
 
           <input
-            className="w-full bg-transparent px-1 text-themeTextFieldColor focus:outline-none"
+            className={styles.SearchInput}
             data-test-id="Network-TextFilterInput"
             onChange={event => setFilterByText(event.target.value)}
             placeholder="Filter requests"
             value={filterByText}
           />
-        </div>
+        </label>
       </div>
     </>
   );

--- a/src/ui/components/SecondaryToolbox/ReduxDevTools.module.css
+++ b/src/ui/components/SecondaryToolbox/ReduxDevTools.module.css
@@ -2,11 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
+.LeftPanel {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: auto;
+}
+
 .actions [role="list"] {
   list-style: none;
   margin: 0;
-  padding: 4px 0;
   overflow: auto;
+  overflow-x: hidden;
 }
 
 .actions [role="list"] [role="listitem"] {
@@ -51,6 +58,7 @@
   font-weight: normal;
   margin: 0;
   flex-grow: 1;
+  width: 100%;
   max-width: 100%;
   overflow: hidden;
   white-space: nowrap;
@@ -154,10 +162,6 @@
   overflow: initial;
 }
 
-.ActionFilter::before {
-  -webkit-mask-image: url(/_next/static/media/search.d93aff58.svg) !important;
-}
-
 .ResizeHandle {
   height: 0.75rem;
 }
@@ -165,4 +169,51 @@
   width: 100%;
   height: 1px;
   background-color: var(--theme-border);
+}
+
+.SearchRow {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem;
+  border-bottom: 1px solid var(--theme-splitter-color);
+}
+
+.SearchIconAndInput {
+  flex: 1 1 auto;
+  height: 1.25rem;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  font-size: var(--font-size-regular);
+  background-color: var(--background-color-inputs);
+  color: var(--color-default);
+  padding: 0 0.25rem 0 0;
+  border: 2px solid #0000;
+  border-radius: 0.25rem;
+}
+.SearchIconAndInput:focus-within {
+  border-color: var(--color-brand);
+}
+
+.SearchInput {
+  flex: 1;
+  background: none;
+  border: none;
+  outline: none;
+  padding: 0;
+  font-size: var(--font-size-regular);
+}
+.SearchInput:focus {
+  outline: none;
+  border: none;
+  box-shadow: none;
+}
+
+.SearchIcon {
+  width: 1rem;
+  height: 1rem;
+  margin: 0.25rem;
 }

--- a/src/ui/components/SecondaryToolbox/ReduxDevTools.tsx
+++ b/src/ui/components/SecondaryToolbox/ReduxDevTools.tsx
@@ -4,6 +4,7 @@ import React, { Suspense, useContext, useMemo, useState } from "react";
 import { PanelGroup, PanelResizeHandle, Panel as ResizablePanel } from "react-resizable-panels";
 import { useImperativeCacheValue } from "suspense";
 
+import Icon from "replay-next/components/Icon";
 import IndeterminateLoader from "replay-next/components/IndeterminateLoader";
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
 import { isExecutionPointsGreaterThan } from "replay-next/src/utils/time";
@@ -59,21 +60,23 @@ export const ReduxDevToolsPanel = () => {
     >
       <PanelGroup autoSaveId="ReduxDevTools" direction="horizontal">
         <ResizablePanel collapsible>
-          <ActionFilter searchValue={searchValue} onSearch={setSearchValue} />
-          <div role="list" className={styles.list}>
-            {annotationsStatus === "pending" ? (
-              <IndeterminateLoader />
-            ) : (
-              reduxAnnotations.map(annotation => (
-                <ActionItem
-                  key={annotation.point}
-                  annotation={annotation}
-                  selectedPoint={selectedPoint}
-                  setSelectedPoint={setSelectedPoint}
-                  firstAnnotationInTheFuture={firstAnnotationInTheFuture === annotation}
-                />
-              ))
-            )}
+          <div className={styles.LeftPanel}>
+            <ActionFilter searchValue={searchValue} onSearch={setSearchValue} />
+            <div role="list" className={styles.list}>
+              {annotationsStatus === "pending" ? (
+                <IndeterminateLoader />
+              ) : (
+                reduxAnnotations.map(annotation => (
+                  <ActionItem
+                    key={annotation.point}
+                    annotation={annotation}
+                    selectedPoint={selectedPoint}
+                    setSelectedPoint={setSelectedPoint}
+                    firstAnnotationInTheFuture={firstAnnotationInTheFuture === annotation}
+                  />
+                ))
+              )}
+            </div>
           </div>
         </ResizablePanel>
         <PanelResizeHandle className="h-full w-1 bg-chrome" />
@@ -97,24 +100,19 @@ function ActionFilter({
   onSearch: (value: string) => void;
 }) {
   return (
-    <div className="inspector devtools-toolbar devtools-input-toolbar">
-      <div
-        id="redux-search"
-        className={classnames(
-          "devtools-searchbox grow text-themeTextFieldColor",
-          styles.ActionFilter
-        )}
-      >
+    <div className={styles.SearchRow}>
+      <label className={styles.SearchIconAndInput} id="redux-search">
+        <Icon className={styles.SearchIcon} type="search" />
         <input
-          id="redux-searchbox"
-          className="devtools-searchinput"
-          type="input"
-          placeholder="Filter..."
           autoComplete="off"
-          value={searchValue}
+          className={styles.SearchInput}
+          id="redux-searchbox"
           onChange={e => onSearch(e.target.value)}
+          placeholder="Filter actions"
+          type="text"
+          value={searchValue}
         />
-      </div>
+      </label>
     </div>
   );
 }


### PR DESCRIPTION
We were very inconsistent before. Part of this is probably due to our mixing of styling approaches.

Now is a good time to fix this so the new React panel can align with this style as well.

### Before

| Unfocused | Focused |
| :--- | :--- |
| <img width="687" alt="Screen Shot 2023-09-27 at 12 42 26 PM" src="https://github.com/replayio/devtools/assets/29597/9dfb5b1f-939a-4225-949c-9ff2580c4170"> | <img width="685" alt="Screen Shot 2023-09-27 at 12 42 50 PM" src="https://github.com/replayio/devtools/assets/29597/1a90ce06-6d89-408c-abfc-b6f44d50d7fa"> |
| <img width="661" alt="Screen Shot 2023-09-27 at 1 06 25 PM" src="https://github.com/replayio/devtools/assets/29597/54401cb9-1ab3-4487-9f0b-5139d223f899"> | <img width="659" alt="Screen Shot 2023-09-27 at 1 06 36 PM" src="https://github.com/replayio/devtools/assets/29597/b1413744-1603-4d3e-b3c6-80bb4aa6cf82"> |
| <img width="660" alt="Screen Shot 2023-09-27 at 1 07 36 PM" src="https://github.com/replayio/devtools/assets/29597/b82f2b54-8bf5-43b6-bdcc-f20cc4c5b39d"> | <img width="660" alt="Screen Shot 2023-09-27 at 1 07 36 PM" src="https://github.com/replayio/devtools/assets/29597/b82f2b54-8bf5-43b6-bdcc-f20cc4c5b39d"> |
| <img width="660" alt="Screen Shot 2023-09-27 at 1 07 01 PM" src="https://github.com/replayio/devtools/assets/29597/3ee91284-68b5-4154-82f0-60e27cf6fc63"> | <img width="660" alt="Screen Shot 2023-09-27 at 1 07 05 PM" src="https://github.com/replayio/devtools/assets/29597/4e8f5f43-52df-43b6-b214-e0b8e044bced"> |

### After

| Unfocused | Focused |
| :--- | :--- |
| <img width="687" alt="Screen Shot 2023-09-27 at 12 42 26 PM" src="https://github.com/replayio/devtools/assets/29597/9dfb5b1f-939a-4225-949c-9ff2580c4170"> | <img width="685" alt="Screen Shot 2023-09-27 at 12 42 50 PM" src="https://github.com/replayio/devtools/assets/29597/1a90ce06-6d89-408c-abfc-b6f44d50d7fa"> |
| <img width="685" alt="Screen Shot 2023-09-27 at 12 42 35 PM" src="https://github.com/replayio/devtools/assets/29597/abb25536-4bb9-4c25-821a-3b1cba358b1a"> | <img width="687" alt="Screen Shot 2023-09-27 at 12 42 43 PM" src="https://github.com/replayio/devtools/assets/29597/c57b030c-43b1-4af4-a046-6834680241f5"> |
| <img width="687" alt="Screen Shot 2023-09-27 at 12 51 34 PM" src="https://github.com/replayio/devtools/assets/29597/3a5d3730-77f8-4cc6-a96c-002461af143e"> | <img width="686" alt="Screen Shot 2023-09-27 at 12 51 39 PM" src="https://github.com/replayio/devtools/assets/29597/b7dfa3ed-5a46-4323-98a6-b0f2ee351b52"> |
| <img width="685" alt="Screen Shot 2023-09-27 at 1 02 30 PM" src="https://github.com/replayio/devtools/assets/29597/0772be0b-b5c5-4062-84d0-5e5f6cbaf4f7"> | <img width="684" alt="Screen Shot 2023-09-27 at 1 02 36 PM" src="https://github.com/replayio/devtools/assets/29597/a9914ab1-4919-4bd7-95d7-4d6a2145618e"> |

---

cc @jonbell-lot23 