### PR TITLE
Align redux, network monitor, and console rows

### DIFF
--- a/packages/replay-next/components/console/renderers/shared.module.css
+++ b/packages/replay-next/components/console/renderers/shared.module.css
@@ -9,7 +9,7 @@
   padding-top: calc(0.25rem + 1px);
   padding-left: 1.5rem;
 
-  border-bottom: 1px solid var(--theme-splitter-color);
+  border-bottom: 1px solid var(--listitem-row-divider);
   position: relative;
 }
 .ErrorRow {

--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -541,6 +541,7 @@
   --title-hover-bgcolor: var(--theme-toggle-bgcolor);
   --toolbarbutton-focus-bgcolor: var(--theme-base-95);
   --unloaded-region-img: url("/images/dotted-mask-dark.svg");
+  --listitem-row-divider: var(--chrome);
 
   /* Toolbar (Dark) */
   --theme-tab-toolbar-background: var(--grey-90);
@@ -1065,6 +1066,7 @@
   --title-hover-bgcolor: #e6e6e6;
   --toolbarbutton-focus-bgcolor: var(--theme-base-90);
   --unloaded-region-img: url("/images/dotted-mask-light.svg");
+  --listitem-row-divider: var(--grey-20);
 
   /* Toolbar */
   --theme-tab-toolbar-background: var(--grey-20);

--- a/src/ui/components/NetworkMonitor/NetworkMonitorListRow.module.css
+++ b/src/ui/components/NetworkMonitor/NetworkMonitorListRow.module.css
@@ -5,7 +5,7 @@
   flex-direction: row;
   align-items: center;
   background-color: var(--body-bgcolor);
-  border-bottom: 1px solid var(--theme-toolbar-background);
+  border-bottom: 1px solid var(--listitem-row-divider);
   padding: 0 1ch;
 }
 .Row {
@@ -124,7 +124,7 @@
 
 .TimingContainer {
   position: relative;
-  height: 0.75rem;
+  height: 0.8rem;
   border-radius: 3px;
   background-color: var(--chrome);
   margin-right: 1ch;

--- a/src/ui/components/NetworkMonitor/NetworkMonitorListRow.tsx
+++ b/src/ui/components/NetworkMonitor/NetworkMonitorListRow.tsx
@@ -10,7 +10,7 @@ import { RequestSummary } from "ui/components/NetworkMonitor/utils";
 
 import styles from "./NetworkMonitorListRow.module.css";
 
-export const LIST_ROW_HEIGHT = 27;
+export const LIST_ROW_HEIGHT = 26;
 
 export type ItemData = {
   columns: EnabledColumns;

--- a/src/ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsListItem.module.css
+++ b/src/ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsListItem.module.css
@@ -3,7 +3,7 @@
   padding: 0 1ch;
   text-overflow: ellipsis;
   overflow: hidden;
-  border-bottom: 1px solid var(--theme-toolbar-background);
+  border-bottom: 1px solid var(--listitem-row-divider);
 }
 .ListItem[data-relative-position="after"] {
   opacity: 0.5;

--- a/src/ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsListItem.tsx
+++ b/src/ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsListItem.tsx
@@ -10,7 +10,7 @@ import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import useReduxDevtoolsContextMenu from "./useReduxDevtoolsContextMenu";
 import styles from "./ReduxDevToolsListItem.module.css";
 
-export const ITEM_SIZE = 24;
+export const ITEM_SIZE = 26;
 
 export type ItemData = {
   annotations: ReduxActionAnnotation[];


### PR DESCRIPTION
Old:
![image](https://github.com/replayio/devtools/assets/9154902/bfb1b56f-8c6c-46f3-b43a-83981211c0f4)

* Row heights are misaligned
* Row borders are inconsistent

New, with these fixes:
![image](https://github.com/replayio/devtools/assets/9154902/371cee3a-c005-4df9-8f58-45a35334b75c)
