### PR TITLE
Properly render HTMLCollections

### DIFF
--- a/packages/e2e-tests/tests/object_preview-06.test.ts
+++ b/packages/e2e-tests/tests/object_preview-06.test.ts
@@ -1,0 +1,41 @@
+import { openDevToolsTab, startTest } from "../helpers";
+import {
+  clearConsoleEvaluations,
+  disableAllConsoleMessageTypes,
+  executeTerminalExpression,
+  openConsolePanel,
+  verifyConsoleMessage,
+  warpToMessage,
+} from "../helpers/console-panel";
+import test from "../testFixtureCloneRecording";
+
+test.use({ exampleKey: "doc_rr_objects.html" });
+
+test(`object_preview-06: HTML elements`, async ({
+  pageWithMeta: { page, recordingId },
+  exampleKey,
+}) => {
+  await startTest(page, recordingId);
+  await openDevToolsTab(page);
+  await openConsolePanel(page);
+
+  await warpToMessage(page, "5ExampleFinished");
+  await disableAllConsoleMessageTypes(page);
+
+  await executeTerminalExpression(page, "document.body");
+  await verifyConsoleMessage(page, "<body>…<body>");
+  await clearConsoleEvaluations(page);
+
+  await executeTerminalExpression(page, "document.getElementsByTagName('body')");
+  await verifyConsoleMessage(page, "HTMLCollection(1)");
+  await verifyConsoleMessage(page, "<body>…<body>");
+  await clearConsoleEvaluations(page);
+
+  await executeTerminalExpression(page, "document.querySelector('script')");
+  await verifyConsoleMessage(page, "function recordingFinished");
+  await clearConsoleEvaluations(page);
+
+  await executeTerminalExpression(page, "document.querySelector('[blahblah]').textContent");
+  await verifyConsoleMessage(page, "BAR");
+  await clearConsoleEvaluations(page);
+});

--- a/packages/replay-next/src/utils/protocol.ts
+++ b/packages/replay-next/src/utils/protocol.ts
@@ -207,7 +207,16 @@ export async function protocolValueToClientValue(
           ) {
             type = "error";
           } else if (className.startsWith("HTML")) {
-            type = "html-element";
+            switch (className) {
+              case "HTMLCollection": {
+                type = "array";
+                break;
+              }
+              default: {
+                type = "html-element";
+                break;
+              }
+            }
           } else if (className === "Text") {
             type = "html-text";
           }


### PR DESCRIPTION
Replay [d33fa6c2-cedf-45ed-a644-1025b7bd0f57](https://app.replay.io/recording/replay-of-localhost8080--d33fa6c2-cedf-45ed-a644-1025b7bd0f57) shows where we weren't properly handling values of type `HTMLCollection`.

I also added a new e2e test to cover some of this behavior. Note that it currently fails due the getMappedLocation BAC issue but I verified the test passes if that error popup is manually dismissed.

Before:
<img width="665" alt="Screen Shot 2023-11-03 at 11 03 23 AM" src="https://github.com/replayio/devtools/assets/29597/0e1230c7-e732-448d-9360-8b160928edcd">

After:
<img width="701" alt="Screen Shot 2023-11-03 at 11 02 53 AM" src="https://github.com/replayio/devtools/assets/29597/9d146bed-1441-46e4-80d0-a9eead4ff143">

cc @filiphric