### PR TITLE
Reflect the correct date filter in the test date filter dropdown

### DIFF
--- a/src/ui/components/Library/Team/View/Tests/TestsPage.tsx
+++ b/src/ui/components/Library/Team/View/Tests/TestsPage.tsx
@@ -61,7 +61,7 @@ function TestsContent() {
       <ContextMenuItem disabled onSelect={() => setFilterByTime(7)}>
         Last week
       </ContextMenuItem>
-      <ContextMenuItem onSelect={() => setFilterByTime(null)}>All time</ContextMenuItem>
+      <ContextMenuItem onSelect={() => setFilterByTime(null)}>Last two weeks</ContextMenuItem>
     </>,
     { alignTo: "auto-target" }
   );
@@ -83,7 +83,7 @@ function TestsContent() {
                 testId="TestPage-BranchFilter-DropdownTrigger"
                 onClick={onClickTimeFilter}
                 onKeyDown={onKeyDownTimeFilter}
-                label={filterByTime === null ? "All time" : ""}
+                label={filterByTime === null ? "Last two weeks" : ""}
               />
               {contextMenuTimeFilter}
               <div className={styles.filterContainer}>


### PR DESCRIPTION
Small change to make the default filter accurate. We don't actually show all test executions by default; instead, we cap it at [2 weeks from the backend](https://github.com/replayio/backend/blob/master/src/graphql-api/models.ts#L935).

This changes "All time" to "Last two weeks".

## Before

<img width="920" alt="image" src="https://github.com/replayio/devtools/assets/15959269/149e7e19-aaff-465d-8864-b72eb8b18e14">

## After

<img width="1103" alt="image" src="https://github.com/replayio/devtools/assets/15959269/5d85a8f6-529b-47bf-8271-eefb91217626">
