### PR TITLE
File search dims results that weren't executed

### DIFF
--- a/packages/e2e-tests/authenticated/passport-03.test.ts
+++ b/packages/e2e-tests/authenticated/passport-03.test.ts
@@ -35,7 +35,7 @@ test(`authenticated/passport-03: Swiss army knife`, async ({
   );
 
   await page.locator('[data-test-name="ToolbarButton-Search"]').click();
-  const searchInput = page.locator('[data-test-id="SearchFiles-Input"]');
+  const searchInput = page.locator('[data-test-id="FileSearch-Input"]');
   await searchInput.focus();
   await clearTextArea(page, searchInput);
   await searchInput.fill("iteration");

--- a/packages/e2e-tests/tests/file-search-01.test.ts
+++ b/packages/e2e-tests/tests/file-search-01.test.ts
@@ -1,0 +1,52 @@
+import { openDevToolsTab, startTest } from "../helpers";
+import {
+  openFileSearchPanel,
+  searchSources,
+  toggleIncludeNodeModulesCheckbox,
+  toggleSearchResultsForFileName,
+  verifyMatchExecuted,
+  verifySourceSearchOverflowMessageShown,
+  verifySourceSearchSummary,
+  verifyVisibleResultsCount,
+} from "../helpers/file-search";
+import test from "../testFixtureCloneRecording";
+
+test.use({ exampleKey: "cra/dist/index.html" });
+
+test("file-search-01: should search files", async ({ pageWithMeta: { page, recordingId } }) => {
+  await startTest(page, recordingId);
+  await openDevToolsTab(page);
+  await openFileSearchPanel(page);
+
+  // Verify search results for the string "test"
+  await searchSources(page, "test");
+  await verifySourceSearchOverflowMessageShown(page, false);
+  await verifySourceSearchSummary(page, "21 results");
+  await verifyVisibleResultsCount(page, 25); // 21 results in 4 different files
+
+  // Verify files can be collapsed
+  await toggleSearchResultsForFileName(page, false, { fileName: "jsonp%20chunk%20loading" });
+  await toggleSearchResultsForFileName(page, false, { fileName: "load%20script" });
+  await verifyVisibleResultsCount(page, 22);
+
+  // Verify files can be re-expanded
+  await toggleSearchResultsForFileName(page, true, { fileName: "jsonp%20chunk%20loading" });
+  await verifyVisibleResultsCount(page, 24);
+
+  // Now include node_modules in the search
+  await toggleIncludeNodeModulesCheckbox(page, true);
+  await verifySourceSearchOverflowMessageShown(page, false);
+  await verifySourceSearchSummary(page, "25 results");
+  await verifyVisibleResultsCount(page, 31); // 25 results in 6 different files
+
+  // Collapse the first few results
+  await toggleSearchResultsForFileName(page, false, { fileName: "unsupportedIterableToArray.js" });
+  await toggleSearchResultsForFileName(page, false, { fileName: "jsonp%20chunk%20loading" });
+  await toggleSearchResultsForFileName(page, false, { fileName: "load%20script" });
+  await toggleSearchResultsForFileName(page, false, { fileName: "react-dom.production.min.js" });
+  await toggleSearchResultsForFileName(page, false, { fileName: "main.eb199253.js" });
+
+  // Verify result 7 was executed but result 8 was not
+  await verifyMatchExecuted(page, 7, true);
+  await verifyMatchExecuted(page, 8, false);
+});

--- a/packages/replay-next/components/search-files/FileSearchListData.ts
+++ b/packages/replay-next/components/search-files/FileSearchListData.ts
@@ -1,0 +1,82 @@
+import assert from "assert";
+
+import { GenericListData } from "replay-next/components/windowing/GenericListData";
+import {
+  SourceSearchResult,
+  assertSourceSearchResultLocation,
+} from "replay-next/src/suspense/SearchCache";
+
+export type Item = {
+  isCollapsed: boolean;
+  result: SourceSearchResult;
+};
+
+export class FileSearchListData extends GenericListData<Item> {
+  private collapsedResultIndexToCountMap: Map<number, number> = new Map();
+  private collapsedRowCount: number = 0;
+  private orderedResults: SourceSearchResult[];
+
+  constructor(orderedResults: SourceSearchResult[]) {
+    super();
+
+    this.orderedResults = orderedResults;
+  }
+
+  resultsUpdated() {
+    this.collapsedResultIndexToCountMap.clear();
+    this.collapsedRowCount = 0;
+    this.invalidate();
+  }
+
+  toggleCollapsed(index: number, collapsed: boolean) {
+    const { result } = this.getItemAtIndexImplementation(index);
+
+    assertSourceSearchResultLocation(result);
+
+    const resultIndex = this.orderedResults.indexOf(result);
+    const prevCollapsed = this.collapsedResultIndexToCountMap.has(resultIndex);
+    if (prevCollapsed === collapsed) {
+      return;
+    }
+
+    if (collapsed) {
+      this.collapsedResultIndexToCountMap.set(resultIndex, result.matchCount);
+      this.collapsedRowCount += result.matchCount;
+    } else {
+      this.collapsedResultIndexToCountMap.delete(resultIndex);
+      this.collapsedRowCount -= result.matchCount;
+    }
+
+    this.invalidate();
+  }
+
+  protected getItemAtIndexImplementation(index: number): Item {
+    let resultIndex = -1;
+    let totalCollapsedRowCount = 0;
+
+    for (resultIndex = 0; resultIndex < this.orderedResults.length; resultIndex++) {
+      if (resultIndex - totalCollapsedRowCount === index) {
+        break;
+      }
+
+      // Skip over collapsed rows
+      const collapsedRowCount = this.collapsedResultIndexToCountMap.get(resultIndex);
+      if (collapsedRowCount != null) {
+        totalCollapsedRowCount += collapsedRowCount;
+        resultIndex += collapsedRowCount;
+      }
+    }
+
+    const result = this.orderedResults[resultIndex];
+    assert(result, `No result found at index ${index}`);
+
+    return {
+      isCollapsed: this.collapsedResultIndexToCountMap.has(resultIndex),
+      result,
+    };
+  }
+
+  protected getItemCountImplementation(): number {
+    return this.orderedResults.length - this.collapsedRowCount;
+  }
+}

--- a/packages/replay-next/components/search-files/HighlightMatch.module.css
+++ b/packages/replay-next/components/search-files/HighlightMatch.module.css
@@ -1,6 +1,6 @@
 .Match {
   background-color: var(--background-color-source-search);
   border-bottom: 1px solid var(--border-color-source-search);
-  color: var(--color-default);
+  color: inherit;
   font-weight: bold;
 }

--- a/packages/replay-next/components/search-files/ResultsList.tsx
+++ b/packages/replay-next/components/search-files/ResultsList.tsx
@@ -1,37 +1,19 @@
-import {
-  CSSProperties,
-  useCallback,
-  useContext,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useContext, useEffect, useMemo } from "react";
 import AutoSizer from "react-virtualized-auto-sizer";
-import { FixedSizeList as List } from "react-window";
 import { STATUS_PENDING, STATUS_RESOLVED, useStreamingValue } from "suspense";
 
 import Icon from "replay-next/components/Icon";
-import {
-  SourceSearchResult,
-  StreamingSearchValue,
-  isSourceSearchResultLocation,
-} from "replay-next/src/suspense/SearchCache";
+import { FileSearchListData, Item } from "replay-next/components/search-files/FileSearchListData";
+import { GenericList } from "replay-next/components/windowing/GenericList";
+import { SourceSearchResult, StreamingSearchValue } from "replay-next/src/suspense/SearchCache";
 import { sourcesCache } from "replay-next/src/suspense/SourcesCache";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
 import type { ItemData } from "./ResultsListRow";
-import ResultsListRow from "./ResultsListRow";
+import ResultsListRow, { ITEM_SIZE } from "./ResultsListRow";
 import styles from "./ResultsList.module.css";
 
 const EMPTY_ARRAY = [] as SourceSearchResult[];
-
-const ROW_HEIGHT = 18;
-
-type CollapsedState = {
-  collapsedResultIndices: Set<number>;
-  collapsedRowCount: number;
-};
 
 export default function ResultsList({
   query,
@@ -42,143 +24,28 @@ export default function ResultsList({
 }) {
   const replayClient = useContext(ReplayClientContext);
 
-  const [{ collapsedResultIndices, collapsedRowCount }, setCollapsedState] =
-    useState<CollapsedState>({
-      collapsedResultIndices: new Set(),
-      collapsedRowCount: 0,
-    });
-
-  const listRef = useRef<List>(null);
-
-  const { data, status, value } = useStreamingValue(streaming);
+  const { data, status, value: orderedResults = EMPTY_ARRAY } = useStreamingValue(streaming);
 
   const isPending = status === STATUS_PENDING;
 
   const sources = sourcesCache.read(replayClient);
 
-  const orderedResults = value ?? EMPTY_ARRAY;
   const didOverflow = data?.didOverflow ?? false;
 
-  useLayoutEffect(() => {
-    const list = listRef.current;
-    if (list !== null) {
-      // Reset the scroll position when a new query is run.
-      list.scrollToItem(0);
-    }
+  const listData = useMemo(() => new FileSearchListData(orderedResults), [orderedResults]);
 
-    // Reset collapsed state when query changes.
-    setCollapsedState({
-      collapsedResultIndices: new Set(),
-      collapsedRowCount: 0,
-    });
-  }, [streaming]);
-
-  const getResultIndexFromRowIndex = useCallback(
-    (rowIndex: number) => {
-      let hiddenRowCount = 0;
-      for (let loopIndex = 0; loopIndex < orderedResults.length; loopIndex++) {
-        const resultIndex = loopIndex + hiddenRowCount;
-        if (loopIndex === rowIndex) {
-          return resultIndex;
-        }
-
-        // If this is a collapsed location, skip over the hidden matches
-        const result = orderedResults[resultIndex];
-        if (result == null) {
-          console.error(`Unexpected null result at index ${resultIndex}`);
-        }
-        if (isSourceSearchResultLocation(result)) {
-          const isCollapsed = collapsedResultIndices.has(resultIndex);
-          if (isCollapsed) {
-            hiddenRowCount += result.matchCount;
-          }
-        }
-      }
-
-      return null;
-    },
-    [collapsedResultIndices, orderedResults]
-  );
-
-  const getResultAtIndex = useCallback(
-    (rowIndex: number) => {
-      const resultIndex = getResultIndexFromRowIndex(rowIndex);
-      if (resultIndex !== null) {
-        return orderedResults[resultIndex] || null;
-      }
-
-      return null;
-    },
-    [getResultIndexFromRowIndex, orderedResults]
-  );
-
-  const isLocationCollapsed = useCallback(
-    (rowIndex: number) => {
-      const resultIndex = getResultIndexFromRowIndex(rowIndex);
-      if (resultIndex !== null) {
-        const result = orderedResults[resultIndex] || null;
-        if (result != null && isSourceSearchResultLocation(result)) {
-          return collapsedResultIndices.has(resultIndex);
-        }
-      }
-
-      return false;
-    },
-    [collapsedResultIndices, getResultIndexFromRowIndex, orderedResults]
-  );
-
-  const toggleLocation = useCallback(
-    (rowIndex: number, isOpen: boolean) => {
-      setCollapsedState(prevCollapsedState => {
-        const {
-          collapsedResultIndices: prevCollapsedResultIndices,
-          collapsedRowCount: prevCollapsedRowCount,
-        } = prevCollapsedState;
-
-        const resultsIndex = getResultIndexFromRowIndex(rowIndex);
-        if (resultsIndex != null) {
-          const prevIsOpen = !prevCollapsedResultIndices.has(resultsIndex);
-          if (prevIsOpen !== isOpen) {
-            const result = orderedResults[resultsIndex];
-            if (result != null && isSourceSearchResultLocation(result)) {
-              if (isOpen) {
-                const nextCollapsedResultIndices = new Set(prevCollapsedResultIndices);
-                nextCollapsedResultIndices.delete(resultsIndex);
-                const nextCollapsedRowCount = prevCollapsedRowCount - result.matchCount;
-
-                return {
-                  collapsedResultIndices: nextCollapsedResultIndices,
-                  collapsedRowCount: nextCollapsedRowCount,
-                };
-              } else {
-                const nextCollapsedResultIndices = new Set(prevCollapsedResultIndices);
-                nextCollapsedResultIndices.add(resultsIndex);
-                const nextCollapsedRowCount = prevCollapsedRowCount + result.matchCount;
-
-                return {
-                  collapsedResultIndices: nextCollapsedResultIndices,
-                  collapsedRowCount: nextCollapsedRowCount,
-                };
-              }
-            }
-          }
-        }
-
-        return prevCollapsedState;
-      });
-    },
-    [orderedResults, getResultIndexFromRowIndex]
-  );
+  // Data streams in to the same array, so we need to let the list know when to recompute the item count.
+  useEffect(() => {
+    listData.resultsUpdated();
+  }, [listData, orderedResults, orderedResults.length]);
 
   const itemData = useMemo<ItemData>(
     () => ({
-      getResultAtIndex,
-      isLocationCollapsed,
+      listData,
       query,
       sources,
-      toggleLocation,
     }),
-    [getResultAtIndex, isLocationCollapsed, query, sources, toggleLocation]
+    [listData, query, sources]
   );
 
   if (status === STATUS_RESOLVED && orderedResults.length === 0) {
@@ -188,12 +55,6 @@ export default function ResultsList({
       </div>
     );
   }
-
-  const style = {
-    "--list-row-line-height": `${ROW_HEIGHT}px`,
-  };
-
-  const itemCount = orderedResults.length - collapsedRowCount;
 
   return (
     <div
@@ -210,18 +71,15 @@ export default function ResultsList({
       <div className={styles.List}>
         <AutoSizer
           children={({ height, width }) => (
-            <List
+            <GenericList<Item, ItemData>
               className={styles.List}
               height={height}
-              itemCount={itemCount}
               itemData={itemData}
-              itemSize={ROW_HEIGHT}
-              ref={listRef}
-              style={style as CSSProperties}
+              itemRendererComponent={ResultsListRow}
+              itemSize={ITEM_SIZE}
+              listData={listData}
               width={width}
-            >
-              {ResultsListRow}
-            </List>
+            />
           )}
         />
       </div>

--- a/packages/replay-next/components/search-files/ResultsListRow.module.css
+++ b/packages/replay-next/components/search-files/ResultsListRow.module.css
@@ -1,7 +1,7 @@
 .LocationRow,
 .MatchRow {
-  height: var(--list-row-line-height);
-  line-height: var(--list-row-line-height);
+  height: 1.25rem;
+  line-height: 1.25rem;
 
   white-space: pre;
   overflow: hidden;
@@ -18,6 +18,7 @@
 .MatchRow {
   white-space: pre;
   padding: 0 0.5rem;
+  transition: opacity 250ms;
 }
 .LocationRow:hover,
 .MatchRow:hover {
@@ -31,10 +32,13 @@
   font-size: var(--font-size-small);
   color: var(--color-search-results);
 }
+.MatchRow[data-hit-count="0"] {
+  color: var(--color-dimmer);
+}
 
 .GroupLine {
   display: inline-block;
-  height: var(--list-row-line-height);
+  height: 1.25rem;
   border-left: 1px solid var(--collapsible-toggle-color);
   font-size: var(--font-size-regular);
   margin: 0 0.5rem;

--- a/packages/replay-next/components/search-files/ResultsListRow.tsx
+++ b/packages/replay-next/components/search-files/ResultsListRow.tsx
@@ -1,80 +1,84 @@
-import { CSSProperties, memo, useContext, useMemo } from "react";
-import { areEqual } from "react-window";
+import { CSSProperties, useContext, useMemo } from "react";
+import { useImperativeIntervalCacheValues } from "suspense";
 
 import Expandable from "replay-next/components/Expandable";
 import Icon from "replay-next/components/Icon";
+import { FileSearchListData, Item } from "replay-next/components/search-files/FileSearchListData";
 import HighlightMatch from "replay-next/components/search-files/HighlightMatch";
+import { GenericListItemData } from "replay-next/components/windowing/GenericList";
+import { FocusContext } from "replay-next/src/contexts/FocusContext";
 import { SourcesContext } from "replay-next/src/contexts/SourcesContext";
 import {
-  SourceSearchResult,
   SourceSearchResultLocation,
   SourceSearchResultMatch,
   isSourceSearchResultLocation,
   isSourceSearchResultMatch,
 } from "replay-next/src/suspense/SearchCache";
+import { sourceHitCountsCache } from "replay-next/src/suspense/SourceHitCountsCache";
 import { Source } from "replay-next/src/suspense/SourcesCache";
 import { getSourceFileName } from "replay-next/src/utils/source";
 import { getRelativePathWithoutFile } from "replay-next/src/utils/url";
+import { ReplayClientContext } from "shared/client/ReplayClientContext";
+import { toPointRange } from "shared/utils/time";
 
 import styles from "./ResultsListRow.module.css";
 
+export const ITEM_SIZE = 20;
+
 export type ItemData = {
-  getResultAtIndex(index: number): SourceSearchResult | null;
-  isLocationCollapsed(index: number): boolean;
+  listData: FileSearchListData;
   query: string;
   sources: Source[];
-  toggleLocation(rowIndex: number, isOpen: boolean): void;
 };
 
-const MemoizedResultsListRow = memo(
-  ({ data, index, style }: { data: ItemData; index: number; style: CSSProperties }) => {
-    const { getResultAtIndex, isLocationCollapsed, query, sources, toggleLocation } = data;
+export default function ResultsListItem({
+  data,
+  index,
+  style,
+}: {
+  data: GenericListItemData<Item, ItemData>;
+  index: number;
+  style: CSSProperties;
+}) {
+  const { itemData, listData: genericListData } = data;
 
-    const result = getResultAtIndex(index);
-    if (result == null) {
-      console.error(`No result for row ${index}`);
-      return null;
-    }
+  const listData = genericListData as FileSearchListData;
+  const { isCollapsed, result } = listData.getItemAtIndex(index);
 
-    if (isSourceSearchResultLocation(result)) {
-      const isCollapsed = isLocationCollapsed(index);
-      return (
-        <LocationRow
-          isCollapsed={isCollapsed}
-          result={result}
-          rowIndex={index}
-          sources={sources}
-          style={style}
-          toggleLocation={toggleLocation}
-        />
-      );
-    } else if (isSourceSearchResultMatch(result)) {
-      return <MatchRow result={result} query={query} style={style} />;
-    } else {
-      console.error("Unexpected result type:", result);
-      return null;
-    }
-  },
-  areEqual
-);
-MemoizedResultsListRow.displayName = "ResultsListRow";
+  if (isSourceSearchResultLocation(result)) {
+    return (
+      <LocationRow
+        index={index}
+        isCollapsed={isCollapsed}
+        listData={listData}
+        result={result}
+        sources={itemData.sources}
+        style={style}
+      />
+    );
+  } else if (isSourceSearchResultMatch(result)) {
+    return <MatchRow query={itemData.query} result={result} style={style} />;
+  } else {
+    throw Error("Unexpected result type");
+  }
+}
 
 function LocationRow({
+  index,
   isCollapsed,
+  listData,
   result,
-  rowIndex,
   sources,
   style,
-  toggleLocation,
 }: {
+  index: number;
   isCollapsed: boolean;
+  listData: FileSearchListData;
   result: SourceSearchResultLocation;
-  rowIndex: number;
   sources: Source[];
   style: CSSProperties;
-  toggleLocation: (rowIndex: number, isOpen: boolean) => void;
 }) {
-  const { location, matchCount } = result;
+  const { id, location, matchCount } = result;
 
   const [fileName, path] = useMemo(() => {
     const source = sources.find(({ sourceId }) => sourceId === location.sourceId);
@@ -113,40 +117,51 @@ function LocationRow({
           </>
         }
         headerClassName={styles.LocationRow}
-        onChange={isOpen => toggleLocation(rowIndex, isOpen)}
+        key={id /* Re-apply defaultCollapsed if row content changes */}
+        onChange={collapsed => listData.toggleCollapsed(index, !collapsed)}
       />
     </div>
   );
 }
 
 function MatchRow({
-  result,
   query,
+  result,
   style,
 }: {
-  result: SourceSearchResultMatch;
   query: string;
+  result: SourceSearchResultMatch;
   style: CSSProperties;
 }) {
-  const { match } = result;
-
+  const { range } = useContext(FocusContext);
+  const replayClient = useContext(ReplayClientContext);
   const { openSource } = useContext(SourcesContext);
+
+  const { context, location } = result.match;
+
+  const { value: hitCounts } = useImperativeIntervalCacheValues(
+    sourceHitCountsCache,
+    result.match.location.line,
+    result.match.location.line,
+    replayClient,
+    result.match.location.sourceId,
+    range ? toPointRange(range) : null
+  );
 
   return (
     <div
       className={styles.MatchRow}
+      data-hit-count={hitCounts?.length}
       data-test-name="SearchFiles-ResultRow"
       data-test-type="Match"
       onClick={() => {
-        const lineIndex = match.location.line - 1;
-        openSource("search-result", match.location.sourceId, lineIndex, lineIndex);
+        const lineIndex = location.line - 1;
+        openSource("search-result", location.sourceId, lineIndex, lineIndex);
       }}
       style={style}
     >
       <span className={styles.GroupLine}>&nbsp;&nbsp;</span>
-      <HighlightMatch caseSensitive={false} needle={query} text={match.context.trim()} />
+      <HighlightMatch caseSensitive={false} needle={query} text={context.trim()} />
     </div>
   );
 }
-
-export default MemoizedResultsListRow;

--- a/packages/replay-next/components/search-files/SearchFiles.tsx
+++ b/packages/replay-next/components/search-files/SearchFiles.tsx
@@ -70,7 +70,7 @@ export default function SearchFiles({ limit }: { limit?: number }) {
   }, [dismissSearchSourceTextNag]);
 
   return (
-    <div className={styles.SearchFiles}>
+    <div className={styles.SearchFiles} data-test-id="FileSearch-Pane">
       <div className={styles.Content}>
         <div
           className={styles.InputWrapper}
@@ -81,7 +81,7 @@ export default function SearchFiles({ limit }: { limit?: number }) {
           <input
             autoFocus
             className={styles.Input}
-            data-test-id="SearchFiles-Input"
+            data-test-id="FileSearch-Input"
             onChange={onChange}
             onKeyDown={onKeyDown}
             placeholder="Find in files..."
@@ -96,7 +96,7 @@ export default function SearchFiles({ limit }: { limit?: number }) {
 
         <div className={styles.CheckboxWrapper}>
           <Checkbox
-            dataTestId="SearchFiles-IncludeNodeModules"
+            dataTestId="FileSearch-IncludeNodeModules"
             label="Include node modules"
             checked={includeNodeModules}
             onChange={() => setIncludeNodeModules(!includeNodeModules)}

--- a/packages/replay-next/components/search-files/findMatches.test.ts
+++ b/packages/replay-next/components/search-files/findMatches.test.ts
@@ -24,7 +24,7 @@ describe("findMatches", () => {
           "the",
         ],
         Array [
-          " THE E ",
+          " THE thE ",
           "the",
         ],
       ]
@@ -72,6 +72,15 @@ describe("findMatches", () => {
         ],
       ]
     `);
+
+    expect(findMatches("export const", "render", false)).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "export const",
+          "",
+        ],
+      ]
+    `);
   });
 
   it("should handle consecutive matches", () => {
@@ -86,7 +95,7 @@ describe("findMatches", () => {
           "bar",
         ],
         Array [
-          "z",
+          "baz",
           "",
         ],
       ]

--- a/packages/replay-next/components/search-files/findMatches.ts
+++ b/packages/replay-next/components/search-files/findMatches.ts
@@ -32,7 +32,7 @@ export function findMatches(
         pendingMatch = "";
       }
     } else {
-      pendingNonMatch = pendingNonMatch + textCharacter;
+      pendingNonMatch = pendingNonMatch + pendingMatch + textCharacter;
       pendingMatch = "";
     }
 

--- a/packages/replay-next/src/suspense/SearchCache.ts
+++ b/packages/replay-next/src/suspense/SearchCache.ts
@@ -1,3 +1,4 @@
+import assert from "assert";
 import { Location, SearchSourceContentsMatch, SourceId } from "@replayio/protocol";
 import { StreamingCacheLoadOptions, StreamingValue, createStreamingCache } from "suspense";
 
@@ -20,7 +21,10 @@ import { sourcesByIdCache } from "./SourcesCache";
 export type Subscriber = () => void;
 export type UnsubscribeFunction = () => void;
 
+let idCounter = 0;
+
 export type SourceSearchResultLocation = {
+  id: number;
   location: Location;
   matchCount: number;
   type: "location";
@@ -50,6 +54,18 @@ export function isSourceSearchResultMatch(
   result: SourceSearchResult
 ): result is SourceSearchResultMatch {
   return result.type === "match";
+}
+
+export function assertSourceSearchResultLocation(
+  result: SourceSearchResult
+): asserts result is SourceSearchResultLocation {
+  assert(isSourceSearchResultLocation(result));
+}
+
+export function assertSourceSearchResultMatch(
+  result: SourceSearchResult
+): asserts result is SourceSearchResultMatch {
+  assert(isSourceSearchResultLocation(result));
 }
 
 export const searchCache = createStreamingCache<
@@ -101,7 +117,12 @@ export const searchCache = createStreamingCache<
               currentResultLocation === null ||
               currentResultLocation.location.sourceId !== match.location.sourceId
             ) {
-              currentResultLocation = { location: match.location, matchCount: 0, type: "location" };
+              currentResultLocation = {
+                id: ++idCounter,
+                location: match.location,
+                matchCount: 0,
+                type: "location",
+              };
 
               orderedResults.push(currentResultLocation);
             }


### PR DESCRIPTION
- [x] Update file search results to use GenericList/GenericListData
- [x] Dim matches for locations that did not execution (within the focus window)
- [x] Fix bug in `findMatches` (and add test)
- [x] Add e2e test for file search

<img width="392" alt="Screen Shot 2023-10-02 at 7 55 01 PM" src="https://github.com/replayio/devtools/assets/29597/8efcdf88-b6df-4720-bcfc-bc3780c1e653">
