### PR TITLE
Update timeline immediately when seeking

### DIFF
--- a/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
@@ -25,7 +25,7 @@ import {
   isUserActionTestEvent,
 } from "shared/test-suites/RecordingTestMetadata";
 import { isPointInRegion } from "shared/utils/time";
-import { requestFocusWindow, seek, setTimelineToTime } from "ui/actions/timeline";
+import { requestFocusWindow, seek, setHoverTime } from "ui/actions/timeline";
 import { TestSuiteCache } from "ui/components/TestSuite/suspense/TestSuiteCache";
 import { useTestEventContextMenu } from "ui/components/TestSuite/views/TestRecording/useTestEventContextMenu";
 import { TestSuiteContext } from "ui/components/TestSuite/views/TestSuiteContext";
@@ -180,7 +180,7 @@ export function TestSectionRow({
 
   const onMouseEnter = async () => {
     if (!isSelected) {
-      dispatch(setTimelineToTime(getTestEventTime(testEvent)));
+      dispatch(setHoverTime(getTestEventTime(testEvent)));
 
       if (isUserActionTestEvent(testEvent)) {
         // We hope to have details on the relevant DOM node cached by now.
@@ -200,7 +200,7 @@ export function TestSectionRow({
 
   const onMouseLeave = () => {
     if (!isSelected) {
-      dispatch(setTimelineToTime(null));
+      dispatch(setHoverTime(null));
 
       if (isUserActionTestEvent(testEvent)) {
         dispatch(unhighlightNode());

--- a/src/ui/components/Timeline/Timeline.tsx
+++ b/src/ui/components/Timeline/Timeline.tsx
@@ -2,12 +2,7 @@ import { MouseEvent, useContext, useLayoutEffect, useRef, useState } from "react
 
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
 import { throttle } from "shared/utils/function";
-import {
-  seek,
-  setDisplayedFocusWindow,
-  setTimelineToTime,
-  stopPlayback,
-} from "ui/actions/timeline";
+import { seek, setDisplayedFocusWindow, setHoverTime, stopPlayback } from "ui/actions/timeline";
 import useTimelineContextMenu from "ui/components/Timeline/useTimelineContextMenu";
 import { selectors } from "ui/reducers";
 import {
@@ -97,7 +92,7 @@ export default function Timeline() {
     dispatch(setDragging(isDragging));
 
     if (hoverTime != mouseTime) {
-      dispatch(setTimelineToTime(mouseTime, isDragging));
+      dispatch(setHoverTime(mouseTime, isDragging));
     }
 
     if (isDragging) {
@@ -126,7 +121,7 @@ export default function Timeline() {
 
   const onMouseLeave = () => {
     setIsHovered(false);
-    dispatch(setTimelineToTime(null, false));
+    dispatch(setHoverTime(null, false));
   };
 
   return (


### PR DESCRIPTION
We were already [trying to do this](https://github.com/replayio/devtools/blob/bf1bec8037dd4bb67efbea09fbae2273e043c781/src/ui/actions/timeline.ts#L265-L267) but we were using `setTimelineToTime()` which doesn't really do what it says. To avoid similar confusion in the future, I renamed it to `setHoverTime()`.