### PR TITLE
Fix Elements resize handle style

### DIFF
--- a/src/devtools/client/inspector/components/App.module.css
+++ b/src/devtools/client/inspector/components/App.module.css
@@ -1,0 +1,12 @@
+.ResizeHandle {
+  border-right: 1px solid var(--theme-splitter-color);
+  height: 100%;
+  width: 1px;
+}
+
+.ResizeHandleTarget {
+  width: 0.25rem;
+  height: 100%;
+  position: relative;
+  left: -0.125rem;
+}

--- a/src/devtools/client/inspector/components/App.tsx
+++ b/src/devtools/client/inspector/components/App.tsx
@@ -16,6 +16,7 @@ import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { ResponsiveTabs, Tab } from "../../shared/components/ResponsiveTabs";
 import { setActiveTab } from "../actions";
 import { EventListenersApp } from "../event-listeners/EventListenersApp";
+import styles from "./App.module.css";
 
 const INSPECTOR_TAB_TITLES: Record<ActiveInspectorTab, string> = {
   ruleview: "Rules",
@@ -58,7 +59,9 @@ export default function InspectorApp() {
           <Panel minSize={20}>
             {enableNewElementsPanel ? <ElementsPanelAdapter /> : <MarkupApp />}
           </Panel>
-          <PanelResizeHandle className="h-full w-1" />
+          <PanelResizeHandle className={styles.ResizeHandle}>
+            <div className={styles.ResizeHandleTarget} />
+          </PanelResizeHandle>
           <Panel defaultSize={40} minSize={20}>
             <div className="devtools-inspector-tab-panel">
               <div id="inspector-sidebar-container">


### PR DESCRIPTION
Before

<img width="645" alt="Screen Shot 2023-10-19 at 11 17 11 AM" src="https://github.com/replayio/devtools/assets/29597/1ac990a1-4ae3-44bb-9d83-e6ef76750ff3">

After

<img width="624" alt="Screen Shot 2023-10-19 at 11 16 42 AM" src="https://github.com/replayio/devtools/assets/29597/887df24c-a3dc-4423-ae86-36dec6fb2eba">
