### PR TITLE
Remove unnecessary timing bar override for selected network requests

### DIFF
--- a/src/ui/components/NetworkMonitor/NetworkMonitorListRow.module.css
+++ b/src/ui/components/NetworkMonitor/NetworkMonitorListRow.module.css
@@ -141,10 +141,6 @@
   min-width: 1px;
 }
 
-.Row[data-selected] .Timing {
-  background-color: var(--testsuites-success-color);
-}
-
 .Row:hover .TimingContainer {
   background-color: var(--body-bgcolor);
 }


### PR DESCRIPTION
This PR:

- Fixes the color of the timing section for failed network requests when selected

### Screenshots:

- Before (unselected):

![image](https://github.com/replayio/devtools/assets/1128784/ca8ff160-df02-4f22-bf3d-ea677f1e5c9d)

- Before (selected) - note the green color for a failed 500 request:

![image](https://github.com/replayio/devtools/assets/1128784/ce302fe7-e11a-4240-a19a-314cba65f122)

- After (light theme) - note the timing bar is now red:

![image](https://github.com/replayio/devtools/assets/1128784/c5d3893a-3672-4adb-b57d-0a1fcadf387c)

- After (dark theme):

![image](https://github.com/replayio/devtools/assets/1128784/dbeca7ee-4942-40a2-8c8c-8559d7a1fbe3)


I see that the original CSS behavior here was intentional, but I'm not sure why this was necessary.  We wouldn't want to hardcode `--success-color`, and I don't _think_ we need to change the timing bar color in general when it's selected.