### PR TITLE
Keep all traces

### DIFF
--- a/packages/protocol/socket.ts
+++ b/packages/protocol/socket.ts
@@ -109,7 +109,7 @@ export type ExperimentalSettings = {
   disableRecordingAssetsInDatabase?: boolean;
   disableScanDataCache?: boolean;
   enableRoutines?: boolean;
-  keepAllTraces?: boolean;
+  sampleAllTraces?: boolean;
   listenForMetrics: boolean;
   profileWorkerThreads?: boolean;
   rerunRoutines?: boolean;

--- a/packages/shared/user-data/GraphQL/config.ts
+++ b/packages/shared/user-data/GraphQL/config.ts
@@ -80,9 +80,10 @@ export const config = {
     label: "Enable backend processing routines",
     legacyKey: "devtools.features.enableRoutines",
   },
-  backend_keepAllTraces: {
+  backend_sampleAllTraces: {
     defaultValue: Boolean(false),
     internalOnly: Boolean(true),
+    label: "Keep all Honeycomb events",
     legacyKey: "devtools.features.keepAllTraces",
   },
   backend_listenForMetrics: {

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -197,7 +197,7 @@ export function createSocket(
         enableRoutines: userData.get("backend_enableRoutines"),
         rerunRoutines: userData.get("backend_rerunRoutines"),
         disableRecordingAssetsInDatabase: userData.get("backend_disableRecordingAssetsInDatabase"),
-        keepAllTraces: userData.get("backend_keepAllTraces"),
+        sampleAllTraces: userData.get("backend_sampleAllTraces"),
         disableIncrementalSnapshots: userData.get("backend_disableIncrementalSnapshots"),
         disableConcurrentControllerLoading: userData.get(
           "backend_disableConcurrentControllerLoading"

--- a/src/ui/components/ProtocolViewer/hooks/useHoneycombQueryLink.ts
+++ b/src/ui/components/ProtocolViewer/hooks/useHoneycombQueryLink.ts
@@ -15,15 +15,15 @@ export function useHoneycombQueryLink() {
         JSON.stringify({
           time_range: 3600,
           granularity: 0,
-          breakdowns: ["trace.trace_id"],
-          calculations: [{ op: "COUNT" }],
+          breakdowns: ["trace.trace_id", "name", "rpc.replayprotocol.command_id"],
+          calculations: [{ op: "AVG", column: "duration_ms" }],
           filters: [
             { column: "name", op: "starts-with", value: "replayprotocol" },
             { column: "replay.session.id", op: "=", value: window.sessionId },
             { column: "rpc.replayprotocol.command_id", op: "=", value: request.id },
           ],
           filter_combination: "AND",
-          orders: [{ op: "COUNT", order: "descending" }],
+          orders: [{ op: "AVG", column: "duration_ms", order: "descending" }],
           havings: [],
           limit: 100,
         })

--- a/src/ui/components/shared/UserSettingsModal/panels/Advanced.tsx
+++ b/src/ui/components/shared/UserSettingsModal/panels/Advanced.tsx
@@ -3,6 +3,7 @@ import { PreferencesKey } from "shared/user-data/GraphQL/types";
 import { BooleanPreference } from "ui/components/shared/UserSettingsModal/components/BooleanPreference";
 
 export const PREFERENCES: PreferencesKey[] = [
+  "backend_sampleAllTraces",
   "global_logTelemetryEvent",
   "feature_protocolTimeline",
   "feature_protocolPanel",


### PR DESCRIPTION
This tells the backend to save all the honeycomb events so that we'll have an event in honeycomb for every protocol request we see in the viewer.