### PR TITLE
Remove support for Node and Gecko recordings

### DIFF
--- a/packages/e2e-tests/config.ts
+++ b/packages/e2e-tests/config.ts
@@ -1,14 +1,10 @@
 import { join } from "path";
 
-export type BrowserName = "firefox" | "chromium";
-
 export default {
   backendUrl: process.env.DISPATCH_ADDRESS || "wss://dispatch.replay.io",
   graphqlUrl: process.env.GRAPHQL_ADDRESS || "https://api.replay.io/v1/graphql",
   browserExamplesPath: join(__dirname, "../../public/test/examples"),
-  browserName: (process.env.RECORD_REPLAY_TARGET === "chromium"
-    ? "chromium"
-    : "firefox") as BrowserName,
+  browserName: "chromium",
   browserPath: process.env.RECORD_REPLAY_PATH,
   devtoolsUrl: process.env.PLAYWRIGHT_TEST_BASE_URL || "http://localhost:8080",
   driverPath: process.env.RECORD_REPLAY_DRIVER,

--- a/packages/e2e-tests/scripts/record-cypress.ts
+++ b/packages/e2e-tests/scripts/record-cypress.ts
@@ -1,9 +1,9 @@
 import { listAllRecordings, uploadRecording } from "@replayio/replay";
 import cypress from "cypress";
 
-import config, { BrowserName } from "../config";
+import config from "../config";
 
-export async function recordCypress(browserName: BrowserName, exampleFilename: string) {
+export async function recordCypress(exampleFilename: string) {
   const specName = `cypress/e2e/${exampleFilename}.cy.ts`;
   const exampleUrl = `${config.devtoolsUrl}/test/examples`;
 
@@ -12,7 +12,7 @@ export async function recordCypress(browserName: BrowserName, exampleFilename: s
     "run",
     "-q",
     "--browser",
-    browserName === "chromium" ? "replay-chromium" : "replay-firefox",
+    "replay-chromium",
     "--spec",
     specName,
   ]);

--- a/packages/e2e-tests/scripts/save-examples.ts
+++ b/packages/e2e-tests/scripts/save-examples.ts
@@ -44,7 +44,7 @@ const argv = yargs
     alias: "r",
     default: "",
     description: "Override runtime specified in test config",
-    choices: ["", "chromium", "firefox", "node"],
+    choices: ["", "chromium", "node"],
   })
   .option("target", {
     alias: "t",
@@ -68,7 +68,7 @@ type TestExampleFile = {
   category: "browser" | "node";
   filename: string;
   folder: string;
-  runtime: "firefox" | "chromium" | "node";
+  runtime: "chromium" | "node";
   playwrightScript?: PlaywrightScript;
 };
 const examplesJsonPath = join(__dirname, "..", "examples.json");

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -15,7 +15,9 @@ import { ExpandablesContextRoot } from "replay-next/src/contexts/ExpandablesCont
 import { PointsContextRoot } from "replay-next/src/contexts/points/PointsContext";
 import { SelectedFrameContextRoot } from "replay-next/src/contexts/SelectedFrameContext";
 import usePreferredFontSize from "replay-next/src/hooks/usePreferredFontSize";
+import { recordingTargetCache } from "replay-next/src/suspense/BuildIdCache";
 import { setDefaultTags } from "replay-next/src/utils/telemetry";
+import { replayClient } from "shared/client/ReplayClientContext";
 import { ReplayClientInterface } from "shared/client/types";
 import { getTestEnvironment } from "shared/test-suites/RecordingTestMetadata";
 import { useGraphQLUserData } from "shared/user-data/GraphQL/useGraphQLUserData";
@@ -28,6 +30,7 @@ import { NodePickerContextRoot } from "ui/components/NodePickerContext";
 import { RecordingDocumentTitle } from "ui/components/RecordingDocumentTitle";
 import TerminalContextAdapter from "ui/components/SecondaryToolbox/TerminalContextAdapter";
 import { TestSuiteContextRoot } from "ui/components/TestSuite/views/TestSuiteContext";
+import { UnsupportedTarget } from "ui/components/UnsupportedTarget";
 import { useGetRecording, useGetRecordingId } from "ui/hooks/recordings";
 import { useTrackLoadingIdleTime } from "ui/hooks/tracking";
 import { useGetUserInfo, useUserIsAuthor } from "ui/hooks/users";
@@ -167,6 +170,23 @@ function _DevTools({
   const { id: userId, email: userEmail, loading: userLoading, name: userName } = useGetUserInfo();
   const processing = useAppSelector(getProcessing);
 
+  // Sanity check to make sure we aren't viewing a recording from an unsupported target
+  const [unsupportedTarget, setUnsupportedTarget] = useState<null | string>(null);
+  useEffect(() => {
+    (async () => {
+      const target = await recordingTargetCache.readAsync(replayClient);
+      switch (target) {
+        case "chromium":
+        case "node":
+          break;
+        case "gecko":
+        default:
+          setUnsupportedTarget(target);
+          break;
+      }
+    })();
+  });
+
   const isExternalRecording = useMemo(
     () => recording?.user && !recording.user.internal,
     [recording]
@@ -263,6 +283,10 @@ function _DevTools({
   const dismissSupportForm = () => {
     dispatch(setShowSupportForm(false));
   };
+
+  if (unsupportedTarget) {
+    return <UnsupportedTarget target={unsupportedTarget} />;
+  }
 
   if (!loadingFinished) {
     return processing ? <DevToolsProcessingScreen /> : <DevToolsDynamicLoadingMessage />;

--- a/src/ui/components/UnsupportedTarget.tsx
+++ b/src/ui/components/UnsupportedTarget.tsx
@@ -1,0 +1,21 @@
+export function UnsupportedTarget({ target }: { target: string }) {
+  const url = new URL(window.location.href);
+  url.pathname + url.search;
+
+  return (
+    <div className="flex h-full flex-col items-center justify-center space-y-4">
+      <div>This player no longer supports recordings made with {target}.</div>
+
+      <div>
+        Please try{" "}
+        <a
+          className="pointer-hand underline"
+          href={`https://legacy-app.replay.io/${url.pathname + url.search}`}
+        >
+          legacy-app.replay.io
+        </a>{" "}
+        instead.
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- [x] Throw if a Gecko or Node recording is opened.
- [ ] Update all e2e test recordings to be in Chromium, delete any Firefox specific tests
- [ ] Remove legacy Elements and React DevTools panels (and conditionals)