### PR TITLE
[DRAFT] Totally WIP attempt at reworking the Playwright function/step grouping logic

### DIFF
--- a/packages/shared/test-suites/RecordingTestMetadata.ts
+++ b/packages/shared/test-suites/RecordingTestMetadata.ts
@@ -1,3 +1,4 @@
+import { nanoid } from "@reduxjs/toolkit";
 import {
   ExecutionPoint,
   RequestId,
@@ -255,6 +256,9 @@ export namespace RecordingTestMetadataV3 {
       // An error that occurred while executing this action (if any)
       error: TestError | null;
 
+      // Used to associate related annotations
+      id: string;
+
       // Used to associate chained commands
       parentId: string | null;
 
@@ -318,6 +322,8 @@ export namespace RecordingTestMetadataV3 {
   }
 
   export interface NetworkRequestEvent {
+    id: string;
+
     // Data needed to render this event
     data: {
       request: {
@@ -426,6 +432,7 @@ export async function processCypressTestRecording(
               assert(annotation.message.url, "Navigation annotation must have a URL");
 
               const navigationEvent: RecordingTestMetadataV3.NavigationEvent = {
+                id: nanoid(),
                 data: {
                   url: annotation.message.url,
                 },
@@ -586,6 +593,7 @@ export async function processCypressTestRecording(
             });
 
             testEvents.push({
+              id: nanoid(),
               data: {
                 category,
                 command,
@@ -895,6 +903,7 @@ export async function processPlaywrightTestRecording(
         }
 
         testEvents.push({
+          id: nanoid(),
           data: {
             category,
             command,
@@ -1002,6 +1011,7 @@ class FunctionNode {
     const combined = this.events.concat(childList);
 
     return {
+      id: nanoid(),
       type: "function",
       data: {
         function: this.functionName,
@@ -1129,6 +1139,7 @@ async function processNetworkData(
     }
 
     networkRequestEvents.push({
+      id: nanoid(),
       data: {
         request: {
           id,

--- a/packages/shared/test-suites/RecordingTestMetadata.ts
+++ b/packages/shared/test-suites/RecordingTestMetadata.ts
@@ -241,6 +241,9 @@ export namespace RecordingTestMetadataV3 {
   export type UserActionEventStack = Array<UserActionStackEntry>;
 
   export interface UserActionEvent {
+    // Used to associate related annotations
+    id: string;
+
     data: {
       category: "assertion" | "command" | "other";
 
@@ -251,9 +254,6 @@ export namespace RecordingTestMetadataV3 {
 
       // An error that occurred while executing this action (if any)
       error: TestError | null;
-
-      // Used to associate related annotations
-      id: string;
 
       // Used to associate chained commands
       parentId: string | null;
@@ -286,6 +286,7 @@ export namespace RecordingTestMetadataV3 {
   }
 
   export interface NavigationEvent {
+    id: string;
     // Data needed to render this event
     data: {
       url: string;
@@ -298,6 +299,7 @@ export namespace RecordingTestMetadataV3 {
   }
 
   export interface FunctionEvent {
+    id: string;
     // Data needed to render this event
     data: {
       function: string;

--- a/packages/shared/test-suites/__tests__/playwrightSteps.fixture.json
+++ b/packages/shared/test-suites/__tests__/playwrightSteps.fixture.json
@@ -1,0 +1,24189 @@
+[
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          }, 
+          "error": null,
+          "id": "pw:api@9",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/index.ts",
+                  "functionName": "startTest",
+                  "lineNumber": 115
+              },
+              {
+                  "columnNumber": 18,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 13
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": null,
+              "beforeStep": null,
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.goto"
+          },
+          "error": null,
+          "id": "pw:api@11",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/index.ts",
+                  "functionName": "startTest",
+                  "lineNumber": 117
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 13
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "7139408180734257625213866440917273",
+                  "time": 5043
+              },
+              "beforeStep": {
+                  "point": "7139408180734257625213866440917273",
+                  "time": 5043
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@14",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitForRecordingToFinishIndexing",
+                  "lineNumber": 88
+              },
+              {
+                  "columnNumber": 41,
+                  "fileName": "helpers/index.ts",
+                  "functionName": "startTest",
+                  "lineNumber": 122
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 13
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "7139408180734371764442822518767901",
+                  "time": 5121
+              },
+              "beforeStep": {
+                  "point": "7139408180734272613193426329927963",
+                  "time": 5048
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.getAttribute"
+          },
+          "error": null,
+          "id": "pw:api@17",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 49,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "callback",
+                  "lineNumber": 97
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitForRecordingToFinishIndexing",
+                  "lineNumber": 95
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/index.ts",
+                  "functionName": "startTest",
+                  "lineNumber": 122
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 13
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "20444668881406778906787523606872831",
+                  "time": 11114
+              },
+              "beforeStep": {
+                  "point": "7463926734393000252489284737564958",
+                  "time": 5159
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@21",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 85,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor.retryInterval",
+                  "lineNumber": 97
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "20444668881406786977238055854801664",
+                  "time": 11114
+              },
+              "beforeStep": {
+                  "point": "20444668881406786977238055854801664",
+                  "time": 11114
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.getAttribute"
+          },
+          "error": null,
+          "id": "pw:api@23",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 49,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "callback",
+                  "lineNumber": 97
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitForRecordingToFinishIndexing",
+                  "lineNumber": 95
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/index.ts",
+                  "functionName": "startTest",
+                  "lineNumber": 122
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 13
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "22391780203419998245418832649782068",
+                  "time": 11950
+              },
+              "beforeStep": {
+                  "point": "22067261649761563448185144381276979",
+                  "time": 11922
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@26",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 85,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor.retryInterval",
+                  "lineNumber": 97
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "22391780203420006315869364897710901",
+                  "time": 11965
+              },
+              "beforeStep": {
+                  "point": "22391780203420006315869364897710901",
+                  "time": 11965
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@29",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 17,
+                  "fileName": "helpers/index.ts",
+                  "functionName": "openDevToolsTab",
+                  "lineNumber": 31
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 14
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "22391780203420647340225926304629560",
+                  "time": 12012
+              },
+              "beforeStep": {
+                  "point": "22391780203420639269775394056700727",
+                  "time": 12004
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@31",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 56,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "getElementClasses",
+                  "lineNumber": 167
+              },
+              {
+                  "columnNumber": 42,
+                  "fileName": "helpers/index.ts",
+                  "functionName": "isDevToolsTabActive",
+                  "lineNumber": 69
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/index.ts",
+                  "functionName": "openDevToolsTab",
+                  "lineNumber": 32
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 14
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "23040817310761851648891039560762214",
+                  "time": 12172
+              },
+              "beforeStep": {
+                  "point": "22391780203420960934875179367007034",
+                  "time": 12023
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@34",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 15,
+                  "fileName": "helpers/index.ts",
+                  "functionName": "openDevToolsTab",
+                  "lineNumber": 36
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 14
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "24338891525478310649938324691616858",
+                  "time": 12702
+              },
+              "beforeStep": {
+                  "point": "23040817310762157173089760375210855",
+                  "time": 12189
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@37",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 56,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "getElementClasses",
+                  "lineNumber": 167
+              },
+              {
+                  "columnNumber": 42,
+                  "fileName": "helpers/index.ts",
+                  "functionName": "isDevToolsTabActive",
+                  "lineNumber": 69
+              },
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/index.ts",
+                  "functionName": "callback",
+                  "lineNumber": 38
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 18,
+                  "fileName": "helpers/index.ts",
+                  "functionName": "openDevToolsTab",
+                  "lineNumber": 37
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 14
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "25961484293785906114152387219293304",
+                  "time": 13256
+              },
+              "beforeStep": {
+                  "point": "24663410079137052124292238381417566",
+                  "time": 12804
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@41",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 24,
+                  "fileName": "helpers/index.ts",
+                  "lineNumber": 39
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "25961484293785914184602919467222137",
+                  "time": 13258
+              },
+              "beforeStep": {
+                  "point": "25961484293785914184602919467222137",
+                  "time": 13258
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@44",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 17,
+                  "fileName": "helpers/index.ts",
+                  "functionName": "openDevToolsTab",
+                  "lineNumber": 31
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 30
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "26935039954895532778669177338594517",
+                  "time": 13663
+              },
+              "beforeStep": {
+                  "point": "26286002847536500844778328407672002",
+                  "time": 13534
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@46",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 56,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "getElementClasses",
+                  "lineNumber": 167
+              },
+              {
+                  "columnNumber": 42,
+                  "fileName": "helpers/index.ts",
+                  "functionName": "isDevToolsTabActive",
+                  "lineNumber": 69
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/index.ts",
+                  "functionName": "openDevToolsTab",
+                  "lineNumber": 32
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 30
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "27259558508561274792399063803233504",
+                  "time": 13803
+              },
+              "beforeStep": {
+                  "point": "26935039954895973194683937154139350",
+                  "time": 13690
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@49",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 24
+              },
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "27259558508561716361335328225625316",
+                  "time": 13823
+              },
+              "beforeStep": {
+                  "point": "27259558508561705985041786764002529",
+                  "time": 13805
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@52",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 31
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "27259558508561740572686924969411816",
+                  "time": 13839
+              },
+              "beforeStep": {
+                  "point": "27259558508561731349314888114636006",
+                  "time": 13826
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@55",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 32,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSourceExplorerPanel",
+                  "lineNumber": 84
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "27259558508562193670838235460273388",
+                  "time": 13870
+              },
+              "beforeStep": {
+                  "point": "27259558508562183294544693998650601",
+                  "time": 13851
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@58",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 44,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 41
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 39
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "27584077062221477018299314368152817",
+                  "time": 13929
+              },
+              "beforeStep": {
+                  "point": "27584077062221465489084268299683053",
+                  "time": 13880
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@62",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 22,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "lineNumber": 42
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "27584077062221485088749846616081650",
+                  "time": 13930
+              },
+              "beforeStep": {
+                  "point": "27584077062221485088749846616081650",
+                  "time": 13930
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@65",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 28,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 52
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "27908595615880882575439881601811704",
+                  "time": 13991
+              },
+              "beforeStep": {
+                  "point": "27584077062222445472363184119612661",
+                  "time": 13971
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@67",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 27,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 65
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "27908595615881414072253505358267644",
+                  "time": 14019
+              },
+              "beforeStep": {
+                  "point": "27908595615881403695959963896644857",
+                  "time": 13995
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@70",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 27,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 70
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "28557632723230550480870313721595154",
+                  "time": 14292
+              },
+              "beforeStep": {
+                  "point": "27908595615881960557046689003734269",
+                  "time": 14028
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.innerHTML"
+          },
+          "error": null,
+          "id": "pw:api@73",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 49
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "28882151276889448752548853942584597",
+                  "time": 14335
+              },
+              "beforeStep": {
+                  "point": "28882151276889439529176817087808787",
+                  "time": 14321
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@76",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 28,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 52
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "28882151276890833411275886765802776",
+                  "time": 14364
+              },
+              "beforeStep": {
+                  "point": "28882151276889975637676459271652630",
+                  "time": 14348
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@79",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 27,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 65
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "28882151276891378743147565804422427",
+                  "time": 14381
+              },
+              "beforeStep": {
+                  "point": "28882151276891369519775528949646617",
+                  "time": 14374
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@82",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 27,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 70
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "29855706937941451247343889243178365",
+                  "time": 14752
+              },
+              "beforeStep": {
+                  "point": "28882151276891941368841813945746716",
+                  "time": 14386
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.innerHTML"
+          },
+          "error": null,
+          "id": "pw:api@85",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 49
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "30180225491608517967882568974992771",
+                  "time": 14799
+              },
+              "beforeStep": {
+                  "point": "30180225491600349519022429464167806",
+                  "time": 14775
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@88",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 28,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 52
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "30504744045267503861595459316352390",
+                  "time": 14883
+              },
+              "beforeStep": {
+                  "point": "30180225491609067911440266441000324",
+                  "time": 14875
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.scrollIntoViewIfNeeded"
+          },
+          "error": null,
+          "id": "pw:api@91",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 18,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 57
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "30504744045268249801808939946345866",
+                  "time": 14963
+              },
+              "beforeStep": {
+                  "point": "30504744045268072251897230491911559",
+                  "time": 14891
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@94",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 18,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 58
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "32776373921194538181181405480879794",
+                  "time": 16084
+              },
+              "beforeStep": {
+                  "point": "30504744045268813580424692694517131",
+                  "time": 14971
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.getAttribute"
+          },
+          "error": null,
+          "id": "pw:api@97",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 37,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 833
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "33425411028638780237634737258104542",
+                  "time": 16224
+              },
+              "beforeStep": {
+                  "point": "32776373921195505482323770625492659",
+                  "time": 16098
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@101",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 66,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 833
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "33425411028638788308085269506033375",
+                  "time": 16225
+              },
+              "beforeStep": {
+                  "point": "33425411028638788308085269506033375",
+                  "time": 16225
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.getAttribute"
+          },
+          "error": null,
+          "id": "pw:api@104",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 63,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 838
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "33749929582335170363721587535906535",
+                  "time": 16376
+              },
+              "beforeStep": {
+                  "point": "33749929582330615170856885883504353",
+                  "time": 16330
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@107",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 839
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "33749929582335178434172119783835368",
+                  "time": 16378
+              },
+              "beforeStep": {
+                  "point": "33749929582335178434172119783835368",
+                  "time": 16378
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@110",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 75,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "map",
+                  "lineNumber": 82
+              },
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "mapLocators",
+                  "lineNumber": 81
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 845
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204490556038163015403680",
+                  "time": 17664
+              },
+              "beforeStep": {
+                  "point": "36021559458214191267248181558118500",
+                  "time": 17354
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@182",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 34,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 846
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSelectedSource",
+                  "lineNumber": 829
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-explorer-panel.ts",
+                  "functionName": "openSource",
+                  "lineNumber": 78
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "36995115119204498626488695263332513",
+                  "time": 17668
+              },
+              "beforeStep": {
+                  "point": "37319633672864712381603991896721604",
+                  "time": 17794
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@221",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 22,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 855
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "37319633672864727369583551785732294",
+                  "time": 17811
+              },
+              "beforeStep": {
+                  "point": "37319633672864727369583551785732294",
+                  "time": 17811
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@223",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 34,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 856
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "37319633672864735440034084033661127",
+                  "time": 17814
+              },
+              "beforeStep": {
+                  "point": "37319633672864735440034084033661127",
+                  "time": 17814
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@226",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 46,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "getCurrentSource",
+                  "lineNumber": 187
+              },
+              {
+                  "columnNumber": 31,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "getSourceLine",
+                  "lineNumber": 439
+              },
+              {
+                  "columnNumber": 29,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "scrollUntilLineIsVisible",
+                  "lineNumber": 165
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 42
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "37644152226524057986826319574337738",
+                  "time": 17848
+              },
+              "beforeStep": {
+                  "point": "37644152226524049916375787326408905",
+                  "time": 17837
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@228",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 22,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "getCurrentSource",
+                  "lineNumber": 189
+              },
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "getSourceLine",
+                  "lineNumber": 439
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "scrollUntilLineIsVisible",
+                  "lineNumber": 165
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 42
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "37644152226524957265599912914979020",
+                  "time": 17883
+              },
+              "beforeStep": {
+                  "point": "37644152226524949195149380667050187",
+                  "time": 17861
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@231",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "scrollUntilLineIsVisible",
+                  "lineNumber": 169
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 42
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "37644152226524980324030005051918543",
+                  "time": 17905
+              },
+              "beforeStep": {
+                  "point": "37644152226524972253579472803989710",
+                  "time": 17888
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "keyboard.down"
+          },
+          "error": null,
+          "id": "pw:api@234",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "scrollUntilLineIsVisible",
+                  "lineNumber": 171
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 42
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "38293189333876579372980653640386812",
+                  "time": 18177
+              },
+              "beforeStep": {
+                  "point": "37968670780214633929765437522839802",
+                  "time": 18118
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "keyboard.type"
+          },
+          "error": null,
+          "id": "pw:api@237",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 15,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "scrollUntilLineIsVisible",
+                  "lineNumber": 176
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 42
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "38293189333881458536788149816789248",
+                  "time": 18194
+              },
+              "beforeStep": {
+                  "point": "38293189333876587443431185888315645",
+                  "time": 18183
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "keyboard.up"
+          },
+          "error": null,
+          "id": "pw:api@237",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 15,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "scrollUntilLineIsVisible",
+                  "lineNumber": 176
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 42
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "38293189333881458536788149816789248",
+                  "time": 18194
+              },
+              "beforeStep": {
+                  "point": "38293189333876587443431185888315645",
+                  "time": 18183
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.focus"
+          },
+          "error": null,
+          "id": "pw:api@237",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 15,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "scrollUntilLineIsVisible",
+                  "lineNumber": 176
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 42
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "38293189333881458536788149816789248",
+                  "time": 18194
+              },
+              "beforeStep": {
+                  "point": "38293189333876587443431185888315645",
+                  "time": 18183
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@246",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "clearTextArea",
+                  "lineNumber": 15
+              },
+              {
+                  "columnNumber": 22,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "scrollUntilLineIsVisible",
+                  "lineNumber": 177
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 42
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "38942226441202154677729316478912785",
+                  "time": 18493
+              },
+              "beforeStep": {
+                  "point": "38942226441202144301435775017289998",
+                  "time": 18442
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.focus"
+          },
+          "error": null,
+          "id": "pw:api@249",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 18,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "clearTextArea",
+                  "lineNumber": 19
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "scrollUntilLineIsVisible",
+                  "lineNumber": 177
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 42
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "39266744994861579834535462028970260",
+                  "time": 18563
+              },
+              "beforeStep": {
+                  "point": "39266744994861506047559167190763794",
+                  "time": 18507
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "keyboard.press"
+          },
+          "error": null,
+          "id": "pw:api@252",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "clearTextArea",
+                  "lineNumber": 20
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "scrollUntilLineIsVisible",
+                  "lineNumber": 177
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 42
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "39591263548540095065614887751256352",
+                  "time": 18719
+              },
+              "beforeStep": {
+                  "point": "39266744994861587904985994276899093",
+                  "time": 18571
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "keyboard.press"
+          },
+          "error": null,
+          "id": "pw:api@255",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "clearTextArea",
+                  "lineNumber": 21
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "scrollUntilLineIsVisible",
+                  "lineNumber": 177
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 42
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "39915782102199821134933735688374565",
+                  "time": 18766
+              },
+              "beforeStep": {
+                  "point": "39591263548540103136065419999185185",
+                  "time": 18720
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "keyboard.type"
+          },
+          "error": null,
+          "id": "pw:api@258",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "scrollUntilLineIsVisible",
+                  "lineNumber": 178
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 42
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "40240300656068975395564417378683242",
+                  "time": 18969
+              },
+              "beforeStep": {
+                  "point": "39915782102199829205384267936303398",
+                  "time": 18768
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "keyboard.press"
+          },
+          "error": null,
+          "id": "pw:api@261",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "scrollUntilLineIsVisible",
+                  "lineNumber": 179
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 42
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "40240300656069008830288050977245548",
+                  "time": 18975
+              },
+              "beforeStep": {
+                  "point": "40240300656068983466014949626612075",
+                  "time": 18973
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@265",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 29,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "scrollUntilLineIsVisible",
+                  "lineNumber": 181
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "40240300656069016900738583225174381",
+                  "time": 18990
+              },
+              "beforeStep": {
+                  "point": "40240300656069016900738583225174381",
+                  "time": 18990
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@267",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 46,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "getCurrentSource",
+                  "lineNumber": 187
+              },
+              {
+                  "columnNumber": 31,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "getSourceLine",
+                  "lineNumber": 439
+              },
+              {
+                  "columnNumber": 29,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSourceLineHitCounts",
+                  "lineNumber": 816
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 43
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "40564819209800619555419135823317364",
+                  "time": 19114
+              },
+              "beforeStep": {
+                  "point": "40564819209730232544641383208585582",
+                  "time": 19042
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@269",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 22,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "getCurrentSource",
+                  "lineNumber": 189
+              },
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "getSourceLine",
+                  "lineNumber": 439
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSourceLineHitCounts",
+                  "lineNumber": 816
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 43
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "40889337763473403613699160909285751",
+                  "time": 19166
+              },
+              "beforeStep": {
+                  "point": "40564819209801510763742196916029813",
+                  "time": 19128
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@272",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSourceLineHitCounts",
+                  "lineNumber": 817
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 43
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "40889337763488920784229664462735738",
+                  "time": 19202
+              },
+              "beforeStep": {
+                  "point": "40889337763474776743211147664034168",
+                  "time": 19181
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.getAttribute"
+          },
+          "error": null,
+          "id": "pw:api@275",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 52,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 820
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForSourceLineHitCounts",
+                  "lineNumber": 819
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 43
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "40889337763498182202676171264493949",
+                  "time": 19228
+              },
+              "beforeStep": {
+                  "point": "40889337763490322736779266388658555",
+                  "time": 19213
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@278",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 46,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "getCurrentSource",
+                  "lineNumber": 187
+              },
+              {
+                  "columnNumber": 31,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "getSourceLine",
+                  "lineNumber": 439
+              },
+              {
+                  "columnNumber": 29,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 45
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "41213856317177072133244594212047234",
+                  "time": 19254
+              },
+              "beforeStep": {
+                  "point": "40889337763499063034705690895583614",
+                  "time": 19244
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@281",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 22,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "getCurrentSource",
+                  "lineNumber": 189
+              },
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "getSourceLine",
+                  "lineNumber": 439
+              },
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 45
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "41213856317179210802635639913187717",
+                  "time": 19268
+              },
+              "beforeStep": {
+                  "point": "41213856317177963341567655304759683",
+                  "time": 19264
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.getAttribute"
+          },
+          "error": null,
+          "id": "pw:api@284",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 43,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 49
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 48
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "41213856317180620825635774087039367",
+                  "time": 19286
+              },
+              "beforeStep": {
+                  "point": "41213856317180612755185241839110534",
+                  "time": 19283
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@288",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 50
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "41213856317180628896086306334968200",
+                  "time": 19287
+              },
+              "beforeStep": {
+                  "point": "41213856317180628896086306334968200",
+                  "time": 19287
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "mouse.move"
+          },
+          "error": null,
+          "id": "pw:api@291",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 22,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 60
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 58
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "41213856317187359651830201107614092",
+                  "time": 19315
+              },
+              "beforeStep": {
+                  "point": "41213856317182079271339101748464009",
+                  "time": 19301
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.hover"
+          },
+          "error": null,
+          "id": "pw:api@293",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 29,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 61
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 58
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "41862893424592740183127749893818780",
+                  "time": 19490
+              },
+              "beforeStep": {
+                  "point": "41213856317188828473827070230661517",
+                  "time": 19322
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.waitFor"
+          },
+          "error": null,
+          "id": "pw:api@296",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 64
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 58
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "41862893424626670663008329400322466",
+                  "time": 19527
+              },
+              "beforeStep": {
+                  "point": "41862893424594188252537536093620637",
+                  "time": 19497
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.getAttribute"
+          },
+          "error": null,
+          "id": "pw:api@299",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 49,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 66
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 58
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "41862893424628130261633161668594084",
+                  "time": 19560
+              },
+              "beforeStep": {
+                  "point": "41862893424628122191182629420665251",
+                  "time": 19555
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@302",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 77,
+                  "fileName": "helpers/source-panel.ts",
+                  "lineNumber": 68
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 58
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "42511930532148624240558181091117493",
+                  "time": 19833
+              },
+              "beforeStep": {
+                  "point": "42187411978287996987375571641043365",
+                  "time": 19581
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@305",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForBreakpoint",
+                  "lineNumber": 670
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "42511930532162340547698488749590968",
+                  "time": 19857
+              },
+              "beforeStep": {
+                  "point": "42511930532148639228537740980128183",
+                  "time": 19845
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@308",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "openPauseInformationPanel",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 34,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForBreakpoint",
+                  "lineNumber": 676
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "42836449085828740879607505723853245",
+                  "time": 19891
+              },
+              "beforeStep": {
+                  "point": "42511930532163220226806503773833657",
+                  "time": 19875
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@311",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 77,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "openPauseInformationPanel",
+                  "lineNumber": 125
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForBreakpoint",
+                  "lineNumber": 676
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "45108078961698826641473396682001178",
+                  "time": 20914
+              },
+              "beforeStep": {
+                  "point": "42836449085829632087930566816565694",
+                  "time": 19899
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.waitForSelector"
+          },
+          "error": null,
+          "id": "pw:api@314",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 38,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForBreakpoint",
+                  "lineNumber": 678
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "46406153176376027512367314066475811",
+                  "time": 21344
+              },
+              "beforeStep": {
+                  "point": "45108078961699853894534001382656795",
+                  "time": 20947
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "elementHandle.waitForSelector"
+          },
+          "error": null,
+          "id": "pw:api@317",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 27,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "waitForBreakpoint",
+                  "lineNumber": 687
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/source-panel.ts",
+                  "functionName": "addBreakpoint",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 16
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "46730671730039174299790330518571892",
+                  "time": 21458
+              },
+              "beforeStep": {
+                  "point": "46406153176376035582817846314404644",
+                  "time": 21345
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@320",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 200
+              },
+              {
+                  "columnNumber": 21,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 18
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "46730671730039197358220422655511415",
+                  "time": 21485
+              },
+              "beforeStep": {
+                  "point": "46730671730039189287769890407582582",
+                  "time": 21469
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@323",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 170
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 202
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 18
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "46730671730039220416650514792450938",
+                  "time": 21508
+              },
+              "beforeStep": {
+                  "point": "46730671730039212346199982544522105",
+                  "time": 21504
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@326",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "openPauseInformationPanel",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 172
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 202
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 18
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "47055190283698572939401870111148924",
+                  "time": 21539
+              },
+              "beforeStep": {
+                  "point": "46730671730040138142168181842643835",
+                  "time": 21516
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isEnabled"
+          },
+          "error": null,
+          "id": "pw:api@329",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 175
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 202
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 18
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "47055190283699638238872126837754750",
+                  "time": 21569
+              },
+              "beforeStep": {
+                  "point": "47055190283699630168421594589825917",
+                  "time": 21548
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@332",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 176
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 202
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 18
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "47379708837490631339019491944172742",
+                  "time": 21875
+              },
+              "beforeStep": {
+                  "point": "47055190283700557117311298494794623",
+                  "time": 21573
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@335",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 284
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 18
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "48028745944967629048340208850832766",
+                  "time": 22084
+              },
+              "beforeStep": {
+                  "point": "47379708837490646326999051833183432",
+                  "time": 21890
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@338",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "openPauseInformationPanel",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 290
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 18
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "48353264498633366450384076888083922",
+                  "time": 22191
+              },
+              "beforeStep": {
+                  "point": "48028745944968546773857875901025663",
+                  "time": 22126
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@341",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 18
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "48677783052349087611338670169132612",
+                  "time": 22310
+              },
+              "beforeStep": {
+                  "point": "48353264498635224959849503125409235",
+                  "time": 22213
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@341",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 18
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "48677783052349087611338670169132612",
+                  "time": 22310
+              },
+              "beforeStep": {
+                  "point": "48353264498635224959849503125409235",
+                  "time": 22213
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@348",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 304
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "48677783052349103752239734664990278",
+                  "time": 22314
+              },
+              "beforeStep": {
+                  "point": "48677783052349103752239734664990278",
+                  "time": 22314
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@350",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 18
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "49975857267386581064108245660995779",
+                  "time": 22875
+              },
+              "beforeStep": {
+                  "point": "49651338713627694522021172029165754",
+                  "time": 22784
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@350",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 18
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "49975857267386581064108245660995779",
+                  "time": 22875
+              },
+              "beforeStep": {
+                  "point": "49651338713627694522021172029165754",
+                  "time": 22784
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@356",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 304
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "49975857267386597205009310156853445",
+                  "time": 22881
+              },
+              "beforeStep": {
+                  "point": "49975857267386597205009310156853445",
+                  "time": 22881
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@358",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 18
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "50949412928478939270329034426290410",
+                  "time": 23209
+              },
+              "beforeStep": {
+                  "point": "50949412928473604702527218545332454",
+                  "time": 23184
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@358",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 18
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "50949412928478939270329034426290410",
+                  "time": 23209
+              },
+              "beforeStep": {
+                  "point": "50949412928473604702527218545332454",
+                  "time": 23184
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@364",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 304
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "50949412928478955411230098922148076",
+                  "time": 23212
+              },
+              "beforeStep": {
+                  "point": "50949412928478955411230098922148076",
+                  "time": 23212
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@366",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 305
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "50949412928478963481680631170076909",
+                  "time": 23214
+              },
+              "beforeStep": {
+                  "point": "50949412928478963481680631170076909",
+                  "time": 23214
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@368",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 18
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "51922968589530768826898378699837721",
+                  "time": 23508
+              },
+              "beforeStep": {
+                  "point": "51922968589528864200572768188633365",
+                  "time": 23487
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@368",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 18
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "51922968589530768826898378699837721",
+                  "time": 23508
+              },
+              "beforeStep": {
+                  "point": "51922968589528864200572768188633365",
+                  "time": 23487
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@374",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 304
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "52247487143196704531441039114768671",
+                  "time": 23621
+              },
+              "beforeStep": {
+                  "point": "52247487143196704531441039114768671",
+                  "time": 23621
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@376",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 305
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "52247487143196712601891571362697504",
+                  "time": 23622
+              },
+              "beforeStep": {
+                  "point": "52247487143196712601891571362697504",
+                  "time": 23622
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@378",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 18
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "52572005696905375577394961526559021",
+                  "time": 23812
+              },
+              "beforeStep": {
+                  "point": "52572005696905359436493897030701355",
+                  "time": 23810
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@378",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 18
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "52572005696905375577394961526559021",
+                  "time": 23812
+              },
+              "beforeStep": {
+                  "point": "52572005696905359436493897030701355",
+                  "time": 23810
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@384",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 304
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "52896524250577926745531056029438262",
+                  "time": 23879
+              },
+              "beforeStep": {
+                  "point": "52896524250577926745531056029438262",
+                  "time": 23879
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@386",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 305
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "52896524250577934815981588277367095",
+                  "time": 23881
+              },
+              "beforeStep": {
+                  "point": "52896524250577934815981588277367095",
+                  "time": 23881
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.waitFor"
+          },
+          "error": null,
+          "id": "pw:api@389",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "getCurrentCallStackFrameInfo",
+                  "lineNumber": 75
+              },
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 312
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 311
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 18
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "52896524250582416221869995091562812",
+                  "time": 23916
+              },
+              "beforeStep": {
+                  "point": "52896524250582400080968930595705147",
+                  "time": 23904
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@391",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 39,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "getCurrentCallStackFrameInfo",
+                  "lineNumber": 79
+              },
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 312
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 311
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 18
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "52896524250583562225845574297456958",
+                  "time": 23929
+              },
+              "beforeStep": {
+                  "point": "52896524250583554155395042049528125",
+                  "time": 23926
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@394",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 43,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "getCurrentCallStackFrameInfo",
+                  "lineNumber": 80
+              },
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 312
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 311
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 18
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "53221042804243134956604309523927360",
+                  "time": 23956
+              },
+              "beforeStep": {
+                  "point": "52896524250584700159370621255422271",
+                  "time": 23939
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@398",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 26,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 313
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "53221042804243143027054841771856193",
+                  "time": 23958
+              },
+              "beforeStep": {
+                  "point": "53221042804243143027054841771856193",
+                  "time": 23958
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@401",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 110
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 19
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "53870079911612016298909014748565842",
+                  "time": 24283
+              },
+              "beforeStep": {
+                  "point": "53870079911612008228458482500637009",
+                  "time": 24279
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@403",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 62,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "openConsolePanel",
+                  "lineNumber": 239
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 116
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 19
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "54194598465289782131010446020317533",
+                  "time": 24440
+              },
+              "beforeStep": {
+                  "point": "53870079911613123103553437321662803",
+                  "time": 24297
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.waitFor"
+          },
+          "error": null,
+          "id": "pw:api@406",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 52,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 121
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 19
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "54194598465291222129969699972190559",
+                  "time": 24463
+              },
+              "beforeStep": {
+                  "point": "54194598465291205989068635476332894",
+                  "time": 24450
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.focus"
+          },
+          "error": null,
+          "id": "pw:api@409",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "focus",
+                  "lineNumber": 23
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "clearText",
+                  "lineNumber": 6
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 65
+              },
+              {
+                  "columnNumber": 20,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 19
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "54843635572619677432636870714462564",
+                  "time": 24590
+              },
+              "beforeStep": {
+                  "point": "54519117018950772955219847668568416",
+                  "time": 24484
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@412",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 24,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "clearText",
+                  "lineNumber": 12
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 65
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 19
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "54843635572620817672004926886121830",
+                  "time": 24626
+              },
+              "beforeStep": {
+                  "point": "54843635572620809601554394638192997",
+                  "time": 24616
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.type"
+          },
+          "error": null,
+          "id": "pw:api@415",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 15,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 68
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 19
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "56790746895039331577601213094436399",
+                  "time": 27250
+              },
+              "beforeStep": {
+                  "point": "54843635572621941770471918561923431",
+                  "time": 24633
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@419",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 43
+              },
+              {
+                  "columnNumber": 11,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 19
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "57439784002377616689016661814025787",
+                  "time": 27452
+              },
+              "beforeStep": {
+                  "point": "57439784002377608618566129566096954",
+                  "time": 27442
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@421",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 18,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "hideTypeAheadSuggestions",
+                  "lineNumber": 29
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 45
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 19
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "57439784002378806504009416080105021",
+                  "time": 27479
+              },
+              "beforeStep": {
+                  "point": "57439784002378798433558883832176188",
+                  "time": 27466
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.press"
+          },
+          "error": null,
+          "id": "pw:api@424",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 17,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "hideTypeAheadSuggestions",
+                  "lineNumber": 31
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 45
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 19
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "57764302556052200457765378188123788",
+                  "time": 27607
+              },
+              "beforeStep": {
+                  "point": "57439784002380003236531197987266110",
+                  "time": 27511
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@427",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 51
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 19
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "57764302556053346461740957394017934",
+                  "time": 27624
+              },
+              "beforeStep": {
+                  "point": "57764302556053338391290425146089101",
+                  "time": 27622
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.press"
+          },
+          "error": null,
+          "id": "pw:api@431",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 17,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 54
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 19
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "58413339663474685732505274156064434",
+                  "time": 27929
+              },
+              "beforeStep": {
+                  "point": "58088821109712903051598628124630672",
+                  "time": 27732
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@433",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 51
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 19
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "58737858217159192696644141662084788",
+                  "time": 27955
+              },
+              "beforeStep": {
+                  "point": "58737858217134244628205954100371123",
+                  "time": 27948
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@436",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "verifyEvaluationResult",
+                  "lineNumber": 345
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 134
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 19
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "58737858217167635540822377602490039",
+                  "time": 27986
+              },
+              "beforeStep": {
+                  "point": "58737858217159207684623701551095478",
+                  "time": 27962
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.waitFor"
+          },
+          "error": null,
+          "id": "pw:api@439",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "verifyExpectedCount",
+                  "lineNumber": 369
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "verifyEvaluationResult",
+                  "lineNumber": 354
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 134
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 19
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "59062376770864545634507805568278230",
+                  "time": 28132
+              },
+              "beforeStep": {
+                  "point": "58737858217168744651309809389280952",
+                  "time": 28004
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@442",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 72,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "clearConsoleEvaluations",
+                  "lineNumber": 45
+              },
+              {
+                  "columnNumber": 11,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 136
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 19
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "59711413878237237382385236422172446",
+                  "time": 28358
+              },
+              "beforeStep": {
+                  "point": "59062376770865680109268338705702615",
+                  "time": 28142
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@445",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 54,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 47
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "clearConsoleEvaluations",
+                  "lineNumber": 47
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 136
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 19
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "59711413878238340728265145174728480",
+                  "time": 28377
+              },
+              "beforeStep": {
+                  "point": "59711413878238332657814612926799647",
+                  "time": 28373
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@449",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 63,
+                  "fileName": "helpers/console-panel.ts",
+                  "lineNumber": 47
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "59711413878238348798715677422657313",
+                  "time": 28381
+              },
+              "beforeStep": {
+                  "point": "59711413878238348798715677422657313",
+                  "time": 28381
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@452",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 170
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 202
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 20
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "60035932431896803195614944007560997",
+                  "time": 28416
+              },
+              "beforeStep": {
+                  "point": "60035932431896795125164411759632164",
+                  "time": 28401
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@454",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "openPauseInformationPanel",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 172
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 202
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 20
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "60035932431897918070709898828586791",
+                  "time": 28438
+              },
+              "beforeStep": {
+                  "point": "60035932431897910000259366580657958",
+                  "time": 28424
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isEnabled"
+          },
+          "error": null,
+          "id": "pw:api@457",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 175
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 202
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 20
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "60035932431899172449306911078096681",
+                  "time": 28460
+              },
+              "beforeStep": {
+                  "point": "60035932431899164378856378830167848",
+                  "time": 28446
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@460",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 176
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 202
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 20
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "61334006646881160802080199135994511",
+                  "time": 29052
+              },
+              "beforeStep": {
+                  "point": "60035932431900279253951333651193642",
+                  "time": 28490
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@463",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 284
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 20
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "61983043754249726243892642084561660",
+                  "time": 29178
+              },
+              "beforeStep": {
+                  "point": "61658525200539601363921410438734481",
+                  "time": 29076
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@466",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "openPauseInformationPanel",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 290
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 20
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "61983043754298098218539926956286859",
+                  "time": 29269
+              },
+              "beforeStep": {
+                  "point": "61983043754250645122331813741601533",
+                  "time": 29216
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@469",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 20
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "62632080861766827174829603556435303",
+                  "time": 29498
+              },
+              "beforeStep": {
+                  "point": "62307562307958442253785244163384205",
+                  "time": 29343
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@469",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 20
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "62632080861766827174829603556435303",
+                  "time": 29498
+              },
+              "beforeStep": {
+                  "point": "62307562307958442253785244163384205",
+                  "time": 29343
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@476",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 304
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "62956599415425270042513824072869225",
+                  "time": 29511
+              },
+              "beforeStep": {
+                  "point": "62956599415425270042513824072869225",
+                  "time": 29511
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@478",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 20
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "63281117969107360483179035627627907",
+                  "time": 29708
+              },
+              "beforeStep": {
+                  "point": "63281117969096830851077461294196088",
+                  "time": 29675
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@478",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 20
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "63281117969107360483179035627627907",
+                  "time": 29708
+              },
+              "beforeStep": {
+                  "point": "63281117969096830851077461294196088",
+                  "time": 29675
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@484",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 304
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "63605636522765803350863256144061829",
+                  "time": 29719
+              },
+              "beforeStep": {
+                  "point": "63605636522765803350863256144061829",
+                  "time": 29719
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@486",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 20
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "64579192183842382673371995601642937",
+                  "time": 30082
+              },
+              "beforeStep": {
+                  "point": "64254673630180574427815827698886071",
+                  "time": 30041
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@486",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 20
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "64579192183842382673371995601642937",
+                  "time": 30082
+              },
+              "beforeStep": {
+                  "point": "64254673630180574427815827698886071",
+                  "time": 30041
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@492",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 304
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "64579192183842398814273060097500603",
+                  "time": 30092
+              },
+              "beforeStep": {
+                  "point": "64579192183842398814273060097500603",
+                  "time": 30092
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@494",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 305
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "64579192183842406884723592345429436",
+                  "time": 30093
+              },
+              "beforeStep": {
+                  "point": "64579192183842406884723592345429436",
+                  "time": 30093
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@496",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 20
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "65228229291229905603484688935036376",
+                  "time": 30379
+              },
+              "beforeStep": {
+                  "point": "65228229291214922235610818351736273",
+                  "time": 30337
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@496",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 20
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "65228229291229905603484688935036376",
+                  "time": 30379
+              },
+              "beforeStep": {
+                  "point": "65228229291214922235610818351736273",
+                  "time": 30337
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@502",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 304
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "65228229291229921744385753430894042",
+                  "time": 30386
+              },
+              "beforeStep": {
+                  "point": "65228229291229921744385753430894042",
+                  "time": 30386
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@504",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 305
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "65228229291229929814836285678822875",
+                  "time": 30389
+              },
+              "beforeStep": {
+                  "point": "65228229291229929814836285678822875",
+                  "time": 30389
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.waitFor"
+          },
+          "error": null,
+          "id": "pw:api@507",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "getCurrentCallStackFrameInfo",
+                  "lineNumber": 75
+              },
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 312
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 311
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 20
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "65552747844892140429997561371174366",
+                  "time": 30445
+              },
+              "beforeStep": {
+                  "point": "65552747844890450247071807733507548",
+                  "time": 30433
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@509",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 39,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "getCurrentCallStackFrameInfo",
+                  "lineNumber": 79
+              },
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 312
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 311
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 20
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "65877266398565642758374956522808805",
+                  "time": 30570
+              },
+              "beforeStep": {
+                  "point": "65552747844893278363522608329139679",
+                  "time": 30477
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@512",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 43,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "getCurrentCallStackFrameInfo",
+                  "lineNumber": 80
+              },
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 312
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 311
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 20
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "65877266398568432828416105092490728",
+                  "time": 30600
+              },
+              "beforeStep": {
+                  "point": "65877266398566882148992408883308006",
+                  "time": 30590
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@516",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 26,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 313
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "65877266398568440898866637340419561",
+                  "time": 30602
+              },
+              "beforeStep": {
+                  "point": "65877266398568440898866637340419561",
+                  "time": 30602
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@519",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 110
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 21
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "66201784952253654603887828843636213",
+                  "time": 30745
+              },
+              "beforeStep": {
+                  "point": "66201784952253646533437296595707380",
+                  "time": 30741
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@521",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 62,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "openConsolePanel",
+                  "lineNumber": 239
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 116
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 21
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "66850822059589907114690655692006912",
+                  "time": 30885
+              },
+              "beforeStep": {
+                  "point": "66201784952254761408532251416733174",
+                  "time": 30753
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.waitFor"
+          },
+          "error": null,
+          "id": "pw:api@524",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 52,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 121
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 21
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "66850822059591345960728405037032962",
+                  "time": 30909
+              },
+              "beforeStep": {
+                  "point": "66850822059591329819827340541175297",
+                  "time": 30897
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.focus"
+          },
+          "error": null,
+          "id": "pw:api@527",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "focus",
+                  "lineNumber": 23
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "clearText",
+                  "lineNumber": 6
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 65
+              },
+              {
+                  "columnNumber": 20,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 21
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "67175340613254207976539783597925893",
+                  "time": 30977
+              },
+              "beforeStep": {
+                  "point": "66850822059592468906273892105987587",
+                  "time": 30912
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@530",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 24,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "clearText",
+                  "lineNumber": 12
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 65
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 21
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "67175340613255348215907839769585159",
+                  "time": 31003
+              },
+              "beforeStep": {
+                  "point": "67175340613255340145457307521656326",
+                  "time": 30980
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.type"
+          },
+          "error": null,
+          "id": "pw:api@533",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 15,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 68
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 21
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "68797933382014787452835380909322959",
+                  "time": 32866
+              },
+              "beforeStep": {
+                  "point": "67175340613256471161453326838539784",
+                  "time": 31007
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@537",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 43
+              },
+              {
+                  "columnNumber": 11,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 21
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "69122451935685270279792210728727254",
+                  "time": 33081
+              },
+              "beforeStep": {
+                  "point": "69122451935685262209341678480798421",
+                  "time": 33055
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@539",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 18,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "hideTypeAheadSuggestions",
+                  "lineNumber": 29
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 45
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 21
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "69122451935686458941863460387959512",
+                  "time": 33107
+              },
+              "beforeStep": {
+                  "point": "69122451935686450871412928140030679",
+                  "time": 33097
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.press"
+          },
+          "error": null,
+          "id": "pw:api@542",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 17,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "hideTypeAheadSuggestions",
+                  "lineNumber": 31
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 45
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 21
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "69446970489359888636186065308234535",
+                  "time": 33166
+              },
+              "beforeStep": {
+                  "point": "69122451935687655674385242295120601",
+                  "time": 33113
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@545",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 51
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 21
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "69446970489361034640161644514128681",
+                  "time": 33174
+              },
+              "beforeStep": {
+                  "point": "69446970489361026569711112266199848",
+                  "time": 33172
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.press"
+          },
+          "error": null,
+          "id": "pw:api@549",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 17,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 54
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 21
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "70420526150445416935413563112043367",
+                  "time": 33606
+              },
+              "beforeStep": {
+                  "point": "69771489043020591230019315244741419",
+                  "time": 33279
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@551",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 51
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 21
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "70420526150457786630236489973248875",
+                  "time": 33649
+              },
+              "beforeStep": {
+                  "point": "70420526150446573315682683779560296",
+                  "time": 33625
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@554",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "verifyEvaluationResult",
+                  "lineNumber": 345
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 134
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 21
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "70420526150464560044076055199232880",
+                  "time": 33684
+              },
+              "beforeStep": {
+                  "point": "70420526150457801618216049862259565",
+                  "time": 33671
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.waitFor"
+          },
+          "error": null,
+          "id": "pw:api@557",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "verifyExpectedCount",
+                  "lineNumber": 369
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "verifyEvaluationResult",
+                  "lineNumber": 354
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 134
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 21
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "70745044704124189267988516161205106",
+                  "time": 33715
+              },
+              "beforeStep": {
+                  "point": "70745044704124167362479928631112561",
+                  "time": 33703
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@560",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 72,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "clearConsoleEvaluations",
+                  "lineNumber": 45
+              },
+              {
+                  "columnNumber": 11,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 136
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 21
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "71394081811496899462610020724650938",
+                  "time": 33963
+              },
+              "beforeStep": {
+                  "point": "70745044704125322589827544691782515",
+                  "time": 33737
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@563",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 54,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 47
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "clearConsoleEvaluations",
+                  "lineNumber": 47
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 136
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 21
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "71394081811498001655568424870359996",
+                  "time": 33976
+              },
+              "beforeStep": {
+                  "point": "71394081811497993585117892622431163",
+                  "time": 33974
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@567",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 63,
+                  "fileName": "helpers/console-panel.ts",
+                  "lineNumber": 47
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "71394081811498009726018957118288829",
+                  "time": 33978
+              },
+              "beforeStep": {
+                  "point": "71394081811498009726018957118288829",
+                  "time": 33978
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@570",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 170
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 202
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 22
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "71394081811498037396135067682616257",
+                  "time": 33992
+              },
+              "beforeStep": {
+                  "point": "71394081811498029325684535434687424",
+                  "time": 33987
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@572",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "openPauseInformationPanel",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 172
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 202
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 22
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "71394081811499152271230022503642051",
+                  "time": 34001
+              },
+              "beforeStep": {
+                  "point": "71394081811499144200779490255713218",
+                  "time": 33997
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isEnabled"
+          },
+          "error": null,
+          "id": "pw:api@575",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 175
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 202
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 22
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "71394081811500406649827034753151941",
+                  "time": 34013
+              },
+              "beforeStep": {
+                  "point": "71394081811500398579376502505223108",
+                  "time": 34007
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@578",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 176
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 202
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 22
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "72692156026482395002600322811049771",
+                  "time": 34588
+              },
+              "beforeStep": {
+                  "point": "71394081811501513454471457326248902",
+                  "time": 34020
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@581",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 284
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 22
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "73016674580192568305274747944449943",
+                  "time": 34652
+              },
+              "beforeStep": {
+                  "point": "72692156026482408837658378093213485",
+                  "time": 34603
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@584",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "openPauseInformationPanel",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 290
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 22
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "73016674580240913762727426858694695",
+                  "time": 34739
+              },
+              "beforeStep": {
+                  "point": "73016674580193487183713919601489816",
+                  "time": 34679
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@587",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 22
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "73665711687569456687428947721336882",
+                  "time": 34884
+              },
+              "beforeStep": {
+                  "point": "73341193133901247421679202604169256",
+                  "time": 34771
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@587",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 22
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "73665711687569456687428947721336882",
+                  "time": 34884
+              },
+              "beforeStep": {
+                  "point": "73341193133901247421679202604169256",
+                  "time": 34771
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@594",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 304
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "73665711687569472828330012217194548",
+                  "time": 34891
+              },
+              "beforeStep": {
+                  "point": "73665711687569472828330012217194548",
+                  "time": 34891
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@596",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 22
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "74639267348691100252788255006669323",
+                  "time": 35458
+              },
+              "beforeStep": {
+                  "point": "74314748795031443358759683480369671",
+                  "time": 35399
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@596",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 22
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "74639267348691100252788255006669323",
+                  "time": 35458
+              },
+              "beforeStep": {
+                  "point": "74314748795031443358759683480369671",
+                  "time": 35399
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@602",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 304
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "74639267348691116393689319502526989",
+                  "time": 35459
+              },
+              "beforeStep": {
+                  "point": "74639267348691116393689319502526989",
+                  "time": 35459
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@604",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 22
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "75288304456058774486277636862523971",
+                  "time": 35673
+              },
+              "beforeStep": {
+                  "point": "75288304456058758345376572366666305",
+                  "time": 35667
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@604",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 22
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "75288304456058774486277636862523971",
+                  "time": 35673
+              },
+              "beforeStep": {
+                  "point": "75288304456058758345376572366666305",
+                  "time": 35667
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@610",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 304
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "75288304456058790627178701358381637",
+                  "time": 35689
+              },
+              "beforeStep": {
+                  "point": "75288304456058790627178701358381637",
+                  "time": 35689
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@612",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 305
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "75288304456058798697629233606310470",
+                  "time": 35690
+              },
+              "beforeStep": {
+                  "point": "75288304456058798697629233606310470",
+                  "time": 35690
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@614",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 22
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "76261860117173137352335351909202541",
+                  "time": 35985
+              },
+              "beforeStep": {
+                  "point": "75937341563514694484651131392768619",
+                  "time": 35970
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@614",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 22
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "76261860117173137352335351909202541",
+                  "time": 35985
+              },
+              "beforeStep": {
+                  "point": "75937341563514694484651131392768619",
+                  "time": 35970
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@620",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 304
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "76261860117187554635750460530637425",
+                  "time": 36006
+              },
+              "beforeStep": {
+                  "point": "76261860117187554635750460530637425",
+                  "time": 36006
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@622",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 305
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "76261860117187562706200992778566258",
+                  "time": 36008
+              },
+              "beforeStep": {
+                  "point": "76261860117187562706200992778566258",
+                  "time": 36008
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@624",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 22
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "77235415778207332974491734458251904",
+                  "time": 36298
+              },
+              "beforeStep": {
+                  "point": "76910897224548890106807513941817982",
+                  "time": 36254
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@624",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 22
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "77235415778207332974491734458251904",
+                  "time": 36298
+              },
+              "beforeStep": {
+                  "point": "76910897224548890106807513941817982",
+                  "time": 36254
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@630",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 304
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "77235415778207349115392798954109570",
+                  "time": 36317
+              },
+              "beforeStep": {
+                  "point": "77235415778207349115392798954109570",
+                  "time": 36317
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@632",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 305
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "77235415778207357185843331202038403",
+                  "time": 36317
+              },
+              "beforeStep": {
+                  "point": "77235415778207357185843331202038403",
+                  "time": 36317
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.waitFor"
+          },
+          "error": null,
+          "id": "pw:api@635",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "getCurrentCallStackFrameInfo",
+                  "lineNumber": 75
+              },
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 312
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 311
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 22
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "77559934331868096673164728557648517",
+                  "time": 36433
+              },
+              "beforeStep": {
+                  "point": "77235415778209653805480508041214596",
+                  "time": 36395
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@637",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 39,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "getCurrentCallStackFrameInfo",
+                  "lineNumber": 79
+              },
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 312
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 311
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 22
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "77559934331869344134232713166076551",
+                  "time": 36456
+              },
+              "beforeStep": {
+                  "point": "77559934331869336063782180918147718",
+                  "time": 36439
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@640",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 43,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "getCurrentCallStackFrameInfo",
+                  "lineNumber": 80
+              },
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 312
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 311
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 22
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "77559934331870591595300697774504585",
+                  "time": 36488
+              },
+              "beforeStep": {
+                  "point": "77559934331870583524850165526575752",
+                  "time": 36471
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@644",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 26,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 313
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "77559934331870599665751230022433418",
+                  "time": 36490
+              },
+              "beforeStep": {
+                  "point": "77559934331870599665751230022433418",
+                  "time": 36490
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@647",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 110
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 23
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "78208971439214305814081340136503958",
+                  "time": 36645
+              },
+              "beforeStep": {
+                  "point": "78208971439214297743630807888575125",
+                  "time": 36642
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@649",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 62,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "openConsolePanel",
+                  "lineNumber": 239
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 116
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 23
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "78533489992892052046517193091857057",
+                  "time": 36772
+              },
+              "beforeStep": {
+                  "point": "78208971439215412618725762709600919",
+                  "time": 36658
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.waitFor"
+          },
+          "error": null,
+          "id": "pw:api@652",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 52,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 121
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 23
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "78533489992893490892554942436883107",
+                  "time": 36788
+              },
+              "beforeStep": {
+                  "point": "78533489992893474751653877941025442",
+                  "time": 36778
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.focus"
+          },
+          "error": null,
+          "id": "pw:api@655",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "focus",
+                  "lineNumber": 23
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "clearText",
+                  "lineNumber": 6
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 65
+              },
+              {
+                  "columnNumber": 20,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 23
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "78858008546556352908366320997776038",
+                  "time": 36859
+              },
+              "beforeStep": {
+                  "point": "78533489992894613838100429505837732",
+                  "time": 36794
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@658",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 24,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "clearText",
+                  "lineNumber": 12
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 65
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 23
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "78858008546557493147734377169435304",
+                  "time": 36894
+              },
+              "beforeStep": {
+                  "point": "78858008546557485077283844921506471",
+                  "time": 36864
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.type"
+          },
+          "error": null,
+          "id": "pw:api@661",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 15,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 68
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 23
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "80805119868975519367534214681479024",
+                  "time": 38934
+              },
+              "beforeStep": {
+                  "point": "78858008546558616093279864238389929",
+                  "time": 36911
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@665",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 43
+              },
+              {
+                  "columnNumber": 11,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 23
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "81454156976313990099311905103431548",
+                  "time": 39129
+              },
+              "beforeStep": {
+                  "point": "81129638422655555302078216834926459",
+                  "time": 39118
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@667",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 18,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "hideTypeAheadSuggestions",
+                  "lineNumber": 29
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 45
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 23
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "81454156976315178761383154762663806",
+                  "time": 39159
+              },
+              "beforeStep": {
+                  "point": "81454156976315170690932622514734973",
+                  "time": 39138
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.press"
+          },
+          "error": null,
+          "id": "pw:api@670",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 17,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "hideTypeAheadSuggestions",
+                  "lineNumber": 31
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 45
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 23
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "81454156976330192105216145123985357",
+                  "time": 39204
+              },
+              "beforeStep": {
+                  "point": "81454156976316375493904936669824895",
+                  "time": 39165
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@673",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 51
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 23
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "81454156976331338109191724329879503",
+                  "time": 39224
+              },
+              "beforeStep": {
+                  "point": "81454156976331330038741192081950670",
+                  "time": 39222
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.press"
+          },
+          "error": null,
+          "id": "pw:api@677",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 17,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 54
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 23
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "82103194083738786981668537799559155",
+                  "time": 39538
+              },
+              "beforeStep": {
+                  "point": "81778675529990893546127890453645264",
+                  "time": 39333
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@679",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 51
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 23
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "82427712637400532969463456932579317",
+                  "time": 39586
+              },
+              "beforeStep": {
+                  "point": "82427712637398345877369217743865844",
+                  "time": 39575
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@682",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "verifyEvaluationResult",
+                  "lineNumber": 345
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 134
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 23
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "82427712637402255434191339561961464",
+                  "time": 39612
+              },
+              "beforeStep": {
+                  "point": "82427712637400547957443016821590007",
+                  "time": 39602
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.waitFor"
+          },
+          "error": null,
+          "id": "pw:api@685",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "verifyExpectedCount",
+                  "lineNumber": 369
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "verifyEvaluationResult",
+                  "lineNumber": 354
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 134
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 23
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "83076749744754204971279388631910423",
+                  "time": 39799
+              },
+              "beforeStep": {
+                  "point": "82427712637403364544678771348752377",
+                  "time": 39630
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@688",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 72,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "clearConsoleEvaluations",
+                  "lineNumber": 45
+              },
+              {
+                  "columnNumber": 11,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 136
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 23
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "83401268298468466533609149644687455",
+                  "time": 39980
+              },
+              "beforeStep": {
+                  "point": "83076749744755338293118417162487832",
+                  "time": 39805
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@691",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 54,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 47
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "clearConsoleEvaluations",
+                  "lineNumber": 47
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 136
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 23
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "83401268298469568726567553790396513",
+                  "time": 40001
+              },
+              "beforeStep": {
+                  "point": "83401268298469560656117021542467680",
+                  "time": 40000
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@695",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 63,
+                  "fileName": "helpers/console-panel.ts",
+                  "lineNumber": 47
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "83401268298469576797018086038325346",
+                  "time": 40002
+              },
+              "beforeStep": {
+                  "point": "83401268298469576797018086038325346",
+                  "time": 40002
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@698",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 170
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 202
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 24
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "83725786852128031193917352623229030",
+                  "time": 40043
+              },
+              "beforeStep": {
+                  "point": "83725786852128023123466820375300197",
+                  "time": 40023
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@700",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "openPauseInformationPanel",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 172
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 202
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 24
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "83725786852129146069012307444254824",
+                  "time": 40063
+              },
+              "beforeStep": {
+                  "point": "83725786852129137998561775196325991",
+                  "time": 40049
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isEnabled"
+          },
+          "error": null,
+          "id": "pw:api@703",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 175
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 202
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 24
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "83725786852130400447609319693764714",
+                  "time": 40082
+              },
+              "beforeStep": {
+                  "point": "83725786852130392377158787445835881",
+                  "time": 40070
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@706",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 176
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 202
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 24
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "84374823959650503586144277395163853",
+                  "time": 40331
+              },
+              "beforeStep": {
+                  "point": "83725786852131507252253742266861675",
+                  "time": 40090
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@709",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 284
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 24
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "84374823959650525491652864925256400",
+                  "time": 40345
+              },
+              "beforeStep": {
+                  "point": "84374823959650517421202332677327567",
+                  "time": 40344
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@712",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "openPauseInformationPanel",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 290
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 24
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "84699342513309875708561211030260434",
+                  "time": 40361
+              },
+              "beforeStep": {
+                  "point": "84374823959651440911327522761755345",
+                  "time": 40353
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@715",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 24
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "84699342513311743441398674122361557",
+                  "time": 40377
+              },
+              "beforeStep": {
+                  "point": "84699342513311727300497609626503891",
+                  "time": 40373
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@715",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 24
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "84699342513311743441398674122361557",
+                  "time": 40377
+              },
+              "beforeStep": {
+                  "point": "84699342513311727300497609626503891",
+                  "time": 40373
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@722",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 304
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "84699342513311759582299738618219223",
+                  "time": 40389
+              },
+              "beforeStep": {
+                  "point": "84699342513311759582299738618219223",
+                  "time": 40389
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@724",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 24
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "85672898174458735138958267545308128",
+                  "time": 40823
+              },
+              "beforeStep": {
+                  "point": "85348379620795995332826377310194651",
+                  "time": 40776
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@724",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 24
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "85672898174458735138958267545308128",
+                  "time": 40823
+              },
+              "beforeStep": {
+                  "point": "85348379620795995332826377310194651",
+                  "time": 40776
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@730",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 304
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "85672898174458751279859332041165794",
+                  "time": 40828
+              },
+              "beforeStep": {
+                  "point": "85672898174458751279859332041165794",
+                  "time": 40828
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@732",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 24
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "86321935281883053558890488399940752",
+                  "time": 41051
+              },
+              "beforeStep": {
+                  "point": "86321935281883037417989423904083086",
+                  "time": 41049
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@732",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 24
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "86321935281883053558890488399940752",
+                  "time": 41051
+              },
+              "beforeStep": {
+                  "point": "86321935281883037417989423904083086",
+                  "time": 41049
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@738",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 304
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "86321935281883069699791552895798418",
+                  "time": 41053
+              },
+              "beforeStep": {
+                  "point": "86321935281883069699791552895798418",
+                  "time": 41053
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@740",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 24
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "87295490943015073417791257308057207",
+                  "time": 41384
+              },
+              "beforeStep": {
+                  "point": "86970972389354525315439624689045099",
+                  "time": 41338
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@740",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 24
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "87295490943015073417791257308057207",
+                  "time": 41384
+              },
+              "beforeStep": {
+                  "point": "86970972389354525315439624689045099",
+                  "time": 41338
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@746",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 304
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "87295490943015089558692321803914873",
+                  "time": 41388
+              },
+              "beforeStep": {
+                  "point": "87295490943015089558692321803914873",
+                  "time": 41388
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@748",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 24
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "87944528050384509315339678426091176",
+                  "time": 41651
+              },
+              "beforeStep": {
+                  "point": "87944528050378715884779029020036771",
+                  "time": 41603
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@748",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 24
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "87944528050384509315339678426091176",
+                  "time": 41651
+              },
+              "beforeStep": {
+                  "point": "87944528050378715884779029020036771",
+                  "time": 41603
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@754",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 304
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "87944528050384525456240742921948842",
+                  "time": 41656
+              },
+              "beforeStep": {
+                  "point": "87944528050384525456240742921948842",
+                  "time": 41656
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@756",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 305
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "87944528050384533526691275169877675",
+                  "time": 41666
+              },
+              "beforeStep": {
+                  "point": "87944528050384533526691275169877675",
+                  "time": 41666
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@758",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 24
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "88918083711417488605308700751580861",
+                  "time": 41962
+              },
+              "beforeStep": {
+                  "point": "88918083711412273941343363982708411",
+                  "time": 41944
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@758",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 24
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "88918083711417488605308700751580861",
+                  "time": 41962
+              },
+              "beforeStep": {
+                  "point": "88918083711412273941343363982708411",
+                  "time": 41944
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@764",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 304
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "88918083711417504746209765247438527",
+                  "time": 41965
+              },
+              "beforeStep": {
+                  "point": "88918083711417504746209765247438527",
+                  "time": 41965
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@766",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 305
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "88918083711417512816660297495367360",
+                  "time": 41983
+              },
+              "beforeStep": {
+                  "point": "88918083711417512816660297495367360",
+                  "time": 41983
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@768",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 24
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "89891639372480711332186569886944986",
+                  "time": 42239
+              },
+              "beforeStep": {
+                  "point": "89567120818814851720463213523914456",
+                  "time": 42216
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@768",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 24
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "89891639372480711332186569886944986",
+                  "time": 42239
+              },
+              "beforeStep": {
+                  "point": "89567120818814851720463213523914456",
+                  "time": 42216
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@774",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 304
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "89891639372480727473087634382802652",
+                  "time": 42245
+              },
+              "beforeStep": {
+                  "point": "89891639372480727473087634382802652",
+                  "time": 42245
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@776",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 305
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "89891639372480735543538166630731485",
+                  "time": 42246
+              },
+              "beforeStep": {
+                  "point": "89891639372480735543538166630731485",
+                  "time": 42246
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.waitFor"
+          },
+          "error": null,
+          "id": "pw:api@779",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "getCurrentCallStackFrameInfo",
+                  "lineNumber": 75
+              },
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 312
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 311
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 24
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "89891639372495895308402242061618916",
+                  "time": 42317
+              },
+              "beforeStep": {
+                  "point": "89891639372495879167501177565761251",
+                  "time": 42274
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@781",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 39,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "getCurrentCallStackFrameInfo",
+                  "lineNumber": 79
+              },
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 312
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 311
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 24
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "90216157926166214420505417708752614",
+                  "time": 42347
+              },
+              "beforeStep": {
+                  "point": "89891639372507779623271729440247525",
+                  "time": 42327
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@784",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 43,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "getCurrentCallStackFrameInfo",
+                  "lineNumber": 80
+              },
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 312
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 311
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 24
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "90216157926167360424480996914646760",
+                  "time": 42372
+              },
+              "beforeStep": {
+                  "point": "90216157926167352354030464666717927",
+                  "time": 42350
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@788",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 26,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 313
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "90216157926167368494931529162575593",
+                  "time": 42373
+              },
+              "beforeStep": {
+                  "point": "90216157926167368494931529162575593",
+                  "time": 42373
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@791",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 110
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 25
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "90865195033525458491953114299518714",
+                  "time": 42655
+              },
+              "beforeStep": {
+                  "point": "90865195033523912424215436517723895",
+                  "time": 42573
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@793",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 62,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "openConsolePanel",
+                  "lineNumber": 239
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 116
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 25
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "91514232140861651050837701591846661",
+                  "time": 42793
+              },
+              "beforeStep": {
+                  "point": "91189713587184992023380692893191931",
+                  "time": 42667
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.waitFor"
+          },
+          "error": null,
+          "id": "pw:api@796",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 52,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 121
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 25
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "91838750694521516623658606957448967",
+                  "time": 42878
+              },
+              "beforeStep": {
+                  "point": "91514232140863073755974386441015046",
+                  "time": 42866
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.focus"
+          },
+          "error": null,
+          "id": "pw:api@799",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "focus",
+                  "lineNumber": 23
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "clearText",
+                  "lineNumber": 6
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 65
+              },
+              {
+                  "columnNumber": 20,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 25
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "91838750694525951912686829497765642",
+                  "time": 42929
+              },
+              "beforeStep": {
+                  "point": "91838750694522639569204094026403592",
+                  "time": 42891
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@802",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 24,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "clearText",
+                  "lineNumber": 12
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 65
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 25
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "91838750694527092152054885669424908",
+                  "time": 42961
+              },
+              "beforeStep": {
+                  "point": "91838750694527084081604353421496075",
+                  "time": 42951
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.type"
+          },
+          "error": null,
+          "id": "pw:api@805",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 15,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 68
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 25
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "93785862016945848171167139315604437",
+                  "time": 44892
+              },
+              "beforeStep": {
+                  "point": "92163269248186641824383528758955789",
+                  "time": 42978
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@809",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 43
+              },
+              {
+                  "columnNumber": 11,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 25
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "94434899124274559422408332777905116",
+                  "time": 45077
+              },
+              "beforeStep": {
+                  "point": "94434899124274551351957800529976283",
+                  "time": 45068
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@811",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 18,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "hideTypeAheadSuggestions",
+                  "lineNumber": 29
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 45
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 25
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "94434899124275748084479582437137374",
+                  "time": 45086
+              },
+              "beforeStep": {
+                  "point": "94434899124275740014029050189208541",
+                  "time": 45080
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.press"
+          },
+          "error": null,
+          "id": "pw:api@814",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 17,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "hideTypeAheadSuggestions",
+                  "lineNumber": 31
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 45
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 25
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "94759417677949198531389270280657965",
+                  "time": 45166
+              },
+              "beforeStep": {
+                  "point": "94434899124276944817001364344298463",
+                  "time": 45091
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@817",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 51
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 25
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "94759417677950344535364849486552111",
+                  "time": 45183
+              },
+              "beforeStep": {
+                  "point": "94759417677950336464914317238623278",
+                  "time": 45171
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.press"
+          },
+          "error": null,
+          "id": "pw:api@821",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 17,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 54
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 25
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "95408454785376327773949722628217963",
+                  "time": 45467
+              },
+              "beforeStep": {
+                  "point": "95083936231609909195673052465093680",
+                  "time": 45288
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@823",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 51
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 25
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "95732973339044535886777963138538607",
+                  "time": 45563
+              },
+              "beforeStep": {
+                  "point": "95732973339035912033923503923158125",
+                  "time": 45523
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@826",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "verifyEvaluationResult",
+                  "lineNumber": 345
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 134
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 25
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "95732973339053918361982453659229301",
+                  "time": 45590
+              },
+              "beforeStep": {
+                  "point": "95732973339044550874757523027549297",
+                  "time": 45580
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.waitFor"
+          },
+          "error": null,
+          "id": "pw:api@829",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "verifyExpectedCount",
+                  "lineNumber": 369
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "verifyEvaluationResult",
+                  "lineNumber": 354
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 134
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 25
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "96057491892713547585894914621201527",
+                  "time": 45626
+              },
+              "beforeStep": {
+                  "point": "96057491892713525680386327091108982",
+                  "time": 45607
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@832",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 72,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "clearConsoleEvaluations",
+                  "lineNumber": 45
+              },
+              {
+                  "columnNumber": 11,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 136
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 25
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "96706529000086147100051976927337663",
+                  "time": 45833
+              },
+              "beforeStep": {
+                  "point": "96057491892714680907733943151778936",
+                  "time": 45639
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@835",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 54,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 47
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "clearConsoleEvaluations",
+                  "lineNumber": 47
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 136
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 25
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "96706529000087339220887740407110849",
+                  "time": 45857
+              },
+              "beforeStep": {
+                  "point": "96706529000087241222559848825117888",
+                  "time": 45849
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@839",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 63,
+                  "fileName": "helpers/console-panel.ts",
+                  "lineNumber": 47
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "96706529000087347291338272655039682",
+                  "time": 45859
+              },
+              "beforeStep": {
+                  "point": "96706529000087347291338272655039682",
+                  "time": 45859
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@842",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 170
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 202
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 26
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "96706529000087374961454383219367110",
+                  "time": 45878
+              },
+              "beforeStep": {
+                  "point": "96706529000087366891003850971438277",
+                  "time": 45870
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@844",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "openPauseInformationPanel",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 172
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 202
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 26
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "96706529000088489836549338040392904",
+                  "time": 45889
+              },
+              "beforeStep": {
+                  "point": "96706529000088481766098805792464071",
+                  "time": 45882
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isEnabled"
+          },
+          "error": null,
+          "id": "pw:api@847",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 175
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 202
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 26
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "97031047553748170941929506310479050",
+                  "time": 45906
+              },
+              "beforeStep": {
+                  "point": "96706529000089736144695818041973961",
+                  "time": 45895
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@850",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 176
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 202
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 26
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "97355566107609767802097490118860589",
+                  "time": 46086
+              },
+              "beforeStep": {
+                  "point": "97031047553749277746573928883576011",
+                  "time": 45911
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@853",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 284
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 26
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "97355566107609869259189895521394480",
+                  "time": 46112
+              },
+              "beforeStep": {
+                  "point": "97355566107609781637155545401024303",
+                  "time": 46111
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@856",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "openPauseInformationPanel",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 290
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 26
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "98004603215086792028612812983001060",
+                  "time": 46339
+              },
+              "beforeStep": {
+                  "point": "97680084661269211405647709378469681",
+                  "time": 46139
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@859",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 26
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "98004603215106915120554220890120279",
+                  "time": 46387
+              },
+              "beforeStep": {
+                  "point": "98004603215088650538078239220326373",
+                  "time": 46357
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@859",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 26
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "98004603215106915120554220890120279",
+                  "time": 46387
+              },
+              "beforeStep": {
+                  "point": "98004603215088650538078239220326373",
+                  "time": 46357
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@866",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 304
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "98004603215106931261455285385977945",
+                  "time": 46390
+              },
+              "beforeStep": {
+                  "point": "98004603215106931261455285385977945",
+                  "time": 46390
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@868",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 26
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "99302677429992510012170339686048494",
+                  "time": 46816
+              },
+              "beforeStep": {
+                  "point": "98978158876329782888175000126251750",
+                  "time": 46726
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@868",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 26
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "99302677429992510012170339686048494",
+                  "time": 46816
+              },
+              "beforeStep": {
+                  "point": "98978158876329782888175000126251750",
+                  "time": 46726
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@874",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 304
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "99302677429992526153071404181906160",
+                  "time": 46841
+              },
+              "beforeStep": {
+                  "point": "99302677429992526153071404181906160",
+                  "time": 46841
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@876",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 26
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "100276233090993157924385672201790224",
+                  "time": 47154
+              },
+              "beforeStep": {
+                  "point": "100276233090987191555599331768689415",
+                  "time": 47139
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@876",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 26
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "100276233090993157924385672201790224",
+                  "time": 47154
+              },
+              "beforeStep": {
+                  "point": "100276233090987191555599331768689415",
+                  "time": 47139
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@882",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 304
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "100276233090993174065286736697647890",
+                  "time": 47163
+              },
+              "beforeStep": {
+                  "point": "100276233090993174065286736697647890",
+                  "time": 47163
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@884",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 305
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "100276233090993182135737268945576723",
+                  "time": 47169
+              },
+              "beforeStep": {
+                  "point": "100276233090993182135737268945576723",
+                  "time": 47169
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@886",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 26
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "100925270198355781208763371461042982",
+                  "time": 47426
+              },
+              "beforeStep": {
+                  "point": "100925270198345807284827017627853597",
+                  "time": 47422
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@886",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 26
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "100925270198355781208763371461042982",
+                  "time": 47426
+              },
+              "beforeStep": {
+                  "point": "100925270198345807284827017627853597",
+                  "time": 47422
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@892",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 304
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "100925270198378929566732867734627124",
+                  "time": 47462
+              },
+              "beforeStep": {
+                  "point": "100925270198378929566732867734627124",
+                  "time": 47462
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@894",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 305
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "100925270198378937637183399982555957",
+                  "time": 47463
+              },
+              "beforeStep": {
+                  "point": "100925270198378937637183399982555957",
+                  "time": 47463
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@896",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 26
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "101898825859444839753637975430292307",
+                  "time": 47756
+              },
+              "beforeStep": {
+                  "point": "101574307305766002857458764397699916",
+                  "time": 47714
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@896",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 26
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "101898825859444839753637975430292307",
+                  "time": 47756
+              },
+              "beforeStep": {
+                  "point": "101574307305766002857458764397699916",
+                  "time": 47714
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@902",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 304
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "101898825859444855894539039926149973",
+                  "time": 47762
+              },
+              "beforeStep": {
+                  "point": "101898825859444855894539039926149973",
+                  "time": 47762
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@904",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 305
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "101898825859444863964989572174078806",
+                  "time": 47762
+              },
+              "beforeStep": {
+                  "point": "101898825859444863964989572174078806",
+                  "time": 47762
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.waitFor"
+          },
+          "error": null,
+          "id": "pw:api@907",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "getCurrentCallStackFrameInfo",
+                  "lineNumber": 75
+              },
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 312
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 311
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 26
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "101898825859446973811343002704044888",
+                  "time": 47801
+              },
+              "beforeStep": {
+                  "point": "101898825859446957670441938208187223",
+                  "time": 47779
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@909",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 39,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "getCurrentCallStackFrameInfo",
+                  "lineNumber": 79
+              },
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 312
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 311
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 26
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "101898825859448119815318581909939034",
+                  "time": 47811
+              },
+              "beforeStep": {
+                  "point": "101898825859448111744868049662010201",
+                  "time": 47803
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@912",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 43,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "getCurrentCallStackFrameInfo",
+                  "lineNumber": 80
+              },
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 312
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 311
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "rewindToLine",
+                  "lineNumber": 204
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 26
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "102223344413107692546077317136409436",
+                  "time": 47830
+              },
+              "beforeStep": {
+                  "point": "101898825859449257748843628867904347",
+                  "time": 47814
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@916",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 26,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 313
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "102223344413107700616527849384338269",
+                  "time": 47833
+              },
+              "beforeStep": {
+                  "point": "102223344413107700616527849384338269",
+                  "time": 47833
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@919",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 110
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 27
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "102547862966795251293438878966375275",
+                  "time": 47989
+              },
+              "beforeStep": {
+                  "point": "102547862966795243222988346718446442",
+                  "time": 47980
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@921",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 62,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "openConsolePanel",
+                  "lineNumber": 239
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 116
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 27
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "102872381520487670757863863263191931",
+                  "time": 48138
+              },
+              "beforeStep": {
+                  "point": "102547862966796517201250937284354924",
+                  "time": 48008
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.waitFor"
+          },
+          "error": null,
+          "id": "pw:api@924",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 52,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 121
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 27
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "102872381520489109603901612608217981",
+                  "time": 48152
+              },
+              "beforeStep": {
+                  "point": "102872381520489093463000548112360316",
+                  "time": 48140
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.focus"
+          },
+          "error": null,
+          "id": "pw:api@927",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "focus",
+                  "lineNumber": 23
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "clearText",
+                  "lineNumber": 6
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 65
+              },
+              {
+                  "columnNumber": 20,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 27
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "103196900074151971619712991169110912",
+                  "time": 48192
+              },
+              "beforeStep": {
+                  "point": "103196900074148659276230255697748862",
+                  "time": 48167
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@930",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 24,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "clearText",
+                  "lineNumber": 12
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 65
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 27
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "103196900074153111859081047340770178",
+                  "time": 48214
+              },
+              "beforeStep": {
+                  "point": "103196900074153103788630515092841345",
+                  "time": 48198
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.type"
+          },
+          "error": null,
+          "id": "pw:api@933",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 15,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 68
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 27
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "104494974289247618433174936022446149",
+                  "time": 49489
+              },
+              "beforeStep": {
+                  "point": "103196900074154234804626534409724803",
+                  "time": 48242
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@937",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 43
+              },
+              {
+                  "columnNumber": 11,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 27
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "104819492842928218146334690924064849",
+                  "time": 49700
+              },
+              "beforeStep": {
+                  "point": "104819492842928210075884158676136016",
+                  "time": 49693
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@939",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 18,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "hideTypeAheadSuggestions",
+                  "lineNumber": 29
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 45
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 27
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "104819492842929406808405940583297107",
+                  "time": 49729
+              },
+              "beforeStep": {
+                  "point": "104819492842929398737955408335368274",
+                  "time": 49715
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.press"
+          },
+          "error": null,
+          "id": "pw:api@942",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 17,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "hideTypeAheadSuggestions",
+                  "lineNumber": 31
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 45
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 27
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "105144011396602867631609169888440482",
+                  "time": 49792
+              },
+              "beforeStep": {
+                  "point": "104819492842930603540927722490458196",
+                  "time": 49735
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@945",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 51
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 27
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "105144011396604013635584749094334628",
+                  "time": 49799
+              },
+              "beforeStep": {
+                  "point": "105144011396604005565134216846405795",
+                  "time": 49798
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.press"
+          },
+          "error": null,
+          "id": "pw:api@949",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 17,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 54
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 27
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "105793048504011211171173558271373512",
+                  "time": 50011
+              },
+              "beforeStep": {
+                  "point": "105468529950263600201401539602968741",
+                  "time": 49908
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@951",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 51
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 27
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "105793048504015271760712783586422986",
+                  "time": 50032
+              },
+              "beforeStep": {
+                  "point": "105793048504012343340091082195103945",
+                  "time": 50023
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@954",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "verifyEvaluationResult",
+                  "lineNumber": 345
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 134
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 27
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "106117567057689772519113168267538662",
+                  "time": 50165
+              },
+              "beforeStep": {
+                  "point": "105793048504015286748692343475433676",
+                  "time": 50045
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.waitFor"
+          },
+          "error": null,
+          "id": "pw:api@957",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "verifyExpectedCount",
+                  "lineNumber": 369
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "verifyEvaluationResult",
+                  "lineNumber": 354
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 134
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 27
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "106117567057708902945639109679411436",
+                  "time": 50217
+              },
+              "beforeStep": {
+                  "point": "106117567057690953110733885678842087",
+                  "time": 50179
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@960",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 72,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "clearConsoleEvaluations",
+                  "lineNumber": 45
+              },
+              {
+                  "columnNumber": 11,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 136
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 27
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "106442085611423075733013015964971316",
+                  "time": 50342
+              },
+              "beforeStep": {
+                  "point": "106117567057710036267478138209988845",
+                  "time": 50227
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@963",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 54,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 47
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "clearConsoleEvaluations",
+                  "lineNumber": 47
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 136
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 27
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "106766604165082693427710430858473782",
+                  "time": 50369
+              },
+              "beforeStep": {
+                  "point": "106766604165082596582304043883327797",
+                  "time": 50364
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@967",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 63,
+                  "fileName": "helpers/console-panel.ts",
+                  "lineNumber": 47
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "106766604165082701498160963106402615",
+                  "time": 50371
+              },
+              "beforeStep": {
+                  "point": "106766604165082701498160963106402615",
+                  "time": 50371
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@970",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 170
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 164
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 28
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "106766604165082731474120082884423995",
+                  "time": 50398
+              },
+              "beforeStep": {
+                  "point": "106766604165082723403669550636495162",
+                  "time": 50390
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@972",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "openPauseInformationPanel",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 172
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 164
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 28
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "106766604165083846349215037705449789",
+                  "time": 50428
+              },
+              "beforeStep": {
+                  "point": "106766604165083838278764505457520956",
+                  "time": 50410
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isEnabled"
+          },
+          "error": null,
+          "id": "pw:api@975",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 175
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 164
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 28
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "106766604165085100727812049954959679",
+                  "time": 50449
+              },
+              "beforeStep": {
+                  "point": "106766604165085092657361517707030846",
+                  "time": 50435
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@978",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 176
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 164
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 28
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "107415641272605178502073906305725346",
+                  "time": 50632
+              },
+              "beforeStep": {
+                  "point": "107091122718744635412161133155479872",
+                  "time": 50457
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@981",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 284
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 166
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 28
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "107415641272605200407582493835817893",
+                  "time": 50645
+              },
+              "beforeStep": {
+                  "point": "107415641272605192337131961587889060",
+                  "time": 50644
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@984",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "openPauseInformationPanel",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 290
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 166
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 28
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "107740159826550084317243276269745439",
+                  "time": 50825
+              },
+              "beforeStep": {
+                  "point": "107415641272606115827257151672316838",
+                  "time": 50653
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@987",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 166
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 28
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "107740159826587802144266489268565283",
+                  "time": 50872
+              },
+              "beforeStep": {
+                  "point": "107740159826552580392300750093448480",
+                  "time": 50850
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@987",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 166
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 28
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "107740159826587802144266489268565283",
+                  "time": 50872
+              },
+              "beforeStep": {
+                  "point": "107740159826552580392300750093448480",
+                  "time": 50850
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@994",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 304
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "107740159826587818285167553764422949",
+                  "time": 50875
+              },
+              "beforeStep": {
+                  "point": "107740159826587818285167553764422949",
+                  "time": 50875
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@996",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 305
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "107740159826587826355618086012351782",
+                  "time": 50877
+              },
+              "beforeStep": {
+                  "point": "107740159826587826355618086012351782",
+                  "time": 50877
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.waitFor"
+          },
+          "error": null,
+          "id": "pw:api@999",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "getCurrentCallStackFrameInfo",
+                  "lineNumber": 75
+              },
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 312
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 311
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 166
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 28
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "108064678380257552866067893740139819",
+                  "time": 50915
+              },
+              "beforeStep": {
+                  "point": "107740159826599109998383673223705898",
+                  "time": 50899
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@1001",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 39,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "getCurrentCallStackFrameInfo",
+                  "lineNumber": 79
+              },
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 312
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 311
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 166
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 28
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "108064678380258800327135878348567853",
+                  "time": 50928
+              },
+              "beforeStep": {
+                  "point": "108064678380258792256685346100639020",
+                  "time": 50925
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@1004",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 43,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "getCurrentCallStackFrameInfo",
+                  "lineNumber": 80
+              },
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 312
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 311
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 166
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 28
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "108064678380260047788203862956995887",
+                  "time": 50948
+              },
+              "beforeStep": {
+                  "point": "108064678380260039717753330709067054",
+                  "time": 50936
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@1008",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 26,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 313
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "108064678380260055858654395204924720",
+                  "time": 50950
+              },
+              "beforeStep": {
+                  "point": "108064678380260055858654395204924720",
+                  "time": 50950
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@1011",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 110
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 29
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "108389196933945292622105678845080892",
+                  "time": 51040
+              },
+              "beforeStep": {
+                  "point": "108389196933945254575696026819130683",
+                  "time": 51038
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@1013",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 62,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "openConsolePanel",
+                  "lineNumber": 239
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 116
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 29
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "108713715487623038854541531800433991",
+                  "time": 51141
+              },
+              "beforeStep": {
+                  "point": "108389196933946399426750101418177853",
+                  "time": 51045
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.waitFor"
+          },
+          "error": null,
+          "id": "pw:api@1016",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 52,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 121
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 29
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "108713715487624477700579281145460041",
+                  "time": 51156
+              },
+              "beforeStep": {
+                  "point": "108713715487624461559678216649602376",
+                  "time": 51144
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.focus"
+          },
+          "error": null,
+          "id": "pw:api@1019",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "focus",
+                  "lineNumber": 23
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "clearText",
+                  "lineNumber": 6
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 65
+              },
+              {
+                  "columnNumber": 20,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 29
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "108713715487628912989607503685776716",
+                  "time": 51183
+              },
+              "beforeStep": {
+                  "point": "108713715487625600646124768214414666",
+                  "time": 51160
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@1022",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 24,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "clearText",
+                  "lineNumber": 12
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 65
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 29
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "108713715487630053228975559857435982",
+                  "time": 51191
+              },
+              "beforeStep": {
+                  "point": "108713715487630045158525027609507149",
+                  "time": 51186
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.type"
+          },
+          "error": null,
+          "id": "pw:api@1025",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 15,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 68
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 29
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "110660826810048978727548990710120983",
+                  "time": 52486
+              },
+              "beforeStep": {
+                  "point": "108713715487631176174521046926390607",
+                  "time": 51194
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@1029",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 43
+              },
+              {
+                  "columnNumber": 11,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 29
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "110985345363718523076401070556086814",
+                  "time": 52682
+              },
+              "beforeStep": {
+                  "point": "110985345363718515005950538308157981",
+                  "time": 52672
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@1031",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 18,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "hideTypeAheadSuggestions",
+                  "lineNumber": 29
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 45
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 29
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "110985345363719709432629311001625120",
+                  "time": 52704
+              },
+              "beforeStep": {
+                  "point": "110985345363719701362178778753696287",
+                  "time": 52688
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.press"
+          },
+          "error": null,
+          "id": "pw:api@1034",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 17,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "hideTypeAheadSuggestions",
+                  "lineNumber": 31
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 45
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 29
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "111309863917393178326283072554697327",
+                  "time": 52795
+              },
+              "beforeStep": {
+                  "point": "110985345363720903859308083695092257",
+                  "time": 52734
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@1037",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 51
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 29
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "111309863917394322024415642546897521",
+                  "time": 52809
+              },
+              "beforeStep": {
+                  "point": "111309863917394313953965110298968688",
+                  "time": 52807
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.press"
+          },
+          "error": null,
+          "id": "pw:api@1041",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 17,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 54
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 29
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "111958901024804848044388251691156117",
+                  "time": 53092
+              },
+              "beforeStep": {
+                  "point": "111634382471053876308430304063816307",
+                  "time": 52925
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@1043",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 51
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 29
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "112283419578481066655830500574266032",
+                  "time": 53219
+              },
+              "beforeStep": {
+                  "point": "112283419578464406940088931635462806",
+                  "time": 53127
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@1046",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "verifyEvaluationResult",
+                  "lineNumber": 345
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 134
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 29
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "112607938132151908041375263123079861",
+                  "time": 53260
+              },
+              "beforeStep": {
+                  "point": "112607938132139507217671711877006002",
+                  "time": 53239
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.waitFor"
+          },
+          "error": null,
+          "id": "pw:api@1049",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "verifyExpectedCount",
+                  "lineNumber": 369
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "verifyEvaluationResult",
+                  "lineNumber": 354
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 134
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 29
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "113581493793146029264953016278090432",
+                  "time": 53544
+              },
+              "beforeStep": {
+                  "point": "112607938132153070186251906824831670",
+                  "time": 53271
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@1052",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 72,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "clearConsoleEvaluations",
+                  "lineNumber": 45
+              },
+              {
+                  "columnNumber": 11,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 136
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 29
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "114230530900518790188120723542803208",
+                  "time": 53792
+              },
+              "beforeStep": {
+                  "point": "113581493793147162586792044808667841",
+                  "time": 53557
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@1055",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 54,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 47
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "clearConsoleEvaluations",
+                  "lineNumber": 47
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 136
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 29
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "114230530900519892381079127688512266",
+                  "time": 53821
+              },
+              "beforeStep": {
+                  "point": "114230530900519884310628595440583433",
+                  "time": 53815
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@1059",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 63,
+                  "fileName": "helpers/console-panel.ts",
+                  "lineNumber": 47
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "114230530900519900451529659936441099",
+                  "time": 53824
+              },
+              "beforeStep": {
+                  "point": "114230530900519900451529659936441099",
+                  "time": 53824
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@1062",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 170
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 164
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 30
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "114555049454178354848428926521344783",
+                  "time": 53890
+              },
+              "beforeStep": {
+                  "point": "114230530900519920051195238252839694",
+                  "time": 53849
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@1064",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "openPauseInformationPanel",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 172
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 164
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 30
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "114555049454179469723523881342370577",
+                  "time": 53943
+              },
+              "beforeStep": {
+                  "point": "114555049454179461653073349094441744",
+                  "time": 53910
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isEnabled"
+          },
+          "error": null,
+          "id": "pw:api@1067",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 175
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 164
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 30
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "114555049454180724102120893591880467",
+                  "time": 53974
+              },
+              "beforeStep": {
+                  "point": "114555049454180716031670361343951634",
+                  "time": 53949
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@1070",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 176
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 164
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 30
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "115528605115680019788450724279518959",
+                  "time": 54607
+              },
+              "beforeStep": {
+                  "point": "114555049454181830906765316164977428",
+                  "time": 53980
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@1073",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 284
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 166
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 30
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "115853123669347455443870878202365685",
+                  "time": 54642
+              },
+              "beforeStep": {
+                  "point": "115853123669338460350291935582258929",
+                  "time": 54622
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@1076",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "openPauseInformationPanel",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 290
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 166
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 30
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "115853123669348570318965833023391479",
+                  "time": 54668
+              },
+              "beforeStep": {
+                  "point": "115853123669348562248515300775462646",
+                  "time": 54666
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@1079",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 166
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 30
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "116177642223009509261707527363528442",
+                  "time": 54780
+              },
+              "beforeStep": {
+                  "point": "115853123669351066394023306847094520",
+                  "time": 54692
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@1079",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 166
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 30
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "116177642223009509261707527363528442",
+                  "time": 54780
+              },
+              "beforeStep": {
+                  "point": "115853123669351066394023306847094520",
+                  "time": 54692
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@1086",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 304
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "116177642223009525402608591859386108",
+                  "time": 54788
+              },
+              "beforeStep": {
+                  "point": "116177642223009525402608591859386108",
+                  "time": 54788
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@1088",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 305
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "116177642223009533473059124107314941",
+                  "time": 54789
+              },
+              "beforeStep": {
+                  "point": "116177642223009533473059124107314941",
+                  "time": 54789
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.waitFor"
+          },
+          "error": null,
+          "id": "pw:api@1091",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "getCurrentCallStackFrameInfo",
+                  "lineNumber": 75
+              },
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 312
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 311
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 166
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 30
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "116177642223011846233597365442348799",
+                  "time": 54832
+              },
+              "beforeStep": {
+                  "point": "116177642223011830092696300946491134",
+                  "time": 54815
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@1093",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 39,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "getCurrentCallStackFrameInfo",
+                  "lineNumber": 79
+              },
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 312
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 311
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 166
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 30
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "116177642223013124823545974435645185",
+                  "time": 54856
+              },
+              "beforeStep": {
+                  "point": "116177642223013085624214817802848000",
+                  "time": 54850
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@1096",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 43,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "getCurrentCallStackFrameInfo",
+                  "lineNumber": 80
+              },
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 312
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 311
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 166
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 30
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "116502160776672799011397115064649475",
+                  "time": 54887
+              },
+              "beforeStep": {
+                  "point": "116177642223014364214163426796144386",
+                  "time": 54869
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@1100",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 26,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 313
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "116502160776672807081847647312578308",
+                  "time": 54892
+              },
+              "beforeStep": {
+                  "point": "116502160776672807081847647312578308",
+                  "time": 54892
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@1103",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 110
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 31
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "116826679330358083044630087585531664",
+                  "time": 55079
+              },
+              "beforeStep": {
+                  "point": "116826679330358074974179555337602831",
+                  "time": 55073
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@1105",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 62,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "openConsolePanel",
+                  "lineNumber": 239
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 116
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 31
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "117151197884035829277065940540884763",
+                  "time": 55192
+              },
+              "beforeStep": {
+                  "point": "116826679330359189849274510158628625",
+                  "time": 55086
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.waitFor"
+          },
+          "error": null,
+          "id": "pw:api@1108",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 52,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 121
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 31
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "117475716437695694849886845906487069",
+                  "time": 55218
+              },
+              "beforeStep": {
+                  "point": "117151197884037251982202625390053148",
+                  "time": 55197
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.focus"
+          },
+          "error": null,
+          "id": "pw:api@1111",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "focus",
+                  "lineNumber": 23
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "clearText",
+                  "lineNumber": 6
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 65
+              },
+              {
+                  "columnNumber": 20,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 31
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "117800234991358556865698224467380000",
+                  "time": 55310
+              },
+              "beforeStep": {
+                  "point": "117475716437696817795432332975441694",
+                  "time": 55247
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@1114",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 24,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "clearText",
+                  "lineNumber": 12
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 65
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 31
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "117800234991359697105066280639039266",
+                  "time": 55328
+              },
+              "beforeStep": {
+                  "point": "117800234991359689034615748391110433",
+                  "time": 55325
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.type"
+          },
+          "error": null,
+          "id": "pw:api@1117",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 15,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 68
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 31
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "119747346313779483836003652806415338",
+                  "time": 57191
+              },
+              "beforeStep": {
+                  "point": "117800234991360820050611767707993891",
+                  "time": 55345
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@1121",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 43
+              },
+              {
+                  "columnNumber": 11,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 31
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "120071864867449898640591710821848049",
+                  "time": 57358
+              },
+              "beforeStep": {
+                  "point": "120071864867449890570141178573919216",
+                  "time": 57337
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@1123",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 18,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "hideTypeAheadSuggestions",
+                  "lineNumber": 29
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 45
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 31
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "120396383421109514029446116501656563",
+                  "time": 57391
+              },
+              "beforeStep": {
+                  "point": "120396383421109505958995584253727730",
+                  "time": 57375
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.press"
+          },
+          "error": null,
+          "id": "pw:api@1126",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 17,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "hideTypeAheadSuggestions",
+                  "lineNumber": 31
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 45
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 31
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "120720901974782995605236428730045506",
+                  "time": 57471
+              },
+              "beforeStep": {
+                  "point": "120396383421110710761967898408817652",
+                  "time": 57402
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@1129",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 51
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 31
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "120720901974784145067976521756480580",
+                  "time": 57481
+              },
+              "beforeStep": {
+                  "point": "120720901974784133538761475688010819",
+                  "time": 57478
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.press"
+          },
+          "error": null,
+          "id": "pw:api@1133",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 17,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 54
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 31
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "121694457635868617291105799688459393",
+                  "time": 57810
+              },
+              "beforeStep": {
+                  "point": "121045420528443701657834192487093318",
+                  "time": 57584
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@1135",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 51
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 31
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "122018976189536825403934040198780037",
+                  "time": 57936
+              },
+              "beforeStep": {
+                  "point": "121694457635869774824296424962823299",
+                  "time": 57846
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@1138",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "verifyEvaluationResult",
+                  "lineNumber": 345
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 134
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 31
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "122018976189545099921572603539526794",
+                  "time": 57950
+              },
+              "beforeStep": {
+                  "point": "122018976189536839238992095480943751",
+                  "time": 57941
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.waitFor"
+          },
+          "error": null,
+          "id": "pw:api@1141",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "verifyExpectedCount",
+                  "lineNumber": 369
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "verifyEvaluationResult",
+                  "lineNumber": 354
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 134
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 31
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "122018976189547419599639872515642509",
+                  "time": 57979
+              },
+              "beforeStep": {
+                  "point": "122018976189547397694131284985549964",
+                  "time": 57969
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@1144",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 72,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "clearConsoleEvaluations",
+                  "lineNumber": 45
+              },
+              {
+                  "columnNumber": 11,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 136
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 31
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "122668013296920107888752789548995797",
+                  "time": 58166
+              },
+              "beforeStep": {
+                  "point": "122018976189548552921478901046219918",
+                  "time": 57986
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@1147",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 54,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 47
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "clearConsoleEvaluations",
+                  "lineNumber": 47
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 136
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 31
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "122668013296921210081711193694704855",
+                  "time": 58202
+              },
+              "beforeStep": {
+                  "point": "122668013296921202011260661446776022",
+                  "time": 58175
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@1151",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 63,
+                  "fileName": "helpers/console-panel.ts",
+                  "lineNumber": 47
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "122668013296921218152161725942633688",
+                  "time": 58202
+              },
+              "beforeStep": {
+                  "point": "122668013296921218152161725942633688",
+                  "time": 58202
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@1154",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 170
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 164
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 32
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "122992531850579672549060992527537372",
+                  "time": 58233
+              },
+              "beforeStep": {
+                  "point": "122668013296921237751827304259032283",
+                  "time": 58217
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@1156",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "openPauseInformationPanel",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 172
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 164
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 32
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "122992531850580787424155947348563166",
+                  "time": 58255
+              },
+              "beforeStep": {
+                  "point": "122992531850580779353705415100634333",
+                  "time": 58240
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isEnabled"
+          },
+          "error": null,
+          "id": "pw:api@1159",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 175
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 164
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 32
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "122992531850582041802752959598073056",
+                  "time": 58272
+              },
+              "beforeStep": {
+                  "point": "122992531850582033732302427350144223",
+                  "time": 58260
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@1162",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 176
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 164
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 32
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "123317050404443762025521936339081027",
+                  "time": 58453
+              },
+              "beforeStep": {
+                  "point": "122992531850583148607397382171170017",
+                  "time": 58277
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@1165",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 284
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 166
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 32
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "123317050404443783931030523869173574",
+                  "time": 58467
+              },
+              "beforeStep": {
+                  "point": "123317050404443775860579991621244741",
+                  "time": 58455
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@1168",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "openPauseInformationPanel",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 290
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 166
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 32
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "123317050404444707421155713953601352",
+                  "time": 58477
+              },
+              "beforeStep": {
+                  "point": "123317050404444699350705181705672519",
+                  "time": 58470
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@1171",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 166
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 32
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "123317050404446575153993177045702475",
+                  "time": 58493
+              },
+              "beforeStep": {
+                  "point": "123317050404446559013092112549844809",
+                  "time": 58482
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@1171",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 166
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 32
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "123317050404446575153993177045702475",
+                  "time": 58493
+              },
+              "beforeStep": {
+                  "point": "123317050404446559013092112549844809",
+                  "time": 58482
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@1178",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 304
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "123641568958390498680040621976099013",
+                  "time": 58819
+              },
+              "beforeStep": {
+                  "point": "123641568958390498680040621976099013",
+                  "time": 58819
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@1180",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 166
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 32
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "123966087512095630256975401367673036",
+                  "time": 58918
+              },
+              "beforeStep": {
+                  "point": "123966087512086621328338403465402567",
+                  "time": 58892
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@1180",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 166
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 32
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "123966087512095630256975401367673036",
+                  "time": 58918
+              },
+              "beforeStep": {
+                  "point": "123966087512086621328338403465402567",
+                  "time": 58892
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@1186",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 304
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "123966087512095646397876465863530702",
+                  "time": 58922
+              },
+              "beforeStep": {
+                  "point": "123966087512095646397876465863530702",
+                  "time": 58922
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@1188",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 305
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "123966087512095654468326998111459535",
+                  "time": 58932
+              },
+              "beforeStep": {
+                  "point": "123966087512095654468326998111459535",
+                  "time": 58932
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.waitFor"
+          },
+          "error": null,
+          "id": "pw:api@1191",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "getCurrentCallStackFrameInfo",
+                  "lineNumber": 75
+              },
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 312
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 311
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 166
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 32
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "123966087512097967228865239446493393",
+                  "time": 58962
+              },
+              "beforeStep": {
+                  "point": "123966087512097951087964174950635728",
+                  "time": 58951
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@1193",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 39,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "getCurrentCallStackFrameInfo",
+                  "lineNumber": 79
+              },
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 312
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 311
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 166
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 32
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "123966087512099214689933224054921427",
+                  "time": 58978
+              },
+              "beforeStep": {
+                  "point": "123966087512099206619482691806992594",
+                  "time": 58974
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@1196",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 43,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "getCurrentCallStackFrameInfo",
+                  "lineNumber": 80
+              },
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 312
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 311
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 166
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 32
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "124290606065758888877784364683925717",
+                  "time": 59005
+              },
+              "beforeStep": {
+                  "point": "124290606065758880807333832435996884",
+                  "time": 58998
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@1200",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 26,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 313
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "124290606065758896948234896931854550",
+                  "time": 59007
+              },
+              "beforeStep": {
+                  "point": "124290606065758896948234896931854550",
+                  "time": 59007
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@1203",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 110
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 33
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "124615124619444178675624860239042786",
+                  "time": 59153
+              },
+              "beforeStep": {
+                  "point": "124615124619444104888648565400836321",
+                  "time": 59150
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@1205",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 62,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "openConsolePanel",
+                  "lineNumber": 239
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 116
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 33
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "124939643173121928366825227014936813",
+                  "time": 59270
+              },
+              "beforeStep": {
+                  "point": "124615124619445285480269282812139747",
+                  "time": 59158
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.waitFor"
+          },
+          "error": null,
+          "id": "pw:api@1208",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 52,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 121
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 33
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "125264161726781793939646132380539119",
+                  "time": 59301
+              },
+              "beforeStep": {
+                  "point": "124939643173123351071961911864105198",
+                  "time": 59282
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.focus"
+          },
+          "error": null,
+          "id": "pw:api@1211",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "focus",
+                  "lineNumber": 23
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "clearText",
+                  "lineNumber": 6
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 65
+              },
+              {
+                  "columnNumber": 20,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 33
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "125264161726786229228674354920855794",
+                  "time": 59341
+              },
+              "beforeStep": {
+                  "point": "125264161726782916885191619449493744",
+                  "time": 59305
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@1214",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 24,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "clearText",
+                  "lineNumber": 12
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 65
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 33
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "125264161726787369468042411092515060",
+                  "time": 59362
+              },
+              "beforeStep": {
+                  "point": "125264161726787361397591878844586227",
+                  "time": 59357
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.type"
+          },
+          "error": null,
+          "id": "pw:api@1217",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 15,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 68
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 33
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "126562235941900815083692476449465794",
+                  "time": 61201
+              },
+              "beforeStep": {
+                  "point": "125264161726788492413587898161469685",
+                  "time": 59375
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@1221",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 43
+              },
+              {
+                  "columnNumber": 11,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 33
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "127211273049228877240126576256918985",
+                  "time": 61423
+              },
+              "beforeStep": {
+                  "point": "127211273049228869169676044008990152",
+                  "time": 61418
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@1223",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 18,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "hideTypeAheadSuggestions",
+                  "lineNumber": 29
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 45
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 33
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "127211273049230065902197825916151243",
+                  "time": 61436
+              },
+              "beforeStep": {
+                  "point": "127211273049230057831747293668222410",
+                  "time": 61425
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.press"
+          },
+          "error": null,
+          "id": "pw:api@1226",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 17,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "hideTypeAheadSuggestions",
+                  "lineNumber": 31
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 45
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 33
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "127211273049245131127498523585586714",
+                  "time": 61487
+              },
+              "beforeStep": {
+                  "point": "127211273049231262634719607823312332",
+                  "time": 61450
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@1229",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 51
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 33
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "127211273049246286354846139646256668",
+                  "time": 61492
+              },
+              "beforeStep": {
+                  "point": "127211273049246269061023570543552027",
+                  "time": 61490
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.press"
+          },
+          "error": null,
+          "id": "pw:api@1233",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 17,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 54
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 33
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "127860310156655003440978020647609920",
+                  "time": 61779
+              },
+              "beforeStep": {
+                  "point": "127535791602905841791782305770022429",
+                  "time": 61619
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@1235",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 51
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 33
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "128184828710333165878077036674721371",
+                  "time": 61884
+              },
+              "beforeStep": {
+                  "point": "127860310156656149444953599853504065",
+                  "time": 61786
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@1238",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "verifyEvaluationResult",
+                  "lineNumber": 345
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 134
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 33
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "128184828710349948956419598546151010",
+                  "time": 61907
+              },
+              "beforeStep": {
+                  "point": "128184828710333179713135091956885085",
+                  "time": 61893
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.waitFor"
+          },
+          "error": null,
+          "id": "pw:api@1241",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "verifyExpectedCount",
+                  "lineNumber": 369
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "verifyEvaluationResult",
+                  "lineNumber": 354
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 134
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 33
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "128184828710351150300627398880700004",
+                  "time": 61931
+              },
+              "beforeStep": {
+                  "point": "128184828710351128395118811350607459",
+                  "time": 61910
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@1244",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 72,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "clearConsoleEvaluations",
+                  "lineNumber": 45
+              },
+              {
+                  "columnNumber": 11,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 136
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 33
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "128833865817723810919624205349725868",
+                  "time": 62090
+              },
+              "beforeStep": {
+                  "point": "128184828710352283622466427411277413",
+                  "time": 61934
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@1247",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 54,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 47
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "clearConsoleEvaluations",
+                  "lineNumber": 47
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 136
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 33
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "128833865817724913112582609495434926",
+                  "time": 62115
+              },
+              "beforeStep": {
+                  "point": "128833865817724905042132077247506093",
+                  "time": 62092
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@1251",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 63,
+                  "fileName": "helpers/console-panel.ts",
+                  "lineNumber": 47
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "128833865817724921183033141743363759",
+                  "time": 62120
+              },
+              "beforeStep": {
+                  "point": "128833865817724921183033141743363759",
+                  "time": 62120
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@1254",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 170
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 164
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 34
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "128833865817724948853149252307691187",
+                  "time": 62154
+              },
+              "beforeStep": {
+                  "point": "128833865817724940782698720059762354",
+                  "time": 62146
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@1256",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "openPauseInformationPanel",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 172
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 164
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 34
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "129158384371384490455027363149293237",
+                  "time": 62178
+              },
+              "beforeStep": {
+                  "point": "129158384371384482384576830901364404",
+                  "time": 62161
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isEnabled"
+          },
+          "error": null,
+          "id": "pw:api@1259",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 175
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 164
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 34
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "129158384371385744833624375398803127",
+                  "time": 62195
+              },
+              "beforeStep": {
+                  "point": "129158384371385736763173843150874294",
+                  "time": 62183
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@1262",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "clickCommandBarButton",
+                  "lineNumber": 176
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 164
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 34
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "130131940032869210907695954077461139",
+                  "time": 62725
+              },
+              "beforeStep": {
+                  "point": "129158384371386851638268797971900088",
+                  "time": 62200
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@1265",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 284
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 166
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 34
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "130131940032869232813204541607553686",
+                  "time": 62761
+              },
+              "beforeStep": {
+                  "point": "130131940032869224742754009359624853",
+                  "time": 62739
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@1268",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "openPauseInformationPanel",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 290
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 166
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 34
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "130131940032870347688299496428579480",
+                  "time": 62796
+              },
+              "beforeStep": {
+                  "point": "130131940032870339617848964180650647",
+                  "time": 62778
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@1271",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 166
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 34
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "130456458586531286631041190768716443",
+                  "time": 62849
+              },
+              "beforeStep": {
+                  "point": "130131940032872843763356970252282521",
+                  "time": 62807
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@1271",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 21,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 301
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 292
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 166
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 34
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "130456458586531286631041190768716443",
+                  "time": 62849
+              },
+              "beforeStep": {
+                  "point": "130131940032872843763356970252282521",
+                  "time": 62807
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@1278",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 304
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "130456458586531302771942255264574109",
+                  "time": 62860
+              },
+              "beforeStep": {
+                  "point": "130456458586531302771942255264574109",
+                  "time": 62860
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@1280",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 25,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "timeout",
+                  "lineNumber": 305
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "130456458586531310842392787512502942",
+                  "time": 62862
+              },
+              "beforeStep": {
+                  "point": "130456458586531310842392787512502942",
+                  "time": 62862
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.waitFor"
+          },
+          "error": null,
+          "id": "pw:api@1283",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "getCurrentCallStackFrameInfo",
+                  "lineNumber": 75
+              },
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 312
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 311
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 166
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 34
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "130456458586533623602931028847536800",
+                  "time": 62912
+              },
+              "beforeStep": {
+                  "point": "130456458586533607462029964351679135",
+                  "time": 62894
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@1285",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 39,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "getCurrentCallStackFrameInfo",
+                  "lineNumber": 79
+              },
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 312
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 311
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 166
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 34
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "130456458586534871063999013455964834",
+                  "time": 62942
+              },
+              "beforeStep": {
+                  "point": "130456458586534862993548481208036001",
+                  "time": 62927
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@1288",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 43,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "getCurrentCallStackFrameInfo",
+                  "lineNumber": 80
+              },
+              {
+                  "columnNumber": 30,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 312
+              },
+              {
+                  "columnNumber": 7,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "waitForPaused",
+                  "lineNumber": 311
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "functionName": "resumeToLine",
+                  "lineNumber": 166
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 34
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "130780977140194545251850154084969124",
+                  "time": 62980
+              },
+              "beforeStep": {
+                  "point": "130780977140194537181399621837040291",
+                  "time": 62962
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@1292",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 26,
+                  "fileName": "helpers/pause-information-panel.ts",
+                  "lineNumber": 313
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "130780977140194553322300686332897957",
+                  "time": 62984
+              },
+              "beforeStep": {
+                  "point": "130780977140194553322300686332897957",
+                  "time": 62984
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@1295",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 110
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 35
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "131105495693879829285083126605851313",
+                  "time": 63150
+              },
+              "beforeStep": {
+                  "point": "131105495693879821214632594357922480",
+                  "time": 63149
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@1297",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 62,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "openConsolePanel",
+                  "lineNumber": 239
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 116
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 35
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "131754532801216025302732227718720188",
+                  "time": 63313
+              },
+              "beforeStep": {
+                  "point": "131105495693880936089727549178948274",
+                  "time": 63153
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.waitFor"
+          },
+          "error": null,
+          "id": "pw:api@1300",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 52,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 121
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 35
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "131754532801217464148769977063746238",
+                  "time": 63328
+              },
+              "beforeStep": {
+                  "point": "131754532801217448007868912567888573",
+                  "time": 63319
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.focus"
+          },
+          "error": null,
+          "id": "pw:api@1303",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 14,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "focus",
+                  "lineNumber": 23
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "clearText",
+                  "lineNumber": 6
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 65
+              },
+              {
+                  "columnNumber": 20,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 35
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "132079051354880326164581355624639169",
+                  "time": 63392
+              },
+              "beforeStep": {
+                  "point": "131754532801218587094315464132700863",
+                  "time": 63338
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@1306",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 24,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "clearText",
+                  "lineNumber": 12
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 65
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 35
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "132079051354881466403949411796298435",
+                  "time": 63408
+              },
+              "beforeStep": {
+                  "point": "132079051354881458333498879548369602",
+                  "time": 63406
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.type"
+          },
+          "error": null,
+          "id": "pw:api@1309",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 15,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 68
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 35
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "133701644123657220633088644427593617",
+                  "time": 65401
+              },
+              "beforeStep": {
+                  "point": "132079051354882589349494898865253060",
+                  "time": 63429
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@1313",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 35,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 43
+              },
+              {
+                  "columnNumber": 11,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 35
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "134350681230975289265920812085458836",
+                  "time": 65606
+              },
+              "beforeStep": {
+                  "point": "134350681230975281195470279837530003",
+                  "time": 65599
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.isVisible"
+          },
+          "error": null,
+          "id": "pw:api@1315",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 18,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "hideTypeAheadSuggestions",
+                  "lineNumber": 29
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 45
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 35
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "134350681230976477927992061744691094",
+                  "time": 65626
+              },
+              "beforeStep": {
+                  "point": "134350681230976469857541529496762261",
+                  "time": 65609
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.press"
+          },
+          "error": null,
+          "id": "pw:api@1318",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 17,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "hideTypeAheadSuggestions",
+                  "lineNumber": 31
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 45
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 35
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "134350681230991553529586300875749349",
+                  "time": 65677
+              },
+              "beforeStep": {
+                  "point": "134350681230977674660513843651852183",
+                  "time": 65632
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@1321",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 51
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 35
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "134675199784651126260345036102219751",
+                  "time": 65703
+              },
+              "beforeStep": {
+                  "point": "134350681230992691463111347833714662",
+                  "time": 65686
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.press"
+          },
+          "error": null,
+          "id": "pw:api@1325",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 17,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 54
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 35
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "135324236892058103587926465371486219",
+                  "time": 65965
+              },
+              "beforeStep": {
+                  "point": "134675199784652254970498046205409256",
+                  "time": 65798
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.textContent"
+          },
+          "error": null,
+          "id": "pw:api@1327",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 23,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "submitCurrentText",
+                  "lineNumber": 51
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/lexical.ts",
+                  "functionName": "type",
+                  "lineNumber": 72
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeTerminalExpression",
+                  "lineNumber": 123
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 133
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 35
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "135648755445736849403306812463167526",
+                  "time": 66055
+              },
+              "beforeStep": {
+                  "point": "135324236892059235756843989295216652",
+                  "time": 65987
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "page.evaluate"
+          },
+          "error": null,
+          "id": "pw:api@1330",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "debugPrint",
+                  "lineNumber": 33
+              },
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "verifyEvaluationResult",
+                  "lineNumber": 345
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 134
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 35
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "135648755445754772721017430506256429",
+                  "time": 66089
+              },
+              "beforeStep": {
+                  "point": "135648755445736863238364867745331240",
+                  "time": 66075
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.waitFor"
+          },
+          "error": null,
+          "id": "pw:api@1333",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 19,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "verifyExpectedCount",
+                  "lineNumber": 369
+              },
+              {
+                  "columnNumber": 9,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "verifyEvaluationResult",
+                  "lineNumber": 354
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 134
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 35
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "135648755445755974065225230840805423",
+                  "time": 66118
+              },
+              "beforeStep": {
+                  "point": "135648755445755952159716643310712878",
+                  "time": 66099
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.click"
+          },
+          "error": null,
+          "id": "pw:api@1336",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 72,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "clearConsoleEvaluations",
+                  "lineNumber": 45
+              },
+              {
+                  "columnNumber": 11,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 136
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 35
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "135973273999470266756435616238450807",
+                  "time": 66231
+              },
+              "beforeStep": {
+                  "point": "135648755445757107387064259371382832",
+                  "time": 66123
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "command",
+          "command": {
+              "name": "locator.count"
+          },
+          "error": null,
+          "id": "pw:api@1339",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 54,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "callback",
+                  "lineNumber": 47
+              },
+              {
+                  "columnNumber": 13,
+                  "fileName": "helpers/utils.ts",
+                  "functionName": "waitFor",
+                  "lineNumber": 148
+              },
+              {
+                  "columnNumber": 16,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "clearConsoleEvaluations",
+                  "lineNumber": 47
+              },
+              {
+                  "columnNumber": 5,
+                  "fileName": "helpers/console-panel.ts",
+                  "functionName": "executeAndVerifyTerminalExpression",
+                  "lineNumber": 136
+              },
+              {
+                  "columnNumber": 3,
+                  "fileName": "tests/breakpoints-01.test.ts",
+                  "lineNumber": 35
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "136297792553129795676177176404736121",
+                  "time": 66260
+              },
+              "beforeStep": {
+                  "point": "136297792553129787605726644156807288",
+                  "time": 66254
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  },
+  {
+      "data": {
+          "category": "assertion",
+          "command": {
+              "name": "expect"
+          },
+          "error": null,
+          "id": "expect@1343",
+          "parentId": null,
+          "resultVariable": null,
+          "scope": [],
+          "testSourceCallStack": [
+              {
+                  "columnNumber": 63,
+                  "fileName": "helpers/console-panel.ts",
+                  "lineNumber": 47
+              }
+          ],
+          "timeStampedPoints": {
+              "afterStep": {
+                  "point": "136297792553129803746627708652664954",
+                  "time": 66261
+              },
+              "beforeStep": {
+                  "point": "136297792553129803746627708652664954",
+                  "time": 66261
+              },
+              "result": null,
+              "viewSource": null
+          }
+      },
+      "type": "user-action"
+  }
+]

