### PR TITLE
Separate concerns for formatting point stacks to speed up Redux J2C perf

### DIFF
--- a/packages/replay-experimental/src/suspense/reactInternalsCaches.ts
+++ b/packages/replay-experimental/src/suspense/reactInternalsCaches.ts
@@ -19,7 +19,12 @@ import { compareExecutionPoints } from "replay-next/src/utils/time";
 import { ReplayClientInterface } from "shared/client/types";
 import { findFunctionOutlineForLocation } from "ui/actions/eventListeners/jumpToCode";
 import { SourceDetails } from "ui/reducers/sources";
-import { FormattedPointStack, formattedPointStackCache } from "ui/suspense/frameCache";
+import {
+  FormattedPointStack,
+  FormattedPointStackWithRelevantFrame,
+  formattedPointStackCache,
+  relevantAppFrameCache,
+} from "ui/suspense/frameCache";
 
 interface PointWithLocation {
   location: Location;
@@ -228,15 +233,15 @@ export const reactInternalMethodsHitsIntervalCache = createFocusIntervalCacheFor
 export type ReactUpdateScheduled = {
   type: "scheduled";
   cause: "user" | "internal" | "unknown";
-} & FormattedPointStack;
+} & FormattedPointStackWithRelevantFrame;
 
 export type ReactSyncUpdatedStarted = {
   type: "sync_started";
-} & FormattedPointStack;
+} & FormattedPointStackWithRelevantFrame;
 
 export type ReactRenderCommitted = {
   type: "render_committed";
-} & FormattedPointStack;
+} & FormattedPointStackWithRelevantFrame;
 
 export type ReactRenderEntry =
   | ReactUpdateScheduled
@@ -273,10 +278,7 @@ export const reactRendersIntervalCache = createFocusIntervalCacheForExecutionPoi
 
     const scheduleUpdateEntriesPromise = Promise.all(
       scheduleUpdateHits.map(async hit => {
-        const mostlyFormattedPointStack = await formattedPointStackCache.readAsync(
-          replayClient,
-          hit
-        );
+        const mostlyFormattedPointStack = await relevantAppFrameCache.readAsync(replayClient, hit);
 
         const cause = mostlyFormattedPointStack.frame ? "user" : "unknown";
 
@@ -291,10 +293,7 @@ export const reactRendersIntervalCache = createFocusIntervalCacheForExecutionPoi
 
     const renderRootSyncEntriesPromise = Promise.all(
       renderRootSyncHits.map(async hit => {
-        const mostlyFormattedPointStack = await formattedPointStackCache.readAsync(
-          replayClient,
-          hit
-        );
+        const mostlyFormattedPointStack = await relevantAppFrameCache.readAsync(replayClient, hit);
 
         const result: ReactSyncUpdatedStarted = {
           type: "sync_started",
@@ -305,10 +304,7 @@ export const reactRendersIntervalCache = createFocusIntervalCacheForExecutionPoi
     );
     const onCommitRootEntriesPromise = Promise.all(
       onCommitRootHits.map(async hit => {
-        const mostlyFormattedPointStack = await formattedPointStackCache.readAsync(
-          replayClient,
-          hit
-        );
+        const mostlyFormattedPointStack = await relevantAppFrameCache.readAsync(replayClient, hit);
 
         const result: ReactRenderCommitted = {
           type: "render_committed",

--- a/src/ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsContents.tsx
+++ b/src/ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsContents.tsx
@@ -221,12 +221,7 @@ function TabContents({
       break;
     }
     case "trace": {
-      const jumpLocationRes = reduxDispatchJumpLocationCache.read(
-        replayClient,
-        point,
-        time,
-        sourcesState
-      );
+      const jumpLocationRes = reduxDispatchJumpLocationCache.read(replayClient, point, time);
       jumpLocation = jumpLocationRes ?? null;
       break;
     }

--- a/src/ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsPanel.tsx
+++ b/src/ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsPanel.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useContext, useMemo, useState } from "react";
+import { Suspense, useContext, useEffect, useMemo, useState } from "react";
 import { PanelGroup, PanelResizeHandle, Panel as ResizablePanel } from "react-resizable-panels";
 import { useImperativeCacheValue } from "suspense";
 
@@ -15,6 +15,7 @@ import { ReduxDevToolsContents } from "ui/components/SecondaryToolbox/redux-devt
 import { ReduxDevToolsList } from "ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsList";
 import { useAppSelector } from "ui/setup/hooks";
 import { reduxDevToolsAnnotationsCache } from "ui/suspense/annotationsCaches";
+import { applyMiddlewareDeclCache } from "ui/suspense/jumpToLocationCache";
 
 import styles from "./ReduxDevToolsPanel.module.css";
 
@@ -59,6 +60,12 @@ export default function ReduxDevToolsPanel() {
 
     return [filteredAnnotations, firstAnnotationAfterCurrentExecutionPoint];
   }, [annotationsStatus, currentExecutionPoint, focusWindow, parsedAnnotations, searchValue]);
+
+  useEffect(() => {
+    // Preload the cache for where `applyMiddleware` is defined
+    // This will speed up the first click on a Redux "J2C" button
+    applyMiddlewareDeclCache.prefetch(client);
+  }, [client]);
 
   return (
     <div className={styles.Container} data-test-id="ReduxDevtools">

--- a/src/ui/components/SecondaryToolbox/redux-devtools/utils/jumpToLocationForReduxDispatch.ts
+++ b/src/ui/components/SecondaryToolbox/redux-devtools/utils/jumpToLocationForReduxDispatch.ts
@@ -6,13 +6,7 @@ import { reduxDispatchJumpLocationCache } from "ui/suspense/jumpToLocationCache"
 
 export function jumpToLocationForReduxDispatch(point: ExecutionPoint, time: number): UIThunkAction {
   return async (dispatch, getState, { replayClient }) => {
-    const sourcesState = getState().sources;
-    const jumpLocation = await reduxDispatchJumpLocationCache.readAsync(
-      replayClient,
-      point,
-      time,
-      sourcesState
-    );
+    const jumpLocation = await reduxDispatchJumpLocationCache.readAsync(replayClient, point, time);
 
     if (jumpLocation) {
       dispatch(


### PR DESCRIPTION
This PR:

- Reworks the `formattedPointStackCache` to:
  - stop preemptively formatting function details for every stack frame (which requires fetching source outlines)
  - move all of the "relevant app stack frame" logic into a separate cache (as that is really only needed by the "React Render Panel" component, not the Redux J2C logic)
- Updates the "relevant app frame" logic to be smarter about which frame it finds, by doing a check for sourcemapped stack frames if available
- Updates the `applyMiddlewareCache` to do its own call to the `sourcesById` cache instead of passing `sourcesState` through multiple levels
- Preloads the `applyMiddlewareCache` as soon as the "Redux" panel is selected, since that is needed for all Redux J2C calls

This noticeably speeds up Redux J2C calls - we're now mostly limited by how fast `getPointStack` returns.

(I could imagine pre-fetching point stacks on hover, but we'll save that for another time.)