### PR TITLE
e2e toggleConsoleMessageType() util

### DIFF
--- a/packages/e2e-tests/helpers/console-panel.ts
+++ b/packages/e2e-tests/helpers/console-panel.ts
@@ -94,10 +94,12 @@ export async function toggleConsoleMessageType(
   // because the latter wil sometimes fail prematurely if the checkbox state doesn't change quickly enough
   // Note this requires us to verify the initial state of the checkbox before clicking
   const checkbox = getConsoleMessageTypeCheckbox(page, type);
-  const isChecked = await checkbox.isChecked();
-  if (isChecked !== enabled) {
-    await checkbox.click({ timeout: 500 });
-  }
+  await waitFor(async () => {
+    const isChecked = await checkbox.isChecked();
+    if (isChecked !== enabled) {
+      await checkbox.click();
+    }
+  });
 }
 
 export async function executeTerminalExpression(


### PR DESCRIPTION
I noticed that in [this Test Suite run](https://app.replay.io/team/dzowNDAyOGMwYS05ZjM1LTQ2ZjktYTkwYi1jNzJkMTIzNzUxOTI=/runs/c4bb3b4a-e417-4870-920f-25739a958b3e) the `console_errors` test was pretty flaky (failed 4 times before passing). I think the cause is that our `toggleConsoleMessageType` isn't very robust to timing.