### PR TITLE
e2e test fixes

### DIFF
--- a/packages/e2e-tests/helpers/elements-panel.ts
+++ b/packages/e2e-tests/helpers/elements-panel.ts
@@ -323,6 +323,8 @@ export async function searchElementsPanel(page: Page, searchText: string): Promi
   await waitFor(async () => {
     await input.press("Enter");
 
+    await delay(250);
+
     // If the Elements panel is still loading, the search won't be handled.
     // A proxy for confirming that the search has been handled is that a results label will be rendered.
     const resultsLabel = page.locator('[data-test-id="ElementsPanel-SearchResult"]');

--- a/packages/e2e-tests/tests/cypress-03_test-step-interactions.test.ts
+++ b/packages/e2e-tests/tests/cypress-03_test-step-interactions.test.ts
@@ -11,7 +11,7 @@ import {
   openCypressTestPanel,
 } from "../helpers/testsuites";
 import { waitForTimelineAdvanced } from "../helpers/timeline";
-import { getByTestName, waitFor } from "../helpers/utils";
+import { delay, getByTestName, waitFor } from "../helpers/utils";
 import test, { expect } from "../testFixtureCloneRecording";
 
 test.use({ exampleKey: "flake/adding-spec.ts" });
@@ -153,6 +153,8 @@ test("cypress-03: Test Step interactions", async ({ pageWithMeta: { page, record
   });
 
   await steps.nth(9).click();
+  await delay(100);
+
   await waitFor(async () => {
     const detailsPane = getUserActionEventDetails(page);
     const detailsPaneContents = await getDetailsPaneContents(detailsPane);

--- a/packages/e2e-tests/tests/cypress-04_menu-commands.test.ts
+++ b/packages/e2e-tests/tests/cypress-04_menu-commands.test.ts
@@ -59,7 +59,7 @@ test("cypress-04: Test Step buttons and menu item", async ({
 
   await waitForSelectedSource(page, "Link.js");
   await waitFor(async () => {
-    const lineNumber = await getSelectedLineNumber(page, true);
+    const lineNumber = await getSelectedLineNumber(page, false);
     expect(lineNumber).toBe(38);
   });
 


### PR DESCRIPTION
- [x] FE-2030: Avoid race in Elements search helper util; allow search to finish
- [x] FE-2031: Add delay to e2e test to avoid querying DOM too soon after click
- [ ] FE-2032: Fix invalid test util helper params
        Note to self: This test is still failing but now on a different part.