### PR TITLE
Add `Disable All Caches` option

### DIFF
--- a/packages/shared/user-data/GraphQL/config.ts
+++ b/packages/shared/user-data/GraphQL/config.ts
@@ -28,7 +28,11 @@ export type ViewMode = "dev" | "non-dev";
 export const config = {
   backend_disableCache: {
     defaultValue: Boolean(false),
+    description: "Disable all caches, should only be used for debugging purposes",
     legacyKey: "devtools.disableCache",
+    highRisk: Boolean(true),
+    internalOnly: Boolean(true),
+    label: "Disable all caches",
   },
   backend_disableConcurrentControllerLoading: {
     defaultValue: Boolean(false),

--- a/src/ui/components/shared/UserSettingsModal/panels/Advanced.tsx
+++ b/src/ui/components/shared/UserSettingsModal/panels/Advanced.tsx
@@ -10,6 +10,7 @@ export const PREFERENCES: PreferencesKey[] = [
   "protocol_chromiumRepaints",
   "backend_profileWorkerThreads",
   "feature_basicProcessingLoadingBar",
+  "backend_disableCache",
   "backend_disableScanDataCache",
   "backend_enableRoutines",
   "backend_rerunRoutines",


### PR DESCRIPTION
This setting *really* messes up the session when it's set, so I'd like it to be clearly visible. When it's set right now there is no UI element to let you know, even though it *does* get used at session startup.