### PR TITLE
Add `backend_deprioritizeTraffic` setting and use in E2E tests

### DIFF
--- a/packages/e2e-tests/helpers/index.ts
+++ b/packages/e2e-tests/helpers/index.ts
@@ -99,7 +99,16 @@ export async function startTest(
   const base = process.env.PLAYWRIGHT_TEST_BASE_URL || "http://localhost:8080";
 
   const params = new URLSearchParams();
+
+  // Checked by `isE2ETest()` in `packages/shared/utils/environment.ts`,
+  // to allow `apolloClient.ts` to bail out and avoid accidentally showing
+  // a Next.js error overlay.
   params.append("e2e", "1");
+
+  // Frontend E2E tests generate a lot of computing traffic,
+  // so we tell the backend to deprioritize them to conserve resources.
+  params.append("features", "backend_deprioritizeTraffic");
+
   if (apiKey) {
     params.append("apiKey", apiKey);
   }

--- a/packages/e2e-tests/tests/jump-to-code-01_basic.test.ts
+++ b/packages/e2e-tests/tests/jump-to-code-01_basic.test.ts
@@ -69,7 +69,7 @@ test(`jump-to-code-01: Test basic jumping functionality`, async ({
   const queryParams = new URLSearchParams();
   // Force this test to always re-run the Event Listeners (and other) routines
   // See pref names in packages/shared/user-data/GraphQL/config.ts
-  // queryParams.set("features", "backend_rerunRoutines");
+  queryParams.set("features", "backend_rerunRoutines");
 
   await startTest(page, recordingId, undefined, queryParams);
   await openDevToolsTab(page);

--- a/packages/e2e-tests/tests/react_devtools-04-seeking.test.ts
+++ b/packages/e2e-tests/tests/react_devtools-04-seeking.test.ts
@@ -13,9 +13,9 @@ test.use({ exampleKey: "cra/dist/index_chromium.html" });
 test("react_devtools-04: Component selection is maintained when seeking to a new point", async ({
   pageWithMeta: { page, recordingId },
 }) => {
-  const queryParams = new URLSearchParams();
-
-  await startTest(page, recordingId, undefined, queryParams);
+  // Don't need to re-run the RDT routine for this test,
+  // as it's just checking UI behavior and not operations contents
+  await startTest(page, recordingId, undefined);
   await openDevToolsTab(page);
 
   // Seek to the first console message and check that the initial tree has 3 components

--- a/packages/protocol/socket.ts
+++ b/packages/protocol/socket.ts
@@ -102,6 +102,7 @@ const noCallerStackTracesForFailedCommands = new Set<CommandMethods>([
 
 export type ExperimentalSettings = {
   controllerKey?: string;
+  deprioritizeTraffic?: boolean;
   disableCache?: boolean;
   disableConcurrentControllerLoading?: boolean;
   disableIncrementalSnapshots?: boolean;

--- a/packages/shared/user-data/GraphQL/config.ts
+++ b/packages/shared/user-data/GraphQL/config.ts
@@ -26,6 +26,16 @@ export type ViewMode = "dev" | "non-dev";
 // and to reduce the likelihood of merge conflicts
 
 export const config = {
+  // Won't be displayed in the UI - only used as a query param for E2E tests
+  backend_deprioritizeTraffic: {
+    defaultValue: Boolean(false),
+    description:
+      "Mark this session as low priority, to allow the backend to allocate computing resources effectively",
+    legacyKey: null,
+    highRisk: Boolean(true),
+    internalOnly: Boolean(true),
+    label: "Deprioritize backend compute for this session",
+  },
   backend_disableCache: {
     defaultValue: Boolean(false),
     description: "Disable all caches, should only be used for debugging purposes",

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -178,6 +178,7 @@ export function createSocket(recordingId: string): UIThunkAction {
       }
 
       const experimentalSettings: ExperimentalSettings = {
+        deprioritizeTraffic: userData.get("backend_deprioritizeTraffic"),
         disableScanDataCache: userData.get("backend_disableScanDataCache"),
         disableCache: userData.get("backend_disableCache"),
         listenForMetrics: userData.get("backend_listenForMetrics"),


### PR DESCRIPTION
This PR:

- Adds a new `backend_deprioritizeTraffic` config setting, which is _not_ exposed through the UI
- Updates our `startTest` helper to always add that param, so that the backend knows to handle our E2E test sessions at a lower priority