### PR TITLE
Switch DOM Node Picker to use bounding rects for highlighting, for perf

### DIFF
--- a/src/ui/components/NodePicker.tsx
+++ b/src/ui/components/NodePicker.tsx
@@ -104,9 +104,7 @@ export function NodePicker() {
       nodePickerInstance.enable({
         name: "domElement",
         onHighlightNode(nodeId) {
-          // No timer, but use actual box models to show the various sections in the highlight,
-          // rather than just the contents from the bounding rect
-          dispatch(highlightNode(nodeId, true));
+          dispatch(highlightNode(nodeId));
         },
         onUnhighlightNode() {
           dispatch(unhighlightNode());


### PR DESCRIPTION
This PR:

- Switches the DOM node picker from using box models to bounding rects for node highlighting, to improve perf as the user mouses around