### PR TITLE
Add support for tests marked as flaky by backend

### DIFF
--- a/src/ui/utils/testRuns.ts
+++ b/src/ui/utils/testRuns.ts
@@ -75,6 +75,8 @@ export function groupRecordings(tests: TestRunTestWithRecordings[]): TestGroups 
         } else {
           addToTestGroup(failedRecordings, test);
         }
+      } else if (test.result === "flaky") {
+        addToTestGroup(flakyRecordings, test);
       }
     }
 


### PR DESCRIPTION
The backend will now (as of https://github.com/replayio/backend/pull/9065) report cypress replays that include tests that failed and then passed in the same as `flaky` instead of `passed`. This change accounts for this new status in the grouping so they are displayed correctly in the test run details panel.