### PR TITLE
Elements search

### DIFF
--- a/packages/e2e-tests/helpers/elements-panel.ts
+++ b/packages/e2e-tests/helpers/elements-panel.ts
@@ -1,7 +1,6 @@
 import { Locator, Page, expect } from "@playwright/test";
 import chalk from "chalk";
 
-import { clearText } from "./lexical";
 import { getScreenshotScale } from "./screenshot";
 import { debugPrint, delay, waitFor } from "./utils";
 
@@ -318,6 +317,23 @@ async function openSelectedElementTab(page: Page, tabId: string): Promise<void> 
   await tabLocator.click({ force: true });
 }
 
+export async function getElementsSearchResultsCount(
+  page: Page
+): Promise<{ current: number; total: number } | null> {
+  const searchResults = page.locator('[data-test-id="ElementsPanel-SearchResult"]');
+  if (!(await searchResults.isVisible())) {
+    return null;
+  }
+
+  const text = await searchResults.textContent();
+  if (!text) {
+    return null;
+  }
+
+  const [currentString, totalString] = text.split(" of ");
+  return { current: parseInt(currentString), total: parseInt(totalString) };
+}
+
 export async function searchElementsPanel(page: Page, searchText: string): Promise<void> {
   await openElementsPanel(page);
 
@@ -341,6 +357,54 @@ export async function searchElementsPanel(page: Page, searchText: string): Promi
     // A proxy for confirming that the search has been handled is that a results label will be rendered.
     const resultsLabel = page.locator('[data-test-id="ElementsPanel-SearchResult"]');
     await expect(await resultsLabel.count()).toEqual(1);
+  });
+}
+
+export async function verifySearchResults(
+  page: Page,
+  expectations: {
+    currentNumber?: number;
+    text?: string;
+    totalNumber?: number;
+  }
+) {
+  const {
+    currentNumber: expectedCurrent,
+    text: expectedText,
+    totalNumber: expectedTotal,
+  } = expectations;
+
+  if (expectedCurrent != null || expectedTotal != null) {
+    await waitFor(async () => {
+      const { current: actualCurrent, total: actualTotal } =
+        (await getElementsSearchResultsCount(page)) ?? {};
+
+      if (expectedCurrent != null) {
+        expect(actualCurrent).toBe(expectedCurrent);
+      }
+
+      if (expectedTotal != null) {
+        expect(actualTotal).toBe(expectedTotal);
+      }
+    });
+  }
+
+  if (expectedText != null) {
+    await verifySelectedElement(page, expectedText);
+  }
+}
+
+export async function verifySelectedElement(page: Page, expectedText: string) {
+  await debugPrint(
+    page,
+    `Expect selected Element to contain "${expectedText}"`,
+    "verifySelectedElementName"
+  );
+
+  await waitFor(async () => {
+    const locator = await getElementsListRow(page, { isSelected: true });
+    const textContent = await locator.textContent();
+    expect(textContent).toContain(expectedText);
   });
 }
 
@@ -437,4 +501,9 @@ export async function typeKeyAndVerifySelectedElement(
   await page.keyboard.press(key);
   await waitForSelectedElementsRow(page, expectedRowText);
   await delay(500);
+}
+
+export async function verifyElementsNotAvailable(page: Page) {
+  const locator = page.locator('[data-test-id="Elements-NotAvailable"]');
+  await locator.waitFor();
 }

