### PR TITLE
Dismiss preview popup on mouse leave

### DIFF
--- a/packages/replay-next/components/sources/Source.tsx
+++ b/packages/replay-next/components/sources/Source.tsx
@@ -94,6 +94,13 @@ function SourceRenderer({
     trackEventOnce("editor.mouse_over");
   };
 
+  function dismissPopup() {
+    // Mouse-out should immediately cancel any pending actions.
+    // This avoids race cases where we might show a popup after the mouse has moused away.
+    setHoverStateDebounced.cancel();
+    setHoveredState(null);
+  }
+
   const onMouseMove = (event: MouseEvent) => {
     const { clientX, clientY, defaultPrevented, target } = event;
 
@@ -128,10 +135,7 @@ function SourceRenderer({
       }
     }
 
-    // Mouse-out should immediately cancel any pending actions.
-    // This avoids race cases where we might show a popup after the mouse has moused away.
-    setHoverStateDebounced.cancel();
-    setHoveredState(null);
+    dismissPopup();
   };
 
   return (
@@ -142,6 +146,7 @@ function SourceRenderer({
       data-test-source-contents-status={sourceContentsStatus}
       data-test-source-id={source.sourceId}
       onMouseEnter={trackMouseHover}
+      onMouseLeave={dismissPopup}
     >
       <div className={styles.SourceList} onMouseMove={onMouseMove} ref={sourceRef}>
         <AutoSizer


### PR DESCRIPTION
We only dismissed the `PreviewPopup` when the mouse moves to a different token or a place without a token in the source viewer, but not when the mouse leaves the source viewer.