### PR TITLE
Use cache status to show a loading state for the Redux J2C button

### DIFF
--- a/src/ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsListItem.tsx
+++ b/src/ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsListItem.tsx
@@ -1,11 +1,14 @@
-import { CSSProperties } from "react";
+import { CSSProperties, useContext } from "react";
+import { Status, useCacheStatus } from "suspense";
 
 import { getExecutionPoint } from "devtools/client/debugger/src/selectors";
 import { isExecutionPointsGreaterThan } from "replay-next/src/utils/time";
+import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { ReduxActionAnnotation } from "ui/components/SecondaryToolbox/redux-devtools/annotations";
 import { jumpToLocationForReduxDispatch } from "ui/components/SecondaryToolbox/redux-devtools/utils/jumpToLocationForReduxDispatch";
-import { JumpToCodeButton } from "ui/components/shared/JumpToCodeButton";
+import { JumpToCodeButton, JumpToCodeStatus } from "ui/components/shared/JumpToCodeButton";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
+import { reduxDispatchJumpLocationCache } from "ui/suspense/jumpToLocationCache";
 
 import useReduxDevtoolsContextMenu from "./useReduxDevtoolsContextMenu";
 import styles from "./ReduxDevToolsListItem.module.css";
@@ -21,6 +24,19 @@ export type ItemData = {
 
 export type ItemDataWithScroll = ItemData & {
   scrollToPause: () => void;
+};
+
+const suspenseStatusToJ2CStatus: Record<Status, JumpToCodeStatus> = {
+  resolved: "found",
+  pending: "loading",
+  rejected: "no_hits",
+  // Very unintuitive naming here, but the idea is that we haven't actually
+  // fetched a value yet, so it's "not found" in terms of the _cache_ (no entry yet),
+  // However, that means we don't know if there _will be_ a result (and given how
+  // the Redux J2C cache works, there _should_ be a result every time).
+  // So, if there isn't a cache entry, make the button active so we can fetch on click.
+  "not-found": "found",
+  aborted: "no_hits",
 };
 
 export function ReduxDevToolsListItem({
@@ -47,6 +63,16 @@ export function ReduxDevToolsListItem({
 
   const dispatch = useAppDispatch();
   const currentExecutionPoint = useAppSelector(getExecutionPoint);
+  const replayClient = useContext(ReplayClientContext);
+
+  const cacheStatus = useCacheStatus(
+    reduxDispatchJumpLocationCache,
+    replayClient,
+    annotation.point,
+    annotation.time
+  );
+  // Translate the cache status into the "J2C" status for the button
+  const j2cStatus = suspenseStatusToJ2CStatus[cacheStatus];
 
   const onSeek = () => {
     selectAnnotation(annotation);
@@ -79,7 +105,7 @@ export function ReduxDevToolsListItem({
         className={styles.JumpToCodeButton}
         currentExecutionPoint={currentExecutionPoint}
         targetExecutionPoint={annotation.point}
-        status="found"
+        status={j2cStatus}
         onClick={onSeek}
       />
       {annotation.payload.actionType}


### PR DESCRIPTION
This PR:

- Uses the `useCacheStatus` hook from `suspense` to pre-read whether we have a J2C entry cached or loading, and uses that to set the right loading state for the J2C button


Example:

![image](https://github.com/replayio/devtools/assets/1128784/287bbcb6-701a-47ef-a586-515e0909c85f)
