### PR TITLE
Tighten our UI

### DIFF
--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -106,7 +106,7 @@ function Body() {
   }, [sidePanelCollapsed]);
 
   return (
-    <div className="vertical-panels pr-2">
+    <div className="vertical-panels pr-1">
       <div className="flex h-full flex-row overflow-hidden bg-chrome">
         <Toolbar />
         <PanelGroup autoSaveId="DevTools-horizontal" className="split-box" direction="horizontal">
@@ -122,7 +122,7 @@ function Body() {
             <SidePanel />
           </Panel>
           <PanelResizeHandle
-            className={`h-full ${sidePanelCollapsed ? "w-0" : "w-2"}`}
+            className={`h-full ${sidePanelCollapsed ? "w-0" : "w-1"}`}
             id="PanelResizeHandle-SidePanel"
           />
           <Panel className="flex h-full overflow-hidden" minSize={50}>

--- a/src/ui/components/Library/Team/View/TestRuns/TestRunsPage.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunsPage.tsx
@@ -117,7 +117,7 @@ function TestRunsContent() {
           </div>
         </Panel>
 
-        <PanelResizeHandle className="h-full w-2" />
+        <PanelResizeHandle className="h-full w-1" />
         <Panel minSize={20} order={2}>
           <div className="h-full w-full overflow-hidden rounded-xl">
             <Suspense fallback={<LibrarySpinner />}>

--- a/src/ui/components/NetworkMonitor/index.tsx
+++ b/src/ui/components/NetworkMonitor/index.tsx
@@ -168,7 +168,7 @@ export default function NetworkMonitor() {
           </Panel>
           {selectedRequestId && (
             <>
-              <PanelResizeHandle className="h-2 w-full" />
+              <PanelResizeHandle className="h-1 w-full" />
               <Panel defaultSize={50}>
                 {selectedRequestId ? (
                   <RequestDetails requests={requests} selectedRequestId={selectedRequestId} />

--- a/src/ui/components/Timeline/PlaybackControls.tsx
+++ b/src/ui/components/Timeline/PlaybackControls.tsx
@@ -38,7 +38,7 @@ export default function PlayPauseButton() {
 
   return (
     <div
-      className="mx-1.5 flex flex-row"
+      className="ml-1 mr-1.5 flex flex-row"
       style={{ width: "32px", height: "32px" }}
       onClick={onClick}
     >

--- a/src/ui/components/Timeline/Timeline.css
+++ b/src/ui/components/Timeline/Timeline.css
@@ -69,7 +69,6 @@
   height: 32px;
   position: relative;
   width: 100%;
-  margin-right: 40px;
 }
 
 .timeline .progress {

--- a/src/ui/components/Timeline/Timeline.css
+++ b/src/ui/components/Timeline/Timeline.css
@@ -6,7 +6,7 @@
   box-sizing: border-box;
   --progressbar-transition: 200ms;
   display: flex;
-  padding: 10px 12px 12px 6px;
+  padding: 10px 0px 12px 6px;
   align-items: center;
   user-select: none;
 
@@ -52,6 +52,7 @@
   display: flex;
   position: relative;
   flex-grow: 1;
+  padding-right: 10px;
 }
 
 .progress-bar-stack {
@@ -68,6 +69,7 @@
   height: 32px;
   position: relative;
   width: 100%;
+  margin-right: 40px;
 }
 
 .timeline .progress {

--- a/src/ui/components/Viewer.tsx
+++ b/src/ui/components/Viewer.tsx
@@ -63,7 +63,7 @@ const Vertical = ({ toolboxLayout }: { toolboxLayout: ToolboxLayout }) => {
               <Video />
             </div>
           </Panel>
-          <PanelResizeHandle className={videoPanelCollapsed ? "" : "h-2 w-full shrink-0"} />
+          <PanelResizeHandle className={videoPanelCollapsed ? "" : "h-1 w-full shrink-0"} />
         </>
       )}
       <Panel
@@ -105,7 +105,7 @@ const Horizontal = ({ toolboxLayout }: { toolboxLayout: ToolboxLayout }) => {
       >
         <div className="flex w-full flex-1 flex-row">
           {recordingCapabilities.supportsRepaintingGraphics ? <SecondaryToolbox /> : <Toolbox />}
-          <PanelResizeHandle className={videoPanelCollapsed ? "" : "h-full w-2 shrink-0"} />
+          <PanelResizeHandle className={videoPanelCollapsed ? "" : "h-full w-1 shrink-0"} />
         </div>
       </Panel>
       <Panel
@@ -138,7 +138,7 @@ export default function Viewer() {
           <Panel minSize={25} order={1}>
             <Toolbox />
           </Panel>
-          <PanelResizeHandle className="h-full w-2" />{" "}
+          <PanelResizeHandle className="h-full w-1" />{" "}
         </>
       )}
       <Panel minSize={25} order={2}>


### PR DESCRIPTION
We've always used w-2 to space our elements. This change moves to w-1 for a tighter and more professional appearance. 

Before: (look at the vertical gaps between columns, and the horizontal gaps around the video)
![image](https://github.com/replayio/devtools/assets/9154902/d8187f6f-1711-4bb1-966e-f0b375a63aca)

After:
![image](https://github.com/replayio/devtools/assets/9154902/9d34becc-7421-4152-97dd-f1d79992a90b)

I've also addressed the timeline to put things on a more consistent grid:

Here's the inconsistent alignment before:
![image](https://github.com/replayio/devtools/assets/9154902/b84f37da-78be-4310-b7dd-672a970a960b)

Here's how it looks now:
![image](https://github.com/replayio/devtools/assets/9154902/f33e6523-3dc6-4415-8337-c3ac0feae404)

