### PR TITLE
Placeholder NUX for testsuites

### DIFF
--- a/src/ui/components/Library/Team/View/TestRuns/TestRunList.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunList.tsx
@@ -4,6 +4,7 @@ import { FixedSizeList, ListChildComponentProps } from "react-window";
 
 import { TestRun } from "shared/test-suites/TestRun";
 import { TestRunListItem } from "ui/components/Library/Team/View/TestRuns/TestRunListItem";
+import TestRunsNUX from "ui/components/Library/Team/View/TestRuns/TestRunsNUX";
 import { SecondaryButton } from "ui/components/shared/Button";
 
 import { TestRunsContext } from "./TestRunsContextRoot";
@@ -36,17 +37,21 @@ export function TestRunList() {
 
   return (
     <ReactVirtualizedAutoSizer
-      children={({ height, width }) => (
-        <FixedSizeList
-          children={TestRunListRow}
-          className="no-scrollbar text-sm"
-          height={height}
-          itemCount={itemCount}
-          itemData={itemData}
-          itemSize={ROW_HEIGHT}
-          width={width}
-        />
-      )}
+      children={({ height, width }) =>
+        itemCount > 0 ? (
+          <FixedSizeList
+            children={TestRunListRow}
+            className="text-sm"
+            height={height}
+            itemCount={itemCount}
+            itemData={itemData}
+            itemSize={ROW_HEIGHT}
+            width={width}
+          />
+        ) : (
+          <TestRunsNUX />
+        )
+      }
     />
   );
 }

--- a/src/ui/components/Library/Team/View/TestRuns/TestRunsNUX.module.css
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunsNUX.module.css
@@ -1,0 +1,22 @@
+.container {
+  padding: 12px;
+  width: 100vw;
+}
+
+.title {
+  font-weight: 600;
+  font-size: 18px;
+  margin-bottom: 0.5rem;
+}
+
+.content {
+  font-size: 15px;
+}
+
+ul.content {
+  margin: 0.5rem 0;
+}
+
+.content a {
+  text-decoration: underline;
+}

--- a/src/ui/components/Library/Team/View/TestRuns/TestRunsNUX.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunsNUX.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import styles from "./TestRunsNUX.module.css";
 
-const TestRunsNUX: React.FC = () => {
+function TestRunsNUX() {
   return (
     <div className={styles.container}>
       <h1 className={styles.title}>Installation docs</h1>
@@ -32,6 +32,6 @@ const TestRunsNUX: React.FC = () => {
       </p>
     </div>
   );
-};
+}
 
 export default TestRunsNUX;

--- a/src/ui/components/Library/Team/View/TestRuns/TestRunsNUX.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunsNUX.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+
+import styles from "./TestRunsNUX.module.css";
+
+const TestRunsNUX: React.FC = () => {
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.title}>Installation docs</h1>
+      <p>
+        <ul className={styles.content}>
+          <li>
+            <a href="https://docs.replay.io/test-suites/cypress/cypress-installation">Cypress</a>
+          </li>
+          <li>
+            <a href="https://docs.replay.io/test-suites/playwright/playwright-installation">
+              Playwright
+            </a>
+          </li>
+
+          <li>
+            <a href="https://docs.replay.io/test-suites/puppeteer">Puppeteer</a>
+          </li>
+
+          <li>
+            <a href="https://docs.replay.io/test-suites/jest">Jest</a>
+          </li>
+
+          <li>
+            <a href="https://docs.replay.io/test-suites/webdriver-io">Webdriver-io</a>
+          </li>
+        </ul>
+      </p>
+    </div>
+  );
+};
+
+export default TestRunsNUX;


### PR DESCRIPTION
**Summary**

We're going to build something more engaging soon, but in the meantime we should at least link to our docs. I've added a new file called TestRunsNUX for us to build on more later.

(Note for later: I had trouble centering this content horizontally and vertically because the div stretches across the width of the page despite only being 1/3. We'll talk about that later)

**Old:**

<img width="750" alt="image" src="https://github.com/replayio/devtools/assets/9154902/b13eca9e-54b7-4cd7-87d6-67a8c52bb11d">



**New:**

![image](https://github.com/replayio/devtools/assets/9154902/a780f270-8e5c-4fc9-97b8-6bf07cb80b8f)
