### PR TITLE
Increase RDT "inspectElement" timeout from 15s to 30s

### DIFF
--- a/src/ui/components/SecondaryToolbox/react-devtools/suspense/inspectedElementCache.ts
+++ b/src/ui/components/SecondaryToolbox/react-devtools/suspense/inspectedElementCache.ts
@@ -11,6 +11,8 @@ import {
 import { InspectedReactElement } from "ui/components/SecondaryToolbox/react-devtools/types";
 import { createPromiseForRequest } from "ui/components/SecondaryToolbox/react-devtools/utils/createPromiseForRequest";
 
+const TIMEOUT_DELAY = 30_000;
+
 let uidCounter = 0;
 
 export const inspectedElementCache = createCache<
@@ -35,11 +37,13 @@ export const inspectedElementCache = createCache<
     // Wait until the backend has been injected before sending a message through the wall/bridge
     await reactDevToolsInjectionCache.readAsync(replayClient, pauseId);
 
-    const promise = createPromiseForRequest<{ value: InspectedReactElement }>(
+    const promise = createPromiseForRequest<{ value: InspectedReactElement }>({
+      bridge,
+      eventType: "inspectedElement",
       requestID,
-      "inspectedElement",
-      bridge
-    );
+      timeoutDelay: TIMEOUT_DELAY,
+      timeoutMessage: `Timed out while trying to inspect React element ${elementId}`,
+    });
 
     replayWall.send("inspectElement", {
       forceFullData: true,

--- a/src/ui/components/SecondaryToolbox/react-devtools/utils/createPromiseForRequest.ts
+++ b/src/ui/components/SecondaryToolbox/react-devtools/utils/createPromiseForRequest.ts
@@ -1,13 +1,18 @@
 import { BackendEvents, FrontendBridge } from "@replayio/react-devtools-inline";
 
-const TIMEOUT_DELAY = 15_000;
-
-export function createPromiseForRequest<Value>(
-  requestID: number,
-  eventType: keyof BackendEvents,
-  bridge: FrontendBridge,
-  timeoutMessage: string = `Timed out waiting for response to "${eventType}" message`
-): Promise<Value> {
+export function createPromiseForRequest<Value>({
+  bridge,
+  eventType,
+  requestID,
+  timeoutDelay,
+  timeoutMessage = `Timed out waiting for response to "${eventType}" message`,
+}: {
+  bridge: FrontendBridge;
+  eventType: keyof BackendEvents;
+  requestID: number;
+  timeoutDelay: number;
+  timeoutMessage?: string;
+}): Promise<Value> {
   return new Promise((resolve, reject) => {
     const cleanup = () => {
       bridge.removeListener(eventType, onEvent);
@@ -29,6 +34,6 @@ export function createPromiseForRequest<Value>(
 
     bridge.addListener(eventType, onEvent);
 
-    const timeoutID = setTimeout(onTimeout, TIMEOUT_DELAY);
+    const timeoutID = setTimeout(onTimeout, timeoutDelay);
   });
 }


### PR DESCRIPTION
Admitted 15s was a bit arbitrary. In most cases it looks like the response is more like 1s, but since we have seen some intermitted delays recently where requests took ~20-30s, I don't see any harm in increasing this value.