### PR TITLE
Experimental getObjectPreviews fetch

### DIFF
--- a/packages/shared/client/ReplayClient.ts
+++ b/packages/shared/client/ReplayClient.ts
@@ -701,6 +701,20 @@ export class ReplayClient implements ReplayClientInterface {
     return result;
   }
 
+  async getObjectsPreviews(
+    objects: string[],
+    pauseId: PauseId,
+    level: ObjectPreviewLevel
+  ): Promise<PauseData> {
+    const sessionId = this.getSessionIdThrows();
+    const result = await client.Pause.getObjectPreviews(
+      { level, objects },
+      sessionId,
+      pauseId || undefined
+    );
+    return result.data;
+  }
+
   async getObjectWithPreview(
     objectId: ObjectId,
     pauseId: PauseId,


### PR DESCRIPTION
After looking into how `getObjectPreview` and `getObjectPreviews` is implemented, i realized that they both return partially filled PauseData based on what the backend has already received. So from the perspective of the Object Cache, making one call to `getObjectPreviews` and 100 calls to `getObjectPreview` is actually pretty similar wrt to populating the pause cache.

---

So does this work? No. I'm getting the `Method not yet implemented` error which is super strange because the backend clearly has this function.


```
CommandError: Method not yet implemented (request: Pause.getObjectPreviews, {"level":"canOverflow","objects":["2","3"]})
```