### PR TITLE
Pre-fetch Cypress step details and optimize fetching process

### DIFF
--- a/packages/e2e-tests/tests/cypress-05_hover-dom-previews.test.ts
+++ b/packages/e2e-tests/tests/cypress-05_hover-dom-previews.test.ts
@@ -1,0 +1,74 @@
+import { openDevToolsTab, openViewerTab, startTest } from "../helpers";
+import {
+  getSelectedTestCase,
+  getTestCaseSteps,
+  getTestRows,
+  getTestSuitePanel,
+  openCypressTestPanel,
+} from "../helpers/testsuites";
+import { waitFor } from "../helpers/utils";
+import test, { expect } from "../testFixtureCloneRecording";
+
+test.use({ exampleKey: "cypress-realworld/bankaccounts.spec.js" });
+
+test("cypress-05: Test DOM node preview on user action step hover", async ({
+  pageWithMeta: { page, recordingId },
+  exampleKey,
+}) => {
+  await startTest(page, recordingId);
+  await openViewerTab(page);
+
+  await openCypressTestPanel(page);
+
+  await openDevToolsTab(page);
+
+  const testPanel = getTestSuitePanel(page);
+
+  const isVisible = await testPanel.isVisible();
+  expect(isVisible).toBe(true);
+
+  // has 4 tests
+  const rows = getTestRows(page);
+  await waitFor(async () => {
+    await expect(rows).toHaveCount(4);
+  });
+
+  const addAccountTest = rows.filter({ hasText: "creates a new bank account" }).first();
+
+  await addAccountTest.click();
+  const selectedRow = getSelectedTestCase(page);
+  await waitFor(async () => {
+    expect(await selectedRow.isVisible()).toBe(true);
+    expect(selectedRow).toHaveCount(1);
+  });
+
+  const steps = getTestCaseSteps(selectedRow);
+  const firstStep = steps.first();
+
+  // Others are probably actions too, but we know these are here
+  const userActionSteps = steps.filter({
+    hasText: /click|type/,
+  });
+
+  // Hovering over a user action step should show a preview of the DOM node
+  const firstClickStep = userActionSteps.first();
+
+  // Note that the ID is dynamically generated based on the piece of the box model shown
+  const highlighter = page.locator("#box-model-content");
+
+  await waitFor(
+    async () => {
+      // Repeatedly hover over the first step and then the click step, to force the
+      // `onMouseEnter` handler to keep checking if we have a DOM node entry available.
+      await firstStep.hover({ timeout: 1000 });
+      await firstClickStep.hover({ timeout: 1000 });
+      await highlighter.waitFor({ state: "visible", timeout: 1000 });
+    },
+    // Give the evaluation plenty of time to complete
+    { timeout: 30000 }
+  );
+
+  const pathDefinition = await highlighter.getAttribute("d");
+  // Should have a meaningful SVG path of some kind for the highlighter
+  expect(pathDefinition).toBeTruthy();
+});

