### PR TITLE
Bump bankaccounts.spec.ts example recording

### DIFF
--- a/packages/e2e-tests/examples.json
+++ b/packages/e2e-tests/examples.json
@@ -41,7 +41,7 @@
   "node/spawn.js": "c9d0539d-fde0-4949-a9f7-acdb5b56d4a6",
   "log_points_and_block_scope.html": "1eebc813-d877-4c0d-8eeb-f52e268a9c25",
   "doc_minified_chromium.html": "e2c18571-db82-4d52-b4f5-0fc8b63a202f",
-  "cypress-realworld/bankaccounts.spec.js": "6d4abbe1-2fcb-47d9-92d5-f7b45760b01a",
+  "cypress-realworld/bankaccounts.spec.js": "7c605061-71fe-433d-8926-88e91354d21d",
   "flake/adding-spec.ts": "7b0db00a-d9a9-4d2d-b816-af14a1b682a6",
   "breakpoints-01": "c8debea5-3270-4728-8f08-2252855897cc",
   "redux/dist/index.html": "72ffbc74-ea61-492f-af66-cb8302b89c8d",


### PR DESCRIPTION
This PR:

- Bumps our `cypress-realworld/bankaccounts.spec.ts` example recording ID to a fresh PR run from https://github.com/replayio-public/cypress-realworld-app/pull/88 

I was trying to investigate FE-2039, where we've consistently had the RDT routine throwing errors that it's seeing an unexpected "reorder children" op.  After investigation, it appears that React somehow isn't passing a removed `<ListSkeleton>` fiber into the `onCommitFiberUnmount` callback, so we never process that unmount and never generate the operation that would have removed it from the `Store`'s tree.

This fresh recording of the same test from the same app repo does not have that problem - the RDT routine finishes without an error, and a search of the operations descriptions shows me that component actually getting removed from the tree.

So, going to update us to use that fresh example recording and see if the error disappears from there.