### PR TITLE
Testsuites polish: Standarding our messaging

### DIFF
--- a/src/ui/components/Library/Team/View/NewTestRuns/TestRunSpecDetails.tsx
+++ b/src/ui/components/Library/Team/View/NewTestRuns/TestRunSpecDetails.tsx
@@ -6,6 +6,7 @@ import { TestRunTestWithRecordings } from "shared/test-suites/TestRun";
 import { useTestRunDetailsSuspends } from "../TestRuns/hooks/useTestRunDetailsSuspends";
 import { TestResultListItem } from "./Overview/TestResultListItem";
 import { TestRunsContext } from "./TestRunsContextRoot";
+import styles from "../../../Testsuites.module.css";
 
 export function TestRunSpecDetails() {
   const { spec, filterTestsByText } = useContext(TestRunsContext);
@@ -24,9 +25,7 @@ export function TestRunSpecDetails() {
   if (!spec) {
     return (
       <div className="flex h-full w-full items-center justify-center p-2">
-        <div className="rounded-md bg-chrome py-2 px-3 text-center">
-          Select a test to see its details here
-        </div>
+        <div className={styles.standardMessaging}>Select a test to see its details here</div>
       </div>
     );
   } else if (groupedTests === null || selectedTest == null) {

--- a/src/ui/components/Library/Team/View/Tests/Overview/TestOverviewContent.tsx
+++ b/src/ui/components/Library/Team/View/Tests/Overview/TestOverviewContent.tsx
@@ -5,7 +5,8 @@ import { LibrarySpinner } from "ui/components/Library/LibrarySpinner";
 import { useTest } from "../hooks/useTest";
 import { TestContext } from "../TestContextRoot";
 import { TestDetails } from "./TestDetails";
-import styles from "../../../../Library.module.css";
+import libraryStyles from "../../../../Library.module.css";
+import styles from "../../../../Testsuites.module.css";
 
 export function TestOverviewContent() {
   const { testId } = useContext(TestContext);
@@ -17,15 +18,13 @@ export function TestOverviewContent() {
   } else {
     children = (
       <div className="flex h-full items-center justify-center p-2">
-        <div className="rounded-md bg-chrome px-3 py-2 text-center">
-          Select a test to see its details here
-        </div>
+        <div className={styles.standardMessaging}>Select a test to see its details here</div>
       </div>
     );
   }
 
   return (
-    <div className={`flex h-full flex-col text-sm transition ${styles.runOverview} `}>
+    <div className={`flex h-full flex-col text-sm transition ${libraryStyles.runOverview} `}>
       {children}
     </div>
   );
@@ -50,7 +49,7 @@ function TestOverview({ testId }: { testId: string }) {
 
   return (
     <div className="flex flex-col overflow-y-auto">
-      <div className={styles.testTitle}>
+      <div className={libraryStyles.testTitle}>
         <div>{test.title}</div>
       </div>
       <div className="flex flex-col overflow-y-auto">

--- a/src/ui/components/Library/Testsuites.module.css
+++ b/src/ui/components/Library/Testsuites.module.css
@@ -1,0 +1,7 @@
+.standardMessaging {
+  border-radius: 0.375rem;
+  background-color: var(--theme-base-90);
+  padding: 0.5rem 0.75rem;
+  text-align: center;
+  font-size: var(--theme-body-font-size);
+}


### PR DESCRIPTION
More work to polish up our components. Also notice I am starting a new css file to move more things out of tailwind.

**Old:**
<img width="647" alt="image" src="https://github.com/replayio/devtools/assets/9154902/ea082106-5b36-4809-bade-ab170f63925f">

**New:**
<img width="647" alt="image" src="https://github.com/replayio/devtools/assets/9154902/9670565d-5063-4ca3-8ca5-a871aec4a778">
