### PR TITLE
Update RDT test assertion 

### DIFF
--- a/packages/e2e-tests/tests/react_devtools-02-integrations.test.ts
+++ b/packages/e2e-tests/tests/react_devtools-02-integrations.test.ts
@@ -115,7 +115,7 @@ test("react_devtools-02: RDT integrations (Chromium)", async ({
     "Root",
     "Head",
     "AppContainer",
-    "z",
+    "Container",
     "Context.Provider",
     "Context.Provider",
     "PathnameContextProviderAdapter",


### PR DESCRIPTION
This PR:

- Updates the `rdt-02` test component names assertion to match the latest routine behavior

Here's the current tree for this test:

![image](https://github.com/replayio/devtools/assets/1128784/69410f71-c077-4755-b2a8-e2bc0e525ade)
