### PR TITLE
Add a Redux dispatch perf analysis panel

### DIFF
--- a/packages/replay-experimental/src/components/ReactReduxPanels.module.css
+++ b/packages/replay-experimental/src/components/ReactReduxPanels.module.css
@@ -47,3 +47,46 @@
 .eventRow:hover {
   background-color: var(--event-row-hover-background-color);
 }
+
+.Body {
+  flex: 1 1 auto;
+}
+
+.ResizeHandle {
+  height: 0.75rem;
+}
+.ResizeHandleBar {
+  width: 100%;
+  height: 1px;
+  background-color: var(--theme-border);
+}
+
+.DispatchDetailsPanel {
+  min-height: 1.75rem;
+}
+
+.DispatchDetailsHeader {
+  font-size: var(--font-size-large);
+  display: flex;
+  align-items: center;
+  gap: 1ch;
+  cursor: pointer;
+  padding: 0 0.75rem;
+}
+
+.DispatchDetailsContainer {
+  height: 100%;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: auto;
+  gap: 0.75rem;
+}
+
+.ListContainer {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  overflow: auto;
+}

--- a/packages/replay-experimental/src/components/ReactReduxPerfPanel.tsx
+++ b/packages/replay-experimental/src/components/ReactReduxPerfPanel.tsx
@@ -1,0 +1,412 @@
+import { ExecutionPoint, TimeStampedPoint } from "@replayio/protocol";
+import classnames from "classnames";
+import { CSSProperties, ReactNode, Suspense, useContext, useMemo, useRef, useState } from "react";
+import {
+  ImperativePanelHandle,
+  PanelGroup,
+  PanelResizeHandle,
+  Panel as ResizablePanel,
+} from "react-resizable-panels";
+import AutoSizer from "react-virtualized-auto-sizer";
+import { FixedSizeList as List } from "react-window";
+import { ContextMenuItem, useContextMenu } from "use-context-menu";
+
+import AccessibleImage from "devtools/client/debugger/src/components/shared/AccessibleImage";
+import { getExecutionPoint } from "devtools/client/debugger/src/reducers/pause";
+import { jumpToTimeAndLocationForQueuedRender } from "replay-experimental/src/components/ReactPanel";
+import { reactRendersIntervalCache } from "replay-experimental/src/suspense/reactInternalsCaches";
+import {
+  ReduxDispatchDetailsEntry,
+  reduxDispatchesCache,
+} from "replay-experimental/src/suspense/reduxInternalsCaches";
+import Icon from "replay-next/components/Icon";
+import IndeterminateLoader from "replay-next/components/IndeterminateLoader";
+import { FocusContext } from "replay-next/src/contexts/FocusContext";
+import { isExecutionPointsGreaterThan } from "replay-next/src/utils/time";
+import { ReplayClientContext } from "shared/client/ReplayClientContext";
+import { requestFocusWindow } from "ui/actions/timeline";
+import { seek } from "ui/actions/timeline";
+import { JumpToCodeButton, JumpToCodeStatus } from "ui/components/shared/JumpToCodeButton";
+import { getCurrentTime } from "ui/reducers/timeline";
+import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
+import { formattedPointStackCache } from "ui/suspense/frameCache";
+
+import cardsListStyles from "ui/components/Comments/CommentCardsList.module.css";
+import eventStyles from "ui/components/Events/Event.module.css";
+import panelStyles from "./ReactReduxPanels.module.css";
+
+const Label = ({ children }: { children: ReactNode }) => (
+  <div className="overflow-hidden overflow-ellipsis whitespace-pre font-normal">{children}</div>
+);
+
+interface ReduxDispatchItemData {
+  currentTime: number;
+  executionPoint: string;
+  onSeek: (point: string, time: number) => void;
+  onEntrySelected: (point: ExecutionPoint) => void;
+  entries: ReduxDispatchDetailsEntry[];
+}
+
+function ReduxDispatchListItem({
+  data,
+  index,
+  style,
+}: {
+  data: ReduxDispatchItemData;
+  index: number;
+  style: CSSProperties;
+}) {
+  const dispatch = useAppDispatch();
+  const replayClient = useContext(ReplayClientContext);
+  const dispatchDetails = data.entries[index];
+  const { executionPoint, onSeek, currentTime, onEntrySelected } = data;
+  const { actionType, dispatchStart } = dispatchDetails;
+  const isPaused = dispatchStart.time === currentTime && executionPoint === dispatchStart.point;
+  const [jumpToCodeStatus] = useState<JumpToCodeStatus>("not_checked");
+
+  const onClickJumpToCode = async () => {
+    const formattedPointStack = await formattedPointStackCache.readAsync(
+      replayClient,
+      dispatchStart
+    );
+
+    dispatch(
+      jumpToTimeAndLocationForQueuedRender(
+        dispatchStart,
+        formattedPointStack?.frame?.executionLocation,
+        "timeAndLocation",
+        onSeek
+      )
+    );
+  };
+
+  return (
+    <div style={style}>
+      <div
+        className={classnames(eventStyles.eventRow, "group block w-full", {
+          "text-lightGrey": currentTime < dispatchStart.time,
+          "font-semibold text-primaryAccent": isPaused,
+        })}
+        onClick={() => onEntrySelected(dispatchStart.point)}
+      >
+        <div className="flex flex-row items-center space-x-2 overflow-hidden">
+          <AccessibleImage className="redux" />
+          <Label>{actionType}</Label>
+        </div>
+        <div className="flex space-x-2 opacity-0 group-hover:opacity-100">
+          {
+            <JumpToCodeButton
+              onClick={onClickJumpToCode}
+              status={jumpToCodeStatus}
+              currentExecutionPoint={executionPoint}
+              targetExecutionPoint={dispatchStart.point}
+            />
+          }
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ReactReduxPerfPanelSuspends() {
+  const dispatch = useAppDispatch();
+  const currentTime = useAppSelector(getCurrentTime);
+  const executionPoint = useAppSelector(getExecutionPoint);
+  const { range: focusRange } = useContext(FocusContext);
+  const replayClient = useContext(ReplayClientContext);
+  const [selectedPoint, setSelectedPoint] = useState<ExecutionPoint | null>(null);
+
+  const detailsPanelRef = useRef<ImperativePanelHandle>(null);
+
+  const [detailsPanelCollapsed, setDetailsPanelCollapsed] = useState(false);
+
+  const toggleDetailsPanel = () => {
+    const panel = detailsPanelRef.current;
+    if (panel) {
+      const collapsed = panel.getCollapsed();
+      if (collapsed) {
+        panel.expand();
+      } else {
+        panel.collapse();
+      }
+    }
+  };
+
+  const reduxDispatchEntries = reduxDispatchesCache.read(
+    BigInt(focusRange!.begin.point),
+    BigInt(focusRange!.end.point),
+    replayClient
+  );
+
+  const itemData: ReduxDispatchItemData = useMemo(() => {
+    const onSeek = (executionPoint: string, time: number) => {
+      dispatch(seek({ executionPoint, time }));
+    };
+
+    return {
+      executionPoint: executionPoint!,
+      currentTime,
+      entries: reduxDispatchEntries,
+      onSeek,
+      onEntrySelected: (point: ExecutionPoint) => {
+        setSelectedPoint(point);
+        const panel = detailsPanelRef.current;
+        if (panel) {
+          const collapsed = panel.getCollapsed();
+          if (collapsed) {
+            panel.expand();
+          }
+        }
+      },
+    };
+  }, [reduxDispatchEntries, dispatch, currentTime, executionPoint]);
+
+  const selectedEntry = reduxDispatchEntries.find(
+    entry => entry.dispatchStart.point === selectedPoint
+  );
+
+  return (
+    <PanelGroup autoSaveId="TestRecordingPanel" direction="vertical">
+      <ResizablePanel className={panelStyles.DispatchDetails} collapsible>
+        <div className={panelStyles.ListContainer}>
+          <AutoSizer disableWidth>
+            {({ height }: { height: number }) => {
+              return (
+                <List
+                  children={ReduxDispatchListItem}
+                  height={height}
+                  itemCount={itemData.entries.length}
+                  itemData={itemData}
+                  itemSize={30}
+                  width="100%"
+                />
+              );
+            }}
+          </AutoSizer>
+        </div>
+      </ResizablePanel>
+      <PanelResizeHandle className={panelStyles.ResizeHandle}>
+        <div className={panelStyles.ResizeHandleBar} />
+      </PanelResizeHandle>
+      <ResizablePanel
+        className={panelStyles.DispatchDetailsPanel}
+        collapsible
+        defaultSize={35}
+        minSize={35}
+        onCollapse={collapsed => setDetailsPanelCollapsed(collapsed)}
+        ref={detailsPanelRef}
+      >
+        <div className={panelStyles.DispatchDetailsContainer}>
+          <div className={panelStyles.DispatchDetailsHeader} onClick={toggleDetailsPanel}>
+            <CollapseExpandArrow collapsed={detailsPanelCollapsed} /> Details
+          </div>
+          {selectedEntry ? <SelectedReduxDispatchDetails entry={selectedEntry} /> : null}
+        </div>
+      </ResizablePanel>
+    </PanelGroup>
+  );
+}
+
+// TODO This should be a shared component;
+// we use this style in a bunch of places.
+function CollapseExpandArrow({ collapsed }: { collapsed: boolean }) {
+  return <div className={`img arrow ${collapsed ? "" : "expanded"}`} />;
+}
+
+interface RDDEntryProps {
+  entry: ReduxDispatchDetailsEntry;
+}
+
+function ReactRenderQueuedSuspends({ entry }: RDDEntryProps) {
+  const replayClient = useContext(ReplayClientContext);
+
+  const { afterReducer, afterNotifications } = entry;
+
+  const queuedRenders = reactRendersIntervalCache.read(
+    BigInt(afterReducer.point),
+    BigInt(afterNotifications.point),
+    replayClient
+  );
+
+  return <b>{queuedRenders.length > 0 ? queuedRenders.length : "None"}</b>;
+}
+
+function ReactRenderDetailsSuspends({ entry }: RDDEntryProps) {
+  const replayClient = useContext(ReplayClientContext);
+  const { range: focusRange } = useContext(FocusContext);
+
+  const { contextMenu: renderStartContextMenu, onContextMenu: onRenderStartContextMenu } =
+    useDispatchContextMenu(entry.dispatchStart);
+  const { contextMenu: renderCommitContextMenu, onContextMenu: onRenderEndContextMenu } =
+    useDispatchContextMenu(entry.afterNotifications);
+
+  const allRenderDataInRange = reactRendersIntervalCache.read(
+    BigInt(focusRange!.begin.point),
+    BigInt(focusRange!.end.point),
+    replayClient
+  );
+
+  // TODO Looking for the next render after the dispatch is a horrible heuristic,
+  // but we'll go with it for now to prove the concept.
+  const nextRender = allRenderDataInRange.findIndex(
+    r =>
+      r.type === "sync_started" &&
+      isExecutionPointsGreaterThan(r.point.point, entry.afterNotifications.point)
+  );
+
+  if (nextRender === -1) {
+    console.log("No potential render found", entry.afterNotifications, allRenderDataInRange);
+    return <i>None</i>;
+  }
+
+  const nextRenderStart = allRenderDataInRange[nextRender];
+  const nextRenderCommitted = allRenderDataInRange[nextRender + 1];
+  const isValidRenderPair =
+    nextRenderStart.type === "sync_started" && nextRenderCommitted.type === "render_committed";
+  if (!isValidRenderPair) {
+    console.log(
+      "No valid render pair found",
+      entry.afterNotifications,
+      nextRender,
+      nextRenderStart,
+      nextRenderCommitted,
+      allRenderDataInRange
+    );
+    return <i>None</i>;
+  }
+
+  return (
+    <ul className="ml-2 list-inside list-disc">
+      <li>
+        Time:{" "}
+        <span onContextMenu={onRenderStartContextMenu}>
+          {formatTimeMs(nextRenderStart.point.time)}
+        </span>{" "}
+        🡒{" "}
+        <span onContextMenu={onRenderEndContextMenu}>
+          {formatTimeMs(nextRenderCommitted.point.time)}
+        </span>
+      </li>
+      <li>Duration: {formatTimeMs(nextRenderCommitted.point.time - nextRenderStart.point.time)}</li>
+      {renderStartContextMenu}
+      {renderCommitContextMenu}
+    </ul>
+  );
+}
+
+const formatTimeMs = (time: number) => {
+  return `${time.toFixed(1)}ms`;
+};
+
+function useDispatchContextMenu(point: TimeStampedPoint) {
+  const dispatch = useAppDispatch();
+
+  const setFocusEnd = () => {
+    dispatch(
+      requestFocusWindow({
+        end: point,
+      })
+    );
+  };
+
+  const setFocusStart = () => {
+    dispatch(
+      requestFocusWindow({
+        begin: point,
+      })
+    );
+  };
+
+  return useContextMenu(
+    <>
+      <ContextMenuItem dataTestId="ConsoleContextMenu-SetFocusStartButton" onSelect={setFocusStart}>
+        <>
+          <Icon type="set-focus-start" />
+          Set focus start
+        </>
+      </ContextMenuItem>
+      <ContextMenuItem dataTestId="ConsoleContextMenu-SetFocusEndButton" onSelect={setFocusEnd}>
+        <>
+          <Icon type="set-focus-end" />
+          Set focus end
+        </>
+      </ContextMenuItem>
+    </>
+  );
+}
+
+function SelectedReduxDispatchDetails({ entry }: RDDEntryProps) {
+  const { contextMenu: dispatchStartContextMenu, onContextMenu: onDispatchStartContextMenu } =
+    useDispatchContextMenu(entry.dispatchStart);
+  const { contextMenu: dispatchEndContextMenu, onContextMenu: onDispatchEndContextMenu } =
+    useDispatchContextMenu(entry.afterNotifications);
+
+  return (
+    <div style={{ minHeight: 200 }}>
+      <b>{entry.actionType}</b>
+      <ul className="ml-2 list-inside list-disc">
+        <li>
+          Time:{" "}
+          <span onContextMenu={onDispatchStartContextMenu}>
+            {formatTimeMs(entry.dispatchStart.time)}
+          </span>{" "}
+          🡒{" "}
+          <span onContextMenu={onDispatchEndContextMenu}>
+            {formatTimeMs(entry.afterNotifications.time)}
+          </span>
+        </li>
+        <li>
+          Durations:
+          <ul className="ml-2 list-inside  list-disc">
+            <li>Reducer: {formatTimeMs(entry.reducerDuration)}</li>
+            <li>Subscribers: {formatTimeMs(entry.notificationDuration)}</li>
+            <li>Total: {formatTimeMs(entry.afterNotifications.time - entry.dispatchStart.time)}</li>
+          </ul>
+        </li>
+        <li>
+          Component renders queued:{" "}
+          <Suspense fallback={<i>Loading...</i>}>
+            <ReactRenderQueuedSuspends entry={entry} key={entry.dispatchStart.point} />
+          </Suspense>
+        </li>
+        <li>
+          Probable render details:{" "}
+          <Suspense fallback={<i>Loading...</i>}>
+            <ReactRenderDetailsSuspends entry={entry} key={entry.dispatchStart.point} />
+          </Suspense>
+        </li>
+      </ul>
+      {dispatchStartContextMenu}
+      {dispatchEndContextMenu}
+    </div>
+  );
+}
+
+export function ReactReduxPerfPanel() {
+  const { range: focusRange } = useContext(FocusContext);
+  const allSourcesReceived = useAppSelector(state => state.sources.allSourcesReceived);
+  if (!focusRange?.begin) {
+    return <div>No focus range</div>;
+  } else if (!allSourcesReceived) {
+    return <div>Loading sources...</div>;
+  }
+
+  return (
+    <div className={cardsListStyles.Sidebar}>
+      <div className={cardsListStyles.Toolbar}>
+        <div className={cardsListStyles.ToolbarHeader}>Redux Dispatch Perf</div>
+      </div>
+      <div style={{ flexGrow: 2 }}>
+        <Suspense
+          fallback={
+            <div style={{ flexShrink: 1 }}>
+              <IndeterminateLoader />
+            </div>
+          }
+        >
+          <ReactReduxPerfPanelSuspends />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/packages/replay-experimental/src/suspense/reduxInternalsCaches.ts
+++ b/packages/replay-experimental/src/suspense/reduxInternalsCaches.ts
@@ -1,0 +1,249 @@
+import {
+  FunctionMatch,
+  FunctionOutline,
+  Location,
+  PointDescription,
+  RunEvaluationResult,
+} from "@replayio/protocol";
+import chunk from "lodash/chunk";
+import zip from "lodash/zip";
+import { Cache, createCache } from "suspense";
+
+import { breakpointPositionsCache } from "replay-next/src/suspense/BreakpointPositionsCache";
+import { createFocusIntervalCacheForExecutionPoints } from "replay-next/src/suspense/FocusIntervalCache";
+import { hitPointsCache } from "replay-next/src/suspense/HitPointsCache";
+import { sourceOutlineCache } from "replay-next/src/suspense/SourceOutlineCache";
+import { Source, sourcesByIdCache } from "replay-next/src/suspense/SourcesCache";
+import { streamingSourceContentsCache } from "replay-next/src/suspense/SourcesCache";
+import { getPreferredLocation as getPreferredLocationNext } from "replay-next/src/utils/sources";
+import { ReplayClientInterface } from "shared/client/types";
+import { findFunctionOutlineForLocation } from "ui/actions/eventListeners/jumpToCode";
+
+export interface ReduxDispatchLocations {
+  dispatch: FunctionOutline;
+  reduxSource: Source;
+  breakpoints: {
+    dispatchStart: Location;
+    beforeReducer: Location;
+    reducerDone: Location;
+    dispatchDone: Location;
+  };
+}
+
+export const reduxDispatchFunctionCache: Cache<
+  [replayClient: ReplayClientInterface, rangeStart: string, rangeEnd: string],
+  ReduxDispatchLocations | undefined
+> = createCache({
+  debugLabel: "ReduxDispatchFunction",
+  async load([replayClient, rangeStart, rangeEnd]) {
+    // TODO This relies on having a reasonably sourcemapped version of Redux.
+    // This won't work otherwise.
+    // There's some stupid tricks we could pull to find this in minified sources,
+    // like looking for the `ActionTypes.REPLACE` variable
+    const sourcesById = await sourcesByIdCache.readAsync(replayClient);
+    const reduxSources = Array.from(sourcesById.values()).filter(source =>
+      source.url?.includes("/redux/")
+    );
+
+    const dispatchMatches: FunctionMatch[] = [];
+    await replayClient.searchFunctions(
+      { query: "dispatch", sourceIds: reduxSources.map(source => source.id) },
+      matches => {
+        dispatchMatches.push(...matches);
+      }
+    );
+
+    const [firstMatch] = dispatchMatches;
+    if (!firstMatch) {
+      return;
+    }
+
+    const preferredLocation = getPreferredLocationNext(sourcesById, [], [firstMatch.loc]);
+    const reduxSource = sourcesById.get(preferredLocation.sourceId)!;
+    const fileOutline = await sourceOutlineCache.readAsync(replayClient, reduxSource.id);
+
+    const dispatchFunctions = fileOutline.functions.filter(o => o.name === "dispatch");
+    const createStoreFunction = fileOutline.functions.find(o => o.name === "createStore")!;
+    const realDispatchFunction = dispatchFunctions.find(f => {
+      return (
+        f.location.begin.line >= createStoreFunction.location.begin.line &&
+        f.location.end.line < createStoreFunction.location.end.line
+      );
+    })!;
+
+    if (!realDispatchFunction) {
+      return;
+    }
+
+    const [breakablePositions, breakablePositionsByLine] = await breakpointPositionsCache.readAsync(
+      replayClient,
+      reduxSource.id
+    );
+
+    const streaming = streamingSourceContentsCache.stream(replayClient, reduxSource!.id);
+    await streaming.resolver;
+    const reduxSourceLines = streaming.value!.split("\n");
+    const beforeReducerLine =
+      reduxSourceLines.findIndex(line => line.includes("isDispatching = true")) + 1;
+    const reducerDoneLine =
+      reduxSourceLines.findIndex(line => line.includes("currentListeners = nextListeners")) + 1;
+    const dispatchDoneLine = reduxSourceLines.findIndex(line => line.includes("return action")) + 1;
+
+    const [beforeReducer, reducerDone, dispatchDone]: Location[] = [
+      beforeReducerLine,
+      reducerDoneLine,
+      dispatchDoneLine,
+    ].map(line => {
+      return {
+        sourceId: reduxSource.id,
+        line,
+        column: breakablePositionsByLine.get(line)!.columns[0],
+      };
+    });
+
+    const dispatchStart: Location = {
+      ...realDispatchFunction.breakpointLocation!,
+      sourceId: reduxSource.id,
+    };
+
+    return {
+      dispatch: realDispatchFunction,
+      reduxSource,
+      breakpoints: {
+        dispatchStart,
+        beforeReducer,
+        reducerDone,
+        dispatchDone,
+      },
+    };
+  },
+});
+
+export interface ReduxDispatchDetailsEntry {
+  actionType: string;
+  dispatchStart: PointDescription;
+  beforeReducer: PointDescription;
+  afterReducer: PointDescription;
+  afterNotifications: PointDescription;
+  reducerDuration: number;
+  notificationDuration: number;
+}
+
+export const reduxDispatchesCache = createFocusIntervalCacheForExecutionPoints<
+  [replayClient: ReplayClientInterface],
+  ReduxDispatchDetailsEntry
+>({
+  debugLabel: "RecordedProtocolMessages",
+  getPointForValue: data => data.dispatchStart.point,
+  async load(rangeStart, rangeEnd, replayClient) {
+    const dispatchFunctionDetails = await reduxDispatchFunctionCache.readAsync(
+      replayClient,
+      rangeStart,
+      rangeEnd
+    );
+
+    if (!dispatchFunctionDetails) {
+      return [];
+    }
+
+    const { dispatch, reduxSource, breakpoints } = dispatchFunctionDetails;
+
+    const sourcesById = await sourcesByIdCache.readAsync(replayClient);
+
+    const dispatchLocations = [
+      { ...dispatch.breakpointLocation!, sourceId: reduxSource.id },
+      breakpoints.beforeReducer,
+      breakpoints.reducerDone,
+      breakpoints.dispatchDone,
+    ];
+
+    const [reduxDispatchHits, beforeReducerHits, reducerDoneHits, dispatchDoneHits] =
+      await Promise.all(
+        dispatchLocations.map(location => {
+          return hitPointsCache.readAsync(
+            BigInt(rangeStart),
+            BigInt(rangeEnd),
+            replayClient,
+            location,
+            null
+          );
+        })
+      );
+
+    if (!reduxDispatchHits.length) {
+      return [];
+    }
+
+    const [firstHit] = reduxDispatchHits;
+    const frames = firstHit.frame ?? [];
+
+    const possibleParamNames = await Promise.all(
+      frames.map(async frame => {
+        const sourceOutline = await sourceOutlineCache.readAsync(replayClient, frame.sourceId);
+        const functionOutline = findFunctionOutlineForLocation(frame, sourceOutline);
+        return functionOutline?.parameters[0];
+      })
+    );
+
+    const paramName = possibleParamNames.find(name => name !== "action") ?? "action";
+
+    const results: RunEvaluationResult[] = [];
+
+    const chunkedReduxDispatchHits = chunk(reduxDispatchHits, 190);
+    await Promise.all(
+      chunkedReduxDispatchHits.map(async points => {
+        await replayClient.runEvaluation(
+          {
+            selector: {
+              kind: "points",
+              points: points.map(annotation => annotation.point),
+            },
+            expression: `${paramName}.type`,
+            // Run in top frame.
+            frameIndex: 0,
+            shareProcesses: true,
+            fullPropertyPreview: true,
+          },
+          result => {
+            results.push(...result);
+          }
+        );
+      })
+    );
+
+    const actionTypes: string[] = results.map(result => {
+      return result.returned!.value;
+    });
+
+    const maxItems = Math.min(
+      reduxDispatchHits.length,
+      beforeReducerHits.length,
+      reducerDoneHits.length,
+      dispatchDoneHits.length,
+      actionTypes.length
+    );
+
+    const dispatchDetails = zip(
+      reduxDispatchHits.slice(0, maxItems),
+      beforeReducerHits.slice(0, maxItems),
+      reducerDoneHits.slice(0, maxItems),
+      dispatchDoneHits.slice(0, maxItems),
+      actionTypes.slice(0, maxItems)
+    ).map(([dispatchStart, beforeReducer, afterReducer, afterNotifications, actionType]) => {
+      const beforeReducerTime = beforeReducer?.time ?? 0;
+      const afterReducerTime: number = afterReducer?.time ?? 0;
+      const afterNotificationsTime = afterNotifications?.time ?? 0;
+      return {
+        actionType: actionType!,
+        dispatchStart: dispatchStart!,
+        beforeReducer: beforeReducer!,
+        afterReducer: afterReducer!,
+        afterNotifications: afterNotifications!,
+        reducerDuration: afterReducerTime - beforeReducerTime,
+        notificationDuration: afterNotificationsTime - afterReducerTime,
+      };
+    });
+
+    return dispatchDetails;
+  },
+});

--- a/packages/shared/user-data/GraphQL/config.ts
+++ b/packages/shared/user-data/GraphQL/config.ts
@@ -180,8 +180,8 @@ export const config = {
   },
   feature_reactPanel: {
     defaultValue: Boolean(false),
-    description: "Enable experimental React render details panel",
-    label: "Enable React Panel",
+    description: "Enable experimental React render details and Redux dispatch perf panels",
+    label: "Enable React and Redux Panels",
     legacyKey: "devtools.features.reactPanel",
   },
   feature_reduxDevTools: {

--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -4,6 +4,7 @@ import PrimaryPanes from "devtools/client/debugger/src/components/PrimaryPanes";
 import SecondaryPanes from "devtools/client/debugger/src/components/SecondaryPanes";
 import Accordion from "devtools/client/debugger/src/components/shared/Accordion";
 import { ReactPanel } from "replay-experimental/src/components/ReactPanel";
+import { ReactReduxPerfPanel } from "replay-experimental/src/components/ReactReduxPerfPanel";
 import LazyOffscreen from "replay-next/components/LazyOffscreen";
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
 import { isExecutionPointsWithinRange } from "replay-next/src/utils/time";
@@ -179,7 +180,8 @@ export default function SidePanel() {
         {selectedPrimaryPanel === "cypress" && <TestSuitePanel />}
         {selectedPrimaryPanel === "protocol" && <ProtocolViewer />}
         {selectedPrimaryPanel === "search" && <SearchFilesReduxAdapter />}
-        {selectedPrimaryPanel === "react" && <ReactPanel />}
+        {selectedPrimaryPanel === "react" && <ReactPanel />} 
+        {selectedPrimaryPanel === "react-redux-perf" && <ReactReduxPerfPanel />}
       </div>
     </div>
   );

--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -180,7 +180,7 @@ export default function SidePanel() {
         {selectedPrimaryPanel === "cypress" && <TestSuitePanel />}
         {selectedPrimaryPanel === "protocol" && <ProtocolViewer />}
         {selectedPrimaryPanel === "search" && <SearchFilesReduxAdapter />}
-        {selectedPrimaryPanel === "react" && <ReactPanel />} 
+        {selectedPrimaryPanel === "react" && <ReactPanel />}
         {selectedPrimaryPanel === "react-redux-perf" && <ReactReduxPerfPanel />}
       </div>
     </div>

--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -248,6 +248,23 @@ function ReactIcon() {
   );
 }
 
+function ReduxIcon() {
+  return (
+    <div style={{ display: "flex", justifyContent: "center", alignItems: "center" }}>
+      <svg
+        width="20"
+        height="20"
+        viewBox="0 0 15 15"
+        xmlns="http://www.w3.org/2000/svg"
+        className="h-full w-full"
+        fill="currentColor"
+      >
+        <path d="M10.7 10.28a1 1 0 0 0-.1-2h-.04a1 1 0 0 0-.68 1.7 6.37 6.37 0 0 1-2.92 2.8c-.94.5-1.92.67-2.9.55-.8-.1-1.43-.46-1.82-1.05a2.62 2.62 0 0 1-.14-2.76 4.2 4.2 0 0 1 1.2-1.43 9.61 9.61 0 0 1-.22-.9C.49 9.04.76 11.58 1.54 12.77c.6.89 1.78 1.44 3.1 1.44.36 0 .72-.04 1.07-.13 2.28-.44 4.01-1.8 4.99-3.8zM13.84 8.07A7.23 7.23 0 0 0 8.2 5.61h-.29a.98.98 0 0 0-.87-.53H7a1 1 0 0 0 .04 2h.03a1 1 0 0 0 .88-.61h.32c1.35 0 2.63.4 3.8 1.16.88.59 1.52 1.35 1.88 2.28.3.75.29 1.48-.03 2.1a2.62 2.62 0 0 1-2.45 1.46c-.7 0-1.39-.21-1.74-.37-.2.17-.55.46-.8.64a5.5 5.5 0 0 0 2.3.55c1.7 0 2.97-.94 3.45-1.89.52-1.03.48-2.81-.85-4.33zM4.79 10.58a1 1 0 0 0 1 .97h.03a1 1 0 0 0-.04-2h-.03c-.04 0-.1 0-.13.02A6.53 6.53 0 0 1 4.7 5.6c.07-1.06.42-2 1.05-2.76a3.09 3.09 0 0 1 2.19-1c1.89-.03 2.69 2.32 2.74 3.27.23.05.63.17.9.26C11.35 2.5 9.57 1 7.86 1 6.27 1 4.79 2.16 4.2 3.87a7.29 7.29 0 0 0 .71 6.2.8.8 0 0 0-.12.51z" />
+      </svg>
+    </div>
+  );
+}
+
 function ToolbarButtonTab({ active }: { active: boolean }) {
   return (
     <div
@@ -332,6 +349,10 @@ function ToolbarButton({
 
     case "react": {
       iconContents = <ReactIcon />;
+      break;
+    }
+    case "redux": {
+      iconContents = <ReduxIcon />;
       break;
     }
     default:
@@ -490,6 +511,14 @@ export default function Toolbar() {
             />
             {reactPanelExperimentEnabled && (
               <ToolbarButton icon="react" name="react" label="React" onClick={handleButtonClick} />
+            )}
+            {reactPanelExperimentEnabled && (
+              <ToolbarButton
+                icon="redux"
+                name="react-redux-perf"
+                label="React+Redux Perf"
+                onClick={handleButtonClick}
+              />
             )}
           </>
         ) : null}

--- a/src/ui/state/layout.ts
+++ b/src/ui/state/layout.ts
@@ -19,6 +19,7 @@ export type PrimaryPanelName =
   | "protocol"
   | "search"
   | "react"
+  | "react-redux-perf"
   | ViewerPrimaryPanelName;
 export type SecondaryPanelName =
   | "console"


### PR DESCRIPTION
This PR:

- Is stacked on top of #9775 , and also supersedes #9410
- Adds a new "Redux Dispatch Perf" experimental panel and associated logic
  - Adds caches that find the location of the Redux `dispatch` method and calls to `dispatch`.  (This heavily overlaps with the existing Redux DevTools panel, but works even if there are no annotations or Redux DevTools integration.  It _does_ rely on sourcemaps having a `node_modules/redux/redux.js`-type file available)
  - Adds caches that fetch hits for specific lines of code within the Redux dispatch method, and uses those to calculate durations for the reducer execution and subscriber notifications
  - Renders a virtual list of Redux dispatch entries
  - Allows selecting a dispatch entry and showing further details in a bottom panel
- The details panel shows:
  - timing breakdowns for the dispatch
  - estimates for how many components we think were queued to re-render by the dispatch, based on calls to `scheduleUpdateOnFiber` during the subscriber notifications
  - Tries to find a React render that occurred right after the dispatch, and if found, estimates its duration

![image](https://github.com/replayio/devtools/assets/1128784/61db3cbf-3887-4e93-9c6a-b6a5ff484adc)


### Future Work

There's a lot of things I've proved that I _can_ do that are not in the current version of this PR:

- Finding all Redux selectors used in an app
- Counting how many selectors got called during a set of subscriber notifications, and calculating their durations
- Showing the red "you are here" line in the list