### PR TITLE
Improve colors on the Focus capsule

### DIFF
--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -660,12 +660,13 @@
 
   /* Focus mode editor (dark) */
   --focus-mode-capsule-bgcolor-hover: #232938;
-  --focus-mode-capsule-bgcolor: var(--theme-base-90);
+  --focus-mode-capsule-bgcolor: var(--body-bgcolor);
   --focus-mode-loaded-indexed-color: var(--primary-accent);
   --focus-mode-loading-color: #00567f;
   --focus-mode-popout-icon-background-color: white;
   --focus-mode-popout-icon-color: var(--theme-base-100);
-  --focus-mode-popout-text-input-background-color: #33373d;
+  --focus-mode-popout-text-input-background-color: var(--theme-base-100);
+  --focus-mode-popout-text-input-ring: var(--theme-base-90);
   --focus-mode-popout-background-color: rgba(67, 71, 73, 0.6);
   --focus-mode-popout-background-color-no-transparency: rgba(0, 0, 0, 1);
   --focus-mode-popout-color: white;
@@ -1190,12 +1191,13 @@
 
   /* Focus mode editor (light) */
   --focus-mode-capsule-bgcolor-hover: #d8d8d8;
-  --focus-mode-capsule-bgcolor: #e6e6e6;
+  --focus-mode-capsule-bgcolor: var(--theme-base-85);
   --focus-mode-loaded-indexed-color: var(--primary-accent);
   --focus-mode-loading-color: white;
   --focus-mode-popout-icon-background-color: white;
   --focus-mode-popout-icon-color: black;
-  --focus-mode-popout-text-input-background-color: var(--theme-base-85);
+  --focus-mode-popout-text-input-background-color: var(--theme-base-90);
+  --focus-mode-popout-text-input-ring: var(--theme-base-80);
   --focus-mode-popout-background-color: rgba(0, 0, 0, 0.6);
   --focus-mode-popout-background-color-no-transparency: rgba(0, 0, 0, 1);
   --focus-mode-popout-color: white;

--- a/src/ui/components/Timeline/EditableTimeInput.module.css
+++ b/src/ui/components/Timeline/EditableTimeInput.module.css
@@ -8,4 +8,9 @@
 }
 .Input:focus {
   outline: none;
+  box-shadow: 0 0 0 1px var(--focus-mode-popout-text-input-ring);
+}
+
+.Input:first-of-type {
+  border-radius: 9px 0 0 9px;
 }


### PR DESCRIPTION
**Background**

In dark theme, the color of the Focus capsule doesn't match anything else:

![image](https://github.com/replayio/devtools/assets/9154902/87e52416-ede2-43bb-b7dd-2aabddf50208)

So I cleaned it up to match other colors:

![image](https://github.com/replayio/devtools/assets/9154902/bdc932e3-d4e6-4920-912a-4626a8f7c276)

**Detail views**

Currently on production:

* Default
* Edit state
* Focus state

![image](https://github.com/replayio/devtools/assets/9154902/d1a91c68-b3fc-47a0-a072-ee48fac4482c)

New look with CSS changes:

* Default
* Edit state
* Focus state

![image](https://github.com/replayio/devtools/assets/9154902/15d4610d-d7fe-4059-97b5-d4a178978a15)
