### PR TITLE
Fix log point panel loader

### DIFF
--- a/packages/replay-next/components/sources/SourceListRow.tsx
+++ b/packages/replay-next/components/sources/SourceListRow.tsx
@@ -129,7 +129,7 @@ export default function SourceListRow({
     : null;
 
   let showPointPanel = false;
-  if (pointWithPendingEdits && pointForSuspense) {
+  if (pointWithPendingEdits) {
     if (pointBehavior) {
       showPointPanel = pointBehavior.shouldLog !== POINT_BEHAVIOR_DISABLED;
     } else {

--- a/packages/replay-next/components/sources/log-point-panel/LogPointPanel.module.css
+++ b/packages/replay-next/components/sources/log-point-panel/LogPointPanel.module.css
@@ -1,4 +1,5 @@
-.Panel {
+.Panel,
+.Loader {
   position: absolute;
   top: var(--line-height);
   left: var(--source-line-number-offset);

--- a/packages/replay-next/components/sources/log-point-panel/LogPointPanel.tsx
+++ b/packages/replay-next/components/sources/log-point-panel/LogPointPanel.tsx
@@ -8,7 +8,6 @@ import {
   useState,
   useTransition,
 } from "react";
-import { useImperativeCacheValue } from "suspense";
 
 import { assert } from "protocol/utils";
 import AvatarImage from "replay-next/components/AvatarImage";
@@ -53,7 +52,7 @@ type EditReason = "condition" | "content";
 type ExternalProps = {
   className: string;
   pointWithPendingEdits: Point;
-  pointForSuspense: Point;
+  pointForSuspense: Point | null;
 };
 
 type InternalProps = ExternalProps & {
@@ -64,43 +63,48 @@ type InternalProps = ExternalProps & {
   setFocusToEnd: () => void;
 };
 
-export default function PointPanelWrapper(props: ExternalProps) {
-  const { className, pointWithPendingEdits } = props;
+const EMPTY_ARRAY: any[] = [];
 
+export default function PointPanelWrapper(props: ExternalProps) {
   const { range: focusRange } = useContext(FocusContext);
   if (!focusRange) {
     return null;
   }
 
+  const { className, pointForSuspense, pointWithPendingEdits } = props;
+
+  const loader = (
+    <Loader
+      className={`${styles.Loader} ${className}`}
+      style={{
+        height: pointWithPendingEdits.condition
+          ? "var(--point-panel-with-conditional-height)"
+          : "var(--point-panel-height)",
+      }}
+    />
+  );
+
+  if (pointForSuspense == null) {
+    return loader;
+  }
+
   return (
-    <Suspense
-      fallback={
-        <Loader
-          className={`${styles.Loader} ${className}`}
-          style={{
-            height: pointWithPendingEdits.condition
-              ? "var(--point-panel-with-conditional-height)"
-              : "var(--point-panel-height)",
-          }}
-        />
-      }
-    >
-      <PointPanel focusRange={focusRange} {...props} />
+    <Suspense fallback={loader}>
+      <PointPanel {...props} focusRange={focusRange} pointForSuspense={pointForSuspense} />
     </Suspense>
   );
 }
 
-const EMPTY_ARRAY: any[] = [];
-
-function PointPanel(props: ExternalProps & { focusRange: TimeStampedPointRange }) {
+function PointPanel(
+  props: ExternalProps & { focusRange: TimeStampedPointRange; pointForSuspense: Point }
+) {
   const { focusRange, pointForSuspense } = props;
 
   const { enterFocusMode, update } = useContext(FocusContext);
 
   const client = useContext(ReplayClientContext);
 
-  const { value } = useImperativeCacheValue(
-    hitPointsForLocationCache,
+  const value = hitPointsForLocationCache.read(
     client,
     { begin: focusRange.begin.point, end: focusRange.end.point },
     pointForSuspense.location,
@@ -163,7 +167,9 @@ function PointPanelWithHitPoints({
   pointForSuspense,
   setFocusToBeginning,
   setFocusToEnd,
-}: InternalProps) {
+}: InternalProps & {
+  pointForSuspense: Point;
+}) {
   const graphQLClient = useContext(GraphQLClientContext);
   const { showCommentsPanel } = useContext(InspectorContext);
   const {


### PR DESCRIPTION
The trick here was to render the log point panel loader _before_ the update that suspended, as that update also included other suspending components (like `LoggablesContext`) that sometimes would prevent the update from committing the loader. This feels like an awkward React+Suspense edge case but I'm not sure how to work around it in another way.