### PR TITLE
Hide events panel in Test Suites Replays

### DIFF
--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -448,8 +448,8 @@ export default function Toolbar() {
             onClick={handleButtonClick}
           />
         ) : null}
-        {testRunner !== null &&
-          (testRunner === "cypress" ? (
+        {testRunner !== null ? (
+          testRunner === "cypress" ? (
             <ToolbarButton
               icon="cypress"
               label="Cypress Panel"
@@ -463,8 +463,15 @@ export default function Toolbar() {
               name="cypress"
               onClick={handleButtonClick}
             />
-          ))}
-        <ToolbarButton icon="info" label="Replay Info" name="events" onClick={handleButtonClick} />
+          )
+        ) : (
+          <ToolbarButton
+            icon="info"
+            label="Replay Info"
+            name="events"
+            onClick={handleButtonClick}
+          />
+        )}
         <ToolbarButton
           icon="forum"
           label="Comments"


### PR DESCRIPTION
Reverts #9645

| Replay type | Screenshot |
| :--- | :--- |
| Normal | <img width="434" alt="Screen Shot 2023-10-19 at 9 52 49 AM" src="https://github.com/replayio/devtools/assets/29597/62e243bc-9b9b-4bed-a2db-a09ededb342e"> |
| Cypress | <img width="468" alt="Screen Shot 2023-10-19 at 9 52 53 AM" src="https://github.com/replayio/devtools/assets/29597/0f874efe-c79c-498f-ac0e-c472b566dc7a"> |
| Playwright | <img width="625" alt="Screen Shot 2023-10-19 at 9 53 00 AM" src="https://github.com/replayio/devtools/assets/29597/3c2aaad8-b188-40a1-a5ec-3e8e9e90bde9"> |
