### PR TITLE
AnalysisCache: don't call runEvaluation if there are no points

### DIFF
--- a/packages/replay-next/src/suspense/AnalysisCache.ts
+++ b/packages/replay-next/src/suspense/AnalysisCache.ts
@@ -78,6 +78,9 @@ export function createAnalysisCache<
       const points = await findPoints(client, begin, end, ...params);
       onPointsReceived?.(points);
 
+      if (points.length === 0) {
+        return [];
+      }
       if (points.length > MAX_POINTS_TO_RUN_EVALUATION) {
         throw commandError("Too many points to run evaluation", ProtocolError.TooManyPoints);
       }


### PR DESCRIPTION
The AnalysisCache first calls `findPoints` and then `runEvaluation`. The assumption is that `runEvaluation` will return exactly one result per point received from `findPoints`. So if `findPoints` doesn't return any points, there's no need to call `runEvaluation`.