### PR TITLE
Auto-accept invites to workspaces when opening a recording

### DIFF
--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -18,7 +18,7 @@ import { userData } from "shared/user-data/GraphQL/UserData";
 import { getPausePointParams, isTest } from "shared/utils/environment";
 import { UIThunkAction } from "ui/actions";
 import * as actions from "ui/actions/app";
-import { getRecording } from "ui/hooks/recordings";
+import { getRecording, maybeAcceptInviteAndGetRecording } from "ui/hooks/recordings";
 import { getUserId, getUserInfo } from "ui/hooks/users";
 import {
   clearExpectedError,
@@ -60,7 +60,11 @@ export function getAccessibleRecording(
 ): UIThunkAction<Promise<Recording | null>> {
   return async dispatch => {
     try {
-      const [recording, userId] = await Promise.all([getRecording(recordingId), getUserId()]);
+      let [recording, userId] = await Promise.all([
+        maybeAcceptInviteAndGetRecording(recordingId),
+        getUserId(),
+      ]);
+
       if (!recording || recording.isInitialized) {
         const expectedError = getRecordingNotAccessibleError(recording, userId);
         if (expectedError) {


### PR DESCRIPTION
## Issue

Our customers have somewhat frequently encountered the issue of believing they do not have access to their team because they first visit app.replay.io to accept an invite before opening a replay (e.g. from a link in their issue tracking system).

## Resolution

Adds a new method, `mayAcceptInviteAndGetRecording`, which tries to get the recording and, if it fails, tries to join the workspace and then get the recording again.