### PR TITLE
Use latest replay/playwright alpha for Delta tests

### DIFF
--- a/.github/workflows/delta.yml
+++ b/.github/workflows/delta.yml
@@ -85,6 +85,7 @@ jobs:
         env:
           SHARD: ${{ matrix.shard }}
           SHARDS: 10
+          REPLAY_PLAYWRIGHT_FIXTURE: 1
           RECORD_REPLAY_METADATA_TEST_RUN_ID: ${{ needs.generate-test-run-id.outputs.testRunId }}
       - name: Upload Replay recordings
         if: always()

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@playwright/test": "^1.37.0",
     "@replayio/cypress": "^0.5.0",
-    "@replayio/playwright": "2.0.0-alpha.3",
+    "@replayio/playwright": "2.0.0-alpha.5",
     "cli-spinners": "^2.7.0",
     "cypress": "^12.5.1",
     "log-update": "^4",

--- a/packages/replay-next/playwright/package.json
+++ b/packages/replay-next/playwright/package.json
@@ -3,7 +3,7 @@
   "packageManager": "yarn@3.2.1",
   "devDependencies": {
     "@playwright/test": "^1.35.0",
-    "@replayio/playwright": "^1.0.20",
+    "@replayio/playwright": "2.0.0-alpha.5",
     "chalk": "^4"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3648,12 +3648,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@replayio/playwright@npm:2.0.0-alpha.3":
-  version: 2.0.0-alpha.3
-  resolution: "@replayio/playwright@npm:2.0.0-alpha.3"
+"@replayio/playwright@npm:2.0.0-alpha.5":
+  version: 2.0.0-alpha.5
+  resolution: "@replayio/playwright@npm:2.0.0-alpha.5"
   dependencies:
-    "@replayio/replay": ^0.17.2
-    "@replayio/test-utils": ^1.1.9
+    "@replayio/replay": ^0.17.5
+    "@replayio/test-utils": ^1.2.3
     debug: ^4.3.4
     uuid: ^8.3.2
     ws: ^8.13.0
@@ -3661,7 +3661,7 @@ __metadata:
     "@playwright/test": 1.19.x
   bin:
     replayio-playwright: bin/replayio-playwright.js
-  checksum: 39bfe644c6b29a9c7df902e3ec51d1a466e6e295cc07b58217b123ababe7d4f8404d3d4e49d4848bd2e57b5fc487be2b623ecae8f2e95d6a8a224faeaaea0c3c
+  checksum: 1bdf38e4b530aca3db363d6c42f8d3a7770c84061a6d96b3114a7e6af41bdaab2242066c086731b46519b9692d9a66e376be8538af02065e89507d40b0e9c0a8
   languageName: node
   linkType: hard
 
@@ -3702,9 +3702,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@replayio/replay@npm:^0.17.2":
-  version: 0.17.2
-  resolution: "@replayio/replay@npm:0.17.2"
+"@replayio/replay@npm:^0.17.5":
+  version: 0.17.5
+  resolution: "@replayio/replay@npm:0.17.5"
   dependencies:
     "@replayio/sourcemap-upload": ^1.1.1
     commander: ^7.2.0
@@ -3718,7 +3718,27 @@ __metadata:
     ws: ^7.5.0
   bin:
     replay: bin/replay.js
-  checksum: f6f8fc3c6e43a400f0cd6b226375e8f9071707bfdddd6dc47a9ff2a04fb608c623356da1bb53428f10dd4a801c09c4541a8e6230c526559d4ccc4977d792eeb3
+  checksum: 04965282dc3b588fa002d6aaa892d63f17a3471a385669ae80d9cfc9e428daa4de93e578261cef16e4bcc36004073b29832b097e70f9537f85f071053c9606d4
+  languageName: node
+  linkType: hard
+
+"@replayio/replay@npm:^0.19.3":
+  version: 0.19.3
+  resolution: "@replayio/replay@npm:0.19.3"
+  dependencies:
+    "@replayio/sourcemap-upload": ^1.1.1
+    commander: ^7.2.0
+    debug: ^4.3.4
+    is-uuid: ^1.0.2
+    jsonata: ^1.8.6
+    node-fetch: ^2.6.8
+    p-map: ^4.0.0
+    superstruct: ^0.15.4
+    text-table: ^0.2.0
+    ws: ^7.5.0
+  bin:
+    replay: bin/replay.js
+  checksum: 7a6ff78c380ba72863757518be6dca9d17a0a1995b1df80fbfa4b8d6dbe6c7bfe5dfe095ee6f1a5bdf36ba4ef5b785bb2b8f9a96ee59ff7009018c8a4b2988f6
   languageName: node
   linkType: hard
 
@@ -3748,16 +3768,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@replayio/test-utils@npm:^1.1.9":
-  version: 1.1.9
-  resolution: "@replayio/test-utils@npm:1.1.9"
+"@replayio/test-utils@npm:^1.2.3":
+  version: 1.3.4
+  resolution: "@replayio/test-utils@npm:1.3.4"
   dependencies:
-    "@replayio/replay": ^0.17.2
-    "@types/node-fetch": ^2.6.2
+    "@replayio/replay": ^0.19.3
     debug: ^4.3.4
     node-fetch: ^2.6.7
     uuid: ^8.3.2
-  checksum: 1fe789c4e68a97aee27e2a072e88e1460568342a6e112b5b4e202f8f1cc6a5074558808dbfd7d53102a0ec39214fc36965b2946abf8710b87f7d0889d01f02e6
+  checksum: 0f3104ab8dea4f4551ee69b93d4adf473fb327f8e581c43b86830aec5ddae19028817d778c900e40ae88ccf21ff71e7fce08121975532a0cb2b08f03a65e6523
   languageName: node
   linkType: hard
 
@@ -9571,7 +9590,7 @@ __metadata:
   dependencies:
     "@playwright/test": ^1.37.0
     "@replayio/cypress": ^0.5.0
-    "@replayio/playwright": 2.0.0-alpha.3
+    "@replayio/playwright": 2.0.0-alpha.5
     chalk: ^4
     cli-spinners: ^2.7.0
     cypress: ^12.5.1


### PR DESCRIPTION
This PR:

- Updates `packages/replay-next` to use the latest version of `@replayio/playwright`, which is `2.0.0-alpha-5`
- Updates the main app from `2.0.0-alpha-3` to `2.0.0-alpha.5`
- Adds what I hope is the right `REPLAY_PLAYWRIGHT_FIXTURE` env var to the Delta GH Actions script to make this work right