### PR TITLE
Adjusting line number margin to wrap better

### DIFF
--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
@@ -140,7 +140,8 @@ export default memo(function UserActionEventRow({
         }
 
         if (event === userActionEvent) {
-          return eventNumber;
+          // Prepend eventNumber with a zero if it's under 10
+          return eventNumber < 10 ? `0${eventNumber}` : eventNumber;
         }
       }
     }
@@ -150,15 +151,19 @@ export default memo(function UserActionEventRow({
 
   return (
     <div
-      className={styles.Row}
+      className="flex items-start space-x-0"
       data-chained-event={parentId !== null || undefined}
       data-status={error ? "error" : "success"}
       onClick={jumpToTestSourceDisabled ? undefined : onClickJumpToTestSource}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
-      <div className={styles.Text}>
-        {eventNumber != null ? <span className={styles.Number}>{eventNumber}</span> : null}
+      {eventNumber != null ? (
+        <div className="flex-none">
+          <span className={styles.Number}>{eventNumber}</span>
+        </div>
+      ) : null}
+      <div className="flex-grow">
         <span
           className={`${styles.Name} ${styles.Name}`}
           data-name={command.name}
@@ -171,12 +176,14 @@ export default memo(function UserActionEventRow({
         </span>
       </div>
       {showBadge && (
-        <Suspense fallback={<Loader />}>
-          <Badge isSelected={isSelected} timeStampedPoint={resultTimeStampedPoint} />
-        </Suspense>
+        <div className="flex-none">
+          <Suspense fallback={<Loader />}>
+            <Badge isSelected={isSelected} timeStampedPoint={resultTimeStampedPoint} />
+          </Suspense>
+        </div>
       )}
       {showJumpToCode && jumpToCodeAnnotation && (
-        <div className={styles.JumpToCodeButton}>
+        <div className="flex-none">
           <JumpToCodeButton
             currentExecutionPoint={executionPoint}
             onClick={onJumpToClickEvent}

--- a/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.module.css
+++ b/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.module.css
@@ -9,6 +9,7 @@
   border-left: 2px solid transparent;
   background-color: var(--row-background-color);
   color: var(--row-color);
+  column-gap: 0;
 }
 .Row:hover,
 .Row[data-context-menu-active] {


### PR DESCRIPTION
**Summary**

Right now we're prepending line numbers before the command, which means that line wrapping looks off. This change gives the line numbers their own column for easier scanning.

**Code note:**

I'm using tailwind. I tried doing this in a css module but something was overwriting it and I couldn't figure it out for the life of me. So I'm submitting this as-is, and if we feel strongly about the tailwind stuff, any help would be welcome.

**Old:**
<img width="525" alt="image" src="https://github.com/replayio/devtools/assets/9154902/3aead472-d987-4aab-967e-5aae2f4ebd8e">

**New:**
<img width="525" alt="image" src="https://github.com/replayio/devtools/assets/9154902/f5a3ba44-d8ab-45e6-95f8-484c36fb6643">
