### PR TITLE
Add InspectableTimestampedPointContext to TestEventDetails

### DIFF
--- a/packages/e2e-tests/helpers/network-panel.ts
+++ b/packages/e2e-tests/helpers/network-panel.ts
@@ -41,7 +41,7 @@ export async function findNetworkRequestRow(
 
   const locator = page.locator(selector);
 
-  await expect(await locator.count()).toBe(1);
+  await waitFor(async () => expect(await locator.count()).toBe(1));
 
   return locator;
 }

--- a/packages/e2e-tests/helpers/redux-devtools-panel.ts
+++ b/packages/e2e-tests/helpers/redux-devtools-panel.ts
@@ -12,12 +12,7 @@ export async function assertTabValue(page: Page, tab: string, expectedValue: str
   const inspector = page.locator('[data-test-id="ReduxDevToolsContents"]');
   await inspector.waitFor();
 
-  const currentPointContents = page.locator(`[data-test-id="ReduxDevtools"]`);
-  await waitFor(() =>
-    expect(currentPointContents.getByTestId("indeterminate-loader")).toHaveCount(0)
-  );
-
-  expect(await inspector.innerText()).toBe(expectedValue);
+  await waitFor(async () => expect(await inspector.innerText()).toBe(expectedValue));
 }
 
 export async function waitForReduxActionCount(page: Page, expected: number) {

--- a/src/ui/components/TestSuite/views/TestRecording/TestEventDetails.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestEventDetails.tsx
@@ -1,10 +1,11 @@
 import { TimeStampedPoint } from "@replayio/protocol";
-import { useCallback, useContext, useEffect, useRef, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { STATUS_PENDING, useImperativeCacheValue } from "suspense";
 
 import ErrorBoundary from "replay-next/components/ErrorBoundary";
 import PropertiesRenderer from "replay-next/components/inspector/PropertiesRenderer";
 import { SyntaxHighlighter } from "replay-next/components/SyntaxHighlighter/SyntaxHighlighter";
+import { InspectableTimestampedPointContext } from "replay-next/src/contexts/InspectorContext";
 import { SessionContext } from "replay-next/src/contexts/SessionContext";
 import { ParsedToken, parsedTokensToHtml } from "replay-next/src/utils/syntax-parser";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
@@ -62,6 +63,14 @@ function UserActionEventDetails({
     variable
   );
 
+  const context = useMemo(
+    () => ({
+      executionPoint: timeStampedPoint.point,
+      time: timeStampedPoint.time,
+    }),
+    [timeStampedPoint]
+  );
+
   if (status === STATUS_PENDING) {
     return <LoadingInProgress />;
   } else if (value?.props == null || value?.pauseId == null) {
@@ -70,7 +79,9 @@ function UserActionEventDetails({
 
   return (
     <div className={styles.UserActionEventDetails} data-test-name="UserActionEventDetails">
-      <PropertiesRenderer pauseId={value.pauseId} object={value.props} />
+      <InspectableTimestampedPointContext.Provider value={context}>
+        <PropertiesRenderer pauseId={value.pauseId} object={value.props} />
+      </InspectableTimestampedPointContext.Provider>
     </div>
   );
 }


### PR DESCRIPTION
The objects shown in the `TestEventDetails` panel are from a different point than the one that we seek to when the user clicks on the test step. If the objects contain an HTML element and the user clicks the inspect button on that element (to show it in the Elements panel), we need to seek to that point. This is achieved by adding an `InspectableTimestampedPointContext` containing that point to `TestEventDetails`.
This fixes one of the issues in FE-1962, see [this comment](https://linear.app/replay/issue/FE-1962/when-selecting-cypress-applied-to-element-element-tree-is-empty#comment-dc0a6426).