### PR TITLE
Make the useLineHighlights hook stateless

### DIFF
--- a/packages/replay-next/components/sources/hooks/useLineHighlights.ts
+++ b/packages/replay-next/components/sources/hooks/useLineHighlights.ts
@@ -1,16 +1,13 @@
-import { Frame, SourceId } from "@replayio/protocol";
-import { useContext, useEffect, useState } from "react";
+import { SourceId } from "@replayio/protocol";
+import { useContext } from "react";
+import { useImperativeCacheValue } from "suspense";
 
-import { SourceSearchContext } from "replay-next/components/sources/SourceSearchContext";
 import { SelectedFrameContext } from "replay-next/src/contexts/SelectedFrameContext";
 import { SourcesContext } from "replay-next/src/contexts/SourcesContext";
-import { framesCache, topFrameCache } from "replay-next/src/suspense/FrameCache";
-import { sourcesByIdCache } from "replay-next/src/suspense/SourcesCache";
-import {
-  getCorrespondingLocations,
-  getCorrespondingSourceIds,
-} from "replay-next/src/utils/sources";
+import { framesCache } from "replay-next/src/suspense/FrameCache";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
+
+import { SourceSearchContext } from "../SourceSearchContext";
 
 export type ExecutionPointLineHighlight = {
   columnIndex: number;
@@ -40,20 +37,14 @@ export function useLineHighlights(sourceId: SourceId): {
   const client = useContext(ReplayClientContext);
   const [sourceSearchState] = useContext(SourceSearchContext);
   const { selectedPauseAndFrameId, previewLocation } = useContext(SelectedFrameContext);
-  const { focusedSource, visibleLines } = useContext(SourcesContext);
-
-  const [executionPointLineHighlight, setExecutionPointLineHighlight] =
-    useState<ExecutionPointLineHighlight | null>(null);
-  const [searchResultLineHighlight, setSearchResultLineHighlight] =
-    useState<SearchResultLineHighlight | null>(null);
-  const [viewSourceLineHighlight, setViewSourceLineHighlight] =
-    useState<ViewSourceLineHighlight | null>(null);
-
-  // Destructure effect dependencies
+  const { focusedSource } = useContext(SourcesContext);
   const { currentScopeId: searchSourceId } = sourceSearchState;
   const { frameId: selectedFrameId, pauseId: selectedPauseId } = selectedPauseAndFrameId ?? {};
-  const visibleLineIndexStart = visibleLines?.start.line ?? null;
-  const visibleLineIndexEnd = visibleLines?.end.line ?? null;
+  const { status: framesStatus, value: frames } = useImperativeCacheValue(
+    framesCache,
+    client,
+    selectedPauseId
+  );
   const {
     columnNumber: focusedColumnNumber,
     mode: focusedSourceMode,
@@ -66,128 +57,50 @@ export function useLineHighlights(sourceId: SourceId): {
     sourceId: previewSourceId,
   } = previewLocation ?? {};
 
-  useEffect(() => {
-    const abortController = new AbortController();
-
-    async function fetchData() {
-      if (
-        visibleLineIndexEnd == null ||
-        visibleLineIndexStart == null ||
-        focusedSourceId != sourceId
-      ) {
-        setExecutionPointLineHighlight(null);
-        setSearchResultLineHighlight(null);
-        setViewSourceLineHighlight(null);
-        return;
-      }
-
-      if (previewSourceId === focusedSourceId && previewLineNumber != null) {
-        setExecutionPointLineHighlight({
-          columnIndex: previewColumnIndex ?? 0,
-          lineIndex: previewLineNumber - 1,
+  let executionPointLineHighlight: ExecutionPointLineHighlight | null = null;
+  if (previewSourceId === focusedSourceId && previewLineNumber != null) {
+    executionPointLineHighlight = {
+      columnIndex: previewColumnIndex ?? 0,
+      lineIndex: previewLineNumber - 1,
+      type: "execution-point",
+    };
+  }
+  if (selectedFrameId != null && selectedPauseId != null && framesStatus === "resolved" && frames) {
+    const selectedFrame = frames.find(frame => frame.frameId === selectedFrameId);
+    if (selectedFrame) {
+      const location = selectedFrame.location.find(location => location.sourceId === sourceId);
+      if (location) {
+        executionPointLineHighlight = {
+          columnIndex: location.column,
+          lineIndex: location.line - 1,
           type: "execution-point",
-        });
-      }
-
-      if (selectedFrameId != null && selectedPauseId != null) {
-        // The 95% use case is that we'll be in the top frame. Start by fetching that.
-        const topFrame = await topFrameCache.readAsync(client, selectedPauseId);
-        if (abortController.signal.aborted) {
-          return;
-        }
-
-        if (topFrame) {
-          // Assuming there's at least a top frame, we can now see _which_ frame we're paused in.
-          let selectedFrame: Frame | undefined = topFrame;
-          if (selectedFrame?.frameId !== selectedFrameId) {
-            // We must not be paused in the top frame. Get _all_ frames and find a match.
-            // This is a more expensive request, so only fetch all frames if we have to.
-            const allFrames = await framesCache.readAsync(client, selectedPauseId);
-            if (abortController.signal.aborted) {
-              return;
-            }
-
-            selectedFrame = allFrames?.find(frame => frame.frameId === selectedFrameId);
-          }
-
-          const sources = await sourcesByIdCache.readAsync(client);
-          if (abortController.signal.aborted) {
-            return;
-          }
-
-          const correspondingSourceIds = getCorrespondingSourceIds(sources, sourceId);
-
-          // Assuming we found a frame, check to see if there's a matching location for the frame.
-          // If so, we should show the highlight line.
-          const frame = selectedFrame?.location.find(location => {
-            if (correspondingSourceIds.includes(location.sourceId)) {
-              const correspondingLocations = getCorrespondingLocations(sources, location);
-              return (
-                correspondingLocations.findIndex(
-                  correspondingLocation =>
-                    correspondingLocation.line >= visibleLineIndexStart &&
-                    correspondingLocation.line <= visibleLineIndexEnd &&
-                    correspondingLocation.sourceId === sourceId
-                ) >= 0
-              );
-            }
-          });
-
-          if (frame) {
-            setExecutionPointLineHighlight({
-              columnIndex: frame.column,
-              lineIndex: frame.line - 1,
-              type: "execution-point",
-            });
-          }
-        }
-      }
-
-      if (searchSourceId === sourceId && focusedLineIndex != null) {
-        switch (focusedSourceMode) {
-          case "search-result":
-            setSearchResultLineHighlight({
-              columnIndex: focusedColumnNumber != null ? focusedColumnNumber - 1 : 0,
-              lineIndex: focusedLineIndex,
-              type: "search-result",
-            });
-            {
-              break;
-            }
-          case "view-source":
-            setViewSourceLineHighlight({
-              columnIndex: focusedColumnNumber != null ? focusedColumnNumber - 1 : 0,
-              lineIndex: focusedLineIndex,
-              type: "view-source",
-            });
-            {
-              break;
-            }
-        }
+        };
       }
     }
+  }
 
-    fetchData();
-
-    return () => {
-      abortController.abort();
-    };
-  }, [
-    client,
-    focusedColumnNumber,
-    focusedLineIndex,
-    focusedSourceId,
-    focusedSourceMode,
-    previewColumnIndex,
-    previewLineNumber,
-    previewSourceId,
-    searchSourceId,
-    selectedFrameId,
-    selectedPauseId,
-    sourceId,
-    visibleLineIndexEnd,
-    visibleLineIndexStart,
-  ]);
+  let searchResultLineHighlight: SearchResultLineHighlight | null = null;
+  let viewSourceLineHighlight: ViewSourceLineHighlight | null = null;
+  if (searchSourceId === sourceId && focusedLineIndex != null) {
+    switch (focusedSourceMode) {
+      case "search-result": {
+        searchResultLineHighlight = {
+          columnIndex: focusedColumnNumber != null ? focusedColumnNumber - 1 : 0,
+          lineIndex: focusedLineIndex,
+          type: "search-result",
+        };
+        break;
+      }
+      case "view-source": {
+        viewSourceLineHighlight = {
+          columnIndex: focusedColumnNumber != null ? focusedColumnNumber - 1 : 0,
+          lineIndex: focusedLineIndex,
+          type: "view-source",
+        };
+        break;
+      }
+    }
+  }
 
   return {
     executionPointLineHighlight,


### PR DESCRIPTION
I've made the hook stateless (see FE-2055) and also removed the handling of corresponding sources, which isn't necessary since we handle them in our caches.
Before: [Replay](https://app.replay.io/recording/line-highlight-not-cleared--53361b73-2c2a-46dd-b869-51d228aafff2)
After: [Replay](https://app.replay.io/recording/line-highlight-cleared--8cfefac0-3e6b-479b-ae76-16bbe8aba4ff)