### PR TITLE
Fix filtering network events for tests

### DIFF
--- a/packages/e2e-tests/tests/cypress-01_basic-panel.test.ts
+++ b/packages/e2e-tests/tests/cypress-01_basic-panel.test.ts
@@ -25,7 +25,6 @@ test.use({ exampleKey: "flake/adding-spec.ts" });
 
 test("cypress-01: Basic Test Suites panel functionality", async ({
   pageWithMeta: { page, recordingId },
-  exampleKey,
 }) => {
   await startTest(page, recordingId);
   await openDevToolsTab(page);
@@ -98,7 +97,7 @@ test("cypress-01: Basic Test Suites panel functionality", async ({
   expect(await sections.nth(0).textContent()).toMatch(/test body/i);
 
   const steps = getTestCaseSteps(selectedRow);
-  await expect(steps).toHaveCount(17);
+  await expect(steps).toHaveCount(20);
 
   const backButton = getTestRecordingBackButton(page);
   await backButton.click();

--- a/packages/e2e-tests/tests/cypress-03_test-step-interactions.test.ts
+++ b/packages/e2e-tests/tests/cypress-03_test-step-interactions.test.ts
@@ -16,10 +16,7 @@ import test, { expect } from "../testFixtureCloneRecording";
 
 test.use({ exampleKey: "flake/adding-spec.ts" });
 
-test("cypress-03: Test Step interactions", async ({
-  pageWithMeta: { page, recordingId },
-  exampleKey,
-}) => {
+test("cypress-03: Test Step interactions", async ({ pageWithMeta: { page, recordingId } }) => {
   await startTest(page, recordingId);
   await openViewerTab(page);
 
@@ -48,7 +45,7 @@ test("cypress-03: Test Step interactions", async ({
 
   const steps = getTestCaseSteps(selectedRow);
   const numSteps = await steps.count();
-  expect(numSteps).toBe(17);
+  expect(numSteps).toBe(20);
 
   // We should be in Viewer Mode to start with
   expect(await isViewerTabActive(page)).toBe(true);
@@ -63,7 +60,10 @@ test("cypress-03: Test Step interactions", async ({
   // Clicking in viewer mode shouldn't switch to DevTools mode
   expect(await isViewerTabActive(page)).toBe(true);
 
-  const firstGet = clickableSteps.filter({ hasText: /get/ }).first();
+  const firstGet = clickableSteps
+    .and(page.locator("[data-type='user-action']"))
+    .filter({ hasText: /get/ })
+    .first();
 
   // Jump to the first `get` step
   await firstGet.click();

--- a/packages/replay-next/src/utils/array.test.ts
+++ b/packages/replay-next/src/utils/array.test.ts
@@ -1,4 +1,4 @@
-import { findIndex, findIndexBigInt, findIndexString, insert, insertString, slice } from "./array";
+import { findIndex, findIndexBigInt, findIndexString, insert, insertString } from "./array";
 
 describe("array utils", () => {
   describe("findIndex", () => {
@@ -87,42 +87,6 @@ describe("array utils", () => {
       expect(findIndexBigInt(bigints, "5000000000000000000000000000000000", false)).toBe(2);
       expect(findIndexBigInt(bigints, "13000000000000000000000000000000000", false)).toBe(4);
       expect(findIndexBigInt(bigints, "25000000000000000000000000000000000", false)).toBe(4);
-    });
-  });
-
-  describe("slice", () => {
-    const compare = (a: number, b: number) => {
-      return a - b;
-    };
-
-    it("should handle empty arrays", () => {
-      expect(slice([], 0, 5, compare)).toEqual([]);
-    });
-
-    it("should handle arrays with no values in range", () => {
-      expect(slice([1], 5, 7, compare)).toEqual([]);
-      expect(slice([9], 5, 7, compare)).toEqual([]);
-      expect(slice([1, 2], 5, 7, compare)).toEqual([]);
-      expect(slice([8, 9], 5, 7, compare)).toEqual([]);
-      expect(slice([1, 2, 3], 5, 7, compare)).toEqual([]);
-      expect(slice([7, 8, 9], 5, 6, compare)).toEqual([]);
-    });
-
-    it("should handle arrays with all values in range", () => {
-      expect(slice([4], 1, 10, compare)).toEqual([4]);
-      expect(slice([4, 6], 1, 10, compare)).toEqual([4, 6]);
-      expect(slice([4, 6, 7], 1, 10, compare)).toEqual([4, 6, 7]);
-    });
-
-    it("should handle arrays with partial values in range", () => {
-      expect(slice([1, 2], 0, 1, compare)).toEqual([1]);
-      expect(slice([4, 5], 5, 7, compare)).toEqual([5]);
-      expect(slice([1, 2, 3], 0, 1, compare)).toEqual([1]);
-      expect(slice([3, 4, 5], 5, 8, compare)).toEqual([5]);
-      expect(slice([1, 2, 3, 4, 5, 6, 7, 8, 9], 0, 3, compare)).toEqual([1, 2, 3]);
-      expect(slice([1, 2, 3, 4, 5, 6, 7, 8, 9], 5, 6, compare)).toEqual([5, 6]);
-      expect(slice([1, 2, 3, 4, 5, 6, 7, 8, 9], 5, 5, compare)).toEqual([5]);
-      expect(slice([1, 2, 3, 4, 5, 6, 7, 8, 9], 8, 15, compare)).toEqual([8, 9]);
     });
   });
 

--- a/packages/replay-next/src/utils/array.ts
+++ b/packages/replay-next/src/utils/array.ts
@@ -1,5 +1,4 @@
 type ComparisonFunction<T> = (a: T, b: T) => number;
-type SliceCompareFunction<ItemType, TargetType> = (item: ItemType, target: TargetType) => number;
 
 function compareBigInt(a: string, b: string): number {
   const difference = BigInt(a) - BigInt(b);
@@ -109,92 +108,6 @@ export function findInsertIndex<T>(
   return lowIndex;
 }
 
-export function findSliceIndices<ItemType, TargetType>(
-  sortedItems: ItemType[],
-  beginTarget: TargetType,
-  endTarget: TargetType,
-  compareFunction: SliceCompareFunction<ItemType, TargetType>
-): [beginIndex: number, endIndex: number] {
-  let beginIndex = -1;
-  let endIndex = -1;
-
-  let lowIndex = 0;
-  let highIndex = sortedItems.length - 1;
-
-  while (lowIndex <= highIndex) {
-    const middleIndex = (lowIndex + highIndex) >>> 1;
-    const currentItem = sortedItems[middleIndex];
-    const value = compareFunction(currentItem, beginTarget);
-    if (value === 0) {
-      beginIndex = middleIndex;
-      break;
-    } else if (value > 0) {
-      if (middleIndex - 1 > lowIndex) {
-        highIndex = middleIndex - 1;
-      } else {
-        const peekItem = sortedItems[lowIndex];
-        const peekValue = compareFunction(peekItem, beginTarget);
-        if (peekValue >= 0) {
-          beginIndex = lowIndex;
-        }
-        break;
-      }
-    } else {
-      if (middleIndex + 1 < highIndex) {
-        lowIndex = middleIndex + 1;
-      } else {
-        const peekItem = sortedItems[highIndex];
-        const peekValue = compareFunction(peekItem, beginTarget);
-        if (peekValue >= 0) {
-          beginIndex = highIndex;
-        }
-        break;
-      }
-    }
-  }
-
-  if (beginIndex < 0) {
-    return [-1, -1];
-  }
-
-  lowIndex = beginIndex;
-  highIndex = sortedItems.length - 1;
-
-  while (lowIndex <= highIndex) {
-    const middleIndex = (lowIndex + highIndex) >>> 1;
-    const currentItem = sortedItems[middleIndex];
-    const value = compareFunction(currentItem, endTarget);
-    if (value === 0) {
-      endIndex = middleIndex;
-      break;
-    } else if (value > 0) {
-      if (middleIndex - 1 > lowIndex) {
-        highIndex = middleIndex - 1;
-      } else {
-        const peekItem = sortedItems[lowIndex];
-        const peekValue = compareFunction(peekItem, endTarget);
-        if (peekValue <= 0) {
-          endIndex = lowIndex;
-        }
-        break;
-      }
-    } else {
-      if (middleIndex + 1 < highIndex) {
-        lowIndex = middleIndex + 1;
-      } else {
-        const peekItem = sortedItems[highIndex];
-        const peekValue = compareFunction(peekItem, endTarget);
-        if (peekValue <= 0) {
-          endIndex = highIndex;
-        }
-        break;
-      }
-    }
-  }
-
-  return [beginIndex, endIndex];
-}
-
 export function insert<T>(
   sortedItems: T[],
   item: T,
@@ -209,24 +122,4 @@ export function insert<T>(
 
 export function insertString(sortedItems: string[], item: string): string[] {
   return insert<string>(sortedItems, item, (a, b) => a.localeCompare(b));
-}
-
-export function slice<ItemType, TargetType>(
-  sortedItems: ItemType[],
-  beginTarget: TargetType,
-  endTarget: TargetType,
-  compareFunction: SliceCompareFunction<ItemType, TargetType>
-): ItemType[] {
-  const [beginIndex, endIndex] = findSliceIndices(
-    sortedItems,
-    beginTarget,
-    endTarget,
-    compareFunction
-  );
-
-  if (beginIndex < 0 || endIndex < 0) {
-    return [];
-  }
-
-  return sortedItems.slice(beginIndex, endIndex + 1);
 }


### PR DESCRIPTION
The `findSliceIndices()` util didn't work correctly so I replaced it with our `binarySearch()` util.