### PR TITLE
Fix team navigation

### DIFF
--- a/src/ui/components/Library/Team/utils.ts
+++ b/src/ui/components/Library/Team/utils.ts
@@ -33,15 +33,9 @@ export function useRedirectToTeam(replace: boolean = false) {
 }
 
 export function replaceRoute(router: NextRouter, relativeURL: string): void {
-  router.replace({
-    pathname: relativeURL,
-    query: router.query,
-  });
+  router.replace({ pathname: relativeURL });
 }
 
 export function pushRoute(router: NextRouter, relativeURL: string): void {
-  router.push({
-    pathname: relativeURL,
-    query: router.query,
-  });
+  router.push({ pathname: relativeURL });
 }


### PR DESCRIPTION
The `replaceRoute()` and `pushRoute()` utils tried to copy the query parameters from the current URL to the one being navigated to. This doesn't work because `NextRouter` doesn't do what one would expect it to do:
- `router.query` contains non-query parameters: for example, when navigated to the URL `https://app.replay.io/team/me/recordings`, `router.query` will be `{ param: ["me", "recordings"] }`
- passing these parameters to `router.replace()` or `router.push()` doesn't work: the parameters will be added to the URL but with URL-encoded `?` and `&`, so the parameters become part of the new URL's _path_ and end up in the team ID

I don't think we currently need to copy any query parameters here, so I just removed them.