### PR TITLE
Ensure all components use the same current point

### DIFF
--- a/src/devtools/client/debugger/src/components/SecondaryPanes/index.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/index.tsx
@@ -1,8 +1,8 @@
 import { useGraphQLUserData } from "shared/user-data/GraphQL/useGraphQLUserData";
-import { getCurrentPoint } from "ui/actions/app";
 import { getCurrentTime } from "ui/reducers/timeline";
 import { useAppSelector } from "ui/setup/hooks";
 
+import { getExecutionPoint } from "../../selectors";
 import BreakpointsPane from "./BreakpointsPane";
 import CommandBar from "./CommandBar";
 import NewFrames from "./Frames/NewFrames";
@@ -13,7 +13,7 @@ import NewScopes from "./NewScopes";
 import { Accordion, AccordionPane } from "@recordreplay/accordion";
 
 export default function SecondaryPanes() {
-  const currentPoint = useAppSelector(getCurrentPoint);
+  const currentPoint = useAppSelector(getExecutionPoint);
   const currentTime = useAppSelector(getCurrentTime);
 
   const [scopesVisible, setScopesVisible] = useGraphQLUserData("layout_scopesPanelExpanded");

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -24,7 +24,6 @@ import {
   clearExpectedError,
   getExpectedError,
   getUnexpectedError,
-  setCurrentPoint,
   setTrialExpired,
 } from "ui/reducers/app";
 import { getToolboxLayout } from "ui/reducers/layout";
@@ -349,8 +348,6 @@ export function createSocket(
 
       dispatch(actions.setUploading(null));
       dispatch(actions.setAwaitingSourcemaps(false));
-
-      ThreadFront.on("paused", ({ point }) => dispatch(setCurrentPoint(point)));
 
       await replayClient.waitForSession();
       await dispatch(jumpToInitialPausePoint());

--- a/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
+++ b/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
@@ -12,7 +12,7 @@ import React, {
 import { useImperativeCacheValue } from "suspense";
 
 import { selectLocation } from "devtools/client/debugger/src/actions/sources";
-import { getThreadContext } from "devtools/client/debugger/src/reducers/pause";
+import { getExecutionPoint, getThreadContext } from "devtools/client/debugger/src/reducers/pause";
 import { highlightNode, unhighlightNode } from "devtools/client/inspector/markup/actions/markup";
 import { ThreadFront } from "protocol/thread";
 import { assert } from "protocol/utils";
@@ -31,12 +31,7 @@ import { useTheme } from "shared/theme/useTheme";
 import { UIThunkAction } from "ui/actions";
 import { fetchMouseTargetsForPause } from "ui/actions/app";
 import { enterFocusMode } from "ui/actions/timeline";
-import {
-  getCurrentPoint,
-  nodePickerDisabled,
-  nodePickerInitializing,
-  nodePickerReady,
-} from "ui/reducers/app";
+import { nodePickerDisabled, nodePickerInitializing, nodePickerReady } from "ui/reducers/app";
 import { getPreferredLocation } from "ui/reducers/sources";
 import { useAppDispatch, useAppSelector, useAppStore } from "ui/setup/hooks";
 import { UIState } from "ui/state";
@@ -464,7 +459,7 @@ export function ReactDevtoolsPanel() {
   const theme = useTheme();
   const replayClient = useContext(ReplayClientContext);
   const componentPickerActive = useAppSelector(getIsReactComponentPickerActive);
-  const currentPoint = useAppSelector(getCurrentPoint);
+  const currentPoint = useAppSelector(getExecutionPoint);
   const previousPoint = usePrevious(currentPoint);
   const isFirstAnnotationsInjection = useRef(true);
   const [, forceRender] = useReducer(c => c + 1, 0);

--- a/src/ui/components/SecondaryToolbox/TimelineContextAdapter.tsx
+++ b/src/ui/components/SecondaryToolbox/TimelineContextAdapter.tsx
@@ -1,4 +1,4 @@
-import { ExecutionPoint, PauseId } from "@replayio/protocol";
+import { ExecutionPoint } from "@replayio/protocol";
 import React, {
   PropsWithChildren,
   useCallback,
@@ -9,10 +9,10 @@ import React, {
   useTransition,
 } from "react";
 
+import { getExecutionPoint } from "devtools/client/debugger/src/selectors";
 import { TimelineContext, TimelineContextType } from "replay-next/src/contexts/TimelineContext";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { seek } from "ui/actions/timeline";
-import { getCurrentPoint } from "ui/reducers/app";
 import { getCurrentTime } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 
@@ -28,7 +28,7 @@ export default function TimelineContextAdapter({ children }: PropsWithChildren) 
 
   const dispatch = useAppDispatch();
   const time = useAppSelector(getCurrentTime);
-  const executionPoint = useAppSelector(getCurrentPoint) || "0";
+  const executionPoint = useAppSelector(getExecutionPoint) || "0";
 
   const update = useCallback(
     async (time: number, executionPoint: ExecutionPoint, openSource: boolean) => {

--- a/src/ui/components/SecondaryToolbox/TimelineContextAdapter.tsx
+++ b/src/ui/components/SecondaryToolbox/TimelineContextAdapter.tsx
@@ -1,31 +1,14 @@
 import { ExecutionPoint } from "@replayio/protocol";
-import React, {
-  PropsWithChildren,
-  useCallback,
-  useContext,
-  useLayoutEffect,
-  useMemo,
-  useState,
-  useTransition,
-} from "react";
+import React, { PropsWithChildren, useCallback, useMemo } from "react";
 
 import { getExecutionPoint } from "devtools/client/debugger/src/selectors";
 import { TimelineContext, TimelineContextType } from "replay-next/src/contexts/TimelineContext";
-import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { seek } from "ui/actions/timeline";
 import { getCurrentTime } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 
 // Adapter that reads the current execution point and time (from Redux) and passes them to the TimelineContext.
 export default function TimelineContextAdapter({ children }: PropsWithChildren) {
-  const client = useContext(ReplayClientContext);
-  const [state, setState] = useState<Omit<TimelineContextType, "isPending" | "update">>({
-    executionPoint: "0",
-    time: 0,
-  });
-
-  const [isPending, startTransition] = useTransition();
-
   const dispatch = useAppDispatch();
   const time = useAppSelector(getCurrentTime);
   const executionPoint = useAppSelector(getExecutionPoint) || "0";
@@ -37,19 +20,14 @@ export default function TimelineContextAdapter({ children }: PropsWithChildren) 
     [dispatch]
   );
 
-  useLayoutEffect(() => {
-    startTransition(() => {
-      setState({ executionPoint, time });
-    });
-  }, [executionPoint, time]);
-
   const context = useMemo<TimelineContextType>(
     () => ({
-      ...state,
-      isPending,
+      executionPoint,
+      time,
+      isPending: false,
       update,
     }),
-    [isPending, state, update]
+    [executionPoint, time, update]
   );
 
   return <TimelineContext.Provider value={context}>{children}</TimelineContext.Provider>;

--- a/src/ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsListItem.tsx
+++ b/src/ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsListItem.tsx
@@ -1,10 +1,10 @@
-import { CSSProperties, useEffect, useRef } from "react";
+import { CSSProperties } from "react";
 
+import { getExecutionPoint } from "devtools/client/debugger/src/selectors";
 import { isExecutionPointsGreaterThan } from "replay-next/src/utils/time";
 import { ReduxActionAnnotation } from "ui/components/SecondaryToolbox/redux-devtools/annotations";
 import { jumpToLocationForReduxDispatch } from "ui/components/SecondaryToolbox/redux-devtools/utils/jumpToLocationForReduxDispatch";
 import { JumpToCodeButton } from "ui/components/shared/JumpToCodeButton";
-import { getCurrentPoint } from "ui/reducers/app";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 
 import useReduxDevtoolsContextMenu from "./useReduxDevtoolsContextMenu";
@@ -46,7 +46,7 @@ export function ReduxDevToolsListItem({
   );
 
   const dispatch = useAppDispatch();
-  const currentExecutionPoint = useAppSelector(getCurrentPoint);
+  const currentExecutionPoint = useAppSelector(getExecutionPoint);
 
   const onSeek = () => {
     selectAnnotation(annotation);

--- a/src/ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsPanel.tsx
+++ b/src/ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsPanel.tsx
@@ -2,7 +2,7 @@ import { Suspense, useContext, useMemo, useState } from "react";
 import { PanelGroup, PanelResizeHandle, Panel as ResizablePanel } from "react-resizable-panels";
 import { useImperativeCacheValue } from "suspense";
 
-import { annotateFrames } from "devtools/client/debugger/src/utils/pause/frames";
+import { getExecutionPoint } from "devtools/client/debugger/src/selectors";
 import IndeterminateLoader from "replay-next/components/IndeterminateLoader";
 import Loader from "replay-next/components/Loader";
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
@@ -13,7 +13,6 @@ import { ActionFilter } from "ui/components/SecondaryToolbox/redux-devtools/Acti
 import { ReduxActionAnnotation } from "ui/components/SecondaryToolbox/redux-devtools/annotations";
 import { ReduxDevToolsContents } from "ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsContents";
 import { ReduxDevToolsList } from "ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsList";
-import { getCurrentPoint } from "ui/reducers/app";
 import { useAppSelector } from "ui/setup/hooks";
 import { reduxDevToolsAnnotationsCache } from "ui/suspense/annotationsCaches";
 
@@ -26,7 +25,7 @@ export default function ReduxDevToolsPanel() {
   const [selectedAnnotation, selectAnnotation] = useState<ReduxActionAnnotation | null>(null);
   const [searchValue, setSearchValue] = useState("");
 
-  const currentExecutionPoint = useAppSelector(getCurrentPoint);
+  const currentExecutionPoint = useAppSelector(getExecutionPoint);
 
   const { status: annotationsStatus, value: parsedAnnotations } = useImperativeCacheValue(
     reduxDevToolsAnnotationsCache,

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -1,7 +1,7 @@
 import { PayloadAction, createSelector, createSlice } from "@reduxjs/toolkit";
 
 import { RecordingTarget } from "replay-next/src/suspense/BuildIdCache";
-import { compareExecutionPoints, isExecutionPointsWithinRange } from "replay-next/src/utils/time";
+import { compareExecutionPoints } from "replay-next/src/utils/time";
 import { Workspace } from "shared/graphql/types";
 import { UIState } from "ui/state";
 import {
@@ -23,7 +23,6 @@ export const initialAppState: AppState = {
   activeNodePicker: null,
   awaitingSourcemaps: false,
   canvas: null,
-  currentPoint: null,
   defaultSettingsTab: "Preferences",
   displayedLoadingProgress: null,
   events: {},
@@ -131,9 +130,6 @@ const appSlice = createSlice({
     setRecordingWorkspace(state, action: PayloadAction<Workspace>) {
       state.recordingWorkspace = action.payload;
     },
-    setCurrentPoint(state, action: PayloadAction<string | null>) {
-      state.currentPoint = action.payload;
-    },
     setAppMode(state, action: PayloadAction<AppMode>) {
       state.mode = action.payload;
     },
@@ -151,7 +147,6 @@ export const {
   setAppMode,
   setAwaitingSourcemaps,
   setCanvas,
-  setCurrentPoint,
   setDefaultSettingsTab,
   loadReceivedEvents,
   setExpectedError,
@@ -224,4 +219,3 @@ export const getDefaultSettingsTab = (state: UIState) => state.app.defaultSettin
 export const getRecordingTarget = (state: UIState) => state.app.recordingTarget;
 export const getRecordingWorkspace = (state: UIState) => state.app.recordingWorkspace;
 export const getAreMouseTargetsLoading = (state: UIState) => state.app.mouseTargetsLoading;
-export const getCurrentPoint = (state: UIState) => state.app.currentPoint;

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -82,7 +82,6 @@ export interface AppState {
   activeNodePicker: NodePickerType | null;
   awaitingSourcemaps: boolean;
   canvas: Canvas | null;
-  currentPoint: ExecutionPoint | null;
   defaultSettingsTab: SettingsTabTitle;
   displayedLoadingProgress: number | null;
   events: Events;


### PR DESCRIPTION
- we had two current points in redux, which were updated at different times
- the `TimelineContextAdapter` passed on the current point and time with some delay (because they were copied in an effect)

This also fixes possible "tearing" when components use a `pauseId` and a `point` that don't match (i.e. the `pauseId` is for a different `point`).