--- a/packages/e2e-tests/tests/playwright-03_test-step-interactions.test.ts
+++ b/packages/e2e-tests/tests/playwright-03_test-step-interactions.test.ts
@@ -73,7 +73,7 @@ test("playwright-03: Test Step interactions", async ({
 
   // Should show the "Before/After" buttons
   const beforeAfterButtons = getTestStepBeforeAfterButtons(page);
-  await beforeAfterButtons.waitFor({ state: "visible", timeout: 1000 });
+  await beforeAfterButtons.waitFor({ state: "visible" });
 
   const afterButton = beforeAfterButtons.locator("button", { hasText: "After" }).first();
 

--- a/packages/replay-next/src/suspense/AnalysisCache.ts
+++ b/packages/replay-next/src/suspense/AnalysisCache.ts
@@ -102,8 +102,6 @@ export function createAnalysisCache<
               setPointAndTimeForPauseId(result.pauseId, result.point);
               cachePauseData(client, sources, result.pauseId, result.data);
 
-              console.log("Analysis result: ", result);
-
               let values: Value[] = [];
               if (result.exception) {
                 values.push(result.exception);

--- a/packages/replay-next/src/suspense/AnalysisCache.ts
+++ b/packages/replay-next/src/suspense/AnalysisCache.ts
@@ -7,7 +7,7 @@ import { ReplayClientInterface } from "shared/client/types";
 import { ProtocolError, commandError, isCommandError } from "shared/utils/error";
 
 import { createFocusIntervalCacheForExecutionPoints } from "./FocusIntervalCache";
-import { objectPropertyCache } from "./ObjectPreviews";
+import { objectCache, objectPropertyCache } from "./ObjectPreviews";
 import { cachePauseData, setPointAndTimeForPauseId } from "./PauseCache";
 import { sourcesByIdCache } from "./SourcesCache";
 
@@ -102,31 +102,44 @@ export function createAnalysisCache<
               setPointAndTimeForPauseId(result.pauseId, result.point);
               cachePauseData(client, sources, result.pauseId, result.data);
 
+              console.log("Analysis result: ", result);
+
               let values: Value[] = [];
               if (result.exception) {
                 values.push(result.exception);
               } else if (result.returned?.object) {
-                const length =
-                  (
-                    await objectPropertyCache.readAsync(
-                      client,
-                      result.pauseId,
-                      result.returned.object,
-                      "length"
-                    )
-                  )?.value ?? 0;
-                const promises = [];
-                for (let i = 0; i < length; i++) {
-                  promises.push(
-                    objectPropertyCache.readAsync(
-                      client,
-                      result.pauseId,
-                      result.returned.object,
-                      String(i)
-                    )
-                  );
+                const objectPreview = await objectCache.readAsync(
+                  client,
+                  result.pauseId,
+                  result.returned.object,
+                  "canOverflow"
+                );
+                if (objectPreview?.className === "Object") {
+                  values.push(result.returned);
+                } else {
+                  // assume this is an array
+                  const length =
+                    (
+                      await objectPropertyCache.readAsync(
+                        client,
+                        result.pauseId,
+                        result.returned.object,
+                        "length"
+                      )
+                    )?.value ?? 0;
+                  const promises = [];
+                  for (let i = 0; i < length; i++) {
+                    promises.push(
+                      objectPropertyCache.readAsync(
+                        client,
+                        result.pauseId,
+                        result.returned.object,
+                        String(i)
+                      )
+                    );
+                  }
+                  values = (await Promise.all(promises)).filter(value => !!value) as Value[];
                 }
-                values = (await Promise.all(promises)).filter(value => !!value) as Value[];
               }
 
               resultsCache.cacheValue(

--- a/packages/replay-next/src/suspense/FocusIntervalCache.ts
+++ b/packages/replay-next/src/suspense/FocusIntervalCache.ts
@@ -53,8 +53,18 @@ export function createFocusIntervalCache<
         return await options.load(start, end, ...paramsWithCacheLoadOptions);
       } catch (error) {
         if (isCommandError(error, ProtocolError.FocusWindowChange)) {
+          // Handle errors here by telling the cache "nothing got loaded".
+          // This will cause the cache to retry the load if requested later.
+          // The combo of `cache.abort()` + `returnAsPartial()` _seems_ to be necessary here,
+          // based on experimentation.
+
           const params = paramsWithCacheLoadOptions.slice(0, -1) as Params;
+          const intervalCacheOptions: IntervalCacheLoadOptions<Value> =
+            paramsWithCacheLoadOptions[paramsWithCacheLoadOptions.length - 1];
+
           cache.abort(...params);
+
+          return intervalCacheOptions.returnAsPartial([]);
         }
         throw error;
       }

--- a/src/ui/components/TestSuite/suspense/TestEventDetailsCache.ts
+++ b/src/ui/components/TestSuite/suspense/TestEventDetailsCache.ts
@@ -1,31 +1,160 @@
 import { Frame, PauseId, Object as ProtocolObject, TimeStampedPoint } from "@replayio/protocol";
 import cloneDeep from "lodash/cloneDeep";
-import { createCache } from "suspense";
+import { Cache, createCache } from "suspense";
 
+import { createAnalysisCache } from "replay-next/src/suspense/AnalysisCache";
 import { framesCache } from "replay-next/src/suspense/FrameCache";
+import { hitPointsCache } from "replay-next/src/suspense/HitPointsCache";
 import { objectCache } from "replay-next/src/suspense/ObjectPreviews";
 import { pauseEvaluationsCache, pauseIdCache } from "replay-next/src/suspense/PauseCache";
 import { ReplayClientInterface } from "shared/client/types";
 
-export type Type = {
+export type TestEventDetailsEntry = TimeStampedPoint & {
   count: number | null;
   pauseId: PauseId;
   props: ProtocolObject | null;
 };
 
+export const testEventDetailsCache2Internal = createAnalysisCache<
+  TimeStampedPoint,
+  [timeStampedPoint: TimeStampedPoint | null, variable: string]
+>(
+  "TestEventDetailsCache2Internal",
+  (timeStampedPoint, variable) => `${timeStampedPoint?.point}:${variable}`,
+  (client, begin, end, timeStampedPoint, variable) => (timeStampedPoint ? [timeStampedPoint] : []),
+  (client, points, timeStampedPoint, variable) => ({
+    selector: {
+      kind: "points",
+      points: points.map(p => p.point),
+    },
+    expression: variable,
+    frameIndex: 1,
+  }),
+  point => point
+);
+
+export const testEventDetailsCache2: Cache<
+  [
+    client: ReplayClientInterface,
+    timeStampedPoint: TimeStampedPoint | null,
+    variable: string | null
+  ],
+  TestEventDetailsEntry | null
+> = createCache({
+  debugLabel: "TestEventDetailsCache2",
+  getKey: ([client, timeStampedPoint, variable]) => `${timeStampedPoint?.point}:${variable}`,
+  async load([client, timeStampedPoint, variable]) {
+    if (!timeStampedPoint || !variable) {
+      console.log("Bailing out of testEventDetailsCache2: ", timeStampedPoint, variable);
+      return null;
+    }
+
+    const variableNameInArray = `[${variable}]`;
+
+    try {
+      console.log("testEventDetailsCache2 fetching: ", timeStampedPoint, variable);
+      console.time(`testEventDetails2:pointsAndResult:${timeStampedPoint.point}}`);
+      const pointsRes = await testEventDetailsCache2Internal.pointsIntervalCache.readAsync(
+        BigInt(timeStampedPoint.point),
+        BigInt(timeStampedPoint.point),
+        client,
+        timeStampedPoint,
+        variableNameInArray
+      );
+
+      const result = await testEventDetailsCache2Internal.resultsCache.readAsync(
+        timeStampedPoint.point,
+        timeStampedPoint,
+        variableNameInArray
+      );
+
+      console.timeEnd(`testEventDetails2:pointsAndResult:${timeStampedPoint.point}}`);
+      console.log("Actual result: ", result);
+
+      const { pauseId } = result;
+      const [firstValue] = result.values;
+
+      if (firstValue?.object) {
+        const logObject = await objectCache.readAsync(
+          client,
+          pauseId,
+          firstValue.object,
+          "canOverflow"
+        );
+        const consolePropsProperty = logObject.preview?.properties?.find(
+          ({ name }) => name === "consoleProps"
+        );
+
+        if (consolePropsProperty?.object) {
+          const consoleProps = await objectCache.readAsync(
+            client,
+            pauseId,
+            consolePropsProperty.object,
+            "full"
+          );
+
+          const sanitized = cloneDeep(consoleProps);
+
+          console.log("Console props: ", timeStampedPoint.point, sanitized);
+          if (sanitized?.preview?.properties) {
+            sanitized.preview.properties = sanitized.preview.properties.filter(
+              ({ name }) => name !== "Snapshot"
+            );
+
+            // suppress the prototype entry in the properties output
+            sanitized.preview.prototypeId = undefined;
+          }
+
+          const elementsProp = sanitized.preview?.properties?.find(
+            ({ name }) => name === "Elements"
+          );
+          const count = (elementsProp?.value as number) ?? null;
+
+          return {
+            ...timeStampedPoint,
+            count,
+            pauseId,
+            props: sanitized,
+          };
+        }
+      }
+
+      return {
+        ...timeStampedPoint,
+        count: null,
+        pauseId: result.pauseId,
+        props: null,
+      };
+    } catch (err) {
+      console.error("event details error: ", err);
+      return null;
+    }
+  },
+});
+
 export const TestEventDetailsCache = createCache<
   [client: ReplayClientInterface, timeStampedPoint: TimeStampedPoint, variable: string],
-  Type
+  TestEventDetailsEntry
 >({
   debugLabel: "TestEventDetailsCache",
   getKey: ([client, timeStampedPoint, variable]) => `${timeStampedPoint.point}:${variable}`,
   load: async ([client, timeStampedPoint, variable]) => {
+    console.group("Test event details: ", timeStampedPoint);
+    console.time("testEventDetails:hitPoints");
+    const hitPointsWithFrame = await client.findPoints({
+      kind: "points",
+      points: [timeStampedPoint.point],
+    });
+    console.timeEnd("testEventDetails:hitPoints");
+    console.time("testEventDetails:pauseId");
     const endPauseId = await pauseIdCache.readAsync(
       client,
       timeStampedPoint.point,
       timeStampedPoint.time
     );
+    console.timeEnd("testEventDetails:pauseId");
     let frames: Frame[] | undefined;
+    console.time("testEventDetails:frames");
     try {
       frames = await framesCache.readAsync(client, endPauseId);
     } catch (error) {
@@ -33,6 +162,12 @@ export const TestEventDetailsCache = createCache<
       // degrade gracefully in this case by just disabling the details panel
       console.error(error);
     }
+    console.timeEnd("testEventDetails:frames");
+
+    console.time("testEventDetails:pointStack");
+    const pointStack = await client.getPointStack(timeStampedPoint.point, 5);
+    console.log("Point stack: ", pointStack);
+    console.timeEnd("testEventDetails:pointStack");
 
     const callerFrameId = frames?.[1]?.frameId;
     if (callerFrameId) {
@@ -45,23 +180,27 @@ export const TestEventDetailsCache = createCache<
       );
 
       if (logResult?.object) {
+        console.time("testEventDetails:object");
         const logObject = await objectCache.readAsync(
           client,
           endPauseId,
           logResult.object,
           "canOverflow"
         );
+        console.timeEnd("testEventDetails:object");
         const consolePropsProperty = logObject.preview?.properties?.find(
           ({ name }) => name === "consoleProps"
         );
 
         if (consolePropsProperty?.object) {
+          console.time("testEventDetails:consoleProps");
           const consoleProps = await objectCache.readAsync(
             client,
             endPauseId,
             consolePropsProperty.object,
             "full"
           );
+          console.timeEnd("testEventDetails:consoleProps");
 
           const sanitized = cloneDeep(consoleProps);
           if (sanitized?.preview?.properties) {
@@ -79,6 +218,7 @@ export const TestEventDetailsCache = createCache<
           const count = (elementsProp?.value as number) ?? null;
 
           return {
+            ...timeStampedPoint,
             count,
             pauseId: endPauseId,
             props: sanitized,
@@ -86,8 +226,10 @@ export const TestEventDetailsCache = createCache<
         }
       }
     }
+    console.groupEnd();
 
     return {
+      ...timeStampedPoint,
       count: null,
       pauseId: endPauseId,
       props: null,

--- a/src/ui/components/TestSuite/views/TestRecording/Panel.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/Panel.tsx
@@ -24,7 +24,7 @@ import TestEventDetails from "ui/components/TestSuite/views/TestRecording/TestEv
 import TestSection from "ui/components/TestSuite/views/TestRecording/TestSection";
 import { TestSuiteContext } from "ui/components/TestSuite/views/TestSuiteContext";
 
-import { testEventDetailsCache3IntervalCache } from "../../suspense/TestEventDetailsCache";
+import { testEventDetailsIntervalCache } from "../../suspense/TestEventDetailsCache";
 import styles from "./Panel.module.css";
 
 export default function Panel() {
@@ -47,7 +47,7 @@ export default function Panel() {
   });
 
   useImperativeIntervalCacheValues(
-    testEventDetailsCache3IntervalCache,
+    testEventDetailsIntervalCache,
     BigInt(focusWindow ? focusWindow.begin.point : "0"),
     BigInt(focusWindow ? focusWindow.end.point : "0"),
     replayClient,

--- a/src/ui/components/TestSuite/views/TestRecording/Panel.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/Panel.tsx
@@ -56,7 +56,12 @@ export default function Panel() {
     isExecutionPointsWithinRange(
       focusWindow.begin.point,
       testRecording.timeStampedPointRange.begin.point,
-      testRecording.timeStampedPointRange.begin.point
+      testRecording.timeStampedPointRange.end.point
+    ) &&
+    isExecutionPointsWithinRange(
+      focusWindow.end.point,
+      testRecording.timeStampedPointRange.begin.point,
+      testRecording.timeStampedPointRange.end.point
     );
 
   useImperativeIntervalCacheValues(

--- a/src/ui/components/TestSuite/views/TestRecording/Panel.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/Panel.tsx
@@ -49,7 +49,7 @@ export default function Panel() {
 
   // We only want to cache the test event details when the focus window has been updated
   // to match the range of the test recording.  Experimentation shows there can be some renders
-  // where the focus range and test range ar mismatched, so try to avoid caching in those cases.
+  // where the focus range and test range are mismatched, so try to avoid caching in those cases.
   const enableCache =
     focusWindow &&
     testRecording.timeStampedPointRange?.begin &&
@@ -58,22 +58,6 @@ export default function Panel() {
       testRecording.timeStampedPointRange.begin.point,
       testRecording.timeStampedPointRange.begin.point
     );
-  console.log(
-    "Panel focus window: ",
-    {
-      fbp: focusWindow?.begin.point,
-      fbt: focusWindow?.begin.time,
-      fep: focusWindow?.end.point,
-      fet: focusWindow?.end.time,
-      enableCache,
-    },
-    {
-      tbp: testRecording.timeStampedPointRange?.begin.point,
-      tbt: testRecording.timeStampedPointRange?.begin.time,
-      tep: testRecording.timeStampedPointRange?.end.point,
-      tet: testRecording.timeStampedPointRange?.end.time,
-    }
-  );
 
   useImperativeIntervalCacheValues(
     testEventDetailsIntervalCache,

--- a/src/ui/components/TestSuite/views/TestRecording/Panel.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/Panel.tsx
@@ -6,8 +6,11 @@ import {
   PanelResizeHandle,
   Panel as ResizablePanel,
 } from "react-resizable-panels";
+import { useImperativeIntervalCacheValues } from "suspense";
 
+import { FocusContext } from "replay-next/src/contexts/FocusContext";
 import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
+import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import {
   TestEvent,
   TestSectionName,
@@ -21,11 +24,14 @@ import TestEventDetails from "ui/components/TestSuite/views/TestRecording/TestEv
 import TestSection from "ui/components/TestSuite/views/TestRecording/TestSection";
 import { TestSuiteContext } from "ui/components/TestSuite/views/TestSuiteContext";
 
+import { testEventDetailsCache3IntervalCache } from "../../suspense/TestEventDetailsCache";
 import styles from "./Panel.module.css";
 
 export default function Panel() {
   const { setTestEvent, setTestRecording, testEvent, testRecording } = useContext(TestSuiteContext);
   const { update } = useContext(TimelineContext);
+  const { range: focusWindow } = useContext(FocusContext);
+  const replayClient = useContext(ReplayClientContext);
 
   assert(testRecording != null);
 
@@ -39,6 +45,15 @@ export default function Panel() {
   useEffect(() => {
     committedValuesRef.current.testEvent = testEvent;
   });
+
+  useImperativeIntervalCacheValues(
+    testEventDetailsCache3IntervalCache,
+    BigInt(focusWindow ? focusWindow.begin.point : "0"),
+    BigInt(focusWindow ? focusWindow.end.point : "0"),
+    replayClient,
+    testRecording,
+    !!focusWindow
+  );
 
   // Select a test step and update the current time
   const selectTestEvent = useCallback(

--- a/src/ui/components/TestSuite/views/TestRecording/TestEventDetails.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestEventDetails.tsx
@@ -13,7 +13,10 @@ import {
   UserActionEventStack,
   isUserActionTestEvent,
 } from "shared/test-suites/RecordingTestMetadata";
-import { TestEventDetailsCache } from "ui/components/TestSuite/suspense/TestEventDetailsCache";
+import {
+  TestEventDetailsCache,
+  testEventDetailsCache2,
+} from "ui/components/TestSuite/suspense/TestEventDetailsCache";
 import { TestSuiteCache } from "ui/components/TestSuite/suspense/TestSuiteCache";
 import { TestSuiteContext } from "ui/components/TestSuite/views/TestSuiteContext";
 
@@ -57,7 +60,7 @@ function UserActionEventDetails({
   const replayClient = useContext(ReplayClientContext);
 
   const { status, value } = useImperativeCacheValue(
-    TestEventDetailsCache,
+    testEventDetailsCache2,
     replayClient,
     timeStampedPoint,
     variable

--- a/src/ui/components/TestSuite/views/TestRecording/TestEventDetails.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestEventDetails.tsx
@@ -57,24 +57,6 @@ function UserActionEventDetails({
   timeStampedPoint: TimeStampedPoint;
   variable: string;
 }) {
-  const replayClient = useContext(ReplayClientContext);
-
-  // const { status, value } = useImperativeCacheValue(
-  //   testEventDetailsCache2,
-  //   replayClient,
-  //   timeStampedPoint,
-  //   variable
-  // );
-
-  // const {} = useImperativeIntervalCacheValues(
-  //   testEventDetailsCache3IntervalCache,
-  //   BigInt(timeStampedPoint.point),
-  //   BigInt(timeStampedPoint.point),
-  //   replayClient,
-  //   variable,
-  //   true
-  // );
-
   const { status, value } = useImperativeCacheValue(
     testEventDetailsResultsCache as unknown as Cache<
       [executionPoint: ExecutionPoint],
@@ -82,8 +64,6 @@ function UserActionEventDetails({
     >,
     timeStampedPoint.point
   );
-
-  // console.log("User action status: ", status, value);
 
   const context = useMemo(
     () => ({

--- a/src/ui/components/TestSuite/views/TestRecording/TestEventDetails.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestEventDetails.tsx
@@ -1,11 +1,6 @@
 import { ExecutionPoint, TimeStampedPoint } from "@replayio/protocol";
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
-import {
-  Cache,
-  STATUS_PENDING,
-  useImperativeCacheValue,
-  useImperativeIntervalCacheValues,
-} from "suspense";
+import { Cache, STATUS_PENDING, useImperativeCacheValue } from "suspense";
 
 import ErrorBoundary from "replay-next/components/ErrorBoundary";
 import PropertiesRenderer from "replay-next/components/inspector/PropertiesRenderer";
@@ -19,10 +14,7 @@ import {
   isUserActionTestEvent,
 } from "shared/test-suites/RecordingTestMetadata";
 import {
-  TestEventDetailsCache,
   TestEventDetailsEntry,
-  testEventDetailsCache2,
-  testEventDetailsCache3IntervalCache,
   testEventDetailsCache3ResultsCache,
 } from "ui/components/TestSuite/suspense/TestEventDetailsCache";
 import { TestSuiteCache } from "ui/components/TestSuite/suspense/TestSuiteCache";

--- a/src/ui/components/TestSuite/views/TestRecording/TestEventDetails.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestEventDetails.tsx
@@ -1,6 +1,11 @@
-import { TimeStampedPoint } from "@replayio/protocol";
+import { ExecutionPoint, TimeStampedPoint } from "@replayio/protocol";
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
-import { STATUS_PENDING, useImperativeCacheValue } from "suspense";
+import {
+  Cache,
+  STATUS_PENDING,
+  useImperativeCacheValue,
+  useImperativeIntervalCacheValues,
+} from "suspense";
 
 import ErrorBoundary from "replay-next/components/ErrorBoundary";
 import PropertiesRenderer from "replay-next/components/inspector/PropertiesRenderer";
@@ -15,7 +20,10 @@ import {
 } from "shared/test-suites/RecordingTestMetadata";
 import {
   TestEventDetailsCache,
+  TestEventDetailsEntry,
   testEventDetailsCache2,
+  testEventDetailsCache3IntervalCache,
+  testEventDetailsCache3ResultsCache,
 } from "ui/components/TestSuite/suspense/TestEventDetailsCache";
 import { TestSuiteCache } from "ui/components/TestSuite/suspense/TestSuiteCache";
 import { TestSuiteContext } from "ui/components/TestSuite/views/TestSuiteContext";
@@ -59,12 +67,31 @@ function UserActionEventDetails({
 }) {
   const replayClient = useContext(ReplayClientContext);
 
+  // const { status, value } = useImperativeCacheValue(
+  //   testEventDetailsCache2,
+  //   replayClient,
+  //   timeStampedPoint,
+  //   variable
+  // );
+
+  // const {} = useImperativeIntervalCacheValues(
+  //   testEventDetailsCache3IntervalCache,
+  //   BigInt(timeStampedPoint.point),
+  //   BigInt(timeStampedPoint.point),
+  //   replayClient,
+  //   variable,
+  //   true
+  // );
+
   const { status, value } = useImperativeCacheValue(
-    testEventDetailsCache2,
-    replayClient,
-    timeStampedPoint,
-    variable
+    testEventDetailsCache3ResultsCache as unknown as Cache<
+      [executionPoint: ExecutionPoint],
+      TestEventDetailsEntry
+    >,
+    timeStampedPoint.point
   );
+
+  // console.log("User action status: ", status, value);
 
   const context = useMemo(
     () => ({

--- a/src/ui/components/TestSuite/views/TestRecording/TestEventDetails.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestEventDetails.tsx
@@ -15,7 +15,7 @@ import {
 } from "shared/test-suites/RecordingTestMetadata";
 import {
   TestEventDetailsEntry,
-  testEventDetailsCache3ResultsCache,
+  testEventDetailsResultsCache,
 } from "ui/components/TestSuite/suspense/TestEventDetailsCache";
 import { TestSuiteCache } from "ui/components/TestSuite/suspense/TestSuiteCache";
 import { TestSuiteContext } from "ui/components/TestSuite/views/TestSuiteContext";
@@ -76,7 +76,7 @@ function UserActionEventDetails({
   // );
 
   const { status, value } = useImperativeCacheValue(
-    testEventDetailsCache3ResultsCache as unknown as Cache<
+    testEventDetailsResultsCache as unknown as Cache<
       [executionPoint: ExecutionPoint],
       TestEventDetailsEntry
     >,

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
@@ -21,7 +21,7 @@ import { useJumpToSource } from "ui/components/TestSuite/hooks/useJumpToSource";
 import {
   TestEventDetailsEntry,
   TestEventDomNodeDetails,
-  testEventDetailsCache3ResultsCache,
+  testEventDetailsResultsCache,
   testEventDomNodeCache,
 } from "ui/components/TestSuite/suspense/TestEventDetailsCache";
 import { TestSuiteContext } from "ui/components/TestSuite/views/TestSuiteContext";
@@ -206,7 +206,7 @@ function Badge({
   const client = useContext(ReplayClientContext);
 
   const { status, value } = useImperativeCacheValue(
-    testEventDetailsCache3ResultsCache as unknown as Cache<
+    testEventDetailsResultsCache as unknown as Cache<
       [executionPoint: ExecutionPoint],
       TestEventDetailsEntry
     >,

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
@@ -1,7 +1,7 @@
 import assert from "assert";
-import { TimeStampedPoint } from "@replayio/protocol";
-import { Suspense, memo, useContext, useMemo, useState } from "react";
-import { STATUS_PENDING, STATUS_RESOLVED, useImperativeCacheValue } from "suspense";
+import { ExecutionPoint, TimeStampedPoint } from "@replayio/protocol";
+import { Suspense, memo, useContext, useEffect, useMemo, useState } from "react";
+import { Cache, STATUS_PENDING, STATUS_RESOLVED, useImperativeCacheValue } from "suspense";
 
 import { getExecutionPoint } from "devtools/client/debugger/src/selectors";
 import Loader from "replay-next/components/Loader";
@@ -20,7 +20,10 @@ import { JumpToCodeButton, JumpToCodeStatus } from "ui/components/shared/JumpToC
 import { useJumpToSource } from "ui/components/TestSuite/hooks/useJumpToSource";
 import {
   TestEventDetailsCache,
+  TestEventDetailsEntry,
+  TestEventDomNodeDetails,
   testEventDetailsCache2,
+  testEventDomNodeCache,
 } from "ui/components/TestSuite/suspense/TestEventDetailsCache";
 import { TestSuiteContext } from "ui/components/TestSuite/views/TestSuiteContext";
 import { getViewMode } from "ui/reducers/layout";
@@ -69,12 +72,29 @@ export default memo(function UserActionEventRow({
     replayClient
   );
 
-  const { status: hitPointStatus, value: resultData } = useImperativeCacheValue(
-    testEventDetailsCache2,
-    replayClient,
-    userActionEvent.data.timeStampedPoints.result,
-    userActionEvent.data.resultVariable
+  const { value: domNode, status: domNodeStatus } = useImperativeCacheValue(
+    testEventDomNodeCache as unknown as Cache<
+      [executionPoint: ExecutionPoint],
+      TestEventDomNodeDetails
+    >,
+    userActionEvent.data.timeStampedPoints.result?.point ?? "0"
   );
+
+  // useEffect(() => {
+  //   console.log(
+  //     "Event row DOM node: ",
+  //     userActionEvent.data.timeStampedPoints.result?.point,
+  //     domNodeStatus,
+  //     domNode
+  //   );
+  // }, [userActionEvent, domNodeStatus, domNode]);
+
+  // const { status: hitPointStatus, value: resultData } = useImperativeCacheValue(
+  //   testEventDetailsCache2,
+  //   replayClient,
+  //   userActionEvent.data.timeStampedPoints.result,
+  //   userActionEvent.data.resultVariable
+  // );
 
   const [isHovered, setIsHovered] = useState(false);
 

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
@@ -18,7 +18,10 @@ import { jumpToKnownEventListenerHit } from "ui/actions/eventListeners/jumpToCod
 import { seek } from "ui/actions/timeline";
 import { JumpToCodeButton, JumpToCodeStatus } from "ui/components/shared/JumpToCodeButton";
 import { useJumpToSource } from "ui/components/TestSuite/hooks/useJumpToSource";
-import { TestEventDetailsCache } from "ui/components/TestSuite/suspense/TestEventDetailsCache";
+import {
+  TestEventDetailsCache,
+  testEventDetailsCache2,
+} from "ui/components/TestSuite/suspense/TestEventDetailsCache";
 import { TestSuiteContext } from "ui/components/TestSuite/views/TestSuiteContext";
 import { getViewMode } from "ui/reducers/layout";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
@@ -64,6 +67,13 @@ export default memo(function UserActionEventRow({
   const { status: annotationsStatus, value: parsedAnnotations } = useImperativeCacheValue(
     eventListenersJumpLocationsCache,
     replayClient
+  );
+
+  const { status: hitPointStatus, value: resultData } = useImperativeCacheValue(
+    testEventDetailsCache2,
+    replayClient,
+    userActionEvent.data.timeStampedPoints.result,
+    userActionEvent.data.resultVariable
   );
 
   const [isHovered, setIsHovered] = useState(false);
@@ -199,7 +209,7 @@ function Badge({
   const client = useContext(ReplayClientContext);
 
   const { value } = useImperativeCacheValue(
-    TestEventDetailsCache,
+    testEventDetailsCache2,
     client,
     timeStampedPoint,
     variable

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
@@ -71,14 +71,6 @@ export default memo(function UserActionEventRow({
     replayClient
   );
 
-  const { value: domNode, status: domNodeStatus } = useImperativeCacheValue(
-    testEventDomNodeCache as unknown as Cache<
-      [executionPoint: ExecutionPoint],
-      TestEventDomNodeDetails
-    >,
-    userActionEvent.data.timeStampedPoints.result?.point ?? "0"
-  );
-
   const [isHovered, setIsHovered] = useState(false);
 
   const argsString = useMemo(() => {

--- a/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
@@ -183,17 +183,16 @@ export function TestSectionRow({
       dispatch(setTimelineToTime(getTestEventTime(testEvent)));
 
       if (isUserActionTestEvent(testEvent)) {
-        const resultPoint = testEvent.data.timeStampedPoints.result ?? null;
-        console.log("Test row result point", resultPoint);
-        if (resultPoint) {
-          const firstDomNodeDetails = testEventDomNodeCache.getValueIfCached(resultPoint.point);
+        // We hope to have details on the relevant DOM node cached by now.
+        // If we do, go ahead and read that synchronously so we can highlight the node.
+        // Otherwise, nothing to do here.
+        const firstDomNodeDetails = testEventDomNodeCache.getValueIfCached(
+          testEvent.data.timeStampedPoints.result?.point ?? ""
+        );
 
-          console.log("First DOM node details: ", firstDomNodeDetails);
-          if (firstDomNodeDetails?.domNode?.isConnected) {
-            const { domNode, pauseId } = firstDomNodeDetails;
-            console.log("Highlighting DOM node: ", domNode, pauseId);
-            dispatch(highlightNodes([domNode.id], pauseId));
-          }
+        if (firstDomNodeDetails?.domNode?.isConnected) {
+          const { domNode, pauseId } = firstDomNodeDetails;
+          dispatch(highlightNodes([domNode.id], pauseId));
         }
       }
     }

--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -162,6 +162,7 @@ export default async function setupDevtools(store: AppStore, replayClient: Repla
   // @ts-expect-error complains about thunk type mismatches
   window.app.actions = bindActionCreators(actions, store.dispatch);
   window.app.selectors = bindSelectors(store, justSelectors);
+  window.app.replayClient = replayClient;
 
   const initialState = {};
 


### PR DESCRIPTION
## Original WIP notes

- Switched the `createPause/getAllFrames/evaluateInFrame` combo for `runEvaluation`, which does all of those internally and returns more preview data
  - Created an alternate `testEventDetailsCache2` as the public cache to be used
  - Created another analysis-based cache as the internal impl, as it already knows how to call `runEvaluation`, save the generated pause ID, and cache the pause data
- Added a cache hook to `UserActionEventRow` to prefetch all of the step details
  - We don't seem to virtualize the step details list, so right now _all_ steps are getting 
- Further optimized the fetching logic:
  - Switched from an object read of the `consoleProps` field, to using `${variableName}.consoleProps` in the eval directly.  That drops one level of nested previews.
  - Altered the existing analysis cache logic to allow working with evals that return a single object instead of an array (as our logpoints/events caches all intentionally wrap your provided code string in brackets, so all existing usages were evaluating arrays).  This drops another level of nested previews.
  - Kicked off fetches for `Yielded` and `Applied To` fields so we have those available


Generally, I'm seeing that the "Step Details" field loads much faster whenever you select a step (and I'm surprised it isn't _always_ loading instantly - we may be waiting on other pauses to be created or something?)

I think this now mostly gives me the data I'd need to do hover previews.

~~Next step, though, is I want to see if I can gather all this data in _one_ `runEvaluation` call instead of many individual calls.  There's trickiness here because in theory the value `resultsVariable` field _could_ vary, but per Ryan it seems like that's _probably_ only going to be a single value per version of our plugin (and thus consistent across an entire test).  For example, in my current test, it's always `arguments[4]`.~~

## Update

I think this is fully working!

- All step details for a single test are fetched via a single `runEvaluation` call (which is taking ~1-1.5s to complete for 35-50 points), kicked off by a query hook in `<Panel>`
  - I've hardened the interval cache to handle `runEvaluation` failures (potentially caused by toggling between tests and changing focus regions) so that it aborts the interval load.  This seems to force the cache to acknowledge "we don't have this data", and it will re-request it later if you click into that test again.
- The caching logic then does additional work to pre-fetch DOM node data for this step, if any
- The hover handlers for `<TestSectionRow>` synchronously check if a DOM node is cached, and if so, use that to highlight the node