### PR TITLE
Handle potential missing point stack execution points

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@lexical/react": "^0.6.5",
     "@reduxjs/toolkit": "^1.8.4",
     "@replayio/overboard": "^0.4.1",
-    "@replayio/protocol": "^0.62.0",
+    "@replayio/protocol": "^0.63.0",
     "@replayio/react-devtools-inline": "4.28.6",
     "@sentry/react": "^7.9.0",
     "@sentry/tracing": "^7.9.0",

--- a/packages/replay-experimental/src/suspense/reactInternalsCaches.ts
+++ b/packages/replay-experimental/src/suspense/reactInternalsCaches.ts
@@ -52,6 +52,10 @@ export const reactRenderQueuedJumpLocationCache: Cache<
       earliestAppCodeFrame.index
     );
 
+    if (!pointDescription) {
+      return undefined;
+    }
+
     return {
       location,
       point: {

--- a/packages/replay-next/package.json
+++ b/packages/replay-next/package.json
@@ -11,7 +11,7 @@
     "@codemirror/state_replay_next": "npm:@codemirror/state@6.1.2",
     "@lezer/common_replay_next": "npm:@lezer/common@1.0.1",
     "@lezer/highlight_replay_next": "npm:@lezer/highlight@1.1.1",
-    "@replayio/protocol": "^0.60.0",
+    "@replayio/protocol": "^0.63.0",
     "date-fns": "^2.28.0",
     "design": "workspace:*",
     "escape-html": "^1.0.3",

--- a/packages/replay-next/src/suspense/PointStackCache.ts
+++ b/packages/replay-next/src/suspense/PointStackCache.ts
@@ -29,7 +29,7 @@ export function updateMappedLocationForPointStackFrame(
   frame: PointStackFrame
 ) {
   updateMappedLocation(sources, frame.functionLocation);
-  if (frame.point.frame) {
+  if (frame.point?.frame) {
     updateMappedLocation(sources, frame.point.frame);
   }
 }

--- a/packages/replay-next/src/suspense/ResumeTargetCache.ts
+++ b/packages/replay-next/src/suspense/ResumeTargetCache.ts
@@ -73,7 +73,16 @@ export const resumeTargetCache = createCache<
 
       if (frameIndex > 0) {
         const pointStack = await pointStackCache.readAsync(0, frameIndex, replayClient, pausePoint);
-        currentPoint = pointStack[frameIndex].point.point;
+        const frame = pointStack[frameIndex];
+        if (!frame.point) {
+          // Avoid stepping in the top frame - we need to step in the _current_ frame.
+          // Note that it's unlikely that we _will_ hit this case.
+          // Per Josh, the most likely reason a stack frame would _not_ have an execution point
+          // is if there's no actual code inside, such as `class B extends A` where B has no constructor.
+          // We _could_ look for the next frame that _does_ have an execution point instead.
+          return;
+        }
+        currentPoint = frame.point.point;
       }
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3665,17 +3665,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@replayio/protocol@npm:^0.60.0":
-  version: 0.60.0
-  resolution: "@replayio/protocol@npm:0.60.0"
-  checksum: 5b50218fda4357551006ee61076ba3fe3f24ad877a937d787dcd4cdd3deae21fcd84a1e1c75b23520c84d7281b5c75e9096b84fed3725d2e9fce63dca0e552f4
-  languageName: node
-  linkType: hard
-
-"@replayio/protocol@npm:^0.62.0":
-  version: 0.62.0
-  resolution: "@replayio/protocol@npm:0.62.0"
-  checksum: 38b3c04d9e69ec3679a3e3bf2423527f59a3e72c3a64f1f2dd2449bb4459f117e156b650a0409fd199f888baec90409c2d78224e3b9a6f092494fdf63a5b58ca
+"@replayio/protocol@npm:^0.63.0":
+  version: 0.63.0
+  resolution: "@replayio/protocol@npm:0.63.0"
+  checksum: 4e737fa07042bc23c7632a8adeaf2c449e1270675cf2eb988346853f71416f73b7b14a3507125a362567a6d71e661fc349a936172541dccc38b5b8aa6a07ec99
   languageName: node
   linkType: hard
 
@@ -14987,7 +14980,7 @@ __metadata:
     "@next/bundle-analyzer": ^12.2.0
     "@reduxjs/toolkit": ^1.8.4
     "@replayio/overboard": ^0.4.1
-    "@replayio/protocol": ^0.62.0
+    "@replayio/protocol": ^0.63.0
     "@replayio/react-devtools-inline": 4.28.6
     "@replayio/replay": ^0.12.4
     "@sentry/react": ^7.9.0
@@ -15292,7 +15285,7 @@ __metadata:
     "@lezer/common_replay_next": "npm:@lezer/common@1.0.1"
     "@lezer/highlight_replay_next": "npm:@lezer/highlight@1.1.1"
     "@playwright/test": ^1.35.0
-    "@replayio/protocol": ^0.60.0
+    "@replayio/protocol": ^0.63.0
     "@testing-library/jest-dom": ^5.16.3
     "@testing-library/react": ^13.2.0
     "@types/uuid": ^7.0.3


### PR DESCRIPTION
This PR:

- bumps the protocol package to 0.63 to pick up the types changes for `getPointStack`
- Tweaks the logic in some caches to handle `pointStackFrame.point` becoming optional

I _think_, based on https://github.com/replayio/backend/pull/8924 and https://github.com/replayio/backend/pull/8925 , that this will only ever occur if the frame just has an `EnterFrame` point and no meaningful frame steps.  However, I _don't_ know often that will occur in practice.

The code compiles, and I _think_ the logic tweaks make sense reading it.