--- a/packages/e2e-tests/helpers/timeline.ts
+++ b/packages/e2e-tests/helpers/timeline.ts
@@ -141,14 +141,16 @@ export async function getTimelineCurrentPercent(page: Page) {
 }
 
 export async function seekToTimePercent(page: Page, timePercent: number) {
+  await debugPrint(page, `Seeking timeline to ${timePercent}%`, "seekToTimePercent");
+
   const timeline = getTimelineProgressBar(page);
   const timelineBoundingBox = await timeline.boundingBox();
   expect(timelineBoundingBox).not.toBeFalsy();
-  timeline.click({
-    position: {
-      x: timelineBoundingBox!.width * (timePercent / 100),
-      y: timelineBoundingBox!.height / 2,
-    },
+
+  const x = timelineBoundingBox!.width * (timePercent / 100);
+  const y = timelineBoundingBox!.height / 2;
+  await timeline.click({
+    position: { x, y },
   });
 }
 

--- a/packages/e2e-tests/tests/inspector-elements-01_basic-dom-tree-chromium.test.ts
+++ b/packages/e2e-tests/tests/inspector-elements-01_basic-dom-tree-chromium.test.ts
@@ -6,10 +6,12 @@ import {
   openElementsPanel,
   searchElementsPanel,
   selectNextElementsPanelSearchResult,
+  verifyElementsNotAvailable,
   waitForSelectedElementsRow,
 } from "../helpers/elements-panel";
 import { rewindToLine } from "../helpers/pause-information-panel";
 import { addBreakpoint } from "../helpers/source-panel";
+import { seekToTimePercent } from "../helpers/timeline";
 import test from "../testFixtureCloneRecording";
 
 test.use({ exampleKey: "doc_inspector_basic_chromium.html" });
@@ -39,4 +41,7 @@ test("inspector-elements-01: Basic DOM tree node display", async ({
   await searchElementsPanel(page, "STUFF");
   await selectNextElementsPanelSearchResult(page);
   await waitForSelectedElementsRow(page, 'id="div4"');
+
+  await seekToTimePercent(page, 0);
+  await verifyElementsNotAvailable(page);
 });

--- a/packages/e2e-tests/tests/inspector-elements-05_search-chromium.test.ts
+++ b/packages/e2e-tests/tests/inspector-elements-05_search-chromium.test.ts
@@ -1,0 +1,31 @@
+import { openDevToolsTab, startTest } from "../helpers";
+import { warpToMessage } from "../helpers/console-panel";
+import {
+  openElementsPanel,
+  searchElementsPanel,
+  verifySearchResults,
+  waitForElementsToLoad,
+} from "../helpers/elements-panel";
+import { seekToTimePercent } from "../helpers/timeline";
+import test from "../testFixtureCloneRecording";
+
+test.use({ exampleKey: "doc_inspector_basic_chromium.html" });
+
+test(`inspector-elements-05_search-chromium: element picker and iframe behavior`, async ({
+  pageWithMeta: { page, recordingId },
+  exampleKey,
+}) => {
+  await startTest(page, recordingId);
+  await openDevToolsTab(page);
+  await openElementsPanel(page);
+  await waitForElementsToLoad(page);
+
+  // This search string should not match anything initially
+  await seekToTimePercent(page, 1);
+  await searchElementsPanel(page, "inner-body");
+  await verifySearchResults(page, { currentNumber: 0, totalNumber: 0 });
+
+  // The search string should now match the <body> tag inside of the <iframe>
+  await seekToTimePercent(page, 15);
+  await verifySearchResults(page, { currentNumber: 1, text: "<body", totalNumber: 1 });
+});

--- a/packages/e2e-tests/tests/inspector-elements-05_search.test.ts
+++ b/packages/e2e-tests/tests/inspector-elements-05_search.test.ts
@@ -1,0 +1,31 @@
+import { openDevToolsTab, startTest } from "../helpers";
+import { warpToMessage } from "../helpers/console-panel";
+import {
+  openElementsPanel,
+  searchElementsPanel,
+  verifySearchResults,
+  waitForElementsToLoad,
+} from "../helpers/elements-panel";
+import { seekToTimePercent } from "../helpers/timeline";
+import test from "../testFixtureCloneRecording";
+
+test.use({ exampleKey: "doc_inspector_basic.html" });
+
+test(`inspector-elements-05_search: element picker and iframe behavior`, async ({
+  pageWithMeta: { page, recordingId },
+  exampleKey,
+}) => {
+  await startTest(page, recordingId);
+  await openDevToolsTab(page);
+  await openElementsPanel(page);
+  await waitForElementsToLoad(page);
+
+  // This search string should not match anything initially
+  await seekToTimePercent(page, 5);
+  await searchElementsPanel(page, "myiframe");
+  await verifySearchResults(page, { currentNumber: 0, totalNumber: 0 });
+
+  // The search string should now match text inside of the <script> tag
+  await seekToTimePercent(page, 90);
+  await verifySearchResults(page, { currentNumber: 1, text: "<iframe", totalNumber: 1 });
+});

--- a/packages/replay-next/components/elements-new/ElementsPanel.module.css
+++ b/packages/replay-next/components/elements-new/ElementsPanel.module.css
@@ -71,3 +71,19 @@
   flex: 1 1 auto;
   padding-bottom: 0.25rem;
 }
+
+.SpinnerIcon {
+  color: var(--color-dim);
+  width: 1rem;
+  height: 1rem;
+  animation: 1s spin linear infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0);
+  }
+  100% {
+    transform: rotate(359deg);
+  }
+}

