### PR TITLE
Fix flaky icon color

### DIFF
--- a/src/ui/components/Library/Team/View/TestRuns/Overview/RunResults.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/Overview/RunResults.tsx
@@ -17,7 +17,7 @@ import {
   useFileNameTree,
 } from "ui/components/Library/Team/View/TestRuns/Overview/useFileNameTree";
 import { TestRunsContext } from "ui/components/Library/Team/View/TestRuns/TestRunsContextRoot";
-import { TestGroup, testPassed } from "ui/utils/testRuns";
+import { TestGroup, testFailed } from "ui/utils/testRuns";
 
 import { TestResultListItem } from "./TestResultListItem";
 import styles from "../../../../Library.module.css";
@@ -165,7 +165,7 @@ const FileNodeRenderer = memo(function FileNodeRenderer({
               depth={depth + 1}
               filterByText={filterByText}
               key={recording.id}
-              label={testPassed(test) ? "Passed" : label}
+              label={testFailed(test) ? "Failed" : label}
               recording={recording}
               test={test}
               secondaryBadgeCount={/* index > 0 ? index + 1 : null */ null}


### PR DESCRIPTION
Since the backend returns `flaky` as a status for tests now, the condition used to select the label (and therefore the CSS class) for the icon needs to be flipped from `testPassed` to `testFailed`. `testPassed` returns true for both passed and flaky tests but we want different classes in these cases. All failed tests are red so its safe to use that check instead.

<img width="217" alt="image" src="https://github.com/replayio/devtools/assets/788456/958fa154-5e9f-4ead-a82c-44ce46f6d1fc">