--- a/packages/shared/test-suites/__tests__/playwrightStepsParsing.test.ts
+++ b/packages/shared/test-suites/__tests__/playwrightStepsParsing.test.ts
@@ -1,0 +1,182 @@
+import util from "util";
+import groupBy from "lodash/groupBy";
+
+import type { RecordingTestMetadataV3, TestEvent } from "../RecordingTestMetadata";
+import { groupTestStepsByCallStack, isFunctionTestEvent } from "../RecordingTestMetadata";
+
+const playwrightSteps: RecordingTestMetadataV3.TestEvent[] = require("./playwrightSteps.fixture.json");
+
+export function inspectDeep(value: any, depth = 25) {
+  return util.inspect(value, {
+    depth,
+    colors: true,
+    maxArrayLength: null,
+    maxStringLength: Infinity,
+    breakLength: 120,
+  });
+}
+
+describe("groupTestStepsByCallStack", () => {
+  test("groups steps by call stack", () => {
+    const firstSteps = playwrightSteps.slice(0, 25);
+    const groupedSteps = groupTestStepsByCallStack(firstSteps);
+    console.log("Grouped test events: ", inspectDeep(groupedSteps));
+    //  console.log("Grouped steps: ", inspectDeep(groupedSteps));
+    // const strings: string[] = [];
+
+    const entriesWithStacks: EntryWithStack[] = firstSteps.map(step => {
+      const stack = "testSourceCallStack" in step.data ? step.data.testSourceCallStack ?? [] : [];
+      stack.reverse();
+      return {
+        event: step,
+        stack,
+      };
+    });
+
+    // console.log(inspectDeep(entriesWithStacks, 4));
+
+    const groupedSteps2 = recursiveGroupByStack(entriesWithStacks);
+    // console.log("Grouped steps2: ", inspectDeep(groupedSteps2));
+
+    // const initialGroupedSteps = groupBy(firstSteps, step => {
+    //   return getEntryKey(step);
+    // });
+
+    // console.log("Initial grouped steps: ", inspectDeep(initialGroupedSteps));
+
+    // for (const step of firstSteps) {
+    //   if ("testSourceCallStack" in step.data) {
+    //     const testSourceCallStack = step.data.testSourceCallStack ?? [];
+    //     if (testSourceCallStack.length > 0) {
+    //       const [lastEntry] = testSourceCallStack.slice().reverse().slice(-1);
+    //       const { fileName, functionName, lineNumber, columnNumber } = lastEntry;
+    //       const key = `${fileName}:${functionName}:${lineNumber}:${columnNumber}`;
+    //       const numSteps = testSourceCallStack.length;
+    //       const paddedText = key.padStart(key.length + numSteps * 2, " ");
+    //       // console.log(paddedText);
+    //       strings.push(paddedText);
+    //     }
+    //   }
+    // }
+
+    // console.log("Output: \n", strings.join("\n"));
+  });
+});
+
+interface EntryWithStack {
+  event: RecordingTestMetadataV3.TestEvent;
+  stack: RecordingTestMetadataV3.UserActionStackEntry[];
+}
+
+const getStack = (step: RecordingTestMetadataV3.TestEvent) => {
+  const stack = "testSourceCallStack" in step.data ? step.data.testSourceCallStack ?? [] : [];
+  return stack;
+};
+
+const getEntryKey = (step: RecordingTestMetadataV3.TestEvent): string => {
+  const stack = getStack(step);
+  const [nextFrame, ...remainingFrames] = stack;
+  const key = nextFrame
+    ? `${nextFrame.fileName}:${nextFrame.functionName}:${nextFrame.lineNumber}`
+    : "";
+  return key;
+};
+
+export function recursiveGroupByStack(data: EntryWithStack[]) {
+  const obj: Record<string, EntryWithStack[]> = {} as any;
+
+  // if (groupers.length === 0) {
+  //   if (leafItemTransformer) {
+  //     if (leafItemTransformer instanceof Function) {
+  //       return leafItemTransformer(data);
+  //     } else {
+  //       return data.map(x => x[leafItemTransformer]);
+  //     }
+  //   }
+
+  //   return data;
+  // }
+
+  // const grouper = groupers[0];
+
+  for (const item of data) {
+    // const value: V = item[grouper] as V;
+    const [nextFrame, ...remainingFrames] = item.stack;
+    const key = nextFrame
+      ? `${nextFrame.fileName}:${nextFrame.functionName}:${nextFrame.lineNumber}`
+      : "";
+
+    if (!obj[key]) {
+      obj[key] = [];
+    }
+
+    obj[key].push({
+      event: item.event,
+      stack: remainingFrames,
+    });
+  }
+
+  type GroupedObj = Record<string, Record<string, EntryWithStack[]>>; // TODO if last grouper, then only 1-level deep record.
+  const groupedObj: GroupedObj = {} as GroupedObj; // TODO TS
+
+  // const nextGroupers: K[] = groupers.slice(1);
+
+  for (const [group, subvalues] of Object.entries(obj)) {
+    // const group = entry[0] as V; // TODO TS - should infer automatically.
+    // const subvalues: T[] = entry[1] as T[]; // TODO TS - should infer automatically.
+    const subvaluesWithRemainingStacks = subvalues.filter(x => x.stack.length > 0);
+
+    const subgrouped = recursiveGroupByStack(subvaluesWithRemainingStacks);
+    groupedObj[group] = subgrouped as any; // TODO TS FIXME
+  }
+
+  return groupedObj;
+}
+
+export function recursiveGroupByOriginal<
+  T,
+  K extends keyof T,
+  V extends T[K] & (string | number | symbol),
+  U = unknown
+>(data: T[], groupers: K[], leafItemTransformer?: K | ((leafs: T[]) => U)) {
+  const obj: Record<V, T[]> = {} as any;
+
+  if (groupers.length === 0) {
+    if (leafItemTransformer) {
+      if (leafItemTransformer instanceof Function) {
+        return leafItemTransformer(data);
+      } else {
+        return data.map(x => x[leafItemTransformer]);
+      }
+    }
+
+    return data;
+  }
+
+  const grouper = groupers[0];
+
+  for (const item of data) {
+    const value: V = item[grouper] as V;
+
+    if (!obj[value]) {
+      obj[value] = [];
+    }
+
+    obj[value].push(item);
+  }
+
+  type GroupedObj = Record<V, Record<V, T[]>>; // TODO if last grouper, then only 1-level deep record.
+  const groupedObj: GroupedObj = {} as GroupedObj; // TODO TS
+
+  const nextGroupers: K[] = groupers.slice(1);
+
+  for (const entry of Object.entries(obj)) {
+    const group: V = entry[0] as V; // TODO TS - should infer automatically.
+    const subvalues: T[] = entry[1] as T[]; // TODO TS - should infer automatically.
+
+    const subgrouped = recursiveGroupByOriginal(subvalues, nextGroupers, leafItemTransformer);
+    groupedObj[group] = subgrouped as any; // TODO TS FIXME
+  }
+
+  return groupedObj;
+}

