### PR TITLE
Use bounding client rects for node highlighting in some cases

### DIFF
--- a/packages/e2e-tests/tests/highlighter.test.ts
+++ b/packages/e2e-tests/tests/highlighter.test.ts
@@ -32,7 +32,10 @@ test("highlighter: element highlighter works everywhere", async ({
     })
     .join(" ");
 
-  // TODO:FE-805 This is a hack to get the test to pass. We should figure out why the path definition is different from the original and not use a hardcoded value.
+  // The important things to check here are 1) the path exists
+  // at all (is the box even visible on screen), and 2) is it
+  // over the iframe element we're trying to highlight.
+  // These coordinates visually match the location of the iframe.
   const pathDefinitionToCompare = `M8,46 L312,46 L312,200 L8,200`;
   expect(normalizedPathDefinition).toBe(pathDefinitionToCompare);
 });

--- a/packages/e2e-tests/tests/highlighter.test.ts
+++ b/packages/e2e-tests/tests/highlighter.test.ts
@@ -33,6 +33,6 @@ test("highlighter: element highlighter works everywhere", async ({
     .join(" ");
 
   // TODO:FE-805 This is a hack to get the test to pass. We should figure out why the path definition is different from the original and not use a hardcoded value.
-  const pathDefinitionToCompare = `M10,48 L310,48 L310,198 L10,198`;
+  const pathDefinitionToCompare = `M8,46 L312,46 L312,200 L8,200`;
   expect(normalizedPathDefinition).toBe(pathDefinitionToCompare);
 });

--- a/src/devtools/client/inspector/boxmodel/components/BoxModelMain.tsx
+++ b/src/devtools/client/inspector/boxmodel/components/BoxModelMain.tsx
@@ -131,7 +131,9 @@ export class BoxModelMain extends React.PureComponent<FinalBMMProps> {
   onShowBoxModelHighlighter = () => {
     const { selectedNodeId, highlightNode } = this.props;
     if (selectedNodeId) {
-      highlightNode(selectedNodeId);
+      // No timer, but use actual box models to show the various sections in the highlight,
+      // rather than just the contents from the bounding rect
+      highlightNode(selectedNodeId, undefined, true);
     }
   };
 

--- a/src/devtools/client/inspector/boxmodel/components/BoxModelMain.tsx
+++ b/src/devtools/client/inspector/boxmodel/components/BoxModelMain.tsx
@@ -133,7 +133,7 @@ export class BoxModelMain extends React.PureComponent<FinalBMMProps> {
     if (selectedNodeId) {
       // No timer, but use actual box models to show the various sections in the highlight,
       // rather than just the contents from the bounding rect
-      highlightNode(selectedNodeId, undefined, true);
+      highlightNode(selectedNodeId, true);
     }
   };
 

--- a/src/devtools/client/inspector/markup/actions/markup.ts
+++ b/src/devtools/client/inspector/markup/actions/markup.ts
@@ -17,7 +17,7 @@ export function selectNode(nodeId: string): UIThunkAction {
   return async (dispatch, getState, { replayClient }) => {
     const originalPauseId = await getCurrentPauseId(replayClient, getState());
     if (getPauseId(getState()) === originalPauseId) {
-      dispatch(highlightNode(nodeId, 1000));
+      dispatch(highlightNode(nodeId, false, 1000));
       dispatch(nodeSelected(nodeId));
     }
   };
@@ -28,8 +28,8 @@ let unhighlightTimer: ReturnType<typeof window.setTimeout> | null = null;
 export function highlightNodes(
   nodeIds: string[],
   pauseId?: string,
-  duration?: number,
-  useRealBoxModels = false
+  useRealBoxModels = false,
+  duration?: number
 ): UIThunkAction {
   return async (dispatch, getState, { replayClient }) => {
     const recordingCapabilities = await recordingCapabilitiesCache.readAsync(replayClient);
@@ -94,10 +94,11 @@ export function highlightNodes(
 
 export function highlightNode(
   nodeId: string,
-  duration?: number,
-  useRealBoxModels?: boolean
+  useRealBoxModels?: boolean,
+  duration?: number
 ): UIThunkAction {
-  return highlightNodes([nodeId], undefined, duration, useRealBoxModels);
+  // Assume we're highlighting the current pause here
+  return highlightNodes([nodeId], undefined, useRealBoxModels, duration);
 }
 
 export function unhighlightNode(): UIThunkAction {

--- a/src/devtools/client/inspector/markup/actions/markup.ts
+++ b/src/devtools/client/inspector/markup/actions/markup.ts
@@ -1,7 +1,9 @@
+import { BoxModel } from "@replayio/protocol";
+
 import { getPauseId } from "devtools/client/debugger/src/selectors";
 import { recordingCapabilitiesCache } from "replay-next/src/suspense/BuildIdCache";
 import type { UIThunkAction } from "ui/actions";
-import { boxModelCache } from "ui/suspense/nodeCaches";
+import { boundingRectsCache, boundingRectsToBoxModel, boxModelCache } from "ui/suspense/nodeCaches";
 import { getCurrentPauseId } from "ui/utils/app";
 
 import {
@@ -26,7 +28,8 @@ let unhighlightTimer: ReturnType<typeof window.setTimeout> | null = null;
 export function highlightNodes(
   nodeIds: string[],
   pauseId?: string,
-  duration?: number
+  duration?: number,
+  useRealBoxModels = false
 ): UIThunkAction {
   return async (dispatch, getState, { replayClient }) => {
     const recordingCapabilities = await recordingCapabilitiesCache.readAsync(replayClient);
@@ -47,12 +50,33 @@ export function highlightNodes(
     if (!highlightedNodes || !nodeIds.every(id => highlightedNodes.includes(id))) {
       dispatch(nodesHighlighted(nodeIds));
 
-      const boxModels = await Promise.all(
-        nodeIds.map(async nodeId => {
-          const boxModel = await boxModelCache.readAsync(replayClient, pauseId!, nodeId);
-          return boxModel;
-        })
-      );
+      let boxModels: BoxModel[] = [];
+
+      if (useRealBoxModels) {
+        // In some cases, we care about showing "real" box models when highlighting a node:
+        // - hovering over the Box Model section of the "Layout" tab
+        // - the DOM node picker
+        // - relevant DOM nodes from Cypress test step details
+        // In that case, fetch real box models so we can show each piece separately.
+        // (The step details case should have pre-fetched those box models already.)
+        boxModels = await Promise.all(
+          nodeIds.map(async nodeId => {
+            const boxModel = await boxModelCache.readAsync(replayClient, pauseId!, nodeId);
+            return boxModel;
+          })
+        );
+      } else {
+        // But for other cases, we're really just trying to show the node's contents,
+        // such as when hovering over a React component.
+        // Fetching the bounding rects _might_ be a bit slower up front,
+        // but once we have them fetched we can highlight any node in this pause immediately.
+        const boundingClientRects = await boundingRectsCache.readAsync(replayClient, pauseId!);
+        const boxModelsFromClientRects = nodeIds.map(nodeId => {
+          return boundingRectsToBoxModel(nodeId, boundingClientRects);
+        });
+        boxModels = boxModelsFromClientRects;
+      }
+
       dispatch(nodeBoxModelsLoaded(boxModels));
 
       if (unhighlightTimer) {
@@ -68,8 +92,12 @@ export function highlightNodes(
   };
 }
 
-export function highlightNode(nodeId: string, duration?: number): UIThunkAction {
-  return highlightNodes([nodeId], undefined, duration);
+export function highlightNode(
+  nodeId: string,
+  duration?: number,
+  useRealBoxModels?: boolean
+): UIThunkAction {
+  return highlightNodes([nodeId], undefined, duration, useRealBoxModels);
 }
 
 export function unhighlightNode(): UIThunkAction {

--- a/src/ui/components/NodePicker.tsx
+++ b/src/ui/components/NodePicker.tsx
@@ -104,7 +104,9 @@ export function NodePicker() {
       nodePickerInstance.enable({
         name: "domElement",
         onHighlightNode(nodeId) {
-          dispatch(highlightNode(nodeId));
+          // No timer, but use actual box models to show the various sections in the highlight,
+          // rather than just the contents from the bounding rect
+          dispatch(highlightNode(nodeId, undefined, true));
         },
         onUnhighlightNode() {
           dispatch(unhighlightNode());

--- a/src/ui/components/NodePicker.tsx
+++ b/src/ui/components/NodePicker.tsx
@@ -106,7 +106,7 @@ export function NodePicker() {
         onHighlightNode(nodeId) {
           // No timer, but use actual box models to show the various sections in the highlight,
           // rather than just the contents from the bounding rect
-          dispatch(highlightNode(nodeId, undefined, true));
+          dispatch(highlightNode(nodeId, true));
         },
         onUnhighlightNode() {
           dispatch(unhighlightNode());

--- a/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
@@ -191,7 +191,7 @@ export function TestSectionRow({
         if (firstDomNodeDetails?.domNode?.node.isConnected) {
           const { domNode, pauseId } = firstDomNodeDetails;
           // Use the actual box model, which we should have pre-cached already
-          dispatch(highlightNodes([domNode.id], pauseId, undefined, true));
+          dispatch(highlightNodes([domNode.id], pauseId, true));
         }
       }
     }

--- a/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
@@ -190,7 +190,8 @@ export function TestSectionRow({
 
         if (firstDomNodeDetails?.domNode?.node.isConnected) {
           const { domNode, pauseId } = firstDomNodeDetails;
-          dispatch(highlightNodes([domNode.id], pauseId));
+          // Use the actual box model, which we should have pre-cached already
+          dispatch(highlightNodes([domNode.id], pauseId, undefined, true));
         }
       }
     }

--- a/src/ui/suspense/nodeCaches.ts
+++ b/src/ui/suspense/nodeCaches.ts
@@ -78,6 +78,34 @@ export const boxModelCache: Cache<
   },
 });
 
+// For node highlighting perf purposes, we can synthesize `BoxModel` objects
+// out of the `NodeBounds` objects we get from the protocol.
+export function boundingRectsToBoxModel(
+  nodeId: string,
+  boundingClientRects: NodeBounds[]
+): BoxModel {
+  const nodeBounds = boundingClientRects.find(({ node }) => node === nodeId);
+  if (!nodeBounds) {
+    return {
+      ...NO_BOX_MODEL,
+      node: nodeId,
+    };
+  }
+
+  const { rect, rects } = nodeBounds;
+  const [left, top, right, bottom] = rects ? rects[0] : rect;
+
+  const content = [left, top, right, top, right, bottom, left, bottom];
+
+  return {
+    node: nodeId,
+    border: EMPTY_QUADS,
+    content,
+    margin: EMPTY_QUADS,
+    padding: EMPTY_QUADS,
+  };
+}
+
 export function getMouseTarget(
   mouseTargets: NodeBounds[],
   x: number,


### PR DESCRIPTION
This PR:

- Updates the `highlightNodes` logic to accept a flag indicating whether to use "real" box models (which results in different highlighting colors for the padding/margin/contents/border), or just the contents (as derived from bounding client rects)
- Updates different parts of the UI to set that flag accordingly:
  - Real box models: "Layout" tab with the box model rectangles display, Cypress Step Details DOM nodes, DOM Node picker
  - Client rects only: React component picker, video context menu

I can tweak these easily if we have opinions on this.  (I'm not convinced that the DOM node picker needs the full box model, but Jason seemed to suggest in Linear that was worth keeping, so it's here.)