### PR TITLE
GenericList changes

### DIFF
--- a/packages/replay-next/components/elements/ElementList.module.css
+++ b/packages/replay-next/components/elements/ElementList.module.css
@@ -8,5 +8,5 @@
   * The parent list will measure rows after render and adjust the min-width of the list.
   * This prevents horizontal scrolling from jumping as new rows are rendered.
   */
-  width: var(--longest-line-width) !important;
+  width: max(100%, var(--longest-line-width)) !important;
 }

--- a/packages/replay-next/components/elements/ElementsListData.test.ts
+++ b/packages/replay-next/components/elements/ElementsListData.test.ts
@@ -39,7 +39,7 @@ describe("ElementsListData", () => {
     // Wait for the path of nodes to load and expand
     // but not for the full tree data to be loaded
     return new Promise<void>(resolve => {
-      const unsubscribe = listData.subscribe(() => {
+      const unsubscribe = listData.subscribeToInvalidation(() => {
         resolve();
         unsubscribe();
       });

--- a/packages/replay-next/components/elements/ElementsListData.ts
+++ b/packages/replay-next/components/elements/ElementsListData.ts
@@ -25,6 +25,8 @@ export class ElementsListData extends GenericListData<Item> {
   constructor(replayClient: ReplayClientInterface, pauseId: PauseId) {
     super();
 
+    this.setSelectedIndex(0);
+
     this._pauseId = pauseId;
     this._replayClient = replayClient;
   }

--- a/packages/replay-next/components/elements/ElementsListItem.module.css
+++ b/packages/replay-next/components/elements/ElementsListItem.module.css
@@ -1,5 +1,5 @@
 .Node {
-  min-width: var(--longest-line-width) !important;
+  min-width: max(100%, var(--longest-line-width)) !important;
   line-height: 1rem;
   font-family: var(--font-family-monospace);
   font-size: var(--font-size-regular-monospace);

--- a/packages/replay-next/components/elements/ElementsPanel.module.css
+++ b/packages/replay-next/components/elements/ElementsPanel.module.css
@@ -59,7 +59,6 @@
 }
 
 .SearchResults {
-  line-height: 1.5rem;
   font-size: var(--font-size-small);
 }
 

--- a/packages/shared/EventEmitter.ts
+++ b/packages/shared/EventEmitter.ts
@@ -1,0 +1,68 @@
+export type EventMap = {
+  [key: string]: (...args: any[]) => void;
+};
+
+export class EventEmitter<Events extends EventMap> {
+  private listenerMap: Map<keyof Events, Array<Events[keyof Events]>> = new Map();
+
+  addListener<Type extends keyof Events>(type: Type, listener: Events[Type]) {
+    const listeners = this.listenerMap.get(type);
+    if (listeners === undefined) {
+      this.listenerMap.set(type, [listener]);
+    } else {
+      if (!listeners.includes(listener)) {
+        listeners.push(listener);
+      }
+    }
+
+    return () => {
+      this.removeListener(type, listener);
+    };
+  }
+
+  emit<Type extends keyof Events>(event: Type, ...args: Parameters<Events[Type]>) {
+    const listeners = this.listenerMap.get(event);
+    if (listeners !== undefined) {
+      if (listeners.length === 1) {
+        const listener = listeners[0];
+        listener.apply(null, args);
+      } else {
+        let didThrow = false;
+        let caughtError = null;
+
+        // Clone the current listeners before calling
+        // in case calling triggers listeners to be added or removed
+        const clonedListeners = Array.from(listeners);
+        for (let i = 0; i < clonedListeners.length; i++) {
+          const listener = clonedListeners[i];
+          try {
+            listener.apply(null, args);
+          } catch (error) {
+            if (caughtError === null) {
+              didThrow = true;
+              caughtError = error;
+            }
+          }
+        }
+
+        if (didThrow) {
+          throw caughtError;
+        }
+      }
+    }
+  }
+
+  removeAllListeners<Type extends keyof Events>(event?: Type) {
+    this.listenerMap.clear();
+  }
+
+  removeListener<Type extends keyof Events>(event: Type, listener: Events[Type]) {
+    const listeners = this.listenerMap.get(event);
+    if (listeners !== undefined) {
+      const index = listeners.indexOf(listener);
+      if (index >= 0) {
+        listeners.splice(index, 1);
+      }
+    }
+  }
+}


### PR DESCRIPTION
In support of #9807 and the new React DevTools, this PR makes a significant change to the generic list component:
Tracking of the selected index has been moved outside of the `GenericList` component (and React state) and into the `GenericListData` class. This will enable the React DevTools implementation to shift the selected index when the Fiber tree changes so that the same Fiber (persisted id) remains selected.

This PR also adds a TypeScript type-safe `EventEmitter` class because (I don't think?) we have one.

I also tweaked a couple of minor things while I was in:
* Fixed a small CSS bug for narrow trees.
* Max length for plaintext lines to avoid long horizontal scrolling.