### PR TITLE
Tidied up timeline CSS padding/margins

### DIFF
--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -106,7 +106,7 @@ function Body() {
   }, [sidePanelCollapsed]);
 
   return (
-    <div className="vertical-panels pr-1">
+    <div className="vertical-panels">
       <div className="flex h-full flex-row overflow-hidden bg-chrome">
         <Toolbar />
         <PanelGroup autoSaveId="DevTools-horizontal" className="split-box" direction="horizontal">

--- a/src/ui/components/ProtocolTimeline.tsx
+++ b/src/ui/components/ProtocolTimeline.tsx
@@ -1,9 +1,12 @@
-import { TimeStampedPoint, TimeStampedPointRange } from "@replayio/protocol";
+import {
+  loadedRegions as LoadedRegions,
+  TimeStampedPoint,
+  TimeStampedPointRange,
+} from "@replayio/protocol";
 import clamp from "lodash/clamp";
 
 import { gPaintPoints, hasAllPaintPoints } from "protocol/graphics";
 import useLoadedRegions from "replay-next/src/hooks/useLoadedRegions";
-import { useGraphQLUserData } from "shared/user-data/GraphQL/useGraphQLUserData";
 import { getZoomRegion } from "ui/reducers/timeline";
 import { useAppSelector } from "ui/setup/hooks";
 
@@ -68,16 +71,17 @@ const Spans = ({
   );
 };
 
-export default function ProtocolTimeline() {
-  const loadedRegions = useLoadedRegions();
+const EMPTY_LOADED_REGIONS: LoadedRegions = {
+  indexed: [],
+  loaded: [],
+  loading: [],
+};
 
-  const [showProtocolTimeline] = useGraphQLUserData("feature_protocolTimeline");
+export default function ProtocolTimeline() {
+  const loadedRegions = useLoadedRegions() ?? EMPTY_LOADED_REGIONS;
+
   const firstPaint = gPaintPoints[0];
   const lastPaint = gPaintPoints[gPaintPoints.length - 1];
-
-  if (!showProtocolTimeline || !loadedRegions) {
-    return null;
-  }
 
   return (
     <div className="flex w-full flex-col space-y-1">

--- a/src/ui/components/Timeline/PlaybackControls.tsx
+++ b/src/ui/components/Timeline/PlaybackControls.tsx
@@ -37,11 +37,7 @@ export default function PlayPauseButton() {
   }
 
   return (
-    <div
-      className="ml-1 mr-1.5 flex flex-row"
-      style={{ width: "32px", height: "32px" }}
-      onClick={onClick}
-    >
+    <div className="flex flex-row" style={{ width: "24px", height: "32px" }} onClick={onClick}>
       <motion.img
         className="m-auto h-6 w-6 rounded-full hover:cursor-pointer"
         src={icon}

--- a/src/ui/components/Timeline/Timeline.css
+++ b/src/ui/components/Timeline/Timeline.css
@@ -6,11 +6,14 @@
   box-sizing: border-box;
   --progressbar-transition: 200ms;
   display: flex;
-  padding: 10px 0px 12px 6px;
+  padding: 10px;
   align-items: center;
   user-select: none;
 
   --timeline-size: 5px;
+}
+.timeline[data-protocol-timeline-enabled] {
+  padding-bottom: 0;
 }
 
 .theme-light .timeline,

--- a/src/ui/components/Timeline/Timeline.tsx
+++ b/src/ui/components/Timeline/Timeline.tsx
@@ -1,6 +1,7 @@
 import { MouseEvent, useContext, useLayoutEffect, useRef, useState } from "react";
 
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
+import { useGraphQLUserData } from "shared/user-data/GraphQL/useGraphQLUserData";
 import { throttle } from "shared/utils/function";
 import { seek, setDisplayedFocusWindow, setHoverTime, stopPlayback } from "ui/actions/timeline";
 import useTimelineContextMenu from "ui/components/Timeline/useTimelineContextMenu";
@@ -39,6 +40,8 @@ export default function Timeline() {
   const timelineDimensions = useAppSelector(selectors.getTimelineDimensions);
   const zoomRegion = useAppSelector(selectors.getZoomRegion);
   const isPlaying = useAppSelector(isPlayingSelector);
+
+  const [showProtocolTimeline] = useGraphQLUserData("feature_protocolTimeline");
 
   const { rangeForDisplay } = useContext(FocusContext);
 
@@ -129,6 +132,7 @@ export default function Timeline() {
       <FocusModePopout updateFocusWindowThrottled={updateFocusWindowThrottled} />
       <div
         className="timeline"
+        data-protocol-timeline-enabled={showProtocolTimeline || undefined}
         data-test-id="Timeline"
         data-test-focus-begin-time={rangeForDisplay?.begin}
         data-test-focus-end-time={rangeForDisplay?.end}
@@ -146,7 +150,7 @@ export default function Timeline() {
           onMouseUp={onMouseUp}
         >
           <div className="progress-bar-stack" onContextMenu={onContextMenu}>
-            <ProtocolTimeline />
+            {showProtocolTimeline && <ProtocolTimeline />}
             <div className="progress-bar" data-test-id="Timeline-ProgressBar" ref={progressBarRef}>
               <ProgressBars />
               <PreviewMarkers />


### PR DESCRIPTION
### Before

Too little padding on the right:
<kbd>![Screenshot 2023-11-27 at 11 14 19 AM](https://github.com/replayio/devtools/assets/29597/a5ff7b9f-876a-49c1-8f24-a13d6c64a2c7)</kbd>

Too much padding on the bottom:
<kbd>![Screenshot 2023-11-27 at 11 13 53 AM](https://github.com/replayio/devtools/assets/29597/8781061c-ed32-4e2d-bb57-2b5c296616ab)</kbd>

### After

Consistent padding on all sides (at least so much as is possible, with capsule and play button heights being different)
<kbd>![Screenshot 2023-11-27 at 10 44 32 AM](https://github.com/replayio/devtools/assets/29597/5e3bd9a0-bae7-43f8-86db-005b631e2e63)</kbd>
<kbd>![Screenshot 2023-11-27 at 10 45 31 AM](https://github.com/replayio/devtools/assets/29597/d71904d9-7ed5-4778-a5e4-33851943ea68)</kbd>

cc @jonbell-lot23 