### PR TITLE
Add Windows beta notice in Replay's new tab page

### DIFF
--- a/pages/browser/new-tab.tsx
+++ b/pages/browser/new-tab.tsx
@@ -6,13 +6,32 @@ import { useGetUserInfo } from "ui/hooks/users";
 export default function NewTab() {
   const { motd } = useGetUserInfo();
 
+  // Function to detect if the user is on Windows
+  const isWindows = () => {
+    return window.navigator.platform.indexOf("Win") !== -1;
+  };
+
   return (
     <LoadingScreenTemplate>
       <div className="space-y-8 text-center">
         {motd ? <h2 className="text-2xl">{motd}</h2> : null}
-        <div>
-          Please navigate to the page you want to record, then press the blue record button.
-        </div>
+        {isWindows() ? (
+          <div className="rounded-lg p-4 text-blue-100">
+            <div className="mb-4 text-lg font-bold">Replay on Windows is in beta</div>
+            <div className="text-sm">
+              We are hoping to release a new Chrome-based browser in a couple of months which will
+              be more reliable. Please{" "}
+              <a href="https://www.replay.io/contact" className="underline">
+                contact us
+              </a>{" "}
+              with any feedback.
+            </div>
+          </div>
+        ) : (
+          <div>
+            Please navigate to the page you want to record, then press the blue record button.
+          </div>
+        )}
       </div>
     </LoadingScreenTemplate>
   );

--- a/pages/browser/new-tab.tsx
+++ b/pages/browser/new-tab.tsx
@@ -8,7 +8,7 @@ export default function NewTab() {
 
   // Function to detect if the user is on Windows
   const isWindows = () => {
-    return window.navigator.platform.indexOf("Win") !== -1;
+    return window.navigator.platform.indexOf("Win") == -1;
   };
 
   return (
@@ -16,7 +16,7 @@ export default function NewTab() {
       <div className="space-y-8 text-center">
         {motd ? <h2 className="text-2xl">{motd}</h2> : null}
         {isWindows() ? (
-          <div className="rounded-lg p-4 text-blue-100">
+          <div className="rounded-lg p-4">
             <div className="mb-4 text-lg font-bold">Replay on Windows is in beta</div>
             <div className="text-sm">
               We are hoping to release a new Chrome-based browser in a couple of months which will

--- a/pages/browser/new-tab.tsx
+++ b/pages/browser/new-tab.tsx
@@ -8,7 +8,7 @@ export default function NewTab() {
 
   // Function to detect if the user is on Windows
   const isWindows = () => {
-    return window.navigator.platform.indexOf("Win") == -1;
+    return window.navigator.platform.indexOf("Win") !== -1;
   };
 
   return (


### PR DESCRIPTION
<img width="1440" alt="image" src="https://github.com/replayio/devtools/assets/9154902/97aa2a30-102c-4053-b7a7-303b6e87ee00">

This helps us message to Windows users that things may not be ideal. [This is addressing this ticket](https://linear.app/replay/issue/DES-987/message-geckowindows-better).