### PR TITLE
[RUN-2965] Add better error reporting

### DIFF
--- a/packages/replay-next/components/elements-new/utils/serialization.ts
+++ b/packages/replay-next/components/elements-new/utils/serialization.ts
@@ -117,6 +117,8 @@ export function serializeDOM(rootNode: Document): number[] {
         const id = __RECORD_REPLAY_ARGUMENTS__.internal.registerPlainObject(value);
         if (id) {
           return parseInt(id);
+        } else {
+          throw Error(`[RUN-2965] registerPlainObject failed for value: ${JSON.stringify(value, null, 2)}`);
         }
       }
     }


### PR DESCRIPTION
* Make sure that we understand why and if `registerPlainValue` fails.
* https://linear.app/replay/issue/RUN-2965/fe-throws-could-not-find-object-id#comment-2784c3b8