### PR TITLE
Remove recordingIds from test run graphql

### DIFF
--- a/packages/shared/graphql/generated/GetTestRunRecordings.ts
+++ b/packages/shared/graphql/generated/GetTestRunRecordings.ts
@@ -42,7 +42,6 @@ export interface GetTestRunRecordings_node_Workspace_testRuns_edges_node_tests {
   result: string;
   errors: string[] | null;
   durationMs: number;
-  recordingIds: string[];
   recordings: GetTestRunRecordings_node_Workspace_testRuns_edges_node_tests_recordings[];
 }
 

--- a/packages/shared/test-suites/TestRun.ts
+++ b/packages/shared/test-suites/TestRun.ts
@@ -27,7 +27,6 @@ export type TestRunTest = {
   result: string;
   errors: string[] | null;
   durationMs: number;
-  recordingIds: string[];
 };
 
 export interface TestRunTestWithRecordings extends TestRunTest {

--- a/src/ui/components/Library/Team/View/TestRuns/graphql/TestRunsGraphQL.ts
+++ b/src/ui/components/Library/Team/View/TestRuns/graphql/TestRunsGraphQL.ts
@@ -31,7 +31,6 @@ const GET_TEST_RUN_RECORDINGS = gql`
                 result
                 errors
                 durationMs
-                recordingIds
                 recordings {
                   uuid
                   duration


### PR DESCRIPTION
PR #9823 included `recordingIds` in the test run graphql query but it isn't used and will be removed shortly