### PR TITLE
Remove UserActionEvent.timeStampedPointRange

### DIFF
--- a/packages/e2e-tests/tests/cypress-03_test-step-interactions.test.ts
+++ b/packages/e2e-tests/tests/cypress-03_test-step-interactions.test.ts
@@ -139,7 +139,7 @@ test("cypress-03: Test Step interactions", async ({ pageWithMeta: { page, record
     expect(detailsPaneContents["Typed"]).toMatch("buy some cheese");
   });
 
-  await steps.nth(7).click();
+  await steps.nth(8).click();
   await waitFor(async () => {
     const detailsPane = getUserActionEventDetails(page);
     const detailsPaneContents = await getDetailsPaneContents(detailsPane);
@@ -147,7 +147,7 @@ test("cypress-03: Test Step interactions", async ({ pageWithMeta: { page, record
     expect(detailsPaneContents["Typed"]).toMatch("{enter}");
   });
 
-  await steps.nth(8).click();
+  await steps.nth(9).click();
   await waitFor(async () => {
     const detailsPane = getUserActionEventDetails(page);
     const detailsPaneContents = await getDetailsPaneContents(detailsPane);

--- a/src/ui/components/TestSuite/hooks/useJumpToSource.ts
+++ b/src/ui/components/TestSuite/hooks/useJumpToSource.ts
@@ -50,8 +50,7 @@ export function useJumpToSource({
     }
 
     if (testRecording && isUserActionTestEvent(testEvent)) {
-      const { timeStampedPointRange } = testEvent;
-      if (timeStampedPointRange === null) {
+      if (testEvent.data.timeStampedPoints.viewSource === null) {
         return;
       }
 

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
@@ -248,11 +248,11 @@ function findJumpToCodeDetailsIfAvailable(
       }
     }
   } else if (groupedTestCases.environment.testRunner.name === "playwright") {
-    const { data, timeStampedPointRange } = userActionEvent;
-    const { category, command } = data;
+    const { data } = userActionEvent;
+    const { category, command, timeStampedPoints } = data;
     const { name } = command;
 
-    if (timeStampedPointRange !== null) {
+    if (timeStampedPoints.beforeStep !== null && timeStampedPoints.afterStep !== null) {
       canShowJumpToCode =
         category === "command" &&
         (name.startsWith("locator.click") ||
@@ -265,8 +265,8 @@ function findJumpToCodeDetailsIfAvailable(
         jumpToCodeAnnotation = jumpToCodeAnnotations.find(a =>
           isExecutionPointsWithinRange(
             a.point,
-            timeStampedPointRange.begin.point,
-            timeStampedPointRange.end.point
+            timeStampedPoints.beforeStep!.point,
+            timeStampedPoints.afterStep!.point
           )
         );
       }

--- a/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
@@ -16,6 +16,7 @@ import {
   TestRunnerName,
   TestSectionName,
   getTestEventTime,
+  getTestEventTimeStampedPoint,
   isUserActionTestEvent,
 } from "shared/test-suites/RecordingTestMetadata";
 import { isPointInRegion } from "shared/utils/time";
@@ -63,12 +64,7 @@ export function TestSectionRow({
     if (selectedTestEvent) {
       switch (testRunnerName) {
         case "cypress": {
-          let timeStampedPoint: TimeStampedPoint | null = null;
-          if (isUserActionTestEvent(testEvent)) {
-            timeStampedPoint = testEvent.timeStampedPointRange?.begin ?? null;
-          } else {
-            timeStampedPoint = testEvent.timeStampedPoint;
-          }
+          const timeStampedPoint = getTestEventTimeStampedPoint(testEvent);
 
           if (timeStampedPoint) {
             position = isExecutionPointsGreaterThan(timeStampedPoint.point, currentExecutionPoint)

--- a/src/ui/components/TestSuite/views/Toggle/ToggleButton.tsx
+++ b/src/ui/components/TestSuite/views/Toggle/ToggleButton.tsx
@@ -14,10 +14,11 @@ export default function ToggleButton() {
     return null;
   }
 
-  const { timeStampedPointRange } = testEvent;
+  const { timeStampedPoints } = testEvent.data;
   if (
-    timeStampedPointRange == null ||
-    timeStampedPointRange.begin.point === timeStampedPointRange.end.point
+    timeStampedPoints.beforeStep == null ||
+    timeStampedPoints.afterStep == null ||
+    timeStampedPoints.beforeStep.point === timeStampedPoints.afterStep.point
   ) {
     return null;
   }


### PR DESCRIPTION
FE-1901, FE-1957 and FE-1979 are all caused by using `UserActionEvent.timeStampedPointRange` instead of one of the points in `UserActionEvent.data.timeStampedPoints`. I think we should remove `UserActionEvent.timeStampedPointRange` because it doesn't add any value and may lead to more bugs like this in the future.
- change `getTestEventExecutionPoint()`/`getTestEventTime()` (which are used for sorting test events and for "Play from/to here") to use `UserActionEvent.timeStampedPoints.beforeStep` instead of `UserActionEvent.timeStampedPointRange.begin`, which used to be the point of the `step:enqueue` annotation. This fixes FE-1957.
- use `getTestEventTimeStampedPoint()` instead of `timeStampedPointRange.begin` in `TestSectionRow` for deciding whether a step came before or after the currently selected point. This fixes FE-1979.
- use the presence of `timeStampedPoints.viewSource` in `useJumpToSource()` to decide whether to ask `TestStepSourceLocationCache` for a location. That cache asserts `timeStampedPoints.viewSource`, so checking for that instead of `timeStampedPointRange` is more robust.
- use `timeStampedPoints.beforeStep`/`timeStampedPoints.afterStep` instead of `timeStampedPointRange` for showing before/after screenshots. I'm pretty sure this fixes another bug where we sometimes showed the wrong "Before" screenshot although I couldn't find an example for that.
