### PR TITLE
Experiment with auto-batching Pause.getObjectPreviews requests

### DIFF
--- a/packages/shared/client/ReplayClient.ts
+++ b/packages/shared/client/ReplayClient.ts
@@ -75,6 +75,7 @@ import uniqueId from "lodash/uniqueId";
 import { addEventListener, client, initSocket, removeEventListener } from "protocol/socket";
 import { assert, compareNumericStrings, defer, waitForTime } from "protocol/utils";
 import { initProtocolMessagesStore } from "replay-next/components/protocol/ProtocolMessagesStore";
+import { batchedGetObjectPreview } from "shared/client/batchedGetObjectWithPreview";
 import { TOO_MANY_POINTS_TO_FIND } from "shared/constants";
 import { ProtocolError, commandError } from "shared/utils/error";
 import { isPointInRegion, isRangeInRegions } from "shared/utils/time";
@@ -707,12 +708,7 @@ export class ReplayClient implements ReplayClientInterface {
     level?: ObjectPreviewLevel
   ): Promise<PauseData> {
     const sessionId = this.getSessionIdThrows();
-    const result = await client.Pause.getObjectPreview(
-      { level, object: objectId },
-      sessionId,
-      pauseId || undefined
-    );
-    return result.data;
+    return batchedGetObjectPreview(sessionId, objectId, pauseId, level);
   }
 
   async getPointNearTime(time: number): Promise<TimeStampedPoint> {

--- a/packages/shared/client/batchedGetObjectWithPreview.ts
+++ b/packages/shared/client/batchedGetObjectWithPreview.ts
@@ -1,0 +1,103 @@
+import { ObjectId, ObjectPreviewLevel, PauseData, PauseId, SessionId } from "@replayio/protocol";
+import { Deferred, createDeferred } from "suspense";
+
+// eslint-disable-next-line no-restricted-imports
+import { client } from "protocol/socket";
+
+type Request = {
+  objectId: ObjectId;
+  deferred: Deferred<PauseData>;
+};
+
+const BATCH_DELAY_MS = 250;
+
+const queuedRequests: Map<string, Request[]> = new Map();
+
+export async function batchedGetObjectPreview(
+  sessionId: SessionId,
+  objectId: ObjectId,
+  pauseId: PauseId,
+  level?: ObjectPreviewLevel
+): Promise<PauseData> {
+  const deferred = createDeferred<PauseData>(
+    `getObjectPreview: (objectId: ${objectId}, pauseId: ${pauseId}, level: ${level})`
+  );
+
+  batchRequestsForPauseAndLevel(sessionId, objectId, pauseId, level, deferred);
+
+  return deferred.promise;
+}
+
+async function getObjectPreviews(
+  sessionId: SessionId,
+  pauseId: PauseId,
+  level: ObjectPreviewLevel | undefined,
+  requests: Request[]
+): Promise<void> {
+  const objectIds: ObjectId[] = [];
+  const objectIdToDeferred = new Map<ObjectId, Deferred<PauseData>>();
+
+  requests.forEach(({ deferred, objectId }) => {
+    objectIds.push(objectId);
+    objectIdToDeferred.set(objectId, deferred);
+  });
+
+  const { data } = await client.Pause.getObjectPreviews(
+    { level, objects: objectIds },
+    sessionId,
+    pauseId || undefined
+  );
+
+  data.objects?.forEach(object => {
+    const deferred = objectIdToDeferred.get(object.objectId);
+    if (deferred) {
+      deferred.resolve({
+        objects: [object],
+      });
+    }
+  });
+
+  // PauseData is only returned once for any given object and pause
+  // It's possible that some of the objects requested have already been returned
+  // but we still need to resolve their hanging promises
+  objectIdToDeferred.forEach(deferred => {
+    // It's okay to resolve a deferred more than once; it will be ignored
+    deferred.resolve({
+      objects: [],
+    });
+  });
+}
+
+function batchRequestsForPauseAndLevel(
+  sessionId: SessionId,
+  objectId: ObjectId,
+  pauseId: PauseId,
+  level: ObjectPreviewLevel | undefined,
+  deferred: Deferred<PauseData>
+) {
+  const key = getKey(pauseId, level);
+
+  const request: Request = {
+    deferred,
+    objectId,
+  };
+
+  const data = queuedRequests.get(key);
+  if (data) {
+    data.push(request);
+  } else {
+    const requests: Request[] = [request];
+
+    queuedRequests.set(key, requests);
+
+    setTimeout(() => {
+      queuedRequests.delete(key);
+
+      getObjectPreviews(sessionId, pauseId, level, requests);
+    }, BATCH_DELAY_MS);
+  }
+}
+
+function getKey(pauseId: PauseId, level?: ObjectPreviewLevel) {
+  return `${pauseId}:${level ?? ""}`;
+}

--- a/packages/shared/client/batchedGetObjectWithPreview.ts
+++ b/packages/shared/client/batchedGetObjectWithPreview.ts
@@ -9,7 +9,8 @@ type Request = {
   deferred: Deferred<PauseData>;
 };
 
-const BATCH_DELAY_MS = 250;
+const MAX_BATCH_SIZE = 250;
+const BATCH_DELAY_MS = 100;
 
 const queuedRequests: Map<string, [NodeJS.Timeout, Request[]]> = new Map();
 
@@ -91,7 +92,7 @@ function batchRequestsForPauseAndLevel(
     requests.push(request);
 
     // Server limit
-    if (requests.length === 250) {
+    if (requests.length === MAX_BATCH_SIZE) {
       clearTimeout(timeoutId);
 
       queuedRequests.delete(key);

--- a/packages/shared/client/batchedGetObjectWithPreview.ts
+++ b/packages/shared/client/batchedGetObjectWithPreview.ts
@@ -61,10 +61,13 @@ async function getObjectPreviews(
   // It's possible that some of the objects requested have already been returned
   // but we still need to resolve their hanging promises
   objectIdToDeferred.forEach(deferred => {
-    // It's okay to resolve a deferred more than once; it will be ignored
-    deferred.resolve({
-      objects: [],
-    });
+    try {
+      deferred.resolve({
+        objects: [],
+      });
+    } catch (error) {
+      // TODO Add status to Deferred so we can avoid this
+    }
   });
 }
 


### PR DESCRIPTION
Note this currently fails because the backend doesn't fully implement `Pause.getObjectPreviews`