### PR TITLE
Secondary panels style improvements

### DIFF
--- a/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
+++ b/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
@@ -680,7 +680,7 @@ export function ReactDevtoolsPanel() {
 
   if (!isReady) {
     return (
-      <div className="flex flex-col items-center gap-4 p-4">
+      <div className="flex grow flex-col items-center justify-center gap-4 p-4">
         <img src="/images/react.svg" className="mt-2 w-8" />
         {isReactDevToolsReady ? (
           <>

--- a/src/ui/components/SecondaryToolbox/SecondaryToolbox.css
+++ b/src/ui/components/SecondaryToolbox/SecondaryToolbox.css
@@ -80,6 +80,7 @@ overflows its container (https://drafts.csswg.org/css-flexbox-1/#min-size-auto) 
   flex-direction: column;
   flex: 1;
   min-height: 0;
+  background-color: var(--body-bgcolor);
 }
 
 .secondary-toolbox .toolbox-bottom-panels {
@@ -112,4 +113,20 @@ overflows its container (https://drafts.csswg.org/css-flexbox-1/#min-size-auto) 
   width: 2rem;
   height: 100%;
   background-image: linear-gradient(to left, var(--tab-bgcolor), rgba(0, 0, 0, 0));
+}
+
+.toolbox-bottom-loading-panel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--color-dimmer);
+}
+
+.toolbox-bottom-loading-panel-text {
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }

--- a/src/ui/components/SecondaryToolbox/index.tsx
+++ b/src/ui/components/SecondaryToolbox/index.tsx
@@ -189,29 +189,40 @@ function SecondaryToolbox() {
         </div>
       </header>
       <Redacted className="secondary-toolbox-content bg-chrome text-xs">
-        {(chromiumNetMonitorEnabled || recordingCapabilities.supportsNetworkRequests) && (
-          <Panel isActive={selectedPanel === "network"}>
-            <NetworkMonitor />
+        <Suspense fallback={<LoadingPanel />}>
+          {(chromiumNetMonitorEnabled || recordingCapabilities.supportsNetworkRequests) && (
+            <Panel isActive={selectedPanel === "network"}>
+              <NetworkMonitor />
+            </Panel>
+          )}
+          <Panel isActive={selectedPanel === "console"}>
+            <ConsolePanel />
           </Panel>
-        )}
-        <Panel isActive={selectedPanel === "console"}>
-          <ConsolePanel />
-        </Panel>
-        <Panel isActive={selectedPanel === "inspector"}>
-          <InspectorPanel />
-        </Panel>
-        <Panel isActive={selectedPanel === "react-components"}>
-          <ReactDevToolsPanel />
-        </Panel>
-        <Panel isActive={selectedPanel === "redux-devtools"}>
-          <ReduxDevToolsPanel />
-        </Panel>
-        {showDebuggerTab && (
-          <Panel isActive={selectedPanel === "debugger"}>
-            <EditorPane />
+          <Panel isActive={selectedPanel === "inspector"}>
+            <InspectorPanel />
           </Panel>
-        )}
+          <Panel isActive={selectedPanel === "react-components"}>
+            <ReactDevToolsPanel />
+          </Panel>
+          <Panel isActive={selectedPanel === "redux-devtools"}>
+            <ReduxDevToolsPanel />
+          </Panel>
+          {showDebuggerTab && (
+            <Panel isActive={selectedPanel === "debugger"}>
+              <EditorPane />
+            </Panel>
+          )}
+        </Suspense>
       </Redacted>
+    </div>
+  );
+}
+
+function LoadingPanel() {
+  return (
+    <div className="toolbox-bottom-loading-panel">
+      <Loader />
+      <div className="toolbox-bottom-loading-panel-text">Loading...</div>
     </div>
   );
 }

--- a/src/ui/components/shared/Loader.tsx
+++ b/src/ui/components/shared/Loader.tsx
@@ -4,7 +4,7 @@ import LoadingProgressBar from "ui/components/shared/LoadingProgressBar";
 
 export default function Loader() {
   return (
-    <div className="relative">
+    <div className="relative w-full">
       <LoadingProgressBar />
     </div>
   );


### PR DESCRIPTION
| Lazy loading (before) | Lazy loading (after) |
| :--- | :--- |
| <img width="624" alt="Screen Shot 2023-10-03 at 10 05 07 AM" src="https://github.com/replayio/devtools/assets/29597/5639a13c-6f2c-4e59-b5d5-8ae47238d411"> | <img width="628" alt="Screen Shot 2023-10-03 at 10 04 19 AM" src="https://github.com/replayio/devtools/assets/29597/b24a3f54-eb2c-45af-a49a-904005bc3e11"> |

| Loaded (before) | Loaded (after) |
| :--- | :--- |
| <img width="627" alt="Screen Shot 2023-10-03 at 10 04 59 AM" src="https://github.com/replayio/devtools/assets/29597/60a49ca1-7fe1-4de5-9779-8f3c9d661a1c"> | <img width="627" alt="Screen Shot 2023-10-03 at 10 01 49 AM" src="https://github.com/replayio/devtools/assets/29597/6946670a-755a-4f91-aef8-83a0fae5e397"> |

| Network panel (before) | Network panel (after) |
| :--- | :--- |
| <img width="646" alt="Screen Shot 2023-10-03 at 10 02 44 AM" src="https://github.com/replayio/devtools/assets/29597/2248f6c2-7aa5-4200-b875-a281ff503a84"> | <img width="625" alt="Screen Shot 2023-10-03 at 10 02 39 AM" src="https://github.com/replayio/devtools/assets/29597/f53020ed-da4f-4518-948d-70b78b5a21d2"> |
