### PR TITLE
ReferenceErrors rendering

### DIFF
--- a/packages/e2e-tests/tests/logpoints-03.test.ts
+++ b/packages/e2e-tests/tests/logpoints-03.test.ts
@@ -13,10 +13,7 @@ test(`logpoints-03: should display event properties in the console`, async ({
 
   await addEventListenerLogpoints(page, [{ eventType: "event.mouse.click", categoryKey: "mouse" }]);
 
-  const message = await findConsoleMessage(page, "MouseEvent", "event");
+  const message = await findConsoleMessage(page, "(click)", "event");
 
-  await expect(message).toContainText('type: "click"');
-  await expect(message).toContainText("target: <div");
-  await expect(message).toContainText("clientX: 0");
-  await expect(message).toContainText("clientY: 0");
+  await expect(message).toContainText("doc_events.html");
 });

--- a/packages/e2e-tests/tests/logpoints-03_chromium.test.ts
+++ b/packages/e2e-tests/tests/logpoints-03_chromium.test.ts
@@ -21,12 +21,7 @@ test(`logpoints-03_chromium: should display event properties in the console`, as
   // However, the E2E test helpers _do_ need this pattern to determine what categories to expand.
   await addEventListenerLogpoints(page, [{ eventType: "click", categoryKey: "mouse" }]);
 
-  const message = await findConsoleMessage(page, "PointerEvent", "event");
+  const message = await findConsoleMessage(page, "(click)", "event");
 
-  expandConsoleMessage(message);
-
-  await expect(message).toContainText('type: "click"');
-  await expect(message).toContainText("target: <div");
-  await expect(message).toContainText("clientX: 0");
-  await expect(message).toContainText("clientY: 0");
+  await expect(message).toContainText("doc_events_chromium.html");
 });

