### PR TITLE
Update `breakpoints-01` example recording ID to (temporarily) fix missing E2E tests

### DIFF
--- a/packages/e2e-tests/examples.json
+++ b/packages/e2e-tests/examples.json
@@ -43,7 +43,7 @@
   "doc_minified_chromium.html": "e2c18571-db82-4d52-b4f5-0fc8b63a202f",
   "cypress-realworld/bankaccounts.spec.js": "6d4abbe1-2fcb-47d9-92d5-f7b45760b01a",
   "flake/adding-spec.ts": "7b0db00a-d9a9-4d2d-b816-af14a1b682a6",
-  "breakpoints-01": "f5fa8af9-70a4-4c9c-811f-1388b62c0b15",
+  "breakpoints-01": "08072870-2ecc-41bb-bb6d-98ab838c5bbe",
   "redux/dist/index.html": "72ffbc74-ea61-492f-af66-cb8302b89c8d",
   "React Hook Form/conditionalField.cy.ts": "122c4fe7-8a58-4c5c-9639-16b35b5f2ef1",
   "redux-fundamentals/dist/index.html": "76c9a8db-5e05-40c1-89e6-70053248041e"

--- a/packages/e2e-tests/testFixtureCloneRecording.ts
+++ b/packages/e2e-tests/testFixtureCloneRecording.ts
@@ -1,4 +1,6 @@
 import { Page, test as base } from "@playwright/test";
+import type { AxiosError } from "axios";
+import axios from "axios";
 
 import { TestRecordingKey } from "./helpers";
 import { cloneTestRecording, deleteTestRecording } from "./helpers/utils";
@@ -28,7 +30,14 @@ const testWithCloneRecording = base.extend<TestIsolatedRecordingFixture>({
         recordingId: newRecordingId,
       });
     } catch (err: any) {
-      console.error(err);
+      if (axios.isAxiosError(err)) {
+        console.error("Axios error cloning recording: ", {
+          errors: err.response?.data?.errors,
+          details: err.toJSON(),
+        });
+      } else {
+        console.error("Error cloning recording: ", err);
+      }
       throw err;
     } finally {
       if (newRecordingId) {


### PR DESCRIPTION
This PR:

- Updates our `breakpoints-01` example recording to a fresh ID to fix the immediate issue of dependent E2E tests not running
- updates the `rdt-02` test to match changed component counts in the new `breakpoints-01` recording, and improves the debug logging for that test
- Improves the error logging for Axios errors when an error is thrown when cloning (just error details, without dozens of internal Axios req/res fields)

I'll try to follow up with a script we can run to move targeted test recordings to a new workspace via GraphQL, so that we can avoid the retention problems.