### PR TITLE
Fetch test run details along with recordings

### DIFF
--- a/packages/shared/graphql/generated/GetTestRunRecordings.ts
+++ b/packages/shared/graphql/generated/GetTestRunRecordings.ts
@@ -11,6 +11,32 @@ export interface GetTestRunRecordings_node_Recording {
   __typename: "Recording";
 }
 
+export interface GetTestRunRecordings_node_Workspace_testRuns_edges_node_results_counts {
+  __typename: "TestRunStats";
+  failed: number;
+  flaky: number;
+  passed: number;
+}
+
+export interface GetTestRunRecordings_node_Workspace_testRuns_edges_node_results {
+  __typename: "TestRunResults";
+  counts: GetTestRunRecordings_node_Workspace_testRuns_edges_node_results_counts;
+}
+
+export interface GetTestRunRecordings_node_Workspace_testRuns_edges_node_source {
+  __typename: "TestRunSource";
+  commitId: string | null;
+  commitTitle: string | null;
+  groupLabel: string | null;
+  isPrimaryBranch: boolean | null;
+  branchName: string | null;
+  prNumber: number | null;
+  prTitle: string | null;
+  repository: string | null;
+  triggerUrl: string | null;
+  user: string | null;
+}
+
 export interface GetTestRunRecordings_node_Workspace_testRuns_edges_node_tests_recordings_comments_user {
   __typename: "User";
   id: string;
@@ -47,6 +73,11 @@ export interface GetTestRunRecordings_node_Workspace_testRuns_edges_node_tests {
 
 export interface GetTestRunRecordings_node_Workspace_testRuns_edges_node {
   __typename: "TestRun";
+  id: string;
+  date: any;
+  mode: string | null;
+  results: GetTestRunRecordings_node_Workspace_testRuns_edges_node_results;
+  source: GetTestRunRecordings_node_Workspace_testRuns_edges_node_source;
   tests: GetTestRunRecordings_node_Workspace_testRuns_edges_node_tests[];
 }
 

--- a/src/ui/components/Library/Team/View/TestRuns/Overview/TestRunOverviewContent.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/Overview/TestRunOverviewContent.tsx
@@ -8,19 +8,18 @@ import { RunSummary } from "./RunSummary";
 import styles from "../../../../Library.module.css";
 
 export function TestRunOverviewContent() {
-  const { filterByStatus, filterByText, testRunId, testRunIdForDisplay, testRuns } =
+  const { filterByStatus, filterByText, testRunId, testRunIdForDisplay } =
     useContext(TestRunsContext);
 
-  const { recordings, durationMs } = useTestRunDetailsSuspends(testRunId);
+  const { testRun, recordings, durationMs } = useTestRunDetailsSuspends(testRunId);
 
   const isPending = testRunId !== testRunIdForDisplay;
 
   const hasFilters = filterByStatus !== "all" || filterByText !== "";
-  const testRun = testRuns.find(testRun => testRun.id === testRunId);
 
   let children = null;
   if (testRun && recordings) {
-    if (!hasFilters || testRuns.find(testRun => testRun.id === testRunId)) {
+    if (!hasFilters || testRun) {
       children = (
         <>
           <RunSummary

--- a/src/ui/components/Library/Team/View/TestRuns/graphql/TestRunsGraphQL.ts
+++ b/src/ui/components/Library/Team/View/TestRuns/graphql/TestRunsGraphQL.ts
@@ -3,6 +3,7 @@ import { gql } from "@apollo/client";
 import {
   GetTestRunRecordings,
   GetTestRunRecordings_node_Workspace,
+  GetTestRunRecordings_node_Workspace_testRuns_edges_node,
   GetTestRunRecordings_node_Workspace_testRuns_edges_node_tests,
 } from "shared/graphql/generated/GetTestRunRecordings";
 import {
@@ -20,6 +21,28 @@ const GET_TEST_RUN_RECORDINGS = gql`
         testRuns(id: $id) {
           edges {
             node {
+              id
+              date
+              mode
+              results {
+                counts {
+                  failed
+                  flaky
+                  passed
+                }
+              }
+              source {
+                commitId
+                commitTitle
+                groupLabel
+                isPrimaryBranch
+                branchName
+                prNumber
+                prTitle
+                repository
+                triggerUrl
+                user
+              }
               tests {
                 id
                 testId
@@ -94,7 +117,7 @@ export async function getTestRunTestsWithRecordingsGraphQL(
   accessToken: string | null,
   workspaceId: string,
   summaryId: string
-): Promise<GetTestRunRecordings_node_Workspace_testRuns_edges_node_tests[]> {
+): Promise<GetTestRunRecordings_node_Workspace_testRuns_edges_node | null> {
   const response = await graphQLClient.send<GetTestRunRecordings>(
     {
       operationName: "GetTestRunRecordings",
@@ -105,12 +128,10 @@ export async function getTestRunTestsWithRecordingsGraphQL(
   );
 
   if (response?.node == null) {
-    return [];
+    return null;
   }
 
-  return (
-    (response.node as GetTestRunRecordings_node_Workspace).testRuns?.edges[0]?.node.tests ?? []
-  );
+  return (response.node as GetTestRunRecordings_node_Workspace).testRuns?.edges[0]?.node ?? null;
 }
 
 export async function getTestRunsGraphQL(

--- a/src/ui/components/Library/Team/View/TestRuns/hooks/useTestRunDetailsSuspends.ts
+++ b/src/ui/components/Library/Team/View/TestRuns/hooks/useTestRunDetailsSuspends.ts
@@ -14,6 +14,7 @@ export function useTestRunDetailsSuspends(testRunId: string | null) {
   return testRunId
     ? testRunDetailsCache.read(graphQLClient, accessToken?.token ?? null, teamId, testRunId)
     : {
+        testRun: null,
         groupedTests: null,
         recordings: null,
         durationMs: 0,


### PR DESCRIPTION
Fetch test run along with recordings so that deep linking to a test run that might not have been returned in the list can still show the details along with the recordings. This will help when we limit the number of test runs returned for a team.

Fixes SCS-1516