### PR TITLE
Optimize RDT component picker setup perf

### DIFF
--- a/src/ui/components/ProtocolViewer/suspense/recordedProtocolMessagesCache.ts
+++ b/src/ui/components/ProtocolViewer/suspense/recordedProtocolMessagesCache.ts
@@ -146,7 +146,8 @@ export const recordedProtocolMessagesCache = createFocusIntervalCacheForExecutio
             // Run `serializeArgument` in an eval, and pass in the local variable
             // as the argument to serialize
             expression: `
-              // Put this into scope
+              // Ensure this is in scope. Note the import rename to avoid
+              // the name conflict with the declared local TS type.
               ${splitStringIntoChunksOriginal}
             
               (${serializeArgument})(${mappedExpression})

--- a/src/ui/suspense/nodeCaches.ts
+++ b/src/ui/suspense/nodeCaches.ts
@@ -392,11 +392,11 @@ export function getMouseTarget(
   mouseTargets: NodeBounds[],
   x: number,
   y: number,
-  nodeIds?: string[]
+  nodeIds?: Set<string>
 ) {
   for (let nodeBounds of mouseTargets) {
     let { node, rect, rects, clipBounds, visibility, pointerEvents } = nodeBounds;
-    if (nodeIds && !nodeIds.includes(node)) {
+    if (nodeIds && !nodeIds.has(node)) {
       continue;
     }
     if (visibility === "hidden" || pointerEvents === "none") {

--- a/src/ui/utils/evalChunkedStrings.ts
+++ b/src/ui/utils/evalChunkedStrings.ts
@@ -1,0 +1,44 @@
+import { Property } from "@replayio/protocol";
+
+import { UnknownFunction } from "ui/setup/dynamic/devtools";
+
+export type ChunksArray = (UnknownFunction | string | number)[];
+
+// This function must be included in the evaluated expression string.
+// Either copy-paste it directly inside an evaluated TS-based function,
+// or insert it into an outer template literal string so it's in scope.
+export function splitStringIntoChunks(allChunks: ChunksArray, str: string) {
+  // Split the stringified data into chunks
+  const stringChunks: string[] = [];
+  for (let i = 0; i < str.length; i += 9999) {
+    stringChunks.push(str.slice(i, i + 9999));
+  }
+
+  // If there's more than one string chunk, save its size
+  if (stringChunks.length > 1) {
+    allChunks.push(stringChunks.length);
+  }
+
+  for (const chunk of stringChunks) {
+    allChunks.push(chunk);
+  }
+  return stringChunks.length;
+}
+
+// The counterpart will run locally on the eval result data.
+// NOTE: this mutates the `chunks` array!
+export function deserializeChunkedString(chunks: Property[]): string {
+  let numStringChunks = 1;
+  if (typeof chunks[0].value === "number") {
+    const numChunksProp = chunks.shift()!;
+    numStringChunks = numChunksProp.value;
+  }
+  const stringChunks = chunks.splice(0, numStringChunks);
+
+  let str = "";
+  for (const stringChunkProp of stringChunks) {
+    str += stringChunkProp.value;
+  }
+
+  return str;
+}

--- a/src/ui/utils/nodePicker.ts
+++ b/src/ui/utils/nodePicker.ts
@@ -9,8 +9,8 @@ export interface NodePickerOpts {
   onPicked: (nodeId: string | null) => void;
   onHighlightNode: (nodeId: string) => void;
   onUnhighlightNode: () => void;
-  onCheckNodeBounds: (x: number, y: number, nodeIds?: string[]) => Promise<NodeBounds | null>;
-  enabledNodeIds?: string[];
+  onCheckNodeBounds: (x: number, y: number, nodeIds?: Set<string>) => Promise<NodeBounds | null>;
+  enabledNodeIds?: Set<string>;
 }
 
 export class NodePicker {


### PR DESCRIPTION
This PR:

- Adds a new `supportsObjectIdEvaluations` field to our capabilities object
- ~~Tries to rewrite the core `NodePicker` class to centralize some of the behavior that's currently split across multiple files, and cut down on the amount of work done while hovering.  **This is currently pretty broken and needs a lot more thought**.~~
- ~~Experiments with an alternate approach for coming up with a `nodeId->fiberId` map, which makes use of the new `__RECORD_REPLAY__.getProtocolIdForObject()` method available in evaluations as of Chromium 2023-09-16~~
  - ~~Current approach: loop over all renderers and all roots inside the eval, get the root DOM nodes, call `rootNode.querySelectorAll("*")`, then call the simpler `renderer.getFiberIdForNative()` instance that hopefully requires less work inside the RDT bundle~~
  - Additionally, all we care about is the node IDs, not the entire DOM node previews.  We don't currently handle the 1000-property preview limit, and I also suspect serializing all those DOM node previews is expensive.  Switched to a `JSON.stringify(nodeIdsToFiberIds)`, and then having to do the same "chunk this string in the eval and reconstruct it on the other side" trick I'm doing in the RDT routine and in the recorded protocol messages logic.

~~Still _very_ WIP, but I'm tentatively hopeful.  A single hands-on check showed the existing approach took 2000ms to return data on 600 DOM nodes.  My initial attempt of still returning a `Map` ended up hitting the 1000-property limit, and that took 3000ms to return.  BUT, doing the node ID lookups in the eval and returning a record let me return 1100 node IDs in 50ms (!!!).~~

## Update

This should be ready now. Final changes:

- Did add the `capabilities.supportsObjectIdEvaluations` field (but had to fix the build date logic that was broken earlier)
- Dropped the `NodePicker` rewrite entirely, other than switching from passing `nodeIds?: string[]` to `nodeIds?: Set<string>` for slightly faster filtering checks
- Consolidated all the fiber ID eval logic in a cache + one evaluated function.  Both of them handle a fast path (if object ID lookups are available) and a slow path (the existing approach of sending back full DOM node previews).  With the fast path, the eval is coming back in ~150ms rather than 1500ms+.
- Started prefetching the `Map<nodeId, fiberId>` data as soon as we pause.
- Now using the same nodeId/fiberIds cache results to look up what DOM nodes to highlight when hovering over component tree items as well, which avoids further individual evals since we have that data on hand already