### PR TITLE
Add additional telemetry

### DIFF
--- a/packages/replay-next/src/utils/telemetry.ts
+++ b/packages/replay-next/src/utils/telemetry.ts
@@ -8,6 +8,7 @@ export function setDefaultTags(tags: Object) {
 export async function recordData(event: string, tags: Object = {}): Promise<void> {
   const eventTags = { ...defaultTags, ...tags };
 
+  console.log(event, tags)
   if (process.env.NODE_ENV !== "development" || process.env.NEXT_PUBLIC_RECORD_REPLAY_TELEMETRY) {
     try {
       const response = await fetch("https://telemetry.replay.io/", {

--- a/src/ui/components/TestSuite/suspense/TestEventDetailsCache.ts
+++ b/src/ui/components/TestSuite/suspense/TestEventDetailsCache.ts
@@ -41,6 +41,7 @@ export const testEventDetailsIntervalCache = createFocusIntervalCacheForExecutio
   TestEventDetailsEntry
 >({
   debugLabel: "TestEventDetailsCache3",
+  telemetry: true,
   getPointForValue: (event: TestEventDetailsEntry) => event.point,
   getKey(client, testRecording, enabled) {
     const key = `${testRecording.id}-${enabled}`;

--- a/src/ui/suspense/jumpToLocationCache.ts
+++ b/src/ui/suspense/jumpToLocationCache.ts
@@ -6,7 +6,8 @@ import {
   PointDescription,
   SourceLocationRange,
 } from "@replayio/protocol";
-import { createCache, createSingleEntryCache } from "suspense";
+import { createSingleEntryCache } from "suspense";
+import { createCacheWithTelemetry } from "replay-next/src/utils/suspense"
 
 import { sourceOutlineCache } from "replay-next/src/suspense/SourceOutlineCache";
 import { sourcesByIdCache } from "replay-next/src/suspense/SourcesCache";
@@ -174,7 +175,7 @@ async function searchSourceOutlineForDispatch(
   return preferredFrameIdx;
 }
 
-export const reduxDispatchJumpLocationCache = createCache<
+export const reduxDispatchJumpLocationCache = createCacheWithTelemetry<
   [replayClient: ReplayClientInterface, point: ExecutionPoint, time: number],
   PointDescription | undefined
 >({


### PR DESCRIPTION
This PR adds additional telemetry in a couple of places where we had gaps

1. Loading test step details
2. Loading the element tree and an element node. This will likely be replaced soon.
3. Redux jump to code.

One of the common themes with these changes is that we can't track performance at the protocol level because it's many requests. Other performance sensitive areas like the print statement pane or react component picker are a single protocol call like `findPoints` or `getObjectPreview`.