### PR TITLE
Update tests library date checks to match current values

### DIFF
--- a/packages/e2e-tests/authenticated/test-suites/library-test-runs.test.ts
+++ b/packages/e2e-tests/authenticated/test-suites/library-test-runs.test.ts
@@ -29,6 +29,10 @@ test(`authenticated/test-suites/library-test-runs`, async ({ page }) => {
     title: "github: remove semgrep (#9332)",
   }).first();
   await expect(await getTestRunAttribute(testRun, "Branch").textContent()).toBe("main");
-  await expect(await getTestRunAttribute(testRun, "Date").textContent()).toContain("6/14/2023");
+  // Relative dates can change over time.
+  // Check for either the "X units ago" text, or the literal date.
+  await expect(await getTestRunAttribute(testRun, "Date").textContent()).toMatch(
+    / ago|(10\/26\/2023)/
+  );
   await expect(await getTestRunAttribute(testRun, "Username").textContent()).toContain("jazzdan");
 });

--- a/packages/e2e-tests/authenticated/test-suites/library-tests-list.test.ts
+++ b/packages/e2e-tests/authenticated/test-suites/library-tests-list.test.ts
@@ -31,7 +31,11 @@ test(`authenticated/test-suites/library-tests-list`, async ({ page }) => {
   const runSummary = getTestRunSummary(page);
   await expect(await runSummary.textContent()).toContain("github: remove semgrep (#9332)");
   await expect(await getTestRunAttribute(runSummary, "Branch").textContent()).toBe("main");
-  await expect(await getTestRunAttribute(runSummary, "Date").textContent()).toContain("6/14/2023");
+  // Relative dates can change over time.
+  // Check for either the "X units ago" text, or the literal date.
+  await expect(await getTestRunAttribute(runSummary, "Date").textContent()).toMatch(
+    / ago|(10\/26\/2023)/
+  );
   await expect(await getTestRunAttribute(runSummary, "Duration").textContent()).toContain(
     "1h 19m 3.6s"
   );


### PR DESCRIPTION
This PR:

- Updates both auth library tests to handle the changed dates for the example tests in the DB (now 2023-10-26, instead of 2023-06-14), and to handle relative dates as well