### PR TITLE
Fix authenticated E2E tests

### DIFF
--- a/packages/e2e-tests/authenticated/test-suites/library-test-runs.test.ts
+++ b/packages/e2e-tests/authenticated/test-suites/library-test-runs.test.ts
@@ -18,7 +18,7 @@ test(`authenticated/test-suites/library-test-runs`, async ({ page }) => {
 
   await filterTestRunsList(page, { status: "failed" });
   await expect(await findTestRunsInList(page, { status: "success" }).count()).toBe(0);
-  await filterTestRunsList(page, { status: "all" });
+  await filterTestRunsList(page, { text: "something that would never exist" });
 
   await expect(await findTestRunsInList(page, { title: "#9332" }).count()).toBe(0);
   await filterTestRunsList(page, { text: "#9332" });

--- a/packages/e2e-tests/authenticated/test-suites/library-tests-list.test.ts
+++ b/packages/e2e-tests/authenticated/test-suites/library-tests-list.test.ts
@@ -55,16 +55,16 @@ test(`authenticated/test-suites/library-tests-list`, async ({ page }) => {
     text: "comments-02.test.ts",
   });
   const testRetriesLocator = findTestRecordingsInTree(flakyGroup, { title: "comments-02.test.ts" });
-  await expect(await testRetriesLocator.count()).toBe(6);
+  await expect(await testRetriesLocator.count()).toBe(8);
   await fileNodeLocator.click();
-  await expect(await fileNodeLocator.textContent()).toContain("6 tests");
+  await expect(await fileNodeLocator.textContent()).toContain("8 tests");
   await fileNodeLocator.click();
-  await expect(await fileNodeLocator.textContent()).not.toContain("6 tests");
+  await expect(await fileNodeLocator.textContent()).not.toContain("8 tests");
 
   // Verify folders contain tests and can be collapsed
   const pathNodeLocator = findTestRecordingsTreePathNodes(flakyGroup, { text: "authenticated" });
   await pathNodeLocator.click();
-  await expect(await pathNodeLocator.textContent()).toContain("11 tests");
+  await expect(await pathNodeLocator.textContent()).toContain("16 tests");
   await pathNodeLocator.click();
-  await expect(await pathNodeLocator.textContent()).not.toContain("11 tests");
+  await expect(await pathNodeLocator.textContent()).not.toContain("16 tests");
 });

--- a/packages/e2e-tests/helpers/authentication.ts
+++ b/packages/e2e-tests/helpers/authentication.ts
@@ -11,11 +11,11 @@ export const E2E_USER_1_API_KEY = "ruk_jukvxbSz7syp4Tw21RzEwSK2bjucNDklCEDmVkjbH
 // trunk-ignore(gitleaks/generic-api-key)
 export const E2E_USER_2_API_KEY = "ruk_K77rBZ4FuPyfj5ocfpPpTXJx7WGVesSySInnCJ4sS1Y";
 
-// Can view the "Frontend E2E Tests" (Test Suites) workspace
+// Can view the "FE Test Golden Recording" (Test Suites) workspace
 // but cannot upload new recordings nor source-maps
 // trunk-ignore(gitleaks/generic-api-key)
-export const E2E_USER_3_API_KEY = "rwk_sujviCI0f0SsyL0zPo6Wfncdt4PAVdyMsrjGXczZNRB";
-export const E2E_USER_3_TEAM_ID = "dzowNDAyOGMwYS05ZjM1LTQ2ZjktYTkwYi1jNzJkMTIzNzUxOTI=";
+export const E2E_USER_3_API_KEY = "rwk_4kYcBCHQFtZycxMOng4PyOUrqgOnt7W53Iw9iC4ilF8";
+export const E2E_USER_3_TEAM_ID = "dzoxNzlkZGU4Mi00MmVhLTRkZTctYmI1OC04ZWY0NDQxZTcyYTg=";
 
 // Can view the "Replay Devtools Snapshots" (Test Suites) workspace
 // but cannot upload new recordings nor source-maps

--- a/packages/e2e-tests/helpers/authentication.ts
+++ b/packages/e2e-tests/helpers/authentication.ts
@@ -14,7 +14,7 @@ export const E2E_USER_2_API_KEY = "ruk_K77rBZ4FuPyfj5ocfpPpTXJx7WGVesSySInnCJ4sS
 // Can view the "FE Test Golden Recording" (Test Suites) workspace
 // but cannot upload new recordings nor source-maps
 // trunk-ignore(gitleaks/generic-api-key)
-export const E2E_USER_3_API_KEY = "rwk_4kYcBCHQFtZycxMOng4PyOUrqgOnt7W53Iw9iC4ilF8";
+export const E2E_USER_3_API_KEY = "rwk_8AhV0ieAaWYXXXSPiQ3Dag4K8JUZWvsh2PtLra3idwi";
 export const E2E_USER_3_TEAM_ID = "dzoxNzlkZGU4Mi00MmVhLTRkZTctYmI1OC04ZWY0NDQxZTcyYTg=";
 
 // Can view the "Replay Devtools Snapshots" (Test Suites) workspace

--- a/packages/e2e-tests/helpers/authentication.ts
+++ b/packages/e2e-tests/helpers/authentication.ts
@@ -14,7 +14,7 @@ export const E2E_USER_2_API_KEY = "ruk_K77rBZ4FuPyfj5ocfpPpTXJx7WGVesSySInnCJ4sS
 // Can view the "FE Test Golden Recording" (Test Suites) workspace
 // but cannot upload new recordings nor source-maps
 // trunk-ignore(gitleaks/generic-api-key)
-export const E2E_USER_3_API_KEY = "rwk_8AhV0ieAaWYXXXSPiQ3Dag4K8JUZWvsh2PtLra3idwi";
+export const E2E_USER_3_API_KEY = "rwk_FnFcJoJ158eTLXJTg8gpXMto7WT3N8dhNKcAlo2cSHO";
 export const E2E_USER_3_TEAM_ID = "dzoxNzlkZGU4Mi00MmVhLTRkZTctYmI1OC04ZWY0NDQxZTcyYTg=";
 
 // Can view the "Replay Devtools Snapshots" (Test Suites) workspace


### PR DESCRIPTION
Closes BAC-4047 and FE-1958.

I have moved a specific test run metadata (not the recording) to our new Golden Test workspace. This PR updates the API keys and Workspace ID to point to the new workspace.