### PR TITLE
Fixed edge case bug in old Elements panel

### DIFF
--- a/packages/replay-next/components/elements/ElementsPanel.tsx
+++ b/packages/replay-next/components/elements/ElementsPanel.tsx
@@ -87,6 +87,10 @@ export function ElementsPanel({
         if (query === "") {
           setSearchState(null);
         } else if (searchState?.query === query) {
+          if (searchState.results.length === 0) {
+            return;
+          }
+
           let index = searchState.index;
           if (event.shiftKey) {
             index = index > 0 ? index - 1 : searchState.results.length - 1;


### PR DESCRIPTION
Previously, a search with no matches would show "0 of 0" but if you typed Enter then it would show "1 of 0". This PR fixes that for the old Elements panel. (It's already fixed in the new panel.)

Split off of #9936