### PR TITLE
Add move-recordings script and update breakpoints-01 example again

### DIFF
--- a/packages/e2e-tests/examples.json
+++ b/packages/e2e-tests/examples.json
@@ -43,7 +43,7 @@
   "doc_minified_chromium.html": "e2c18571-db82-4d52-b4f5-0fc8b63a202f",
   "cypress-realworld/bankaccounts.spec.js": "6d4abbe1-2fcb-47d9-92d5-f7b45760b01a",
   "flake/adding-spec.ts": "7b0db00a-d9a9-4d2d-b816-af14a1b682a6",
-  "breakpoints-01": "08072870-2ecc-41bb-bb6d-98ab838c5bbe",
+  "breakpoints-01": "c8debea5-3270-4728-8f08-2252855897cc",
   "redux/dist/index.html": "72ffbc74-ea61-492f-af66-cb8302b89c8d",
   "React Hook Form/conditionalField.cy.ts": "122c4fe7-8a58-4c5c-9639-16b35b5f2ef1",
   "redux-fundamentals/dist/index.html": "76c9a8db-5e05-40c1-89e6-70053248041e"

--- a/packages/e2e-tests/scripts/move-recording-workspace.ts
+++ b/packages/e2e-tests/scripts/move-recording-workspace.ts
@@ -1,0 +1,99 @@
+import util from "util";
+import axios from "axios";
+import yargs from "yargs";
+
+import { UpdateRecordingWorkspaceVariables } from "../../shared/graphql/generated/UpdateRecordingWorkspace";
+import config from "../config";
+
+const argv = yargs
+  .option("apiKey", {
+    alias: "a",
+    description:
+      "API key for a user with access to the target workspace (_not_ a workspace API key!)",
+    type: "string",
+  })
+  .option("recordingId", {
+    alias: "r",
+    description: "Recording ID to move",
+    type: "string",
+  })
+  .option("workspaceId", {
+    alias: "w",
+    description:
+      "Workspace ID to move this recording to. This should be a Base64-encoded ID as shown in our URLs",
+    type: "string",
+  })
+  .help()
+  .alias("help", "h")
+  .parseSync();
+
+function logError(e: any, variables: any) {
+  if (e.response) {
+    console.log("GraphQL request failed. Parameters:");
+    console.log(JSON.stringify(variables, undefined, 2));
+    console.log("Response");
+    console.log(JSON.stringify(e.response.data, undefined, 2));
+  }
+
+  throw e.message;
+}
+
+async function moveRecordingWorkspace(apiKey: string, recordingId: string, workspaceId: string) {
+  const variables: UpdateRecordingWorkspaceVariables = {
+    recordingId,
+    workspaceId,
+  };
+
+  console.log("Moving recording to new workspace: ", {
+    apiKey,
+    recordingId,
+    workspaceId,
+  });
+
+  try {
+    const res = await axios({
+      url: config.graphqlUrl,
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+      data: {
+        query: `
+          mutation UpdateRecordingWorkspace($recordingId: ID!, $workspaceId: ID) {
+            updateRecordingWorkspace(input: { id: $recordingId, workspaceId: $workspaceId }) {
+              success
+              recording {
+                uuid
+                workspace {
+                  id
+                }
+              }
+            }
+          }
+        `,
+        variables,
+      },
+    });
+    console.log("Move results: ", util.inspect(res.data, { depth: Infinity }));
+  } catch (err) {
+    logError(err, variables);
+    throw err;
+  }
+}
+
+(async () => {
+  try {
+    if (!argv.apiKey || !argv.recordingId || !argv.workspaceId) {
+      console.error("Need to provide an API key, recording ID, and workspace ID");
+      process.exit(1);
+    }
+
+    await moveRecordingWorkspace(argv.apiKey, argv.recordingId, argv.workspaceId);
+
+    process.exit(0);
+  } catch (error) {
+    console.error("Unexpected error: ", error);
+
+    process.exit(1);
+  }
+})();

--- a/packages/e2e-tests/tsconfig.json
+++ b/packages/e2e-tests/tsconfig.json
@@ -5,6 +5,6 @@
     "downlevelIteration": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "types": ["cypress"]
+    "types": ["cypress", "node"]
   }
 }


### PR DESCRIPTION
This PR:

- Adds a new CLI script that moves a recording to a different workspace on command, via GraphQL
- Bumps the `breakpoints-01` example again to one that I've moved into the separate "FE Test Golden Recordings" workspace via that script