### PR TITLE
Fix e2e test regressions related to new Elements panel

### DIFF
--- a/packages/e2e-tests/helpers/console-panel.ts
+++ b/packages/e2e-tests/helpers/console-panel.ts
@@ -260,6 +260,7 @@ export async function seekToConsoleMessage(
   await debugPrint(page, `Seeking to message "${chalk.bold(textContent)}"`, "seekToConsoleMessage");
 
   await consoleMessage.scrollIntoViewIfNeeded();
+  await consoleMessage.waitFor();
   await consoleMessage.hover();
   await consoleMessage.locator('[data-test-id="ConsoleMessageHoverButton"]').click();
 
@@ -267,6 +268,7 @@ export async function seekToConsoleMessage(
     async () =>
       await expect(await consoleMessage.getAttribute("data-test-paused-here")).toBe("true")
   );
+
   await waitForPaused(page, line);
 }
 
@@ -464,8 +466,11 @@ export async function verifyTrimmedConsoleMessages(
 
 export async function warpToMessage(page: Page, text: string, line?: number) {
   await openConsolePanel(page);
+
   const messages = await findConsoleMessage(page, text);
   const message = messages.first();
+  await message.waitFor();
+
   await seekToConsoleMessage(page, message, line);
 }
 

--- a/packages/e2e-tests/helpers/elements-panel.ts
+++ b/packages/e2e-tests/helpers/elements-panel.ts
@@ -1,6 +1,7 @@
 import { Locator, Page, expect } from "@playwright/test";
 import chalk from "chalk";
 
+import { clearText } from "./lexical";
 import { debugPrint, delay, waitFor } from "./utils";
 
 type ElementsListRowOptions = {
@@ -315,9 +316,18 @@ export async function searchElementsPanel(page: Page, searchText: string): Promi
   );
 
   const input = page.locator('[data-test-id="ElementsSearchInput"]')!;
+  await input.isEnabled();
   await input.focus();
   await input.type(searchText);
-  await input.press("Enter");
+
+  await waitFor(async () => {
+    await input.press("Enter");
+
+    // If the Elements panel is still loading, the search won't be handled.
+    // A proxy for confirming that the search has been handled is that a results label will be rendered.
+    const resultsLabel = page.locator('[data-test-id="ElementsPanel-SearchResult"]');
+    await expect(await resultsLabel.count()).toEqual(1);
+  });
 }
 
 export async function selectElementsListRow(

--- a/packages/e2e-tests/tests/highlighter.test.ts
+++ b/packages/e2e-tests/tests/highlighter.test.ts
@@ -1,11 +1,6 @@
 import { openDevToolsTab, startTest } from "../helpers";
 import { openConsolePanel, warpToMessage } from "../helpers/console-panel";
-import {
-  getElementsListRow,
-  openElementsPanel,
-  selectElementsListRow,
-  toggleElementsListRow,
-} from "../helpers/elements-panel";
+import { openElementsPanel, selectElementsListRow } from "../helpers/elements-panel";
 import test, { expect } from "../testFixtureCloneRecording";
 
 test.use({ exampleKey: "doc_inspector_basic.html" });
@@ -20,9 +15,6 @@ test("highlighter: element highlighter works everywhere", async ({
   await openConsolePanel(page);
   await warpToMessage(page, "ExampleFinished");
   await openElementsPanel(page);
-
-  const bodyLocator = await getElementsListRow(page, { text: "body", type: "opening" });
-  await toggleElementsListRow(page, bodyLocator, true);
 
   await selectElementsListRow(page, { text: "myiframe" });
 

--- a/packages/e2e-tests/tests/inspector-elements-01_basic-dom-tree.test.ts
+++ b/packages/e2e-tests/tests/inspector-elements-01_basic-dom-tree.test.ts
@@ -27,9 +27,6 @@ test("inspector-elements-01: Basic DOM tree node display", async ({
 
   await openElementsPanel(page);
 
-  const bodyNode = await getElementsListRow(page, { text: "<body" });
-  await toggleElementsListRow(page, bodyNode, true);
-
   await activateInspectorTool(page);
   let node = await getElementsListRow(page, { text: '<div id="maindiv"' });
   await node.waitFor();
@@ -41,7 +38,6 @@ test("inspector-elements-01: Basic DOM tree node display", async ({
   await addBreakpoint(page, { url: "doc_inspector_basic.html", lineNumber: 9 });
   await rewindToLine(page, 9);
 
-  await toggleElementsListRow(page, bodyNode, true);
   node = await getElementsListRow(page, { text: '<div id="maindiv"' });
   await node.waitFor();
   await toggleElementsListRow(page, node, true);

--- a/packages/e2e-tests/tests/inspector-elements-03_nested-node-selection.test.ts
+++ b/packages/e2e-tests/tests/inspector-elements-03_nested-node-selection.test.ts
@@ -7,7 +7,6 @@ import {
   getElementsListRow,
   openElementsPanel,
   searchElementsPanel,
-  toggleElementsListRow,
   typeKeyAndVerifySelectedElement,
   waitForElementsToLoad,
   waitForSelectedElementsRow,
@@ -60,9 +59,7 @@ test("inspector-elements-03: Nested node picker and selection behavior", async (
   await openElementsPanel(page);
 
   await waitForElementsToLoad(page);
-  const bodyTag = await getElementsListRow(page, { text: "body", type: "opening" });
-  await toggleElementsListRow(page, bodyTag, true);
-  await waitForSelectedElementsRow(page, "body");
+
   debugPrint(page, "Waiting for body children to load...");
   const elementsTree = getElementsList(page);
   await waitFor(async () => {
@@ -74,6 +71,7 @@ test("inspector-elements-03: Nested node picker and selection behavior", async (
   const canvas = page.locator("canvas#graphics");
   const rulesContainer = page.locator('[data-test-id="RulesPanel"]');
 
+  const bodyTag = await getElementsListRow(page, { text: "body", type: "opening" });
   await bodyTag.click();
 
   const stackingCaseR3C2 = stackingTestCases.find(tc => tc.id === "r3c2")!;

--- a/packages/e2e-tests/tests/inspector-elements-04_key-shortcuts.test.ts
+++ b/packages/e2e-tests/tests/inspector-elements-04_key-shortcuts.test.ts
@@ -3,16 +3,14 @@ import { expect } from "@playwright/test";
 import { openDevToolsTab, startTest } from "../helpers";
 import { warpToMessage } from "../helpers/console-panel";
 import {
-  getElementsList,
   getElementsListRow,
   openElementsPanel,
-  toggleElementsListRow,
   typeKeyAndVerifySelectedElement,
   waitForElementsToLoad,
   waitForSelectedElementsRow,
 } from "../helpers/elements-panel";
 import { closeSidePanel } from "../helpers/pause-information-panel";
-import { debugPrint, waitFor } from "../helpers/utils";
+import { waitFor } from "../helpers/utils";
 import test from "../testFixtureCloneRecording";
 
 test.use({ exampleKey: "doc_stacking.html" });
@@ -58,9 +56,8 @@ test("inspector-elements-04: Keyboard shortcuts should select the right DOM node
 
   await waitForElementsToLoad(page);
   const bodyTag = await getElementsListRow(page, { text: "body", type: "opening" });
-  await toggleElementsListRow(page, bodyTag, true);
-  await waitForSelectedElementsRow(page, "body");
   await bodyTag.click();
+  await waitForSelectedElementsRow(page, "body");
 
   // Basic up/down selects the next element in the tree
   await typeKeyAndVerifySelectedElement(page, "ArrowDown", bodyChildDomNodes[0]);

--- a/packages/e2e-tests/tests/inspector-rules-01_basic-rules.test.ts
+++ b/packages/e2e-tests/tests/inspector-rules-01_basic-rules.test.ts
@@ -2,10 +2,8 @@ import { openDevToolsTab, startTest } from "../helpers";
 import { openConsolePanel, warpToMessage } from "../helpers/console-panel";
 import {
   checkAppliedRules,
-  getElementsListRow,
   openElementsPanel,
   selectElementsListRow,
-  toggleElementsListRow,
 } from "../helpers/elements-panel";
 import test from "../testFixtureCloneRecording";
 
@@ -21,8 +19,6 @@ test("inspector-rules-01: Basic CSS rules should be viewed", async ({
   await warpToMessage(page, "ExampleFinished");
 
   await openElementsPanel(page);
-  const bodyLocator = await getElementsListRow(page, { text: "body", type: "opening" });
-  await toggleElementsListRow(page, bodyLocator, true);
 
   await selectElementsListRow(page, { text: "maindiv" });
   await checkAppliedRules(page, [

--- a/packages/e2e-tests/tests/inspector-rules-02_sourcemapped-rules.test.ts
+++ b/packages/e2e-tests/tests/inspector-rules-02_sourcemapped-rules.test.ts
@@ -2,10 +2,8 @@ import { openDevToolsTab, startTest } from "../helpers";
 import { openConsolePanel, warpToMessage } from "../helpers/console-panel";
 import {
   checkAppliedRules,
-  getElementsListRow,
   openElementsPanel,
   selectElementsListRow,
-  toggleElementsListRow,
 } from "../helpers/elements-panel";
 import test from "../testFixtureCloneRecording";
 
@@ -21,8 +19,6 @@ test("inspector-rules-02: Sourcemapped rules should be viewed", async ({
   await warpToMessage(page, "ExampleFinished");
 
   await openElementsPanel(page);
-  const bodyLocator = await getElementsListRow(page, { text: "body", type: "opening" });
-  await toggleElementsListRow(page, bodyLocator, true);
 
   await selectElementsListRow(page, { text: "maindiv" });
   await checkAppliedRules(page, [

--- a/packages/e2e-tests/tests/inspector-rules-03_shorthand-rules.test.ts
+++ b/packages/e2e-tests/tests/inspector-rules-03_shorthand-rules.test.ts
@@ -3,10 +3,8 @@ import { openConsolePanel, warpToMessage } from "../helpers/console-panel";
 import {
   checkAppliedRules,
   expandLonghands,
-  getElementsListRow,
   openElementsPanel,
   selectElementsListRow,
-  toggleElementsListRow,
 } from "../helpers/elements-panel";
 import test from "../testFixtureCloneRecording";
 
@@ -21,8 +19,6 @@ test("inspector-rules-03: Shorthand CSS rules should be viewed", async ({
   await openConsolePanel(page);
   await warpToMessage(page, "ExampleFinished");
   await openElementsPanel(page);
-  const bodyLocator = await getElementsListRow(page, { text: "body", type: "opening" });
-  await toggleElementsListRow(page, bodyLocator, true);
 
   await selectElementsListRow(page, { text: '<div class="parent" id="first">' });
   await checkAppliedRules(page, [

--- a/packages/e2e-tests/tests/react_devtools-01-basic.test.ts
+++ b/packages/e2e-tests/tests/react_devtools-01-basic.test.ts
@@ -20,7 +20,7 @@ import test, { expect } from "../testFixtureCloneRecording";
 
 test.use({ exampleKey: "cra/dist/index.html" });
 
-test("react_devtools 01: Basic RDT behavior (FF)", async ({
+test("react_devtools-01: Basic RDT behavior (FF)", async ({
   pageWithMeta: { page, recordingId },
   exampleKey,
 }) => {

--- a/packages/e2e-tests/tests/react_devtools-01-basic_chromium.test.ts
+++ b/packages/e2e-tests/tests/react_devtools-01-basic_chromium.test.ts
@@ -20,7 +20,7 @@ import test, { expect } from "../testFixtureCloneRecording";
 
 test.use({ exampleKey: "cra/dist/index_chromium.html" });
 
-test("react_devtools 01: Basic RDT behavior (Chromium)", async ({
+test("react_devtools-01: Basic RDT behavior (Chromium)", async ({
   pageWithMeta: { page, recordingId },
   exampleKey,
 }) => {

--- a/packages/e2e-tests/tests/react_devtools-02-integrations.test.ts
+++ b/packages/e2e-tests/tests/react_devtools-02-integrations.test.ts
@@ -16,7 +16,7 @@ import test, { expect } from "../testFixtureCloneRecording";
 // trunk-ignore(gitleaks/generic-api-key)
 test.use({ exampleKey: "breakpoints-01" });
 
-test("react_devtools 02: RDT integrations (Chromium)", async ({
+test("react_devtools-02: RDT integrations (Chromium)", async ({
   pageWithMeta: { page, recordingId },
   exampleKey,
 }) => {

--- a/packages/e2e-tests/tests/react_devtools-03-multiple-versions.test.ts
+++ b/packages/e2e-tests/tests/react_devtools-03-multiple-versions.test.ts
@@ -15,7 +15,7 @@ import test, { expect } from "../testFixtureCloneRecording";
 
 test.use({ exampleKey: "rdt-react-versions/dist/index.html" });
 
-test("react_devtools 03: process and display multiple React versions in page", async ({
+test("react_devtools-03: process and display multiple React versions in page", async ({
   pageWithMeta: { page, recordingId },
 }) => {
   const queryParams = new URLSearchParams();

--- a/packages/replay-next/components/elements/ElementsList.tsx
+++ b/packages/replay-next/components/elements/ElementsList.tsx
@@ -18,10 +18,7 @@ import { ElementsListData } from "replay-next/components/elements/ElementsListDa
 import { rootObjectIdCache } from "replay-next/components/elements/suspense/RootObjectIdCache";
 import { Item } from "replay-next/components/elements/types";
 import { DefaultFallback } from "replay-next/components/ErrorBoundary";
-import {
-  GenericList,
-  ImperativeHandle as GenericListImperativeHandle,
-} from "replay-next/components/windowing/GenericList";
+import { GenericList } from "replay-next/components/windowing/GenericList";
 import { useHorizontalScrollingListCssVariables } from "replay-next/components/windowing/hooks/useHorizontalScrollingListCssVariables";
 import { useScrollSelectedListItemIntoView } from "replay-next/components/windowing/hooks/useScrollSelectedListItemIntoView";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";

--- a/packages/replay-next/components/elements/ElementsListData.ts
+++ b/packages/replay-next/components/elements/ElementsListData.ts
@@ -137,7 +137,7 @@ export class ElementsListData extends GenericListData<Item> {
     return index;
   }
 
-  async registerRootNodeId(id: ObjectId, numLevelsToLoad: number = 2) {
+  async registerRootNodeId(id: ObjectId, numLevelsToLoad: number = 3) {
     this._rootObjectId = id;
     this._rootObjectIdWaiter.resolve();
 

--- a/packages/replay-next/components/elements/ElementsPanel.tsx
+++ b/packages/replay-next/components/elements/ElementsPanel.tsx
@@ -142,7 +142,7 @@ export function ElementsPanel({
           />
         </label>
         {searchState !== null && (
-          <div className={styles.SearchResults}>
+          <div className={styles.SearchResults} data-test-id="ElementsPanel-SearchResult">
             {searchState.index + 1} of {searchState.results.length}
           </div>
         )}


### PR DESCRIPTION
### Change 1: Elements panel fetches 3 levels deep by default (instead of 2)

The old Elements panel used to pre-fetch and expand 3 levels deep in the DOM tree. The new one only fetched 2. This caused the `inspector-computed-01` e2e test to fail, since it relied on the Elements tree "remaining" expanded enough to see `id="maindiv"` between execution points.

This commit also removes several "workarounds" for the new Elements panel (selecting and expanding `<body>` manually) that are no longer necessary.

This e2e regression probably slipped through due to everything else being broken.

### Change 2: Elements search helper utility waits until Elements panel finishes loading

This avoids a race case where the test tried searching the Elements panel too soon and the action was ignored.