### PR TITLE
Console event filters

### DIFF
--- a/packages/e2e-tests/tests/logpoints-03.test.ts
+++ b/packages/e2e-tests/tests/logpoints-03.test.ts
@@ -13,10 +13,7 @@ test(`logpoints-03: should display event properties in the console`, async ({
 
   await addEventListenerLogpoints(page, [{ eventType: "event.mouse.click", categoryKey: "mouse" }]);
 
-  const message = await findConsoleMessage(page, "MouseEvent", "event");
+  const message = await findConsoleMessage(page, "(click)", "event");
 
-  await expect(message).toContainText('type: "click"');
-  await expect(message).toContainText("target: <div");
-  await expect(message).toContainText("clientX: 0");
-  await expect(message).toContainText("clientY: 0");
+  await expect(message).toContainText("doc_events.html");
 });

--- a/packages/e2e-tests/tests/logpoints-03_chromium.test.ts
+++ b/packages/e2e-tests/tests/logpoints-03_chromium.test.ts
@@ -21,12 +21,7 @@ test(`logpoints-03_chromium: should display event properties in the console`, as
   // However, the E2E test helpers _do_ need this pattern to determine what categories to expand.
   await addEventListenerLogpoints(page, [{ eventType: "click", categoryKey: "mouse" }]);
 
-  const message = await findConsoleMessage(page, "PointerEvent", "event");
+  const message = await findConsoleMessage(page, "(click)", "event");
 
-  expandConsoleMessage(message);
-
-  await expect(message).toContainText('type: "click"');
-  await expect(message).toContainText("target: <div");
-  await expect(message).toContainText("clientX: 0");
-  await expect(message).toContainText("clientY: 0");
+  await expect(message).toContainText("doc_events_chromium.html");
 });

