### PR TITLE
Filter test runs by branch via graphql

### DIFF
--- a/src/ui/components/Library/Team/View/TestRuns/TestRunsContextRoot.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunsContextRoot.tsx
@@ -37,8 +37,6 @@ type FilterByStatus = "all" | "failed";
 export function TestRunsContextRoot({ children }: { children: ReactNode }) {
   const { teamId, testRunId: defaultTestRunId } = useGetTeamRouteParams();
 
-  const testRuns = useTestRuns();
-
   const [testRunId, setTestRunId] = useState<string | null>(defaultTestRunId);
 
   const [filterByBranch, setFilterByBranch] = useState<FilterByBranch>(() => {
@@ -50,6 +48,8 @@ export function TestRunsContextRoot({ children }: { children: ReactNode }) {
     return (query.get("filterByStatus") as FilterByStatus) ?? "all";
   });
 
+  const testRuns = useTestRuns(filterByBranch === "primary" ? "primary" : null);
+
   const [filterByText, setFilterByText] = useState("");
   const filterByTextDeferred = useDeferredValue(filterByText);
 
@@ -58,7 +58,7 @@ export function TestRunsContextRoot({ children }: { children: ReactNode }) {
   const filteredTestRuns = useMemo(() => {
     let filteredTestRuns = testRuns;
 
-    if (filterByBranch === "primary" || filterByStatus === "failed" || filterByText !== "") {
+    if (filterByStatus === "failed" || filterByText !== "") {
       const lowerCaseText = filterByText.toLowerCase();
 
       filteredTestRuns = filteredTestRuns.filter(testRun => {
@@ -69,13 +69,6 @@ export function TestRunsContextRoot({ children }: { children: ReactNode }) {
         }
 
         const branchName = testRun.source?.branchName ?? "";
-
-        if (filterByBranch === "primary") {
-          // TODO This should be configurable by Workspace
-          if (branchName !== "main" && branchName !== "master") {
-            return false;
-          }
-        }
 
         if (filterByText !== "") {
           const user = testRun.source?.user ?? "";
@@ -95,7 +88,7 @@ export function TestRunsContextRoot({ children }: { children: ReactNode }) {
     }
 
     return filteredTestRuns;
-  }, [filterByBranch, filterByStatus, filterByText, testRuns]);
+  }, [filterByStatus, filterByText, testRuns]);
 
   useEffect(() => {
     if (testRunId == null) {

--- a/src/ui/components/Library/Team/View/TestRuns/TestRunsContextRoot.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunsContextRoot.tsx
@@ -48,7 +48,7 @@ export function TestRunsContextRoot({ children }: { children: ReactNode }) {
     return (query.get("filterByStatus") as FilterByStatus) ?? "all";
   });
 
-  const testRuns = useTestRuns(filterByBranch === "primary" ? "primary" : null);
+  const testRuns = useTestRuns(filterByBranch === "primary" ? "workspace:primary" : null);
 
   const [filterByText, setFilterByText] = useState("");
   const filterByTextDeferred = useDeferredValue(filterByText);

--- a/src/ui/components/Library/Team/View/TestRuns/graphql/TestRunsGraphQL.ts
+++ b/src/ui/components/Library/Team/View/TestRuns/graphql/TestRunsGraphQL.ts
@@ -76,11 +76,11 @@ const GET_TEST_RUN_RECORDINGS = gql`
 `;
 
 const GET_TEST_RUNS = gql`
-  query GetTestsRunsForWorkspace($workspaceId: ID!) {
+  query GetTestsRunsForWorkspace($workspaceId: ID!, $branch: String) {
     node(id: $workspaceId) {
       ... on Workspace {
         id
-        testRuns {
+        testRuns(filter: { branch: $branch }) {
           edges {
             node {
               id
@@ -138,13 +138,14 @@ export async function getTestRunTestsWithRecordingsGraphQL(
 export async function getTestRunsGraphQL(
   graphQLClient: GraphQLClientInterface,
   accessToken: string | null,
-  workspaceId: string
+  workspaceId: string,
+  branch: string | null
 ): Promise<GetTestsRunsForWorkspace_node_Workspace_testRuns_edges_node[]> {
   const response = await graphQLClient.send<GetTestsRunsForWorkspace>(
     {
       operationName: "GetTestsRunsForWorkspace",
       query: GET_TEST_RUNS,
-      variables: { workspaceId },
+      variables: { workspaceId, branch: branch ?? null },
     },
     accessToken
   );

--- a/src/ui/components/Library/Team/View/TestRuns/hooks/useTestRuns.ts
+++ b/src/ui/components/Library/Team/View/TestRuns/hooks/useTestRuns.ts
@@ -9,7 +9,7 @@ import useToken from "ui/utils/useToken";
 
 const EMPTY_ARRAY: any[] = [];
 
-export function useTestRuns(): TestRun[] {
+export function useTestRuns(branch: string | null): TestRun[] {
   const graphQLClient = useContext(GraphQLClientContext);
   const { teamId } = useContext(TeamContext);
 
@@ -19,7 +19,8 @@ export function useTestRuns(): TestRun[] {
     testRunsCache,
     graphQLClient,
     accessToken?.token ?? null,
-    teamId
+    teamId,
+    branch
   );
   return value;
 }

--- a/src/ui/components/Library/Team/View/TestRuns/suspense/TestRunsCache.ts
+++ b/src/ui/components/Library/Team/View/TestRuns/suspense/TestRunsCache.ts
@@ -12,14 +12,19 @@ import { convertRecording } from "ui/hooks/recordings";
 import { TestGroups, groupRecordings, testFailed, testPassed } from "ui/utils/testRuns";
 
 export const testRunsCache = createCache<
-  [graphQLClient: GraphQLClientInterface, accessToken: string | null, workspaceId: string],
+  [
+    graphQLClient: GraphQLClientInterface,
+    accessToken: string | null,
+    workspaceId: string,
+    branch: string | null
+  ],
   TestRun[]
 >({
   config: { immutable: true },
   debugLabel: "testRunsCache",
-  getKey: ([_, __, workspaceId]) => workspaceId,
-  load: async ([graphQLClient, accessToken, workspaceId]) => {
-    const rawTestRuns = await getTestRunsGraphQL(graphQLClient, accessToken, workspaceId);
+  getKey: ([_, __, workspaceId, branch]) => `${workspaceId}+${branch ?? "all"}`,
+  load: async ([graphQLClient, accessToken, workspaceId, branch]) => {
+    const rawTestRuns = await getTestRunsGraphQL(graphQLClient, accessToken, workspaceId, branch);
 
     const testRuns = rawTestRuns.map(processTestRun);
 


### PR DESCRIPTION
Blocked by https://github.com/replayio/backend/pull/9108

Filter test runs by branch via graphql by plumbing the branch name through the cache and to the graphql query