### PR TITLE
Sort test steps by step:start instead of step:enqueue

### DIFF
--- a/packages/shared/test-suites/RecordingTestMetadata.ts
+++ b/packages/shared/test-suites/RecordingTestMetadata.ts
@@ -1006,8 +1006,8 @@ export function getTestEventExecutionPoint(
   if (isNavigationTestEvent(testEvent) || isNetworkRequestTestEvent(testEvent)) {
     return testEvent.timeStampedPoint.point;
   } else {
-    return testEvent.timeStampedPointRange !== null
-      ? testEvent.timeStampedPointRange.begin.point
+    return testEvent.data.timeStampedPoints.beforeStep !== null
+      ? testEvent.data.timeStampedPoints.beforeStep.point
       : null;
   }
 }


### PR DESCRIPTION
This is just an ad-hoc fix to demonstrate another issue where we need to use `step:start` instead of `step:enqueue`. Not meant to be merged.
See [FE-1957](https://linear.app/replay/issue/FE-1957/stepstart-vs-stepenqueue-annotations).