### PR TITLE
Make Elements panels collapsible

### DIFF
--- a/src/devtools/client/inspector/components/App.module.css
+++ b/src/devtools/client/inspector/components/App.module.css
@@ -1,0 +1,48 @@
+.Panel {
+  flex: 1;
+  display: flex;
+  flex-direction: row;
+  height: 100%;
+}
+
+.ResizeHandle,
+.ResizeHandleCollapsedLeft,
+.ResizeHandleCollapsedRight {
+  height: 100%;
+  width: 0.25rem;
+  background-color: var(--chrome);
+}
+.ResizeHandleCollapsedLeft,
+.ResizeHandleCollapsedRight {
+  width: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--body-bgcolor);
+}
+.ResizeHandleCollapsedLeft {
+  border-right: 0.25rem solid var(--chrome);
+}
+.ResizeHandleCollapsedLeft::after {
+  display: blocked;
+  content: "Elements";
+  cursor: pointer !important;
+  transform: rotate(-90deg);
+}
+.ResizeHandleCollapsedRight {
+  border-left: 0.25rem solid var(--chrome);
+}
+.ResizeHandleCollapsedRight::after {
+  display: blocked;
+  content: "Properties";
+  cursor: pointer !important;
+  transform: rotate(90deg);
+}
+.ResizeHandle:focus {
+  outline: none;
+}
+.ResizeHandleCollapsedLeft:focus,
+.ResizeHandleCollapsedRight:focus {
+  outline: none;
+  background: var(--background-color-resize-handle);
+}

--- a/src/devtools/client/inspector/components/App.tsx
+++ b/src/devtools/client/inspector/components/App.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 
 import ComputedApp from "devtools/client/inspector/computed/components/ComputedApp";
@@ -13,6 +14,7 @@ import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { ResponsiveTabs, Tab } from "../../shared/components/ResponsiveTabs";
 import { setActiveTab } from "../actions";
 import { EventListenersApp } from "../event-listeners/EventListenersApp";
+import styles from "./App.module.css";
 
 const INSPECTOR_TAB_TITLES: Record<ActiveInspectorTab, string> = {
   ruleview: "Rules",
@@ -33,6 +35,9 @@ export default function InspectorApp() {
   const activeTab = useAppSelector(state => state.inspector.activeTab);
   const { point } = useMostRecentLoadedPause() ?? {};
 
+  const [collapsedLeft, setCollapsedLeft] = useState(false);
+  const [collapsedRight, setCollapsedRight] = useState(false);
+
   const isPointWithinFocusWindow = useIsPointWithinFocusWindow(point ?? null);
   if (!isPointWithinFocusWindow) {
     return (
@@ -46,15 +51,22 @@ export default function InspectorApp() {
     );
   }
 
+  let resizeHandleClassName = styles.ResizeHandle;
+  if (collapsedLeft) {
+    resizeHandleClassName = styles.ResizeHandleCollapsedLeft;
+  } else if (collapsedRight) {
+    resizeHandleClassName = styles.ResizeHandleCollapsedRight;
+  }
+
   return (
     <div className="inspector-responsive-container theme-body inspector">
       <div id="inspector-splitter-box">
         <PanelGroup autoSaveId="App" className="inspector-sidebar-splitter" direction="horizontal">
-          <Panel minSize={20}>
+          <Panel collapsible minSize={20} onCollapse={setCollapsedLeft}>
             <ElementsPanelAdapter />
           </Panel>
-          <PanelResizeHandle className="h-full w-1 bg-chrome" />
-          <Panel defaultSize={40} minSize={20}>
+          <PanelResizeHandle className={resizeHandleClassName} />
+          <Panel collapsible defaultSize={40} minSize={20} onCollapse={setCollapsedRight}>
             <div className="devtools-inspector-tab-panel">
               <div id="inspector-sidebar-container">
                 <div id="inspector-sidebar">


### PR DESCRIPTION
I did this for the new React DevTools and it's nice to be able to get things out of the way if you want to see more of the tree. I don't think the CSS panels are very useful most of the time anyway.

https://github.com/replayio/devtools/assets/29597/f43beab8-185c-49ba-98a7-23af9bf420e7