--- a/packages/e2e-tests/tests/stepping-05_chromium.test.ts
+++ b/packages/e2e-tests/tests/stepping-05_chromium.test.ts
@@ -38,7 +38,7 @@ test(`stepping-05_chromium: Test stepping in pretty-printed code`, async ({
 
   await openConsolePanel(page);
   await addEventListenerLogpoints(page, [{ eventType: "click", categoryKey: "mouse" }]);
-  await warpToMessage(page, "PointerEvent", 15);
+  await warpToMessage(page, "(click)", 15);
 
   await stepInToLine(page, 15);
   await stepOutToLine(page, 12);

--- a/packages/replay-next/components/console/LoggablesContext.tsx
+++ b/packages/replay-next/components/console/LoggablesContext.tsx
@@ -107,11 +107,11 @@ function LoggablesContextInner({
   const { endpoint } = useContext(SessionContext);
 
   // Find the set of event type handlers we should be displaying in the console.
-  const eventTypesToLoad = useMemo<EventHandlerType[]>(() => {
-    const filteredEventHandlerTypes: EventHandlerType[] = [];
-    for (let [eventType, enabled] of Object.entries(eventTypes)) {
+  const eventTypeAndLabelTuples = useMemo<[type: EventHandlerType, label: string][]>(() => {
+    const filteredEventHandlerTypes: [type: EventHandlerType, label: string][] = [];
+    for (let [eventType, { enabled, label }] of Object.entries(eventTypes)) {
       if (enabled) {
-        filteredEventHandlerTypes.push(eventType);
+        filteredEventHandlerTypes.push([eventType, label]);
       }
     }
     return filteredEventHandlerTypes;
@@ -123,17 +123,28 @@ function LoggablesContextInner({
       return [];
     }
     return suspendInParallel(
-      ...eventTypesToLoad.map(
-        eventType => () =>
-          getInfallibleEventPointsSuspense(
-            BigInt(focusRange.begin.point),
-            BigInt(focusRange.end.point),
-            client,
-            eventType
-          ) ?? []
+      ...eventTypeAndLabelTuples.map(
+        ([eventType, label]) =>
+          () =>
+            (
+              getInfallibleEventPointsSuspense(
+                BigInt(focusRange.begin.point),
+                BigInt(focusRange.end.point),
+                client,
+                [eventType]
+              ) ?? []
+            ).map(
+              pointDescription =>
+                ({
+                  ...pointDescription,
+                  eventType,
+                  label,
+                  type: "EventLog",
+                } satisfies EventLog)
+            )
       )
     ).flat();
-  }, [client, eventTypesToLoad, focusRange]);
+  }, [client, eventTypeAndLabelTuples, focusRange]);
 
   // Pre-filter in-focus messages by non text based search criteria.
   const preFilteredMessages = useMemo<ProtocolMessage[]>(() => {

--- a/packages/replay-next/components/console/filters/EventType.tsx
+++ b/packages/replay-next/components/console/filters/EventType.tsx
@@ -6,7 +6,7 @@ import Icon from "replay-next/components/Icon";
 import { ConsoleFiltersContext } from "replay-next/src/contexts/ConsoleFiltersContext";
 import { useCurrentFocusPointRange } from "replay-next/src/hooks/useCurrentFocusPointRange";
 import useTooltip from "replay-next/src/hooks/useTooltip";
-import { Event, eventsCache } from "replay-next/src/suspense/EventsCache";
+import { Event, eventPointsCache } from "replay-next/src/suspense/EventsCache";
 import { MAX_POINTS_TO_RUN_EVALUATION } from "shared/client/ReplayClient";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
@@ -27,11 +27,11 @@ export default function EventType({
   const focusPointRange = useCurrentFocusPointRange();
 
   const status = useIntervalCacheStatus(
-    eventsCache.pointsIntervalCache,
+    eventPointsCache,
     BigInt(focusPointRange.begin),
     BigInt(focusPointRange.end),
     client,
-    event.type
+    [event.type]
   );
 
   const { onMouseEnter, onMouseLeave, tooltip } = useTooltip({
@@ -39,14 +39,21 @@ export default function EventType({
     tooltip: "There are too many events. Please focus to a smaller time range and try again.",
   });
 
-  const checked = eventTypes[event.rawEventTypes[0]] === true;
+  const checked = eventTypes[event.rawEventTypes[0]]?.enabled ?? false;
   const newChecked = !checked;
-  const toggle = () =>
+  const toggle = () => {
     update({
       eventTypes: Object.fromEntries(
-        event.rawEventTypes.map(rawEventType => [rawEventType, newChecked])
+        event.rawEventTypes.map(rawEventType => [
+          rawEventType,
+          {
+            enabled: newChecked,
+            label: event.label,
+          },
+        ])
       ),
     });
+  };
 
   const stopPropagation = (event: MouseEvent) => {
     event.stopPropagation();

--- a/packages/replay-next/components/console/renderers/EventLogRenderer.tsx
+++ b/packages/replay-next/components/console/renderers/EventLogRenderer.tsx
@@ -1,14 +1,11 @@
-import { Fragment, useMemo, useRef, useState } from "react";
-import { useLayoutEffect } from "react";
-import { Suspense, memo, useContext } from "react";
+import { Suspense, memo, useContext, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import useConsoleContextMenu from "replay-next/components/console/useConsoleContextMenu";
-import Inspector from "replay-next/components/inspector";
 import Loader from "replay-next/components/Loader";
 import { ConsoleFiltersContext } from "replay-next/src/contexts/ConsoleFiltersContext";
 import { InspectableTimestampedPointContext } from "replay-next/src/contexts/InspectorContext";
 import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
-import { EventLog, eventsCache } from "replay-next/src/suspense/EventsCache";
+import { EventLog } from "replay-next/src/suspense/EventsCache";
 import { formatTimestamp } from "replay-next/src/utils/time";
 
 import MessageHoverButton from "../MessageHoverButton";
@@ -94,32 +91,14 @@ function EventLogRenderer({
 function AnalyzedContent({ eventLog }: { eventLog: EventLog }) {
   const { showTimestamps } = useContext(ConsoleFiltersContext);
 
-  const { pauseId, values } = eventsCache.resultsCache.read(eventLog.point, eventLog.eventType);
-
-  const content =
-    values.length > 0
-      ? values.map((value, index) => (
-          <Fragment key={index}>
-            <Inspector context="console" pauseId={pauseId} protocolValue={value} />
-            {index < values.length - 1 && " "}
-          </Fragment>
-        ))
-      : null;
-
   return (
     <>
       {showTimestamps && (
         <span className={styles.TimeStamp}>{formatTimestamp(eventLog.time, true)} </span>
       )}
-      {content ? (
-        <span className={styles.LogContents} data-test-name="LogContents">
-          {content}
-        </span>
-      ) : (
-        <span className={styles.LogContentsEmpty} data-test-name="LogContents">
-          No data to display.
-        </span>
-      )}
+      <span className={styles.LogContentsEmpty} data-test-name="LogContents">
+        ({eventLog.label})
+      </span>
     </>
   );
 }

--- a/packages/replay-next/src/contexts/ConsoleFiltersContext.tsx
+++ b/packages/replay-next/src/contexts/ConsoleFiltersContext.tsx
@@ -24,7 +24,10 @@ export type Toggles = {
 };
 
 export type EventTypes = {
-  [eventType: EventHandlerType]: boolean;
+  [eventType: EventHandlerType]: {
+    enabled: boolean;
+    label: string;
+  };
 };
 
 export type ConsoleFiltersContextType = Toggles & {


### PR DESCRIPTION
Split off from #9965

Note that pending the outcome of RUN-2972, this PR may not be necessary.

---

Chromium returns an unexpected format for reference errors:
```js
{
  result: {
    result: {
      data: {
        objects: [
          {
            className: "ReferenceError",
            objectId: "1",
            // ...
          },
        ],
      },
      exception: {
        unavailable: true,
      },
      returned: {
        object: "1",
      },
    },
  },
  // ...
}
```

So far as I know this should really only happen in two places:
* Log points
* Terminal expressions

This PR updates those two places to better render these errors (by rendering the error message rather than "(unavailable)")

### Log point
| before | after |
| :---: | :---: |
| ![Screenshot 2023-12-05 at 1 48 24 PM](https://github.com/replayio/devtools/assets/29597/31679679-5b20-4284-94b7-4f5bded6a4c1) | ![Screenshot 2023-12-05 at 1 48 28 PM](https://github.com/replayio/devtools/assets/29597/a5f12955-84ee-40bf-9b1c-a194b4402513) |

### Terminal expression
| before | after |
| :---: | :---: |
| ![Screenshot 2023-12-05 at 1 48 40 PM](https://github.com/replayio/devtools/assets/29597/a525669c-1e00-42b0-ad2a-a20da4869879) | ![Screenshot 2023-12-05 at 1 48 45 PM](https://github.com/replayio/devtools/assets/29597/3618ab5f-e209-48ee-94ab-370d27d99216) |