### PR TITLE
Better (loading) UX when inspecting an HTML element

### DIFF
--- a/packages/replay-next/components/LoadingProgressBar.tsx
+++ b/packages/replay-next/components/LoadingProgressBar.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import styles from "./LoadingProgressBar.module.css";
 
 export function LoadingProgressBar({
-  className,
+  className = "",
   initialProgress = 0,
 }: {
   className?: string;

--- a/packages/replay-next/components/PanelLoader.tsx
+++ b/packages/replay-next/components/PanelLoader.tsx
@@ -1,11 +1,13 @@
+import { CSSProperties } from "react";
+
 import Loader from "replay-next/components/Loader";
 import { LoadingProgressBar } from "replay-next/components/LoadingProgressBar";
 
 import styles from "./PanelLoader.module.css";
 
-export function PanelLoader() {
+export function PanelLoader({ className, style }: { className?: string; style?: CSSProperties }) {
   return (
-    <div className={styles.Wrapper}>
+    <div className={`${styles.Wrapper} ${className}`} style={style}>
       <LoadingProgressBar />
       <Loader className={styles.Loader} />
     </div>

--- a/packages/replay-next/components/elements/ElementList.module.css
+++ b/packages/replay-next/components/elements/ElementList.module.css
@@ -1,3 +1,7 @@
+.ListWrapper {
+  position: relative;
+}
+
 .List:focus {
   outline: none;
 }

--- a/packages/replay-next/components/elements/ElementsList.tsx
+++ b/packages/replay-next/components/elements/ElementsList.tsx
@@ -18,6 +18,7 @@ import { ElementsListData } from "replay-next/components/elements/ElementsListDa
 import { rootObjectIdCache } from "replay-next/components/elements/suspense/RootObjectIdCache";
 import { Item } from "replay-next/components/elements/types";
 import { DefaultFallback } from "replay-next/components/ErrorBoundary";
+import { LoadingProgressBar } from "replay-next/components/LoadingProgressBar";
 import { GenericList } from "replay-next/components/windowing/GenericList";
 import { useHorizontalScrollingListCssVariables } from "replay-next/components/windowing/hooks/useHorizontalScrollingListCssVariables";
 import { useScrollSelectedListItemIntoView } from "replay-next/components/windowing/hooks/useScrollSelectedListItemIntoView";
@@ -86,6 +87,16 @@ export function ElementsList({
     listData.didError,
     listData.didError
   );
+  const isLoading = useSyncExternalStore(
+    listData.subscribeToLoading,
+    listData.getIsLoading,
+    listData.getIsLoading
+  );
+  const itemCount = useSyncExternalStore(
+    listData.subscribeToInvalidation,
+    listData.getItemCount,
+    listData.getItemCount
+  );
 
   useImperativeHandle(
     forwardedRef,
@@ -97,6 +108,8 @@ export function ElementsList({
           const index = await listData.loadPathToNode(nodeId);
           if (index != null) {
             listData.setSelectedIndex(index);
+          } else {
+            console.warn(`Index not found for node ${nodeId}`);
           }
         }
       },
@@ -163,19 +176,22 @@ export function ElementsList({
   };
 
   return (
-    <GenericList<Item, ElementsListItemData>
-      className={styles.List}
-      dataTestId="ElementsList"
-      fallbackForEmptyList={noContentFallback}
-      height={height}
-      itemData={itemData}
-      itemRendererComponent={ElementsListItem}
-      itemSize={ITEM_SIZE}
-      listData={listData}
-      onItemsRendered={onItemsRendered}
-      onKeyDown={onKeyDown}
-      style={cssVariables as CSSProperties}
-      width="100%"
-    />
+    <div className={styles.ListWrapper} style={{ height }}>
+      {isLoading && itemCount > 0 && <LoadingProgressBar />}
+      <GenericList<Item, ElementsListItemData>
+        className={styles.List}
+        dataTestId="ElementsList"
+        fallbackForEmptyList={noContentFallback}
+        height={height}
+        itemData={itemData}
+        itemRendererComponent={ElementsListItem}
+        itemSize={ITEM_SIZE}
+        listData={listData}
+        onItemsRendered={onItemsRendered}
+        onKeyDown={onKeyDown}
+        style={cssVariables as CSSProperties}
+        width="100%"
+      />
+    </div>
   );
 }

--- a/packages/replay-next/components/elements/ElementsListData.ts
+++ b/packages/replay-next/components/elements/ElementsListData.ts
@@ -141,7 +141,9 @@ export class ElementsListData extends GenericListData<Item> {
 
     await this.loadAndProcessNodeSubTree(id, numLevelsToLoad);
 
-    this.setSelectedIndex(0);
+    if (this.getSelectedIndex() === null) {
+      this.setSelectedIndex(0);
+    }
   }
 
   async toggleNodeExpanded(id: ObjectId, isExpanded: boolean) {

--- a/packages/replay-next/components/elements/ElementsPanel.module.css
+++ b/packages/replay-next/components/elements/ElementsPanel.module.css
@@ -7,6 +7,11 @@
   background-color: var(--body-bgcolor);
 }
 
+.PanelLoader {
+  position: absolute;
+  width: 100%;
+}
+
 .SearchRow {
   flex: 0 0 auto;
   display: flex;

--- a/packages/replay-next/components/elements/ElementsPanel.tsx
+++ b/packages/replay-next/components/elements/ElementsPanel.tsx
@@ -2,8 +2,8 @@ import { ObjectId, PauseId } from "@replayio/protocol";
 import {
   ChangeEvent,
   KeyboardEvent,
-  RefObject,
   Suspense,
+  useCallback,
   useContext,
   useRef,
   useState,
@@ -19,17 +19,26 @@ import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import styles from "./ElementsPanel.module.css";
 
 export function ElementsPanel({
-  listRef,
+  listRefSetter,
   onSelectionChange,
   pauseId,
 }: {
-  listRef: RefObject<ImperativeHandle>;
+  listRefSetter: (ref: ImperativeHandle | null) => void;
   onSelectionChange?: (id: ObjectId | null) => void;
   pauseId: PauseId | null;
 }) {
   const replayClient = useContext(ReplayClientContext);
 
+  const listRef = useRef<ImperativeHandle | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
+
+  const compositeListRef = useCallback(
+    (ref: ImperativeHandle | null) => {
+      listRef.current = ref;
+      listRefSetter(ref);
+    },
+    [listRefSetter]
+  );
 
   const [searchInProgress, setSearchInProgress] = useState(false);
   const [searchState, setSearchState] = useState<{
@@ -154,7 +163,7 @@ export function ElementsPanel({
               <Suspense fallback={<ElementsPanelLoader />}>
                 <ElementsList
                   height={height}
-                  forwardedRef={listRef}
+                  forwardedRef={compositeListRef}
                   key={pauseId}
                   noContentFallback={<ElementsPanelLoader />}
                   onSelectionChange={onSelectionChange}

--- a/packages/replay-next/components/elements/ElementsPanel.tsx
+++ b/packages/replay-next/components/elements/ElementsPanel.tsx
@@ -11,9 +11,9 @@ import {
 import AutoSizer from "react-virtualized-auto-sizer";
 
 import { ElementsList, ImperativeHandle } from "replay-next/components/elements/ElementsList";
-import { ElementsPanelLoader } from "replay-next/components/elements/ElementsPanelLoader";
 import { domSearchCache } from "replay-next/components/elements/suspense/DOMSearchCache";
 import Icon from "replay-next/components/Icon";
+import { PanelLoader } from "replay-next/components/PanelLoader";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
 import styles from "./ElementsPanel.module.css";
@@ -160,12 +160,16 @@ export function ElementsPanel({
         {pauseId ? (
           <AutoSizer disableWidth>
             {({ height }: { height: number }) => (
-              <Suspense fallback={<ElementsPanelLoader />}>
+              <Suspense
+                fallback={<PanelLoader className={styles.PanelLoader} style={{ height }} />}
+              >
                 <ElementsList
                   height={height}
                   forwardedRef={compositeListRef}
                   key={pauseId}
-                  noContentFallback={<ElementsPanelLoader />}
+                  noContentFallback={
+                    <PanelLoader className={styles.PanelLoader} style={{ height }} />
+                  }
                   onSelectionChange={onSelectionChange}
                   pauseId={pauseId}
                 />
@@ -173,7 +177,7 @@ export function ElementsPanel({
             )}
           </AutoSizer>
         ) : (
-          <ElementsPanelLoader />
+          <PanelLoader className={styles.PanelLoader} />
         )}
       </div>
     </div>

--- a/packages/replay-next/components/elements/ElementsPanelLoader.module.css
+++ b/packages/replay-next/components/elements/ElementsPanelLoader.module.css
@@ -1,3 +1,0 @@
-.Loader {
-  padding: 0 0.5rem;
-}

--- a/packages/replay-next/components/elements/ElementsPanelLoader.tsx
+++ b/packages/replay-next/components/elements/ElementsPanelLoader.tsx
@@ -1,7 +1,0 @@
-import Loader from "replay-next/components/Loader";
-
-import styles from "./ElementsPanelLoader.module.css";
-
-export function ElementsPanelLoader() {
-  return <Loader className={styles.Loader} />;
-}

--- a/packages/replay-next/components/windowing/GenericListData.ts
+++ b/packages/replay-next/components/windowing/GenericListData.ts
@@ -4,11 +4,13 @@ import { EventEmitter } from "shared/EventEmitter";
 
 export abstract class GenericListData<Item> extends EventEmitter<{
   invalidate: () => void;
+  loading: (value: boolean) => void;
   selectedIndex: (index: number | null) => void;
 }> {
   private _cachedItemToIndexMap: Map<Item, number> = new Map();
   private _cachedIndexToItemMap: Map<number, Item> = new Map();
   private _cachedItemCount: number | null = null;
+  private _isLoading: boolean = false;
   private _revision: number = 0;
   private _selectedIndex: number | null = null;
 
@@ -24,6 +26,10 @@ export abstract class GenericListData<Item> extends EventEmitter<{
 
     return index;
   }
+
+  getIsLoading = () => {
+    return this._isLoading;
+  };
 
   getItemAtIndex(index: number): Item {
     assert(
@@ -68,6 +74,13 @@ export abstract class GenericListData<Item> extends EventEmitter<{
     this.emit("selectedIndex", value);
   }
 
+  subscribeToLoading = (callback: (value: boolean) => void) => {
+    // Work around for github.com/facebook/react/issues/27670
+    callback(this._isLoading);
+
+    return this.addListener("loading", callback);
+  };
+
   subscribeToInvalidation = (callback: () => void) => {
     // Work around for github.com/facebook/react/issues/27670
     callback();
@@ -98,5 +111,11 @@ export abstract class GenericListData<Item> extends EventEmitter<{
     this._revision++;
 
     this.emit("invalidate");
+  }
+
+  protected updateLoadingState(value: boolean): void {
+    this._isLoading = value;
+
+    this.emit("loading", value);
   }
 }

--- a/packages/replay-next/pages/tests/elements.tsx
+++ b/packages/replay-next/pages/tests/elements.tsx
@@ -30,7 +30,7 @@ function Elements() {
   const [pauseId, setPauseId] = useState<PauseId | null>(null);
   const [selectedObjectId, setSelectedObjectId] = useState<ObjectId | null>(null);
 
-  const listRef = useRef<ImperativeHandle>(null);
+  const [list, setList] = useState<ImperativeHandle | null>(null);
 
   // Jump to the middle of the Replay; hopefully there will be some Elements there
   useEffect(() => {
@@ -51,7 +51,6 @@ function Elements() {
     switch (event.key) {
       case "Enter":
         if (nodeId) {
-          const list = listRef.current;
           if (list) {
             list.selectNode(nodeId);
           }
@@ -74,7 +73,11 @@ function Elements() {
           value={nodeId}
         />
       </div>
-      <ElementsPanel listRef={listRef} onSelectionChange={setSelectedObjectId} pauseId={pauseId} />
+      <ElementsPanel
+        listRefSetter={setList}
+        onSelectionChange={setSelectedObjectId}
+        pauseId={pauseId}
+      />
       <div>
         {pauseId && selectedObjectId ? (
           <Suspense fallback={<Loader />}>

--- a/src/devtools/client/inspector/markup/components/ElementsPanelAdapter.tsx
+++ b/src/devtools/client/inspector/markup/components/ElementsPanelAdapter.tsx
@@ -1,5 +1,5 @@
 import { ObjectId } from "@replayio/protocol";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { getPauseId } from "devtools/client/debugger/src/selectors";
 import { selectNode } from "devtools/client/inspector/markup/actions/markup";
@@ -10,23 +10,23 @@ import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 
 export function ElementsPanelAdapter() {
   const pauseId = useAppSelector(getPauseId);
-  const selectedNodeId = useAppSelector(getSelectedNodeId);
+  const selectedNodeIdFromRedux = useAppSelector(getSelectedNodeId);
 
   const dispatch = useAppDispatch();
 
-  const listRef = useRef<ImperativeHandle>(null);
+  const [list, setList] = useState<ImperativeHandle | null>(null);
+
   const selectedNodeIdRef = useRef<ObjectId | null>(null);
 
   useEffect(() => {
-    if (selectedNodeId !== selectedNodeIdRef.current) {
-      selectedNodeIdRef.current = selectedNodeId;
+    if (list) {
+      if (selectedNodeIdFromRedux !== selectedNodeIdRef.current) {
+        selectedNodeIdRef.current = selectedNodeIdFromRedux;
 
-      const list = listRef.current;
-      if (list) {
-        list.selectNode(selectedNodeId);
+        list.selectNode(selectedNodeIdFromRedux);
       }
     }
-  }, [selectedNodeId]);
+  }, [list, selectedNodeIdFromRedux]);
 
   const onSelectionChange = (id: ObjectId | null) => {
     if (id !== selectedNodeIdRef.current) {
@@ -40,7 +40,7 @@ export function ElementsPanelAdapter() {
 
   return (
     <ElementsPanel
-      listRef={listRef}
+      listRefSetter={setList}
       onSelectionChange={onSelectionChange}
       pauseId={pauseId ?? null}
     />


### PR DESCRIPTION
- [x] Replace the mutable ref with a ref-setter in `ElementsPanelAdapter` so that we'll pass through the "selected Node" in Redux after the `ElementsList` renders (if it hasn't rendered yet).
- [x] It can take a while to load the nested elements– during which, the Elements panel doesn't show any kind of loading indicator. Show a loading indicator during this time.

https://github.com/replayio/devtools/assets/29597/62aa583f-015e-4f77-b028-31aa1f9810f6

Note I temporarily copied the new background color style from #9880 for the video about (because it contrasts better with the loading progress bar).