### PR TITLE
Fix pause state regressions

### DIFF
--- a/packages/replay-next/components/console/ConsoleInput.tsx
+++ b/packages/replay-next/components/console/ConsoleInput.tsx
@@ -30,7 +30,7 @@ export default function ConsoleInput({ inputRef }: { inputRef?: RefObject<Impera
 
   let disabledMessage = null;
   let disabledReason = undefined;
-  if (!isPointWithinFocusWindow) {
+  if (executionPoint && !isPointWithinFocusWindow) {
     disabledReason = "not-focused";
     disabledMessage = (
       <>
@@ -57,7 +57,7 @@ export default function ConsoleInput({ inputRef }: { inputRef?: RefObject<Impera
   }
 
   return (
-    <ErrorBoundary name="ConsoleInput" resetKey={executionPoint} fallback={<ErrorFallback />}>
+    <ErrorBoundary name="ConsoleInput" resetKey={executionPoint ?? ""} fallback={<ErrorFallback />}>
       <Suspense fallback={<Loader />}>
         <ConsoleInputSuspends inputRef={inputRef} />
       </Suspense>
@@ -148,7 +148,7 @@ function ConsoleInputSuspends({ inputRef }: { inputRef?: RefObject<ImperativeHan
   };
 
   const onSubmit = async (expression: string) => {
-    if (!isExpressionValid) {
+    if (!executionPoint || !isExpressionValid) {
       return;
     }
 

--- a/packages/replay-next/components/console/CurrentTimeIndicator.tsx
+++ b/packages/replay-next/components/console/CurrentTimeIndicator.tsx
@@ -1,13 +1,13 @@
-import { useContext, useLayoutEffect } from "react";
+import { useLayoutEffect } from "react";
 
-import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
+import { useMostRecentLoadedPause } from "replay-next/src/hooks/useMostRecentLoadedPause";
 
 import styles from "./CurrentTimeIndicator.module.css";
 
 export default function CurrentTimeIndicator() {
-  const { executionPoint } = useContext(TimelineContext);
+  const { point } = useMostRecentLoadedPause() ?? {};
 
-  useLayoutEffect(scrollCurrentTimeIndicatorIntoView, [executionPoint]);
+  useLayoutEffect(scrollCurrentTimeIndicatorIntoView, [point]);
 
   return (
     <div className={styles.CurrentTimeIndicator} data-test-id="Console-CurrentTimeIndicator" />

--- a/packages/replay-next/components/console/MessagesList.tsx
+++ b/packages/replay-next/components/console/MessagesList.tsx
@@ -12,7 +12,7 @@ import Icon from "replay-next/components/Icon";
 import Loader from "replay-next/components/Loader";
 import { ConsoleFiltersContext } from "replay-next/src/contexts/ConsoleFiltersContext";
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
-import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
+import { useMostRecentLoadedPause } from "replay-next/src/hooks/useMostRecentLoadedPause";
 import { useStreamingMessages } from "replay-next/src/hooks/useStreamingMessages";
 import {
   getLoggableExecutionPoint,
@@ -68,7 +68,7 @@ function MessagesListSuspends({ forwardedRef }: { forwardedRef: ForwardedRef<HTM
   const { isTransitionPending: isFocusTransitionPending } = useContext(FocusContext);
   const { loggables, streamingStatus } = useContext(LoggablesContext);
   const [searchState] = useContext(ConsoleSearchContext);
-  const { executionPoint: currentExecutionPoint } = useContext(TimelineContext);
+  const { point: currentExecutionPoint } = useMostRecentLoadedPause() ?? {};
 
   // The Console should render a line indicating the current execution point.
   // This point might match multiple logs– or it might be between logs, or after the last log, etc.

--- a/packages/replay-next/components/console/MessagesList.tsx
+++ b/packages/replay-next/components/console/MessagesList.tsx
@@ -73,7 +73,10 @@ function MessagesListSuspends({ forwardedRef }: { forwardedRef: ForwardedRef<HTM
   // The Console should render a line indicating the current execution point.
   // This point might match multiple logs– or it might be between logs, or after the last log, etc.
   // This looking finds the best place to render the indicator.
-  const currentTimeIndicatorPlacement = useMemo<CurrentTimeIndicatorPlacement>(() => {
+  const currentTimeIndicatorPlacement = useMemo<CurrentTimeIndicatorPlacement | null>(() => {
+    if (!currentExecutionPoint) {
+      return null;
+    }
     if (currentExecutionPoint === "0") {
       return "begin";
     }

--- a/packages/replay-next/components/inspector/values/HTMLElementRenderer.tsx
+++ b/packages/replay-next/components/inspector/values/HTMLElementRenderer.tsx
@@ -8,6 +8,7 @@ import {
 } from "replay-next/src/contexts/InspectorContext";
 import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
 import { clientValueCache, objectCache } from "replay-next/src/suspense/ObjectPreviews";
+import { getPointAndTimeForPauseId } from "replay-next/src/suspense/PauseCache";
 import {
   Value as ClientValue,
   filterNonEnumerableProperties,
@@ -83,7 +84,9 @@ export default function HTMLElementRenderer({
       // InspectableTimestampedPointContext (e.g. if the HTML element to render is
       // from a console message)
       const { executionPoint, time } = timestampedPointContext || timelineContext;
-      inspectHTMLElement(protocolValue, pauseId, executionPoint, time);
+      if (executionPoint) {
+        inspectHTMLElement(protocolValue, pauseId, executionPoint, time);
+      }
     }
   };
 

--- a/packages/replay-next/components/lexical/CodeEditor.tsx
+++ b/packages/replay-next/components/lexical/CodeEditor.tsx
@@ -59,7 +59,7 @@ type Props = {
   dataTestId?: string;
   dataTestName?: string;
   editable: boolean;
-  executionPoint: ExecutionPoint;
+  executionPoint: ExecutionPoint | null;
   forwardedRef?: ForwardedRef<ImperativeHandle>;
   initialValue: string;
   onCancel?: () => void;

--- a/packages/replay-next/components/lexical/plugins/code-completion/CodeCompletionPlugin.tsx
+++ b/packages/replay-next/components/lexical/plugins/code-completion/CodeCompletionPlugin.tsx
@@ -24,7 +24,7 @@ export default function CodeCompletionPlugin({
   context: Context;
   dataTestId?: string;
   dataTestName?: string;
-  executionPoint: ExecutionPoint;
+  executionPoint: ExecutionPoint | null;
   time: number;
 }): JSX.Element {
   const [editor] = useLexicalComposerContext();
@@ -34,7 +34,9 @@ export default function CodeCompletionPlugin({
   const focusWindow = useCurrentFocusWindow();
 
   const findMatchesWrapper = (query: string, queryScope: string | null) => {
-    return findMatches(query, queryScope, replayClient, executionPoint, time, focusWindow, context);
+    return executionPoint
+      ? findMatches(query, queryScope, replayClient, executionPoint, time, focusWindow, context)
+      : [];
   };
 
   useEffect(() => {

--- a/packages/replay-next/components/sources/HoverButton.tsx
+++ b/packages/replay-next/components/sources/HoverButton.tsx
@@ -116,7 +116,7 @@ function MetaHoverButton({
   }
 
   let targetPoint: TimeStampedPoint | null = null;
-  if (hitPoints !== null && hitPointStatus !== "too-many-points-to-find") {
+  if (executionPoint && hitPoints !== null && hitPointStatus !== "too-many-points-to-find") {
     if (isShiftKeyActive) {
       targetPoint = findLastHitPoint(hitPoints, executionPoint);
     } else {

--- a/packages/replay-next/components/sources/log-point-panel/HitPointTimeline.tsx
+++ b/packages/replay-next/components/sources/log-point-panel/HitPointTimeline.tsx
@@ -22,7 +22,7 @@ import { formatTimestamp } from "replay-next/src/utils/time";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { HitPointStatus, Point } from "shared/client/types";
 
-import { findHitPointAfter, findHitPointBefore } from "../utils/points";
+import { findHitPointAfter, findHitPointBefore, noMatchTuple } from "../utils/points";
 import { findHitPoint } from "../utils/points";
 import Capsule from "./Capsule";
 import styles from "./HitPointTimeline.module.css";
@@ -72,7 +72,8 @@ export default function HitPointTimeline({
   }, [currentTime]);
 
   const [closestHitPoint, closestHitPointIndex] = useMemo(
-    () => findHitPoint(hitPoints, currentExecutionPoint, false),
+    () =>
+      currentExecutionPoint ? findHitPoint(hitPoints, currentExecutionPoint, false) : noMatchTuple,
     [currentExecutionPoint, hitPoints]
   );
 
@@ -113,9 +114,13 @@ export default function HitPointTimeline({
   const firstHitPoint = hitPoints.length > 0 ? hitPoints[0] : null;
   const lastHitPoint = hitPoints.length > 0 ? hitPoints[hitPoints.length - 1] : null;
   const previousButtonEnabled =
-    firstHitPoint != null && isExecutionPointsLessThan(firstHitPoint.point, currentExecutionPoint);
+    currentExecutionPoint &&
+    firstHitPoint != null &&
+    isExecutionPointsLessThan(firstHitPoint.point, currentExecutionPoint);
   const nextButtonEnabled =
-    lastHitPoint != null && isExecutionPointsGreaterThan(lastHitPoint.point, currentExecutionPoint);
+    currentExecutionPoint &&
+    lastHitPoint != null &&
+    isExecutionPointsGreaterThan(lastHitPoint.point, currentExecutionPoint);
 
   const goToIndex = (index: number) => {
     const hitPoint = hitPoints[index];
@@ -126,6 +131,9 @@ export default function HitPointTimeline({
   };
 
   const goToPrevious = () => {
+    if (!currentExecutionPoint) {
+      return;
+    }
     const [prevHitPoint] = findHitPointBefore(hitPoints, currentExecutionPoint);
     if (prevHitPoint !== null) {
       setOptimisticTime(prevHitPoint.time);
@@ -133,6 +141,9 @@ export default function HitPointTimeline({
     }
   };
   const goToNext = () => {
+    if (!currentExecutionPoint) {
+      return;
+    }
     const [nextHitPoint] = findHitPointAfter(hitPoints, currentExecutionPoint);
     if (nextHitPoint !== null) {
       setOptimisticTime(nextHitPoint.time);

--- a/packages/replay-next/components/sources/log-point-panel/LogPointPanel.tsx
+++ b/packages/replay-next/components/sources/log-point-panel/LogPointPanel.tsx
@@ -204,6 +204,9 @@ function PointPanelWithHitPoints({
   // This is a more intuitive experience than using the current execution point,
   // which may be paused at a different location.
   const closestHitPoint = useMemo(() => {
+    if (!currentExecutionPoint) {
+      return null;
+    }
     const executionPoints = hitPoints.map(hitPoint => hitPoint.point);
     const index = findIndexBigInt(executionPoints, currentExecutionPoint, false);
     return hitPoints[index] || null;
@@ -288,7 +291,7 @@ function PointPanelWithHitPoints({
   };
 
   const addComment = () => {
-    if (accessToken === null) {
+    if (accessToken === null || !currentExecutionPoint) {
       return;
     }
 

--- a/packages/replay-next/components/sources/useSourceContextMenu.tsx
+++ b/packages/replay-next/components/sources/useSourceContextMenu.tsx
@@ -47,6 +47,10 @@ export default function useSourceContextMenu({
 
   const addComment = () => {
     startTransition(async () => {
+      if (!currentExecutionPoint) {
+        return;
+      }
+
       if (showCommentsPanel !== null) {
         showCommentsPanel();
       }
@@ -138,7 +142,7 @@ function FastForwardButton({
   });
 
   let fastForwardToExecutionPoint: TimeStampedPoint | null = null;
-  if (hitPoints !== null && hitPointStatus !== "too-many-points-to-find") {
+  if (currentExecutionPoint && hitPoints !== null && hitPointStatus !== "too-many-points-to-find") {
     fastForwardToExecutionPoint = findNextHitPoint(hitPoints, currentExecutionPoint);
   }
 
@@ -177,7 +181,7 @@ function RewindButton({
   });
 
   let rewindToExecutionPoint: TimeStampedPoint | null = null;
-  if (hitPoints !== null && hitPointStatus !== "too-many-points-to-find") {
+  if (currentExecutionPoint && hitPoints !== null && hitPointStatus !== "too-many-points-to-find") {
     rewindToExecutionPoint = findLastHitPoint(hitPoints, currentExecutionPoint);
   }
 

--- a/packages/replay-next/components/sources/utils/points.ts
+++ b/packages/replay-next/components/sources/utils/points.ts
@@ -11,7 +11,7 @@ import { Point } from "shared/client/types";
 type HitPointAndIndexTuple = [hitPoint: TimeStampedPoint, index: number];
 type NoMatchTuple = [null, number];
 
-const noMatchTuple: NoMatchTuple = [null, -1];
+export const noMatchTuple: NoMatchTuple = [null, -1];
 
 export function findClosestHitPoint(
   hitPoints: TimeStampedPoint[],

--- a/packages/replay-next/src/contexts/SelectedFrameContext.tsx
+++ b/packages/replay-next/src/contexts/SelectedFrameContext.tsx
@@ -85,6 +85,11 @@ function DefaultSelectedFrameContextAdapter() {
     let cancelled = false;
 
     async function getData() {
+      if (!executionPoint) {
+        setSelectedPauseAndFrameId(null);
+        return;
+      }
+
       const pauseId = await pauseIdCache.readAsync(client, executionPoint, time);
 
       // Edge case handle an update that rendered while we were awaiting data.

--- a/packages/replay-next/src/contexts/TimelineContext.tsx
+++ b/packages/replay-next/src/contexts/TimelineContext.tsx
@@ -9,7 +9,7 @@ import {
 } from "react";
 
 export type TimelineContextType = {
-  executionPoint: ExecutionPoint;
+  executionPoint: ExecutionPoint | null;
   isPending: boolean;
   time: number;
   update: (

--- a/packages/replay-next/src/hooks/useCurrentPauseIdSuspense.ts
+++ b/packages/replay-next/src/hooks/useCurrentPauseIdSuspense.ts
@@ -12,7 +12,7 @@ export default function useCurrentPauseIdSuspense(): PauseId | null {
   const { executionPoint, time } = useContext(TimelineContext);
 
   const isInFocusWindow = useIsPointWithinFocusWindow(executionPoint);
-  if (!isInFocusWindow) {
+  if (!executionPoint || !isInFocusWindow) {
     return null;
   }
 

--- a/packages/replay-next/src/hooks/useMostRecentLoadedPause.ts
+++ b/packages/replay-next/src/hooks/useMostRecentLoadedPause.ts
@@ -1,0 +1,30 @@
+import { ExecutionPoint, PauseId } from "@replayio/protocol";
+import { useContext, useRef } from "react";
+import { useImperativeCacheValue } from "suspense";
+
+import { ReplayClientContext } from "shared/client/ReplayClientContext";
+
+import { TimelineContext } from "../contexts/TimelineContext";
+import { pauseIdCache } from "../suspense/PauseCache";
+
+interface LoadedPause {
+  pauseId: PauseId;
+  point: ExecutionPoint;
+  time: number;
+}
+
+export function useMostRecentLoadedPause(): LoadedPause | null {
+  const client = useContext(ReplayClientContext);
+  const pauseRef = useRef<LoadedPause | null>(null);
+  const { executionPoint: point, time } = useContext(TimelineContext);
+  const { status: pauseIdStatus, value: pauseId } = useImperativeCacheValue(
+    pauseIdCache,
+    client,
+    point ?? "0",
+    time
+  );
+  if (point && point !== pauseRef.current?.point && pauseIdStatus === "resolved") {
+    pauseRef.current = { pauseId, point, time };
+  }
+  return pauseRef.current;
+}

--- a/src/devtools/client/inspector/components/App.tsx
+++ b/src/devtools/client/inspector/components/App.tsx
@@ -1,12 +1,11 @@
-import { useContext } from "react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 
 import ComputedApp from "devtools/client/inspector/computed/components/ComputedApp";
 import LayoutApp from "devtools/client/inspector/layout/components/LayoutApp";
 import { ElementsPanelAdapter } from "devtools/client/inspector/markup/components/ElementsPanelAdapter";
 import { RulesPanel } from "devtools/client/inspector/markup/components/rules";
-import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
 import { useIsPointWithinFocusWindow } from "replay-next/src/hooks/useIsPointWithinFocusWindow";
+import { useMostRecentLoadedPause } from "replay-next/src/hooks/useMostRecentLoadedPause";
 import { ActiveInspectorTab } from "shared/user-data/GraphQL/config";
 import { enterFocusMode } from "ui/actions/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
@@ -32,9 +31,9 @@ const availableTabs: readonly ActiveInspectorTab[] = [
 export default function InspectorApp() {
   const dispatch = useAppDispatch();
   const activeTab = useAppSelector(state => state.inspector.activeTab);
-  const { executionPoint } = useContext(TimelineContext);
+  const { point } = useMostRecentLoadedPause() ?? {};
 
-  const isPointWithinFocusWindow = useIsPointWithinFocusWindow(executionPoint);
+  const isPointWithinFocusWindow = useIsPointWithinFocusWindow(point ?? null);
   if (!isPointWithinFocusWindow) {
     return (
       <div className="inspector-responsive-container bg-bodyBgcolor p-2">

--- a/src/devtools/client/inspector/computed/components/ComputedProperties.tsx
+++ b/src/devtools/client/inspector/computed/components/ComputedProperties.tsx
@@ -2,8 +2,8 @@ import React, { useContext } from "react";
 import { shallowEqual } from "react-redux";
 import { useImperativeCacheValue } from "suspense";
 
-import { getPauseId } from "devtools/client/debugger/src/selectors";
 import { elementCache } from "replay-next/components/elements/suspense/ElementCache";
+import { useMostRecentLoadedPause } from "replay-next/src/hooks/useMostRecentLoadedPause";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { isElement } from "ui/suspense/nodeCaches";
@@ -33,9 +33,9 @@ function isHidden(property: ComputedPropertyState, search: string, showBrowserSt
 
 function ComputedProperties() {
   const dispatch = useAppDispatch();
-  const { pauseId, selectedNodeId, expandedProperties, search, showBrowserStyles } = useAppSelector(
+  const { pauseId } = useMostRecentLoadedPause() ?? {};
+  const { selectedNodeId, expandedProperties, search, showBrowserStyles } = useAppSelector(
     state => ({
-      pauseId: getPauseId(state),
       selectedNodeId: getSelectedNodeId(state),
       expandedProperties: state.computed.expandedProperties,
       search: state.computed.search,

--- a/src/devtools/client/inspector/event-listeners/EventListenersApp.tsx
+++ b/src/devtools/client/inspector/event-listeners/EventListenersApp.tsx
@@ -1,8 +1,8 @@
 import React, { useContext, useEffect, useMemo, useState } from "react";
 
-import { getPauseId } from "devtools/client/debugger/src/reducers/pause";
 import { getSelectedDomNodeId } from "devtools/client/inspector/markup/reducers/markup";
 import { onViewSourceInDebugger } from "devtools/client/webconsole/actions/toolbox";
+import { useMostRecentLoadedPause } from "replay-next/src/hooks/useMostRecentLoadedPause";
 import { objectCache } from "replay-next/src/suspense/ObjectPreviews";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { getNodeEventListeners } from "ui/actions/event-listeners";
@@ -20,7 +20,7 @@ export const EventListenersApp = () => {
   const [listeners, setListeners] = useState<EventListenerWithFunctionInfo[]>([]);
   const selectedDomNodeId = useAppSelector(getSelectedDomNodeId);
   const dispatch = useAppDispatch();
-  const pauseId = useAppSelector(getPauseId);
+  const { pauseId } = useMostRecentLoadedPause() ?? {};
   const replayClient = useContext(ReplayClientContext);
 
   useEffect(() => {

--- a/src/devtools/client/inspector/layout/components/LayoutApp.tsx
+++ b/src/devtools/client/inspector/layout/components/LayoutApp.tsx
@@ -6,7 +6,7 @@ import React, { useContext } from "react";
 import { shallowEqual } from "react-redux";
 import { useImperativeCacheValue } from "suspense";
 
-import { getPauseId } from "devtools/client/debugger/src/selectors";
+import { useMostRecentLoadedPause } from "replay-next/src/hooks/useMostRecentLoadedPause";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { useAppSelector } from "ui/setup/hooks";
 import { layoutCache } from "ui/suspense/styleCaches";
@@ -16,9 +16,9 @@ import { getSelectedNodeId } from "../../markup/selectors/markup";
 
 function LayoutApp() {
   const replayClient = useContext(ReplayClientContext);
-  const { pauseId, selectedNodeId } = useAppSelector(
+  const { pauseId } = useMostRecentLoadedPause() ?? {};
+  const { selectedNodeId } = useAppSelector(
     state => ({
-      pauseId: getPauseId(state),
       selectedNodeId: getSelectedNodeId(state),
     }),
     shallowEqual

--- a/src/devtools/client/inspector/markup/components/ElementsPanelAdapter.tsx
+++ b/src/devtools/client/inspector/markup/components/ElementsPanelAdapter.tsx
@@ -1,15 +1,15 @@
 import { ObjectId } from "@replayio/protocol";
 import { useEffect, useRef } from "react";
 
-import { getPauseId } from "devtools/client/debugger/src/selectors";
 import { selectNode } from "devtools/client/inspector/markup/actions/markup";
 import { getSelectedNodeId } from "devtools/client/inspector/markup/selectors/markup";
 import ElementsPanel from "replay-next/components/elements";
 import { ImperativeHandle } from "replay-next/components/elements/ElementsList";
+import { useMostRecentLoadedPause } from "replay-next/src/hooks/useMostRecentLoadedPause";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 
 export function ElementsPanelAdapter() {
-  const pauseId = useAppSelector(getPauseId);
+  const { pauseId } = useMostRecentLoadedPause() ?? {};
   const selectedNodeId = useAppSelector(getSelectedNodeId);
 
   const dispatch = useAppDispatch();

--- a/src/devtools/client/inspector/markup/components/rules/RulesPanel.tsx
+++ b/src/devtools/client/inspector/markup/components/rules/RulesPanel.tsx
@@ -1,11 +1,11 @@
 import { useContext, useDeferredValue, useState } from "react";
 import AutoSizer from "react-virtualized-auto-sizer";
 
-import { getPauseId } from "devtools/client/debugger/src/selectors";
 import { RulesList } from "devtools/client/inspector/markup/components/rules/RulesList";
 import { getSelectedNodeId } from "devtools/client/inspector/markup/selectors/markup";
 import { elementCache } from "replay-next/components/elements/suspense/ElementCache";
 import Icon from "replay-next/components/Icon";
+import { useMostRecentLoadedPause } from "replay-next/src/hooks/useMostRecentLoadedPause";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { shallowEqual } from "shared/utils/compare";
 import { useAppSelector } from "ui/setup/hooks";
@@ -18,9 +18,9 @@ const NO_RULES_AVAILABLE: RuleState[] = [];
 
 export function RulesPanelSuspends() {
   const replayClient = useContext(ReplayClientContext);
-  const { pauseId, selectedNodeId } = useAppSelector(
+  const { pauseId } = useMostRecentLoadedPause() ?? {};
+  const { selectedNodeId } = useAppSelector(
     state => ({
-      pauseId: getPauseId(state),
       selectedNodeId: getSelectedNodeId(state),
     }),
     shallowEqual

--- a/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
+++ b/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
@@ -1,4 +1,4 @@
-import { ExecutionPoint, NodeBounds, PauseId, Object as ProtocolObject } from "@replayio/protocol";
+import { NodeBounds, Object as ProtocolObject } from "@replayio/protocol";
 import { createBridge, createStore, initialize } from "@replayio/react-devtools-inline/frontend";
 import {
   useContext,
@@ -14,13 +14,13 @@ import { useImperativeCacheValue } from "suspense";
 import { selectLocation } from "devtools/client/debugger/src/actions/sources";
 import {
   getExecutionPoint,
-  getPauseId,
   getThreadContext,
   getTime,
 } from "devtools/client/debugger/src/reducers/pause";
 import { highlightNode, unhighlightNode } from "devtools/client/inspector/markup/actions/markup";
 import ErrorBoundary from "replay-next/components/ErrorBoundary";
 import { useIsPointWithinFocusWindow } from "replay-next/src/hooks/useIsPointWithinFocusWindow";
+import { useMostRecentLoadedPause } from "replay-next/src/hooks/useMostRecentLoadedPause";
 import { useNag } from "replay-next/src/hooks/useNag";
 import { recordingCapabilitiesCache } from "replay-next/src/suspense/BuildIdCache";
 import { isExecutionPointsLessThan } from "replay-next/src/utils/time";
@@ -343,13 +343,7 @@ export function ReactDevtoolsPanel() {
 
 export default function ReactDevToolsWithErrorBoundary() {
   const replayClient = useContext(ReplayClientContext);
-  const pointAndPauseIdRef = useRef<[ExecutionPoint | null, PauseId | null]>([null, null]);
-  const pauseId = useAppSelector(getPauseId) ?? null;
-  const currentPoint = useAppSelector(getExecutionPoint);
-  if (currentPoint !== pointAndPauseIdRef.current[0] && pauseId) {
-    pointAndPauseIdRef.current = [currentPoint, pauseId];
-  }
-
+  const { point, pauseId } = useMostRecentLoadedPause() ?? {};
   const [newReactDevTools] = useGraphQLUserData("feature_newReactDevTools");
 
   const recordingCapabilities = recordingCapabilitiesCache.read(replayClient);
@@ -362,10 +356,7 @@ export default function ReactDevToolsWithErrorBoundary() {
   return (
     <ErrorBoundary name="ReactDevTools" resetKey={pauseId ?? ""}>
       {showNewDevTools ? (
-        <NewReactDevtoolsPanel
-          executionPoint={pointAndPauseIdRef.current[0]}
-          pauseId={pointAndPauseIdRef.current[1]}
-        />
+        <NewReactDevtoolsPanel executionPoint={point ?? null} pauseId={pauseId ?? null} />
       ) : (
         <ReactDevtoolsPanel />
       )}

--- a/src/ui/components/SecondaryToolbox/TimelineContextAdapter.tsx
+++ b/src/ui/components/SecondaryToolbox/TimelineContextAdapter.tsx
@@ -10,7 +10,7 @@ import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 export default function TimelineContextAdapter({ children }: PropsWithChildren) {
   const dispatch = useAppDispatch();
   const time = useAppSelector(getTime);
-  const executionPoint = useAppSelector(getExecutionPoint) || "0";
+  const executionPoint = useAppSelector(getExecutionPoint);
 
   const update = useCallback(
     async (

--- a/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
@@ -69,9 +69,11 @@ export function TestSectionRow({
           const timeStampedPoint = getTestEventTimeStampedPoint(testEvent);
 
           if (timeStampedPoint) {
-            position = isExecutionPointsGreaterThan(timeStampedPoint.point, currentExecutionPoint)
-              ? "after"
-              : "before";
+            position =
+              !currentExecutionPoint ||
+              isExecutionPointsGreaterThan(timeStampedPoint.point, currentExecutionPoint)
+                ? "after"
+                : "before";
           }
           break;
         }


### PR DESCRIPTION
- `TimelineContext`: don't fall back to execution point `"0"` - in the past this fallback was only used at the start of the session but now the execution point in redux is set to `null` while we're waiting for the `Session.getPointNearTime` result and we shouldn't jump to `"0"` during that time
- added the `useMostRecentLoadedPause()` hook and used it in the Elements panel (fixing FE-2053), the `CurrentTimeIndicator` in the console (which jumped around while seeking in the timeline) and the RDT panel (which already had its own implementation for getting the most recent loaded pause)