--- a/packages/replay-next/components/elements-new/ElementsPanel.tsx
+++ b/packages/replay-next/components/elements-new/ElementsPanel.tsx
@@ -84,8 +84,7 @@ export function ElementsPanel({
 
     let results = await domSearchCache.readAsync(replayClient, pauseId, query);
 
-    // DOM search API may match on nodes that have been filtered (e.g. text nodes)
-    // Refine the results list in memory to remove these matches.
+    // DOM search API may match on nodes that are not displayed locally.
     results = results.filter(id => listData.contains(id));
 
     setSearchInProgress(false);

--- a/packages/replay-next/components/elements-new/ElementsPanel.tsx
+++ b/packages/replay-next/components/elements-new/ElementsPanel.tsx
@@ -6,6 +6,7 @@ import {
   Suspense,
   useCallback,
   useContext,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -74,6 +75,45 @@ export function ElementsPanel({
     }
   };
 
+  const runSearch = async () => {
+    if (listData == null || pauseId == null) {
+      return;
+    }
+
+    setSearchInProgress(true);
+
+    let results = await domSearchCache.readAsync(replayClient, pauseId, query);
+
+    // DOM search API may match on nodes that have been filtered (e.g. text nodes)
+    // Refine the results list in memory to remove these matches.
+    results = results.filter(id => listData.contains(id));
+
+    setSearchInProgress(false);
+    setSearchState({
+      index: results.length > 0 ? 0 : -1,
+      query,
+      results,
+    });
+
+    if (results.length > 0) {
+      const list = listRef.current;
+      if (list) {
+        const id = results[0];
+        list.selectNode(id);
+      }
+    }
+  };
+
+  const prevPauseIdRef = useRef<PauseId | null>(pauseId);
+  useLayoutEffect(() => {
+    const prevPauseId = prevPauseIdRef.current;
+    prevPauseIdRef.current = pauseId;
+
+    if (prevPauseId !== pauseId && !searchInProgress && query) {
+      runSearch();
+    }
+  });
+
   const onSearchInputChange = (event: ChangeEvent<HTMLInputElement>) => {
     setQuery(event.currentTarget.value);
   };
@@ -119,28 +159,7 @@ export function ElementsPanel({
             list.selectNode(id);
           }
         } else {
-          setSearchInProgress(true);
-
-          let results = await domSearchCache.readAsync(replayClient, pauseId, query);
-
-          // DOM search API may match on nodes that have been filtered (e.g. text nodes)
-          // Refine the results list in memory to remove these matches.
-          results = results.filter(id => listData.contains(id));
-
-          setSearchInProgress(false);
-          setSearchState({
-            index: results.length > 0 ? 0 : -1,
-            query,
-            results,
-          });
-
-          if (results.length > 0) {
-            const list = listRef.current;
-            if (list) {
-              const id = results[0];
-              list.selectNode(id);
-            }
-          }
+          runSearch();
         }
         break;
       }
@@ -170,7 +189,8 @@ export function ElementsPanel({
             value={query}
           />
         </label>
-        {searchState !== null && (
+        {searchInProgress && <Icon className={styles.SpinnerIcon} type="spinner" />}
+        {!searchInProgress && searchState !== null && (
           <div className={styles.SearchResults} data-test-id="ElementsPanel-SearchResult">
             {searchState.index + 1} of {searchState.results.length}
           </div>

--- a/packages/replay-next/components/elements-new/NoContentFallback.tsx
+++ b/packages/replay-next/components/elements-new/NoContentFallback.tsx
@@ -1,5 +1,9 @@
 import styles from "./NoContentFallback.module.css";
 
 export function NoContentFallback() {
-  return <div className={styles.Message}>Elements are not available</div>;
+  return (
+    <div className={styles.Message} data-test-id="Elements-NotAvailable">
+      Elements are not available
+    </div>
+  );
 }

--- a/packages/replay-next/components/elements/ElementsPanel.module.css
+++ b/packages/replay-next/components/elements/ElementsPanel.module.css
@@ -71,3 +71,19 @@
   flex: 1 1 auto;
   padding-bottom: 0.25rem;
 }
+
+.SpinnerIcon {
+  color: var(--color-dim);
+  width: 1rem;
+  height: 1rem;
+  animation: 1s spin linear infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0);
+  }
+  100% {
+    transform: rotate(359deg);
+  }
+}

--- a/packages/replay-next/components/elements/NoContentFallback.tsx
+++ b/packages/replay-next/components/elements/NoContentFallback.tsx
@@ -1,5 +1,9 @@
 import styles from "./NoContentFallback.module.css";
 
 export function NoContentFallback() {
-  return <div className={styles.Message}>Elements are not available</div>;
+  return (
+    <div className={styles.Message} data-test-id="Elements-NotAvailable">
+      Elements are not available
+    </div>
+  );
 }


### PR DESCRIPTION
Resolves FE-2097 and FE-2098.

- [x] Add more explicit "in progress" UI
- [x] Update search results if the user navigates to a new time/execution point
- [x] Add e2e tests for: Search update after seeking and empty Elements list panel

Note this change has been made two places because we have two Elements panels (for now)

### Legacy Elements (Gecko)

https://github.com/replayio/devtools/assets/29597/aa15caf5-9c16-4548-b644-d8a76f5d470e

### Elements (Chromium)

https://github.com/replayio/devtools/assets/29597/ff049c5a-05bc-4aa1-8bf0-5997081ad13a
