### PR TITLE
Show "recording too long" warnings in the React and Redux panels

### DIFF
--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -9,8 +9,10 @@ import {
   createSession,
 } from "protocol/socket";
 import { assert } from "protocol/utils";
-import { recordingTargetCache } from "replay-next/src/suspense/BuildIdCache";
-import { recordingCapabilitiesCache } from "replay-next/src/suspense/BuildIdCache";
+import {
+  recordingCapabilitiesCache,
+  recordingTargetCache,
+} from "replay-next/src/suspense/BuildIdCache";
 import { extractGraphQLError } from "shared/graphql/apolloClient";
 import { Recording } from "shared/graphql/types";
 import { userData } from "shared/user-data/GraphQL/UserData";

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -39,6 +39,7 @@ import {
   timeIsBeyondKnownPaints,
 } from "protocol/graphics";
 import { waitForTime } from "protocol/utils";
+import { recordingCapabilitiesCache } from "replay-next/src/suspense/BuildIdCache";
 import {
   pointsBoundingTimeCache,
   sessionEndPointCache,
@@ -119,8 +120,18 @@ export function jumpToInitialPausePoint(): UIThunkAction<Promise<void>> {
     const state = getState();
     const zoomRegion = getZoomRegion(state);
     const newZoomRegion = { ...zoomRegion, endTime: time };
+
+    const { maxRecordingDurationForRoutines } = await recordingCapabilitiesCache.readAsync(
+      replayClient
+    );
+
     dispatch(
-      setTimelineState({ currentTime: time, recordingDuration: time, zoomRegion: newZoomRegion })
+      setTimelineState({
+        currentTime: time,
+        recordingDuration: time,
+        zoomRegion: newZoomRegion,
+        maxRecordingDurationForRoutines,
+      })
     );
 
     if (isTest()) {

--- a/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
+++ b/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
@@ -38,7 +38,7 @@ import {
 } from "ui/components/SecondaryToolbox/react-devtools/ReplayWall";
 import { nodePickerDisabled, nodePickerInitializing, nodePickerReady } from "ui/reducers/app";
 import { getPreferredLocation } from "ui/reducers/sources";
-import { getRecordingMightHaveRoutines } from "ui/reducers/timeline";
+import { getRecordingTooLongToSupportRoutines } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector, useAppStore } from "ui/setup/hooks";
 import { UIState } from "ui/state";
 import {
@@ -128,7 +128,7 @@ export function ReactDevtoolsPanel() {
   const currentTime = useAppSelector(getTime);
   const isFirstAnnotationsInjection = useRef(true);
   const [, forceRender] = useReducer(c => c + 1, 0);
-  const mightHaveRoutines = useAppSelector(getRecordingMightHaveRoutines);
+  const showRecordingTooLongWarning = useAppSelector(getRecordingTooLongToSupportRoutines);
 
   const isPointWithinFocusWindow = useIsPointWithinFocusWindow(currentPoint);
   const pauseId = useAppSelector(state => state.pause.id);
@@ -139,8 +139,6 @@ export function ReactDevtoolsPanel() {
     reactDevToolsAnnotationsCache,
     replayClient
   );
-
-  const showRecordingTooLongWarning = !mightHaveRoutines;
 
   const annotations: ParsedReactDevToolsAnnotation[] =
     annotationsStatus === "resolved" ? parsedAnnotations : EMPTY_ANNOTATIONS;

--- a/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
+++ b/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
@@ -38,6 +38,7 @@ import {
 } from "ui/components/SecondaryToolbox/react-devtools/ReplayWall";
 import { nodePickerDisabled, nodePickerInitializing, nodePickerReady } from "ui/reducers/app";
 import { getPreferredLocation } from "ui/reducers/sources";
+import { getRecordingMightHaveRoutines } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector, useAppStore } from "ui/setup/hooks";
 import { UIState } from "ui/state";
 import {
@@ -49,6 +50,7 @@ import { NodePicker as NodePickerClass, NodePickerOpts } from "ui/utils/nodePick
 
 import { ReactDevToolsPanel as NewReactDevtoolsPanel } from "./react-devtools/components/ReactDevToolsPanel";
 import { generateTreeResetOpsForPoint } from "./react-devtools/rdtProcessing";
+import styles from "./react-devtools/components/ReactDevToolsPanel.module.css";
 
 function jumpToComponentPreferredSource(componentPreview: ProtocolObject): UIThunkAction {
   return (dispatch, getState) => {
@@ -126,6 +128,7 @@ export function ReactDevtoolsPanel() {
   const currentTime = useAppSelector(getTime);
   const isFirstAnnotationsInjection = useRef(true);
   const [, forceRender] = useReducer(c => c + 1, 0);
+  const mightHaveRoutines = useAppSelector(getRecordingMightHaveRoutines);
 
   const isPointWithinFocusWindow = useIsPointWithinFocusWindow(currentPoint);
   const pauseId = useAppSelector(state => state.pause.id);
@@ -136,6 +139,8 @@ export function ReactDevtoolsPanel() {
     reactDevToolsAnnotationsCache,
     replayClient
   );
+
+  const showRecordingTooLongWarning = !mightHaveRoutines;
 
   const annotations: ParsedReactDevToolsAnnotation[] =
     annotationsStatus === "resolved" ? parsedAnnotations : EMPTY_ANNOTATIONS;
@@ -262,14 +267,28 @@ export function ReactDevtoolsPanel() {
     return null;
   }
 
+  if (showRecordingTooLongWarning) {
+    return (
+      <div className={styles.ProtocolFailedPanel} data-test-id="ReactDevToolsPanel">
+        <div className={styles.NotMountedYetMessage}>
+          <div>
+            React components are unavailable because this recording was too long to process them
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   if (!isPointWithinFocusWindow) {
     return (
-      <div className="h-full bg-bodyBgcolor p-2">
-        React components are unavailable because you're paused at a point outside{" "}
-        <span className="cursor-pointer underline" onClick={() => dispatch(enterFocusMode())}>
-          your debugging window
-        </span>
-        .
+      <div className={styles.ProtocolFailedPanel} data-test-id="ReactDevToolsPanel">
+        <div className={styles.NotMountedYetMessage}>
+          React components are unavailable because you're paused at a point outside{" "}
+          <span className="cursor-pointer underline" onClick={() => dispatch(enterFocusMode())}>
+            your debugging window
+          </span>
+          .
+        </div>
       </div>
     );
   }

--- a/src/ui/components/SecondaryToolbox/index.tsx
+++ b/src/ui/components/SecondaryToolbox/index.tsx
@@ -13,11 +13,13 @@ import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { useGraphQLUserData } from "shared/user-data/GraphQL/useGraphQLUserData";
 import { setSelectedPanel } from "ui/actions/layout";
 import { getSelectedPanel, getToolboxLayout } from "ui/reducers/layout";
-import { getRecordingMightHaveRoutines } from "ui/reducers/timeline";
+import { getRecordingTooLongToSupportRoutines } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { SecondaryPanelName } from "ui/state/layout";
 import {
   REACT_ANNOTATIONS_KIND,
+  REACT_SETUP_ANNOTATIONS_KIND,
+  REDUX_ANNOTATIONS_KIND,
   REDUX_SETUP_ANNOTATIONS_KIND,
   annotationKindsCache,
 } from "ui/suspense/annotationsCaches";
@@ -139,15 +141,28 @@ export default function SecondaryToolbox() {
   const toolboxLayout = useAppSelector(getToolboxLayout);
   const dispatch = useAppDispatch();
   const replayClient = useContext(ReplayClientContext);
-  const mightHaveRoutines = useAppSelector(getRecordingMightHaveRoutines);
+  const recordingTooLongForRoutines = useAppSelector(getRecordingTooLongToSupportRoutines);
 
   // Don't suspend when waiting for annotations to load
-  const { value: hasReactAnnotations = false } = useImperativeCacheValue(
+  const { value: hasReactRoutineAnnotations = false } = useImperativeCacheValue(
     annotationKindsCache,
     replayClient,
     REACT_ANNOTATIONS_KIND
   );
-  const { value: hasReduxAnnotations = false } = useImperativeCacheValue(
+
+  const { value: hasReactRecordingAnnotations = false } = useImperativeCacheValue(
+    annotationKindsCache,
+    replayClient,
+    REACT_SETUP_ANNOTATIONS_KIND
+  );
+
+  const { value: hasReduxRoutineAnnotations = false } = useImperativeCacheValue(
+    annotationKindsCache,
+    replayClient,
+    REDUX_ANNOTATIONS_KIND
+  );
+
+  const { value: hasReduxRecordingAnnotations = false } = useImperativeCacheValue(
     annotationKindsCache,
     replayClient,
     REDUX_SETUP_ANNOTATIONS_KIND
@@ -160,11 +175,15 @@ export default function SecondaryToolbox() {
     ? toolboxLayout !== "ide"
     : toolboxLayout === "full";
 
-  // We definitely show these tabs if we have annotations.
-  // If we don't have annotations, we want to show the tabs anyway _if_ the recording
+  // We definitely show these tabs if we have actual annotations from the routine.
+  // If we don't have routine annotations, we want to show the tabs anyway _if_ the recording
   // is too long, in which case the panels will show a warning message describing why.
-  const shouldShowReactTab = hasReactAnnotations || !mightHaveRoutines;
-  const shouldShowReduxTab = hasReduxAnnotations || !mightHaveRoutines;
+  // Also, we should only show these tabs if we're pretty sure the recording actually has
+  // _some_ kind of React or Redux data available (ie, not a Vue or Angular app).
+  const shouldShowReactTab =
+    hasReactRoutineAnnotations || (hasReactRecordingAnnotations && recordingTooLongForRoutines);
+  const shouldShowReduxTab =
+    hasReduxRoutineAnnotations || (hasReduxRecordingAnnotations && recordingTooLongForRoutines);
 
   useLayoutEffect(() => {
     // If the selected panel is not available, switch to the console panel.

--- a/src/ui/components/SecondaryToolbox/react-devtools/components/ReactDevToolsPanel.module.css
+++ b/src/ui/components/SecondaryToolbox/react-devtools/components/ReactDevToolsPanel.module.css
@@ -90,7 +90,7 @@
   gap: 0.5rem;
   padding: 0.5rem;
   border-radius: 0.25rem;
-  font-size: 1rem;
+  font-size: var(--font-size-regular);
 }
 .ProtocolFailedMessage {
   margin: 0.5rem;

--- a/src/ui/components/SecondaryToolbox/react-devtools/components/ReactDevToolsPanel.module.css
+++ b/src/ui/components/SecondaryToolbox/react-devtools/components/ReactDevToolsPanel.module.css
@@ -90,6 +90,7 @@
   gap: 0.5rem;
   padding: 0.5rem;
   border-radius: 0.25rem;
+  font-size: 1rem;
 }
 .ProtocolFailedMessage {
   margin: 0.5rem;

--- a/src/ui/components/SecondaryToolbox/react-devtools/components/ReactDevToolsPanel.tsx
+++ b/src/ui/components/SecondaryToolbox/react-devtools/components/ReactDevToolsPanel.tsx
@@ -28,6 +28,8 @@ import { SelectedElementLoader } from "ui/components/SecondaryToolbox/react-devt
 import { useReactDevToolsAnnotations } from "ui/components/SecondaryToolbox/react-devtools/hooks/useReactDevToolsAnnotations";
 import { useReplayWall } from "ui/components/SecondaryToolbox/react-devtools/hooks/useReplayWall";
 import { ReactDevToolsListData } from "ui/components/SecondaryToolbox/react-devtools/ReactDevToolsListData";
+import { getRecordingMightHaveRoutines } from "ui/reducers/timeline";
+import { useAppSelector } from "ui/setup/hooks";
 import {
   ParsedReactDevToolsAnnotation,
   reactDevToolsAnnotationsCache,
@@ -71,6 +73,9 @@ function ReactDevToolsPanelInner({
   const [collapsedLeft, setCollapsedLeft] = useState(false);
   const [collapsedRight, setCollapsedRight] = useState(false);
   const [protocolCheckFailed, setProtocolCheckFailed] = useState(false);
+  const mightHaveRoutines = useAppSelector(getRecordingMightHaveRoutines);
+
+  const showRecordingTooLongWarning = !mightHaveRoutines;
 
   const leftPanelRef = useRef<ImperativePanelHandle>(null);
   const rightPanelRef = useRef<ImperativePanelHandle>(null);
@@ -96,6 +101,19 @@ function ReactDevToolsPanelInner({
     pauseId,
     wall,
   });
+
+  if (showRecordingTooLongWarning) {
+    return (
+      <div className={styles.ProtocolFailedPanel} data-test-id="ReactDevToolsPanel">
+        <div className={styles.NotMountedYetMessage}>
+          <div>
+            React components are unavailable because this recording was too long to process them
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   if (!hasReactMounted) {
     return (
       <div className={styles.ProtocolFailedPanel} data-test-id="ReactDevToolsPanel">

--- a/src/ui/components/SecondaryToolbox/react-devtools/components/ReactDevToolsPanel.tsx
+++ b/src/ui/components/SecondaryToolbox/react-devtools/components/ReactDevToolsPanel.tsx
@@ -28,7 +28,7 @@ import { SelectedElementLoader } from "ui/components/SecondaryToolbox/react-devt
 import { useReactDevToolsAnnotations } from "ui/components/SecondaryToolbox/react-devtools/hooks/useReactDevToolsAnnotations";
 import { useReplayWall } from "ui/components/SecondaryToolbox/react-devtools/hooks/useReplayWall";
 import { ReactDevToolsListData } from "ui/components/SecondaryToolbox/react-devtools/ReactDevToolsListData";
-import { getRecordingMightHaveRoutines } from "ui/reducers/timeline";
+import { getRecordingTooLongToSupportRoutines } from "ui/reducers/timeline";
 import { useAppSelector } from "ui/setup/hooks";
 import {
   ParsedReactDevToolsAnnotation,
@@ -73,9 +73,7 @@ function ReactDevToolsPanelInner({
   const [collapsedLeft, setCollapsedLeft] = useState(false);
   const [collapsedRight, setCollapsedRight] = useState(false);
   const [protocolCheckFailed, setProtocolCheckFailed] = useState(false);
-  const mightHaveRoutines = useAppSelector(getRecordingMightHaveRoutines);
-
-  const showRecordingTooLongWarning = !mightHaveRoutines;
+  const showRecordingTooLongWarning = useAppSelector(getRecordingTooLongToSupportRoutines);
 
   const leftPanelRef = useRef<ImperativePanelHandle>(null);
   const rightPanelRef = useRef<ImperativePanelHandle>(null);

--- a/src/ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsPanel.module.css
+++ b/src/ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsPanel.module.css
@@ -22,3 +22,13 @@
   height: 100%;
   overflow-y: auto;
 }
+
+.CouldNotLoadMessage {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+  font-size: 1rem;
+}

--- a/src/ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsPanel.module.css
+++ b/src/ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsPanel.module.css
@@ -30,5 +30,5 @@
   gap: 0.5rem;
   padding: 0.5rem;
   border-radius: 0.25rem;
-  font-size: 1rem;
+  font-size: var(--font-size-regular);
 }

--- a/src/ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsPanel.tsx
+++ b/src/ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsPanel.tsx
@@ -13,7 +13,7 @@ import { ActionFilter } from "ui/components/SecondaryToolbox/redux-devtools/Acti
 import { ReduxActionAnnotation } from "ui/components/SecondaryToolbox/redux-devtools/annotations";
 import { ReduxDevToolsContents } from "ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsContents";
 import { ReduxDevToolsList } from "ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsList";
-import { getRecordingMightHaveRoutines } from "ui/reducers/timeline";
+import { getRecordingTooLongToSupportRoutines } from "ui/reducers/timeline";
 import { useAppSelector } from "ui/setup/hooks";
 import { reduxDevToolsAnnotationsCache } from "ui/suspense/annotationsCaches";
 import { applyMiddlewareDeclCache } from "ui/suspense/jumpToLocationCache";
@@ -28,8 +28,7 @@ export default function ReduxDevToolsPanel() {
   const [searchValue, setSearchValue] = useState("");
 
   const currentExecutionPoint = useAppSelector(getExecutionPoint);
-  const mightHaveRoutines = useAppSelector(getRecordingMightHaveRoutines);
-  const showRecordingTooLongWarning = !mightHaveRoutines;
+  const showRecordingTooLongWarning = useAppSelector(getRecordingTooLongToSupportRoutines);
 
   const { status: annotationsStatus, value: parsedAnnotations } = useImperativeCacheValue(
     reduxDevToolsAnnotationsCache,

--- a/src/ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsPanel.tsx
+++ b/src/ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsPanel.tsx
@@ -13,6 +13,7 @@ import { ActionFilter } from "ui/components/SecondaryToolbox/redux-devtools/Acti
 import { ReduxActionAnnotation } from "ui/components/SecondaryToolbox/redux-devtools/annotations";
 import { ReduxDevToolsContents } from "ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsContents";
 import { ReduxDevToolsList } from "ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsList";
+import { getRecordingMightHaveRoutines } from "ui/reducers/timeline";
 import { useAppSelector } from "ui/setup/hooks";
 import { reduxDevToolsAnnotationsCache } from "ui/suspense/annotationsCaches";
 import { applyMiddlewareDeclCache } from "ui/suspense/jumpToLocationCache";
@@ -27,6 +28,8 @@ export default function ReduxDevToolsPanel() {
   const [searchValue, setSearchValue] = useState("");
 
   const currentExecutionPoint = useAppSelector(getExecutionPoint);
+  const mightHaveRoutines = useAppSelector(getRecordingMightHaveRoutines);
+  const showRecordingTooLongWarning = !mightHaveRoutines;
 
   const { status: annotationsStatus, value: parsedAnnotations } = useImperativeCacheValue(
     reduxDevToolsAnnotationsCache,
@@ -66,6 +69,16 @@ export default function ReduxDevToolsPanel() {
     // This will speed up the first click on a Redux "J2C" button
     applyMiddlewareDeclCache.prefetch(client);
   }, [client]);
+
+  if (showRecordingTooLongWarning) {
+    return (
+      <div className={styles.Container} data-test-id="ReduxDevtools">
+        <div className={styles.CouldNotLoadMessage}>
+          Redux actions are unavailable because this recording was too long to process them
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className={styles.Container} data-test-id="ReduxDevtools">

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -37,7 +37,6 @@ export const initialAppState: AppState = {
   modalOptions: null,
   mode: "devtools",
   mouseTargetsLoading: false,
-  recordingDuration: 0,
   recordingId: null,
   recordingTarget: null,
   recordingWorkspace: null,
@@ -188,7 +187,6 @@ export const getAccessToken = (state: UIState) => state.app.accessToken;
 export const getRecordingId = (state: UIState) => state.app.recordingId;
 export const isInspectorSelected = (state: UIState) =>
   getViewMode(state) === "dev" && getSelectedPanel(state) == "inspector";
-export const getRecordingDuration = (state: UIState) => state.app.recordingDuration;
 
 export const getLoadingFinished = (state: UIState) => state.app.loadingFinished;
 export const getUploading = (state: UIState) => state.app.uploading;

--- a/src/ui/reducers/timeline.ts
+++ b/src/ui/reducers/timeline.ts
@@ -10,15 +10,6 @@ import { mergeSortedPointLists } from "ui/utils/timeline";
 
 const initialFocusWindow = getPausePointParams().focusWindow;
 
-// The backend has a hardcoded limit it will only load recordings
-// up to 3 minutes long when running routines, otherwise it bails out.
-// If the recording is longer than that, we _won't_ have data for
-// React, Redux, or Jump to Code.
-// This corresponds to `RoutineMaxWindowDurationSeconds` in the backend.
-// The client uses recording duration in milliseconds.
-// Use this to show a warning in the React and Redux panels.
-export const MAX_RECORDING_LENGTH_FOR_ROUTINES_MS = 3 * 60 * 1000;
-
 function initialTimelineState(): TimelineState {
   return {
     allPaintsReceived: false,
@@ -28,6 +19,7 @@ function initialTimelineState(): TimelineState {
       : null,
     hoveredItem: null,
     markTimeStampedPoint: null,
+    maxRecordingDurationForRoutines: 0,
     hoverTime: null,
     playback: null,
     playbackFocusWindow: false,
@@ -150,7 +142,7 @@ export const isMaximumFocusWindow = (state: UIState) => {
   }
 };
 
-export const getRecordingMightHaveRoutines = (state: UIState) => {
-  const { recordingDuration } = state.timeline;
-  return recordingDuration !== null && recordingDuration! < MAX_RECORDING_LENGTH_FOR_ROUTINES_MS;
+export const getRecordingTooLongToSupportRoutines = (state: UIState) => {
+  const { recordingDuration, maxRecordingDurationForRoutines } = state.timeline;
+  return recordingDuration !== null && recordingDuration! > maxRecordingDurationForRoutines;
 };

--- a/src/ui/reducers/timeline.ts
+++ b/src/ui/reducers/timeline.ts
@@ -10,6 +10,15 @@ import { mergeSortedPointLists } from "ui/utils/timeline";
 
 const initialFocusWindow = getPausePointParams().focusWindow;
 
+// The backend has a hardcoded limit it will only load recordings
+// up to 3 minutes long when running routines, otherwise it bails out.
+// If the recording is longer than that, we _won't_ have data for
+// React, Redux, or Jump to Code.
+// This corresponds to `RoutineMaxWindowDurationSeconds` in the backend.
+// The client uses recording duration in milliseconds.
+// Use this to show a warning in the React and Redux panels.
+export const MAX_RECORDING_LENGTH_FOR_ROUTINES_MS = 3 * 60 * 1000;
+
 function initialTimelineState(): TimelineState {
   return {
     allPaintsReceived: false,
@@ -139,4 +148,9 @@ export const isMaximumFocusWindow = (state: UIState) => {
   } else {
     return false;
   }
+};
+
+export const getRecordingMightHaveRoutines = (state: UIState) => {
+  const { recordingDuration } = state.timeline;
+  return recordingDuration !== null && recordingDuration! < MAX_RECORDING_LENGTH_FOR_ROUTINES_MS;
 };

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -95,7 +95,6 @@ export interface AppState {
   modalOptions: ModalOptionsType;
   mode: AppMode;
   mouseTargetsLoading: boolean;
-  recordingDuration: number;
   recordingId: string | null;
   recordingTarget: RecordingTarget | null;
   recordingWorkspace: Workspace | null;

--- a/src/ui/state/timeline.ts
+++ b/src/ui/state/timeline.ts
@@ -19,6 +19,7 @@ export interface TimelineState {
   hoveredItem: HoveredItem | null;
   hoverTime: number | null;
   markTimeStampedPoint: TimeStampedPoint | null;
+  maxRecordingDurationForRoutines: number;
   paints: TimeStampedPoint[];
   playback: {
     beginTime: number;

--- a/src/ui/suspense/annotationsCaches.ts
+++ b/src/ui/suspense/annotationsCaches.ts
@@ -29,6 +29,7 @@ export interface ParsedJumpToCodeAnnotation extends TimeStampedPoint {
   nextEventPoint: TimeStampedPoint;
 }
 
+export const REACT_SETUP_ANNOTATIONS_KIND = "react-devtools-hook:v1:commit-fiber-root";
 export const REACT_ANNOTATIONS_KIND = "react-devtools-bridge";
 export const REDUX_SETUP_ANNOTATIONS_KIND = "redux-devtools-setup";
 export const REDUX_ANNOTATIONS_KIND = "redux-devtools-data";


### PR DESCRIPTION
This PR:

- Removes a dead `recordingDuration` field from `reducers/app` (the field we _actually_ use is in `reducers/timeline`)
- Adds logic to calculate if a recording is over 3 minutes long. We know that the backend hardcodes a limit of 3 minutes, otherwise it will skip running routines
- Updates `<SecondaryToolbox>` to show the React and Redux tabs if the recording is too long
- Updates the React and Redux panels to show a "Couldn't load data because the recording was too long" warning in that case