### PR TITLE
Add e2e test for RDT panel selection when seeking

### DIFF
--- a/packages/e2e-tests/helpers/new-react-devtools-panel.ts
+++ b/packages/e2e-tests/helpers/new-react-devtools-panel.ts
@@ -1,0 +1,41 @@
+import { Locator, Page, expect } from "@playwright/test";
+
+import { openConsolePanel, warpToMessage } from "./console-panel";
+import { openReactDevtoolsPanel as openReactDevtoolsPanelWithoutWorkaround } from "./react-devtools-panel";
+import { waitFor } from "./utils";
+
+export function getReactDevToolsPanel(page: Page) {
+  return page.locator('[data-test-id="ReactDevToolsPanel"]');
+}
+
+export function getReactComponents(page: Page) {
+  return getReactDevToolsPanel(page).locator('[data-test-name="ReactDevToolsListItem"]');
+}
+
+export async function waitForReactComponentCount(page: Page, expected: number) {
+  const components = getReactComponents(page);
+  return waitFor(async () => expect(await components.count()).toBe(expected));
+}
+
+export async function jumpToMessageAndCheckComponents(
+  page: Page,
+  message: string,
+  componentCount: number
+) {
+  await openConsolePanel(page);
+  await warpToMessage(page, message);
+  await openReactDevtoolsPanel(page);
+  await waitForReactComponentCount(page, componentCount);
+}
+
+export async function openReactDevtoolsPanel(page: Page) {
+  await openReactDevtoolsPanelWithoutWorkaround(page);
+  // workaround for FE-2044: go to the Console and then back to the RDT panel
+  // to ensure that the RDT panel is updated
+  await openConsolePanel(page);
+  await openReactDevtoolsPanelWithoutWorkaround(page);
+}
+
+export async function verifyReactComponentIsSelected(component: Locator) {
+  await expect(component).toHaveAttribute("data-selected", "true");
+}

--- a/packages/e2e-tests/helpers/timeline.ts
+++ b/packages/e2e-tests/helpers/timeline.ts
@@ -140,6 +140,18 @@ export async function getTimelineCurrentPercent(page: Page) {
   return percent;
 }
 
+export async function seekToTimePercent(page: Page, timePercent: number) {
+  const timeline = getTimelineProgressBar(page);
+  const timelineBoundingBox = await timeline.boundingBox();
+  expect(timelineBoundingBox).not.toBeFalsy();
+  timeline.click({
+    position: {
+      x: timelineBoundingBox!.width * (timePercent / 100),
+      y: timelineBoundingBox!.height / 2,
+    },
+  });
+}
+
 export async function waitForTimelineAdvanced(page: Page, prevPercent: number) {
   let currentPercent = 0;
   await waitFor(async () => {

--- a/packages/e2e-tests/tests/react_devtools-04-seeking.test.ts
+++ b/packages/e2e-tests/tests/react_devtools-04-seeking.test.ts
@@ -1,0 +1,45 @@
+import { openDevToolsTab, startTest } from "../helpers";
+import {
+  getReactComponents,
+  jumpToMessageAndCheckComponents,
+  verifyReactComponentIsSelected,
+  waitForReactComponentCount,
+} from "../helpers/new-react-devtools-panel";
+import { getTimelineCurrentPercent, seekToTimePercent } from "../helpers/timeline";
+import test, { expect } from "../testFixtureCloneRecording";
+
+test.use({ exampleKey: "cra/dist/index_chromium.html" });
+
+test("react_devtools-04: Component selection is maintained when seeking to a new point", async ({
+  pageWithMeta: { page, recordingId },
+}) => {
+  const queryParams = new URLSearchParams();
+  // Enable the new RDT panel
+  queryParams.set("features", "feature_newReactDevTools");
+
+  await startTest(page, recordingId, undefined, queryParams);
+  await openDevToolsTab(page);
+
+  // Seek to the first console message and check that the initial tree has 3 components
+  await jumpToMessageAndCheckComponents(page, "Initial list", 3);
+
+  const initialTimePercent = await getTimelineCurrentPercent(page);
+
+  // Select the root component
+  const firstComponent = getReactComponents(page).nth(0);
+  await firstComponent.click();
+  await verifyReactComponentIsSelected(firstComponent);
+
+  // Seek to the next console message and check that the tree is updated, showing 4 components
+  await jumpToMessageAndCheckComponents(page, "Added an entry", 4);
+  // Check that the root component is still selected
+  await verifyReactComponentIsSelected(firstComponent);
+
+  // Seek back to the time of the first message using the timeline,
+  // so that the RDT panel remains visible while seeking
+  await seekToTimePercent(page, initialTimePercent);
+  // Check that the tree is updated, showing 3 components again
+  await waitForReactComponentCount(page, 3);
+  // Check that the root component is still selected
+  await verifyReactComponentIsSelected(firstComponent);
+});


### PR DESCRIPTION
I wrote this test for the new RDT panel because that was the one showing the regression (FE-2038) and because we will get rid of the old one eventually.