--- a/packages/e2e-tests/tests/stepping-05_chromium.test.ts
+++ b/packages/e2e-tests/tests/stepping-05_chromium.test.ts
@@ -38,7 +38,7 @@ test(`stepping-05_chromium: Test stepping in pretty-printed code`, async ({
 
   await openConsolePanel(page);
   await addEventListenerLogpoints(page, [{ eventType: "click", categoryKey: "mouse" }]);
-  await warpToMessage(page, "PointerEvent", 15);
+  await warpToMessage(page, "(click)", 15);
 
   await stepInToLine(page, 15);
   await stepOutToLine(page, 12);

--- a/packages/replay-next/components/console/LoggablesContext.tsx
+++ b/packages/replay-next/components/console/LoggablesContext.tsx
@@ -107,11 +107,11 @@ function LoggablesContextInner({
   const { endpoint } = useContext(SessionContext);
 
   // Find the set of event type handlers we should be displaying in the console.
-  const eventTypesToLoad = useMemo<EventHandlerType[]>(() => {
-    const filteredEventHandlerTypes: EventHandlerType[] = [];
-    for (let [eventType, enabled] of Object.entries(eventTypes)) {
+  const eventTypeAndLabelTuples = useMemo<[type: EventHandlerType, label: string][]>(() => {
+    const filteredEventHandlerTypes: [type: EventHandlerType, label: string][] = [];
+    for (let [eventType, { enabled, label }] of Object.entries(eventTypes)) {
       if (enabled) {
-        filteredEventHandlerTypes.push(eventType);
+        filteredEventHandlerTypes.push([eventType, label]);
       }
     }
     return filteredEventHandlerTypes;
@@ -123,17 +123,28 @@ function LoggablesContextInner({
       return [];
     }
     return suspendInParallel(
-      ...eventTypesToLoad.map(
-        eventType => () =>
-          getInfallibleEventPointsSuspense(
-            BigInt(focusRange.begin.point),
-            BigInt(focusRange.end.point),
-            client,
-            eventType
-          ) ?? []
+      ...eventTypeAndLabelTuples.map(
+        ([eventType, label]) =>
+          () =>
+            (
+              getInfallibleEventPointsSuspense(
+                BigInt(focusRange.begin.point),
+                BigInt(focusRange.end.point),
+                client,
+                [eventType]
+              ) ?? []
+            ).map(
+              pointDescription =>
+                ({
+                  ...pointDescription,
+                  eventType,
+                  label,
+                  type: "EventLog",
+                } satisfies EventLog)
+            )
       )
     ).flat();
-  }, [client, eventTypesToLoad, focusRange]);
+  }, [client, eventTypeAndLabelTuples, focusRange]);
 
   // Pre-filter in-focus messages by non text based search criteria.
   const preFilteredMessages = useMemo<ProtocolMessage[]>(() => {

--- a/packages/replay-next/components/console/filters/EventType.tsx
+++ b/packages/replay-next/components/console/filters/EventType.tsx
@@ -6,7 +6,7 @@ import Icon from "replay-next/components/Icon";
 import { ConsoleFiltersContext } from "replay-next/src/contexts/ConsoleFiltersContext";
 import { useCurrentFocusPointRange } from "replay-next/src/hooks/useCurrentFocusPointRange";
 import useTooltip from "replay-next/src/hooks/useTooltip";
-import { Event, eventsCache } from "replay-next/src/suspense/EventsCache";
+import { Event, eventPointsCache } from "replay-next/src/suspense/EventsCache";
 import { MAX_POINTS_TO_RUN_EVALUATION } from "shared/client/ReplayClient";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
@@ -27,11 +27,11 @@ export default function EventType({
   const focusPointRange = useCurrentFocusPointRange();
 
   const status = useIntervalCacheStatus(
-    eventsCache.pointsIntervalCache,
+    eventPointsCache,
     BigInt(focusPointRange.begin),
     BigInt(focusPointRange.end),
     client,
-    event.type
+    [event.type]
   );
 
   const { onMouseEnter, onMouseLeave, tooltip } = useTooltip({
@@ -39,14 +39,21 @@ export default function EventType({
     tooltip: "There are too many events. Please focus to a smaller time range and try again.",
   });
 
-  const checked = eventTypes[event.rawEventTypes[0]] === true;
+  const checked = eventTypes[event.rawEventTypes[0]]?.enabled ?? false;
   const newChecked = !checked;
-  const toggle = () =>
+  const toggle = () => {
     update({
       eventTypes: Object.fromEntries(
-        event.rawEventTypes.map(rawEventType => [rawEventType, newChecked])
+        event.rawEventTypes.map(rawEventType => [
+          rawEventType,
+          {
+            enabled: newChecked,
+            label: event.label,
+          },
+        ])
       ),
     });
+  };
 
   const stopPropagation = (event: MouseEvent) => {
     event.stopPropagation();

--- a/packages/replay-next/components/console/renderers/EventLogRenderer.tsx
+++ b/packages/replay-next/components/console/renderers/EventLogRenderer.tsx
@@ -1,14 +1,11 @@
-import { Fragment, useMemo, useRef, useState } from "react";
-import { useLayoutEffect } from "react";
-import { Suspense, memo, useContext } from "react";
+import { Suspense, memo, useContext, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import useConsoleContextMenu from "replay-next/components/console/useConsoleContextMenu";
-import Inspector from "replay-next/components/inspector";
 import Loader from "replay-next/components/Loader";
 import { ConsoleFiltersContext } from "replay-next/src/contexts/ConsoleFiltersContext";
 import { InspectableTimestampedPointContext } from "replay-next/src/contexts/InspectorContext";
 import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
-import { EventLog, eventsCache } from "replay-next/src/suspense/EventsCache";
+import { EventLog } from "replay-next/src/suspense/EventsCache";
 import { formatTimestamp } from "replay-next/src/utils/time";
 
 import MessageHoverButton from "../MessageHoverButton";
@@ -94,32 +91,14 @@ function EventLogRenderer({
 function AnalyzedContent({ eventLog }: { eventLog: EventLog }) {
   const { showTimestamps } = useContext(ConsoleFiltersContext);
 
-  const { pauseId, values } = eventsCache.resultsCache.read(eventLog.point, eventLog.eventType);
-
-  const content =
-    values.length > 0
-      ? values.map((value, index) => (
-          <Fragment key={index}>
-            <Inspector context="console" pauseId={pauseId} protocolValue={value} />
-            {index < values.length - 1 && " "}
-          </Fragment>
-        ))
-      : null;
-
   return (
     <>
       {showTimestamps && (
         <span className={styles.TimeStamp}>{formatTimestamp(eventLog.time, true)} </span>
       )}
-      {content ? (
-        <span className={styles.LogContents} data-test-name="LogContents">
-          {content}
-        </span>
-      ) : (
-        <span className={styles.LogContentsEmpty} data-test-name="LogContents">
-          No data to display.
-        </span>
-      )}
+      <span className={styles.LogContentsEmpty} data-test-name="LogContents">
+        ({eventLog.label})
+      </span>
     </>
   );
 }

--- a/packages/replay-next/src/contexts/ConsoleFiltersContext.tsx
+++ b/packages/replay-next/src/contexts/ConsoleFiltersContext.tsx
@@ -24,7 +24,10 @@ export type Toggles = {
 };
 
 export type EventTypes = {
-  [eventType: EventHandlerType]: boolean;
+  [eventType: EventHandlerType]: {
+    enabled: boolean;
+    label: string;
+  };
 };
 
 export type ConsoleFiltersContextType = Toggles & {


### PR DESCRIPTION
Split off from #9965

Note that pending the outcome of RUN-2969, some of this PR may be unnecessary. (I think we'll likely want to keep the explicit label rendering, but also render the function arguments.)

---

I also noticed one of our e2e tests failing on this branch. Previously it printed "(unavailable)" but now it prints "arguments is not defined" because our e2e test used an arrow function and arrow functions don't have an `arguments` variable:
```js
const arrow = () => {
  console.log(arguments);
}
arrow(); // throws: ReferenceError: arguments is not defined
```

I think this approach is fundamentally flawed for a few reasons ([that I explain in this video](https://www.loom.com/share/689e536d95bf422791b41377e113f943)) but the tl;dr is that I have changed our event logs to print the event type only. If you want to inspect the value, you click through to the execution point.

| before | after |
| :---: | :---: |
| ![Screenshot 2023-12-05 at 9 03 37 PM](https://github.com/replayio/devtools/assets/29597/1e6abef9-7b0e-46a1-992a-e5a38e370569) | ![Screenshot 2023-12-05 at 9 04 01 PM](https://github.com/replayio/devtools/assets/29597/edd67db1-c712-4b70-85aa-8a1832ecaf31) |

Note once RUN-2969 lands, we can add back the arguments info (but maybe **after** the event type label that's been added in this PR).