### PR TITLE
Add support to initialize Test Runs page filters with query params

### DIFF
--- a/src/ui/components/Library/Team/View/TestRuns/TestRunsContextRoot.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunsContextRoot.tsx
@@ -31,6 +31,9 @@ type TestRunsContextType = {
 
 export const TestRunsContext = createContext<TestRunsContextType>(null as any);
 
+type FilterByBranch = "all" | "primary";
+type FilterByStatus = "all" | "failed";
+
 export function TestRunsContextRoot({ children }: { children: ReactNode }) {
   const { teamId, testRunId: defaultTestRunId } = useGetTeamRouteParams();
 
@@ -38,8 +41,14 @@ export function TestRunsContextRoot({ children }: { children: ReactNode }) {
 
   const [testRunId, setTestRunId] = useState<string | null>(defaultTestRunId);
 
-  const [filterByBranch, setFilterByBranch] = useState<"all" | "primary">("all");
-  const [filterByStatus, setFilterByStatus] = useState<"all" | "failed">("all");
+  const [filterByBranch, setFilterByBranch] = useState<FilterByBranch>(() => {
+    const query = new URLSearchParams(window.location.search);
+    return (query.get("filterByBranch") as FilterByBranch) ?? "all";
+  });
+  const [filterByStatus, setFilterByStatus] = useState<FilterByStatus>(() => {
+    const query = new URLSearchParams(window.location.search);
+    return (query.get("filterByStatus") as FilterByStatus) ?? "all";
+  });
 
   const [filterByText, setFilterByText] = useState("");
   const filterByTextDeferred = useDeferredValue(filterByText);


### PR DESCRIPTION
This is in support of us sharing a frontend status dashboard link. Such a link should only care about CI runs on the primary branch (`main`).

cc @jaril (We'll want to preserve this functionality in the new page)