--- a/src/ui/components/TestSuite/views/TestRecording/Panel.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/Panel.tsx
@@ -102,11 +102,11 @@ export default function Panel() {
 
   const { beforeAll, beforeEach, main, afterEach, afterAll } = testRecording.events;
   const testSections: TestSectionEntryWithEvents[] = [
-    { name: "beforeAll", title: "before all", events: beforeAll },
-    { name: "beforeEach", title: "before each", events: beforeEach },
-    { name: "main", title: "test body", events: main },
-    { name: "afterEach", title: "after each", events: afterEach },
-    { name: "afterAll", title: "after all", events: afterAll },
+    { id: "beforeAll", name: "beforeAll", title: "before all", events: beforeAll },
+    { id: "beforeEach", name: "beforeEach", title: "before each", events: beforeEach },
+    { id: "main", name: "main", title: "test body", events: main },
+    { id: "afterEach", name: "afterEach", title: "after each", events: afterEach },
+    { id: "afterAll", name: "afterAll", title: "after all", events: afterAll },
   ];
   // const testSections: [testSectionName: TestSectionName, title: string, testEvents: TestEvent[]][] =
   //   [

--- a/src/ui/components/TestSuite/views/TestRecording/TestEventsList.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestEventsList.tsx
@@ -9,8 +9,8 @@ import {
 } from "shared/test-suites/RecordingTestMetadata";
 
 import { TestListData } from "./TestListData";
-import { ITEM_SIZE, TestListItem, TestListItemData } from "./TestListItem";
-import { Metadata, TestEventItem, TestSectionEntryWithEvents } from "./types";
+import { ITEM_SIZE, TestListItemData, TestListItemRenderer } from "./TestListItem";
+import { Metadata, TestListDisplayItem, TestSectionEntryWithEvents } from "./types";
 
 export function TestEventsList({
   height,
@@ -23,7 +23,11 @@ export function TestEventsList({
   testSections: TestSectionEntryWithEvents[];
   testRunnerName: TestRunnerName | null;
 }) {
-  const testListData = useMemo(() => new TestListData(testSections), [testSections]);
+  const testListData = useMemo(() => {
+    const testListData = new TestListData(testSections);
+    console.log("Test list data: ", testListData);
+    return testListData;
+  }, [testSections]);
 
   const itemData = useMemo<TestListItemData>(
     () => ({
@@ -38,7 +42,7 @@ export function TestEventsList({
       fallbackForEmptyList={noContentFallback}
       height={height}
       itemData={itemData}
-      itemRendererComponent={TestListItem}
+      itemRendererComponent={TestListItemRenderer}
       itemSize={ITEM_SIZE}
       listData={testListData}
       width="100%"

--- a/src/ui/components/TestSuite/views/TestRecording/TestEventsList.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestEventsList.tsx
@@ -1,0 +1,47 @@
+import { ReactElement, useMemo, useState } from "react";
+
+import { RulesListData } from "devtools/client/inspector/markup/components/rules/RulesListData";
+import { GenericList } from "replay-next/components/windowing/GenericList";
+import {
+  TestEvent,
+  TestRunnerName,
+  TestSectionName,
+} from "shared/test-suites/RecordingTestMetadata";
+
+import { TestListData } from "./TestListData";
+import { ITEM_SIZE, TestListItem, TestListItemData } from "./TestListItem";
+import { Metadata, TestEventItem, TestSectionEntryWithEvents } from "./types";
+
+export function TestEventsList({
+  height,
+  noContentFallback,
+  testSections,
+  testRunnerName,
+}: {
+  height: number;
+  noContentFallback: ReactElement;
+  testSections: TestSectionEntryWithEvents[];
+  testRunnerName: TestRunnerName | null;
+}) {
+  const testListData = useMemo(() => new TestListData(testSections), [testSections]);
+
+  const itemData = useMemo<TestListItemData>(
+    () => ({
+      testRunnerName,
+    }),
+    [testRunnerName]
+  );
+
+  return (
+    <GenericList
+      dataTestId="TestEventsList"
+      fallbackForEmptyList={noContentFallback}
+      height={height}
+      itemData={itemData}
+      itemRendererComponent={TestListItem}
+      itemSize={ITEM_SIZE}
+      listData={testListData}
+      width="100%"
+    />
+  );
+}

--- a/src/ui/components/TestSuite/views/TestRecording/TestListData.ts
+++ b/src/ui/components/TestSuite/views/TestRecording/TestListData.ts
@@ -1,0 +1,60 @@
+import { GenericListData } from "replay-next/components/windowing/GenericListData";
+import {
+  GroupedTestCases,
+  TestEvent,
+  TestSectionName,
+} from "shared/test-suites/RecordingTestMetadata";
+
+import {
+  Metadata,
+  TestEventItem,
+  TestEventWithSectionName,
+  TestSectionEntry,
+  TestSectionEntryWithEvents,
+} from "./types";
+
+type TestListItemEntry = TestEventWithSectionName | TestSectionEntry;
+
+export class TestListData extends GenericListData<TestEventItem> {
+  private _testListItems: TestListItemEntry[];
+
+  constructor(testSections: TestSectionEntryWithEvents[]) {
+    super();
+
+    this._testListItems = testSections
+      .map(testSection => {
+        if (testSection.events.length === 0) {
+          return null;
+        }
+        const { name, title } = testSection;
+        return [
+          { name, title },
+          ...testSection.events.map(event => ({
+            testSectionName: name,
+            event,
+          })),
+        ];
+      })
+      .filter(Boolean)
+      .flat();
+  }
+
+  protected getItemCountImplementation(): number {
+    return this._testListItems.length;
+  }
+
+  getItemAtIndexImplementation(index: number): TestEventItem {
+    if (index < 0 || index >= this.getItemCount()) {
+      throw new Error("Invalid index");
+    }
+
+    const testItem = this._testListItems[index];
+    return {
+      depth: 0,
+      item: testItem,
+      id: "event" in testItem ? testItem.event.id : testItem.name,
+      isExpanded: false,
+      isTail: false,
+    };
+  }
+}

--- a/src/ui/components/TestSuite/views/TestRecording/TestListData.ts
+++ b/src/ui/components/TestSuite/views/TestRecording/TestListData.ts
@@ -1,22 +1,55 @@
+import { assert } from "protocol/utils";
 import { GenericListData } from "replay-next/components/windowing/GenericListData";
 import {
   GroupedTestCases,
   TestEvent,
   TestSectionName,
+  isFunctionTestEvent,
 } from "shared/test-suites/RecordingTestMetadata";
 
 import {
   Metadata,
-  TestEventItem,
   TestEventWithSectionName,
+  TestListDisplayItem,
+  TestListItem,
   TestSectionEntry,
   TestSectionEntryWithEvents,
+  isTestEventWithName,
+  isTestSectionEntry,
 } from "./types";
 
-type TestListItemEntry = TestEventWithSectionName | TestSectionEntry;
+const testEventToEventEntry = (
+  testEvent: TestEvent,
+  testSectionName: TestSectionName
+): TestEventWithSectionName => {
+  return {
+    id: testEvent.id,
+    testSectionName,
+    event: testEvent,
+  };
+};
 
-export class TestListData extends GenericListData<TestEventItem> {
-  private _testListItems: TestListItemEntry[];
+function getItemWeight(metadata: Metadata): number {
+  // Note that it's important to use subTreeWeight
+  // because childNode may contained nodes that aren't displayed
+  const { isExpanded, subTreeWeight, hasChildren } = metadata;
+
+  if (hasChildren) {
+    if (isExpanded) {
+      return subTreeWeight + 1;
+    } else {
+      return 1;
+    }
+  } else {
+    return 1;
+  }
+}
+
+export class TestListData extends GenericListData<TestListDisplayItem> {
+  private _testListItems: TestListItem[];
+  private _idToMutableMetadataMap: Map<string, Metadata> = new Map();
+  private _idToTestListItemEntryMap: Map<string, TestListItem> = new Map();
+  private _rootIds: Set<string> = new Set();
 
   constructor(testSections: TestSectionEntryWithEvents[]) {
     super();
@@ -28,33 +61,99 @@ export class TestListData extends GenericListData<TestEventItem> {
         }
         const { name, title } = testSection;
         return [
-          { name, title },
-          ...testSection.events.map(event => ({
-            testSectionName: name,
-            event,
-          })),
+          { id: name, name, title },
+          ...testSection.events.map(testEvent => testEventToEventEntry(testEvent, name)),
         ];
       })
       .filter(Boolean)
       .flat();
+
+    for (const item of this._testListItems) {
+      this._rootIds.add(item.id);
+      this._idToTestListItemEntryMap.set(item.id, item);
+    }
+
+    this._addNestedTestEvents(null, this._testListItems, 0);
+
+    this._calculateSubTreeWeights();
+  }
+
+  private _addNestedTestEvents(
+    parentId: string | null,
+    testListItems: TestListItem[],
+    depth: number
+  ) {
+    let parentMetadata: Metadata | undefined;
+    if (parentId !== null) {
+      this._idToMutableMetadataMap.get(parentId);
+    }
+
+    for (const testListItem of testListItems) {
+      const id = testListItem.id;
+      const metadata: Metadata = {
+        id,
+        parentId,
+        childrenCanBeRendered: true,
+        hasChildren: false,
+        depth,
+        item: testListItem,
+        isExpanded: false,
+        subTreeWeight: 0,
+      };
+
+      this._idToMutableMetadataMap.set(id, metadata);
+
+      if (isTestEventWithName(testListItem) && isFunctionTestEvent(testListItem.event)) {
+        const childEvents = testListItem.event.data.events;
+        if (childEvents.length > 0) {
+          metadata.hasChildren = true;
+
+          const testItemEntries = childEvents.map(childEvent =>
+            testEventToEventEntry(childEvent, testListItem.testSectionName)
+          );
+          for (const testItemEntry of testItemEntries) {
+            this._idToTestListItemEntryMap.set(testItemEntry.id, testItemEntry);
+          }
+
+          this._addNestedTestEvents(id, testItemEntries, depth + 1);
+        }
+      }
+    }
+  }
+
+  private _calculateSubTreeWeights() {
+    const leafNodes = [...this._idToMutableMetadataMap.values()].filter(
+      metadata => !metadata.hasChildren
+    );
+
+    for (const leafNode of leafNodes) {
+      let parentId: string | null = leafNode.parentId;
+      while (parentId) {
+        const parentMetadata = this._idToMutableMetadataMap.get(parentId);
+        assert(parentMetadata);
+        parentMetadata.subTreeWeight += 1;
+        parentId = parentMetadata.parentId;
+      }
+    }
   }
 
   protected getItemCountImplementation(): number {
     return this._testListItems.length;
   }
 
-  getItemAtIndexImplementation(index: number): TestEventItem {
+  getItemAtIndexImplementation(index: number): TestListDisplayItem {
     if (index < 0 || index >= this.getItemCount()) {
       throw new Error("Invalid index");
     }
 
     const testItem = this._testListItems[index];
     return {
+      id: testItem.id,
+      // TODO Fill in parentId
+      parentId: null,
       depth: 0,
       item: testItem,
-      id: "event" in testItem ? testItem.event.id : testItem.name,
       isExpanded: false,
-      isTail: false,
     };
   }
 }

--- a/src/ui/components/TestSuite/views/TestRecording/TestListItem.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestListItem.tsx
@@ -1,0 +1,81 @@
+import { CSSProperties, Dispatch, Fragment, ReactNode, SetStateAction } from "react";
+
+import { GenericListItemData } from "replay-next/components/windowing/GenericList";
+import {
+  TestEvent,
+  TestRunnerName,
+  TestSectionName,
+} from "shared/test-suites/RecordingTestMetadata";
+
+import { TestSectionRow } from "./TestSectionRow";
+import { TestEventItem, TestSectionEntry, isTestSectionEntry } from "./types";
+import testSectionStyles from "./TestSection.module.css";
+
+export const ITEM_SIZE = 32;
+
+export type TestListItemData = {
+  testRunnerName: TestRunnerName | null;
+};
+
+export function TestListItem({
+  data,
+  index,
+  style,
+}: {
+  data: GenericListItemData<TestEventItem, TestListItemData>;
+  index: number;
+  style: CSSProperties;
+}) {
+  const { itemData, listData } = data;
+  const { testRunnerName } = itemData;
+
+  const selectedIndex = listData.getSelectedIndex();
+  const listItem = listData.getItemAtIndex(index);
+  const { depth, item, id, isExpanded, isTail } = listItem;
+
+  let content: React.ReactNode = null;
+
+  if (isTestSectionEntry(item)) {
+    content = <TestSectionHeaderRenderer testSectionEntry={item} />;
+  } else {
+    const { event, testSectionName } = item;
+    content = (
+      <TestSectionRow
+        testEvent={event}
+        testRunnerName={testRunnerName}
+        testSectionName={testSectionName}
+      />
+    );
+  }
+
+  return (
+    <>
+      <div
+        data-list-index={index}
+        data-selected={index === selectedIndex || undefined}
+        data-test-name="ElementsListItem"
+        style={
+          {
+            ...style,
+            width: undefined,
+            "--data-depth": depth != null ? `${depth}rem` : undefined,
+          } as CSSProperties
+        }
+      >
+        {content}
+      </div>
+    </>
+  );
+}
+
+export function TestSectionHeaderRenderer({
+  testSectionEntry,
+}: {
+  testSectionEntry: TestSectionEntry;
+}) {
+  return (
+    <div className={testSectionStyles.Title} data-test-name="TestSection">
+      {testSectionEntry.title}
+    </div>
+  );
+}

--- a/src/ui/components/TestSuite/views/TestRecording/TestListItem.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestListItem.tsx
@@ -59,6 +59,7 @@ export function TestListItemRenderer({
             ...style,
             width: undefined,
             "--data-depth": depth != null ? `${depth}rem` : undefined,
+            paddingLeft: depth != null ? `${depth}rem` : undefined,
           } as CSSProperties
         }
       >

--- a/src/ui/components/TestSuite/views/TestRecording/TestListItem.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestListItem.tsx
@@ -8,7 +8,7 @@ import {
 } from "shared/test-suites/RecordingTestMetadata";
 
 import { TestSectionRow } from "./TestSectionRow";
-import { TestEventItem, TestSectionEntry, isTestSectionEntry } from "./types";
+import { TestListDisplayItem, TestSectionEntry, isTestSectionEntry } from "./types";
 import testSectionStyles from "./TestSection.module.css";
 
 export const ITEM_SIZE = 32;
@@ -17,12 +17,12 @@ export type TestListItemData = {
   testRunnerName: TestRunnerName | null;
 };
 
-export function TestListItem({
+export function TestListItemRenderer({
   data,
   index,
   style,
 }: {
-  data: GenericListItemData<TestEventItem, TestListItemData>;
+  data: GenericListItemData<TestListDisplayItem, TestListItemData>;
   index: number;
   style: CSSProperties;
 }) {
@@ -31,7 +31,7 @@ export function TestListItem({
 
   const selectedIndex = listData.getSelectedIndex();
   const listItem = listData.getItemAtIndex(index);
-  const { depth, item, id, isExpanded, isTail } = listItem;
+  const { depth, item, id } = listItem;
 
   let content: React.ReactNode = null;
 

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/HelperFunctionEvent.module.css
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/HelperFunctionEvent.module.css
@@ -1,0 +1,20 @@
+.Row {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  position: relative;
+}
+
+.Text {
+  flex: 1;
+  /* color: var(--color-dim); */
+}
+
+.Name {
+  flex: 0 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-break: break-all;
+  /* color: var(--color-link); */
+}

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/HelperFunctionEventRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/HelperFunctionEventRow.tsx
@@ -28,21 +28,7 @@ export default memo(function HelperFunctionEventRow({
 
   return (
     <div className={styles.Row}>
-      <Expandable
-        children={
-          <>
-            {events.map((testEvent, index) => (
-              <TestSectionRow
-                key={index}
-                testEvent={testEvent}
-                testRunnerName={testRunnerName}
-                testSectionName={testSectionName}
-              />
-            ))}
-          </>
-        }
-        header={<span className={styles.Name}>{formattedName || "Outer function"}</span>}
-      />
+      <span className={styles.Name}>{formattedName || "Outer function"}</span>
     </div>
   );
 });

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/HelperFunctionEventRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/HelperFunctionEventRow.tsx
@@ -1,0 +1,48 @@
+import { memo, useState } from "react";
+
+import Expandable from "replay-next/components/Expandable";
+import { truncateMiddle } from "replay-next/src/utils/string";
+import {
+  RecordingTestMetadataV3,
+  TestRunnerName,
+  TestSectionName,
+} from "shared/test-suites/RecordingTestMetadata";
+
+import { TestSectionRow } from "../TestSectionRow";
+import styles from "./HelperFunctionEvent.module.css";
+
+export default memo(function HelperFunctionEventRow({
+  functionEvent,
+  testRunnerName,
+  testSectionName,
+}: {
+  functionEvent: RecordingTestMetadataV3.FunctionEvent;
+  testRunnerName: TestRunnerName | null;
+  testSectionName: TestSectionName;
+}) {
+  const formattedName = truncateMiddle(
+    `${functionEvent.data.function}:${functionEvent.data.line}`,
+    150
+  );
+  const events = functionEvent.data.events;
+
+  return (
+    <div className={styles.Row}>
+      <Expandable
+        children={
+          <>
+            {events.map((testEvent, index) => (
+              <TestSectionRow
+                key={index}
+                testEvent={testEvent}
+                testRunnerName={testRunnerName}
+                testSectionName={testSectionName}
+              />
+            ))}
+          </>
+        }
+        header={<span className={styles.Name}>{formattedName || "Outer function"}</span>}
+      />
+    </div>
+  );
+});

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
@@ -74,6 +74,7 @@ export default memo(function UserActionEventRow({
   const [isHovered, setIsHovered] = useState(false);
 
   const argsString = useMemo(() => {
+    console.log("Command args: ", command);
     if (command.arguments) {
       return command.arguments.filter(argument => typeof argument === "string").join(" ");
     }

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
@@ -5,6 +5,7 @@ import { Cache, STATUS_PENDING, STATUS_RESOLVED, useImperativeCacheValue } from 
 
 import { getExecutionPoint } from "devtools/client/debugger/src/selectors";
 import Loader from "replay-next/components/Loader";
+import { truncateMiddle } from "replay-next/src/utils/string";
 import { isExecutionPointsWithinRange } from "replay-next/src/utils/time";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import {
@@ -32,6 +33,7 @@ import {
   eventListenersJumpLocationsCache,
 } from "ui/suspense/annotationsCaches";
 
+import { ITEM_SIZE } from "../TestListItem";
 import styles from "./UserActionEventRow.module.css";
 
 const NO_ANNOTATIONS: ParsedJumpToCodeAnnotation[] = [];
@@ -73,12 +75,15 @@ export default memo(function UserActionEventRow({
 
   const [isHovered, setIsHovered] = useState(false);
 
-  const argsString = useMemo(() => {
-    console.log("Command args: ", command);
+  const [fullArgsString, truncatedArgsString] = useMemo(() => {
     if (command.arguments) {
-      return command.arguments.filter(argument => typeof argument === "string").join(" ");
+      const fullArgsString = command.arguments
+        .filter(argument => typeof argument === "string")
+        .join(" ");
+      const truncatedArgsString = truncateMiddle(fullArgsString, 40);
+      return [fullArgsString, truncatedArgsString];
     }
-    return "";
+    return ["", ""];
   }, [command.arguments]);
 
   const { disabled: jumpToTestSourceDisabled, onClick: onClickJumpToTestSource } = useJumpToSource({
@@ -157,6 +162,7 @@ export default memo(function UserActionEventRow({
       onClick={jumpToTestSourceDisabled ? undefined : onClickJumpToTestSource}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
+      style={{ maxHeight: ITEM_SIZE }}
     >
       <div className={styles.Text}>
         {eventNumber != null ? <span className={styles.Number}>{eventNumber}</span> : null}
@@ -167,8 +173,8 @@ export default memo(function UserActionEventRow({
         >
           {command.name}
         </span>{" "}
-        <span className={`${styles.Args} ${styles.Args}`} title={argsString}>
-          {argsString}
+        <span className={`${styles.Args} ${styles.Args}`} title={fullArgsString}>
+          {truncatedArgsString}
         </span>
       </div>
       {showBadge && (

--- a/src/ui/components/TestSuite/views/TestRecording/TestSection.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestSection.tsx
@@ -1,5 +1,6 @@
 import assert from "assert";
 import { useContext } from "react";
+import AutoSizer from "react-virtualized-auto-sizer";
 
 import { SessionContext } from "replay-next/src/contexts/SessionContext";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
@@ -7,6 +8,7 @@ import { TestEvent, TestSectionName } from "shared/test-suites/RecordingTestMeta
 import { TestSuiteCache } from "ui/components/TestSuite/suspense/TestSuiteCache";
 import { TestSectionRow } from "ui/components/TestSuite/views/TestRecording/TestSectionRow";
 
+import { TestEventsList } from "./TestEventsList";
 import styles from "./TestSection.module.css";
 
 export default function TestSection({
@@ -33,14 +35,23 @@ export default function TestSection({
       <div className={styles.Title} data-test-name="TestSection">
         {title}
       </div>
-      {testEvents.map((testEvent, index) => (
+      {/* <AutoSizer disableWidth>
+        {({ height }: { height: number }) => (
+          <TestEventsList
+            height={height - 32}
+            noContentFallback={<div>Loading...</div>}
+            events={testEvents}
+          />
+        )}
+      </AutoSizer> */}
+      {/* {testEvents.map((testEvent, index) => (
         <TestSectionRow
           key={index}
           testEvent={testEvent}
           testRunnerName={groupedTestCases.environment.testRunner?.name ?? null}
           testSectionName={testSectionName}
         />
-      ))}
+      ))} */}
     </>
   );
 }

--- a/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
@@ -29,6 +29,7 @@ import { useAppDispatch } from "ui/setup/hooks";
 
 import { testEventDomNodeCache } from "../../suspense/TestEventDetailsCache";
 import { TestEventsList } from "./TestEventsList";
+import { ITEM_SIZE } from "./TestListItem";
 import HelperFunctionEventRow from "./TestRecordingEvents/HelperFunctionEventRow";
 import NavigationEventRow from "./TestRecordingEvents/NavigationEventRow";
 import NetworkRequestEventRow from "./TestRecordingEvents/NetworkRequestEventRow";
@@ -235,6 +236,7 @@ export function TestSectionRow({
       onContextMenu={onContextMenu}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
+      style={{ maxHeight: ITEM_SIZE }}
     >
       {child}
 

--- a/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
@@ -28,6 +28,7 @@ import { TestSuiteContext } from "ui/components/TestSuite/views/TestSuiteContext
 import { useAppDispatch } from "ui/setup/hooks";
 
 import { testEventDomNodeCache } from "../../suspense/TestEventDetailsCache";
+import { TestEventsList } from "./TestEventsList";
 import HelperFunctionEventRow from "./TestRecordingEvents/HelperFunctionEventRow";
 import NavigationEventRow from "./TestRecordingEvents/NavigationEventRow";
 import NetworkRequestEventRow from "./TestRecordingEvents/NetworkRequestEventRow";

--- a/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
@@ -28,6 +28,7 @@ import { TestSuiteContext } from "ui/components/TestSuite/views/TestSuiteContext
 import { useAppDispatch } from "ui/setup/hooks";
 
 import { testEventDomNodeCache } from "../../suspense/TestEventDetailsCache";
+import HelperFunctionEventRow from "./TestRecordingEvents/HelperFunctionEventRow";
 import NavigationEventRow from "./TestRecordingEvents/NavigationEventRow";
 import NetworkRequestEventRow from "./TestRecordingEvents/NetworkRequestEventRow";
 import UserActionEventRow from "./TestRecordingEvents/UserActionEventRow";
@@ -109,6 +110,15 @@ export function TestSectionRow({
     case "network-request":
       child = <NetworkRequestEventRow networkRequestEvent={testEvent} />;
       break;
+    case "function":
+      child = (
+        <HelperFunctionEventRow
+          functionEvent={testEvent}
+          testRunnerName={testRunnerName}
+          testSectionName={testSectionName}
+        />
+      );
+      break;
     case "user-action":
       child = (
         <UserActionEventRow
@@ -125,6 +135,10 @@ export function TestSectionRow({
   }
 
   const onClick = async () => {
+    if (testEvent.type === "function") {
+      return false;
+    }
+
     startTransition(() => {
       setTestEvent(testEvent);
     });

--- a/src/ui/components/TestSuite/views/TestRecording/types.ts
+++ b/src/ui/components/TestSuite/views/TestRecording/types.ts
@@ -40,7 +40,7 @@ export type Metadata = {
   id: string;
   parentId: string | null;
   hasChildren: boolean;
-  childrenCanBeRendered: boolean;
+  // childrenCanBeRendered: boolean;
   depth: number;
   item: TestListItem;
   isExpanded: boolean;

--- a/src/ui/components/TestSuite/views/TestRecording/types.ts
+++ b/src/ui/components/TestSuite/views/TestRecording/types.ts
@@ -2,7 +2,10 @@ export type Position = "after" | "before";
 
 import { TestEvent, TestSectionName } from "shared/test-suites/RecordingTestMetadata";
 
+export type TestListItem = TestEventWithSectionName | TestSectionEntry;
+
 export interface TestSectionEntry {
+  id: string;
   name: TestSectionName;
   title: string;
 }
@@ -12,30 +15,34 @@ export interface TestSectionEntryWithEvents extends TestSectionEntry {
 }
 
 export interface TestEventWithSectionName {
+  id: string;
   testSectionName: TestSectionName;
   event: TestEvent;
 }
 
-export const isTestSectionEntry = (
-  item: TestEventWithSectionName | TestSectionEntry
-): item is TestSectionEntry => {
+export const isTestSectionEntry = (item: TestListItem): item is TestSectionEntry => {
   return "name" in item && "title" in item;
 };
 
-export type TestEventItem = {
-  depth: number;
-  item: TestEventWithSectionName | TestSectionEntry;
+export const isTestEventWithName = (item: TestListItem): item is TestEventWithSectionName => {
+  return "event" in item;
+};
+
+export type TestListDisplayItem = {
   id: string;
+  parentId: string | null;
+  depth: number;
+  item: TestListItem;
   isExpanded: boolean;
-  isTail: boolean;
 };
 
 export type Metadata = {
+  id: string;
+  parentId: string | null;
+  hasChildren: boolean;
   childrenCanBeRendered: boolean;
   depth: number;
-  event: Event;
-  hasTail: boolean;
+  item: TestListItem;
   isExpanded: boolean;
-
   subTreeWeight: number;
 };

--- a/src/ui/components/TestSuite/views/TestRecording/types.ts
+++ b/src/ui/components/TestSuite/views/TestRecording/types.ts
@@ -1,1 +1,41 @@
 export type Position = "after" | "before";
+
+import { TestEvent, TestSectionName } from "shared/test-suites/RecordingTestMetadata";
+
+export interface TestSectionEntry {
+  name: TestSectionName;
+  title: string;
+}
+
+export interface TestSectionEntryWithEvents extends TestSectionEntry {
+  events: TestEvent[];
+}
+
+export interface TestEventWithSectionName {
+  testSectionName: TestSectionName;
+  event: TestEvent;
+}
+
+export const isTestSectionEntry = (
+  item: TestEventWithSectionName | TestSectionEntry
+): item is TestSectionEntry => {
+  return "name" in item && "title" in item;
+};
+
+export type TestEventItem = {
+  depth: number;
+  item: TestEventWithSectionName | TestSectionEntry;
+  id: string;
+  isExpanded: boolean;
+  isTail: boolean;
+};
+
+export type Metadata = {
+  childrenCanBeRendered: boolean;
+  depth: number;
+  event: Event;
+  hasTail: boolean;
+  isExpanded: boolean;
+
+  subTreeWeight: number;
+};


### PR DESCRIPTION
This is absolutely WIP and totally not working at all yet, but wanted to push it up just for visibility.

So far:

- grabbed the step data from one of our `breakpoints-01` tests as an example dataset
- Cherry-picked Jason's logic from #9601 and fixed the conflict
- The TS types and data in that PR didn't agree, especially with the `<HelperFunctionEventRow>` component, so I've been fiddling with them
- The recursive logic in #9601 seemed odd, so I'm playing around with alternate implementations. I did some googling for "recursive groupby ts" and found https://unpkg.com/browse/recursive-groupby@0.1.0/recursive-groupby.ts , which seemed like a decent starting point, and I'm hacking up a copy of that.  

The output is sorta getting somewhere, but the logic is clearly missing some pieces atm (including actually saving the test step entries at the right levels):

![image](https://github.com/replayio/devtools/assets/1128784/812469f5-752e-4dd7-bbbf-c269f1d9c111)
