### PR TITLE
Don't use stepStartPoint for "get" steps in cypress recordings

### DIFF
--- a/packages/e2e-tests/tests/cypress-03_test-step-interactions.test.ts
+++ b/packages/e2e-tests/tests/cypress-03_test-step-interactions.test.ts
@@ -60,12 +60,6 @@ test("cypress-03: Test Step interactions", async ({ pageWithMeta: { page, record
   // Clicking in viewer mode shouldn't switch to DevTools mode
   expect(await isViewerTabActive(page)).toBe(true);
 
-  const firstGet = clickableSteps.filter({ hasText: /get/ }).first();
-
-  // Jump to the first `get` step
-  await firstGet.click();
-  prevPercent = await waitForTimelineAdvanced(page, prevPercent);
-
   // Should show the "Before/After" buttons
   const beforeAfterButtons = getTestStepBeforeAfterButtons(page);
   expect(await beforeAfterButtons.isVisible()).toBe(true);
@@ -75,6 +69,17 @@ test("cypress-03: Test Step interactions", async ({ pageWithMeta: { page, record
   // Clicking "After" changes the current time
   await afterButton.click();
   prevPercent = await waitForTimelineAdvanced(page, prevPercent);
+
+  const firstGet = clickableSteps.filter({ hasText: /get/ }).first();
+
+  // Jump to the first `get` step
+  await firstGet.click();
+  prevPercent = await waitForTimelineAdvanced(page, prevPercent);
+
+  // Buttons get hidden for `get` steps
+  await waitFor(async () => {
+    expect(await beforeAfterButtons.isVisible()).toBe(false);
+  });
 
   const networkStep = steps.filter({ hasText: /localhost/ }).first();
   await networkStep.click();

--- a/packages/shared/test-suites/RecordingTestMetadata.ts
+++ b/packages/shared/test-suites/RecordingTestMetadata.ts
@@ -573,7 +573,7 @@ export async function processCypressTestRecording(
                 testSourceCallStack: null,
                 timeStampedPoints: {
                   afterStep: stepEndPoint,
-                  beforeStep: stepStartPoint,
+                  beforeStep: command.name === "get" ? stepEndPoint : stepStartPoint,
                   result: resultPoint,
                   viewSource: viewSourcePoint,
                 },


### PR DESCRIPTION
FE-1944 only asks for the before/after HUD to be hidden for "get" steps (and to always show the "after" screenshot) but I assume that other interactions should also be changed to remain consistent:
- hovering over a "get" step should show the "after" screenshot
- clicking on a "get" step should take you to the "after" point

This is achieved by setting `beforeStep` to `stepEndPoint` for "get" steps.
