### PR TITLE
Disable inspect button for disconnected HTML nodes

### DIFF
--- a/packages/replay-next/components/inspector/values/HTMLElementRenderer.tsx
+++ b/packages/replay-next/components/inspector/values/HTMLElementRenderer.tsx
@@ -72,6 +72,7 @@ export default function HTMLElementRenderer({
   const properties = filterNonEnumerableProperties(object.preview?.node?.attributes ?? []);
   const showOverflowMarker = properties.length > MAX_PROPERTIES_TO_PREVIEW;
   const showInlineText = showChildrenIndicator && (inlineText || childNodes.length > 0);
+  const disableInspectButton = !object.preview?.node?.isConnected;
 
   const viewHtmlElement = (event: MouseEvent) => {
     event.preventDefault();
@@ -109,9 +110,14 @@ export default function HTMLElementRenderer({
       )}
       {inspectHTMLElement !== null && (
         <button
-          className={styles.IconButton}
+          className={disableInspectButton ? styles.DisabledIconButton : styles.IconButton}
+          disabled={disableInspectButton}
           onClick={viewHtmlElement}
-          title="Click to select the node in the inspector"
+          title={
+            disableInspectButton
+              ? "This node can't be selected in the inspector because it isn't connected to the document"
+              : "Click to select the node in the inspector"
+          }
         >
           <Icon className={styles.Icon} type="view-html-element" />
         </button>

--- a/packages/replay-next/components/inspector/values/shared.module.css
+++ b/packages/replay-next/components/inspector/values/shared.module.css
@@ -46,7 +46,8 @@
   color: var(--value-type-undefined);
 }
 
-.IconButton {
+.IconButton,
+.DisabledIconButton {
   height: 1rem;
   width: 1rem;
   outline: none;
@@ -55,6 +56,10 @@
   border: none;
   cursor: pointer;
   vertical-align: top;
+}
+
+.DisabledIconButton svg {
+  color: var(--color-dimmer);
 }
 
 .Icon {


### PR DESCRIPTION
HTML nodes are shown in the object inspector with a button that lets you select it in the Elements panel. But nodes that aren't connected to the document can't be selected in the Elements panel, so the button should either be disabled or removed.
I chose to disable it so that users get an explanation why they can't select it when they hover over it.
To see it in action, go to https://devtools-git-hbenl-fe-1973-recordreplay.vercel.app/recording/connected-and-disconnected-nodes--15d1ad58-bfa3-41ea-9bea-676a8a179bb9 and look at the console.