### PR TITLE
Upgrade frontend launchdarkly sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "graphql-ws": "^5.9.0",
     "immer": "^9.0.7",
     "jwt-decode": "^3.1.2",
-    "launchdarkly-js-client-sdk": "^2.21.0",
+    "launchdarkly-js-client-sdk": "^3.0.0",
     "lexical": "^0.6.5",
     "lodash": "^4.17.21",
     "logrocket": "^2.2.1",

--- a/src/ui/utils/launchdarkly.ts
+++ b/src/ui/utils/launchdarkly.ts
@@ -17,6 +17,7 @@ const LD_KEY = isDevelopment() ? "60ca05fb43d6f10d234bb3ce" : "60ca05fb43d6f10d2
 
 function initLaunchDarkly(user?: UserInfo) {
   client = LDClient.initialize(LD_KEY, {
+    kind: "user",
     key: user ? user.id : "anon",
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12172,24 +12172,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"launchdarkly-js-client-sdk@npm:^2.21.0":
-  version: 2.22.1
-  resolution: "launchdarkly-js-client-sdk@npm:2.22.1"
+"launchdarkly-js-client-sdk@npm:^3.0.0":
+  version: 3.1.4
+  resolution: "launchdarkly-js-client-sdk@npm:3.1.4"
   dependencies:
-    escape-string-regexp: ^1.0.5
-    launchdarkly-js-sdk-common: 3.6.0
-  checksum: fbec5cdb7ca73d353260a2a67ebfa960805ea233eba018645ec29d107219f7f117fccb84ded881736b635ddd74cad8c0acbd9ee70682f1250031a3d48c8e6bbc
+    escape-string-regexp: ^4.0.0
+    launchdarkly-js-sdk-common: 5.0.3
+  checksum: a36ed908122ef6945bf301aa7e2649ac061f1df50f273f36999989f0faa9af615995face30517bdef6a5f8cb22f79487d6767cfae5243e432bdbd0beb41415fa
   languageName: node
   linkType: hard
 
-"launchdarkly-js-sdk-common@npm:3.6.0":
-  version: 3.6.0
-  resolution: "launchdarkly-js-sdk-common@npm:3.6.0"
+"launchdarkly-js-sdk-common@npm:5.0.3":
+  version: 5.0.3
+  resolution: "launchdarkly-js-sdk-common@npm:5.0.3"
   dependencies:
     base64-js: ^1.3.0
     fast-deep-equal: ^2.0.1
-    uuid: ^3.3.2
-  checksum: 3694aac635ffc6e8f6c9292950795accbcd0283a9a6ea1a4f79bdc05c74725befaf648db1ca52c43c6fee94dcbce1af3c2dbdbf09666d34c380762920481c505
+    uuid: ^8.0.0
+  checksum: 69f03217e1810f4a8a1d7f72035022902b96aa0fe4b6a45fe29b9430120a7becdb3540c3a0ffcf2044f88d62aaebef9bc1bb068a59ddc1cacfd447be988aa97f
   languageName: node
   linkType: hard
 
@@ -15160,7 +15160,7 @@ __metadata:
     jest-environment-jsdom: ^28.0.2
     jest-in-case: ^1.0.2
     jwt-decode: ^3.1.2
-    launchdarkly-js-client-sdk: ^2.21.0
+    launchdarkly-js-client-sdk: ^3.0.0
     lexical: ^0.6.5
     lodash: ^4.17.21
     logrocket: ^2.2.1
@@ -17671,15 +17671,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^3.3.2":
-  version: 3.4.0
-  resolution: "uuid@npm:3.4.0"
-  bin:
-    uuid: ./bin/uuid
-  checksum: 58de2feed61c59060b40f8203c0e4ed7fd6f99d42534a499f1741218a1dd0c129f4aa1de797bcf822c8ea5da7e4137aa3673431a96dae729047f7aca7b27866f
-  languageName: node
-  linkType: hard
-
 "uuid@npm:^7.0.3":
   version: 7.0.3
   resolution: "uuid@npm:7.0.3"
@@ -17689,7 +17680,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^8.3.2":
+"uuid@npm:^8.0.0, uuid@npm:^8.3.2":
   version: 8.3.2
   resolution: "uuid@npm:8.3.2"
   bin:


### PR DESCRIPTION
The previous one was no longer supported. See the [migration guide](https://docs.launchdarkly.com/sdk/client-side/javascript/migration-2-to-3) for reference. We don't use anything sophisticated in devtools so there's not much we need to do.