### PR TITLE
Testsuites polish: light theme colors

### DIFF
--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -147,6 +147,7 @@
   --primary-accent-foreground-text: #fff;
 
   --primary-accent-dimmed: #163e58;
+  --primary-accent-dimmed-hover: #12374f;
   --primary-accent-dimmed-foreground-text: var(--body-color);
 
   /* Color ramp (Dark) */
@@ -535,15 +536,15 @@
   --testsuites-stack-frame-background-color-active: #25364e;
   --testsuites-stack-frame-background-color-hover: #252d3b;
 
-  --testsuites-v2-failed-icon: #f02d5e;
-  --testsuites-v2-failed-header: #f02d5e;
-  --testsuites-v2-failed-pill: #f02d5e;
-  --testsuites-v2-flaky-icon: #f3bd41;
-  --testsuites-v2-flaky-header: #f3bd41;
-  --testsuites-v2-flaky-pill: #f3bd41;
-  --testsuites-v2-success-icon: #6bd442;
-  --testsuites-v2-success-header: #6bd442;
-  --testsuites-v2-success-pill: #6bd442;
+  --testsuites-v2-failed-icon: var(--testsuites-failed-color);
+  --testsuites-v2-failed-header: var(--testsuites-failed-color);
+  --testsuites-v2-failed-pill: var(--testsuites-failed-color);
+  --testsuites-v2-flaky-icon: var(--testsuites-flaky-color);
+  --testsuites-v2-flaky-header: var(--testsuites-flaky-color);
+  --testsuites-v2-flaky-pill: var(--testsuites-flaky-color);
+  --testsuites-v2-success-icon: var(--testsuites-success-color);
+  --testsuites-v2-success-header: var(--testsuites-success-color);
+  --testsuites-v2-success-pill: var(--testsuites-success-color);
   --testsuites-v2-description: #f02d5e;
   --testsuites-v2-error-bg: #330c14;
 
@@ -690,6 +691,7 @@
   --primary-accent-foreground-text: #fff;
 
   --primary-accent-dimmed: #cceeff;
+  --primary-accent-dimmed-hover: #c5e9fa;
   --primary-accent-dimmed-foreground-text: var(--body-color);
 
   /* Color ramp (Light) */
@@ -1080,15 +1082,15 @@
   --testsuites-stack-frame-background-color-active: #ebf3ff;
   --testsuites-stack-frame-background-color-hover: #f7f7f7;
 
-  --testsuites-v2-failed-icon: #f02d5e;
-  --testsuites-v2-failed-header: #f02d5e;
-  --testsuites-v2-failed-pill: #f02d5e;
-  --testsuites-v2-flaky-icon: #f3bd41;
-  --testsuites-v2-flaky-header: #f3bd41;
-  --testsuites-v2-flaky-pill: #f3bd41;
-  --testsuites-v2-success-icon: #6bd442;
-  --testsuites-v2-success-header: #6bd442;
-  --testsuites-v2-success-pill: #6bd442;
+  --testsuites-v2-failed-icon: var(--testsuites-failed-color);
+  --testsuites-v2-failed-header: var(--testsuites-failed-color);
+  --testsuites-v2-failed-pill: var(--testsuites-failed-color);
+  --testsuites-v2-flaky-icon: var(--testsuites-flaky-color);
+  --testsuites-v2-flaky-header: var(--testsuites-flaky-color);
+  --testsuites-v2-flaky-pill: var(--testsuites-flaky-color);
+  --testsuites-v2-success-icon: var(--testsuites-success-color);
+  --testsuites-v2-success-header: var(--testsuites-success-color);
+  --testsuites-v2-success-pill: var(--testsuites-success-color);
   --testsuites-v2-description: #f02d5e;
   --testsuites-v2-error-bg: #330c14;
 

--- a/src/ui/components/Library/Team/View/NewTestRuns/TestRuns.module.css
+++ b/src/ui/components/Library/Team/View/NewTestRuns/TestRuns.module.css
@@ -10,11 +10,11 @@
 }
 
 :root:global(.theme-dark) .libraryRowSelected {
-  background-color: rgba(0, 0, 0, 1);
+  background-color: var(--primary-accent-dimmed);
 }
 
 :root:global(.theme-dark) .libraryRowSelected:hover {
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: var(--primary-accent-dimmed-hover);
 }
 
 /* Light theme */
@@ -29,26 +29,27 @@
 }
 
 :root:global(.theme-light) .libraryRowSelected {
-  background-color: rgba(0, 0, 0, 0.2);
+  background-color: var(--primary-accent-dimmed);
 }
 
 :root:global(.theme-light) .libraryRowSelected:hover {
-  background-color: rgba(0, 0, 0, 0.1);
+  background-color: var(--primary-accent-dimmed-hover);
 }
 
 .flakyPill {
-  color: #000;
-  background-color: var(--testsuites-v2-flaky-pill);
+  color: var(--theme-base-100);
+  background-color: var(--testsuites-flaky-color);
 }
 
 .failedPill {
-  color: #000;
-  background-color: var(--testsuites-v2-failed-pill);
+  color: var(--theme-base-100);
+  background-color: var(--testsuites-failed-color);
 }
 
 .successPill {
-  color: #000;
-  background-color: var(--testsuites-v2-success-pill);
+  color: var(--theme-base-100);
+  background-color: var(--testsuites-success-color);
+  border-radius: 50%;
 }
 
 .testsuitesSuccess {


### PR DESCRIPTION
Our light theme colors weren't being special-cased. This addresses some light theme polish.

**Old:**
<img width="904" alt="image" src="https://github.com/replayio/devtools/assets/9154902/daad140b-74ce-494d-9d37-0d7e0241ad60">

**New:**
<img width="904" alt="image" src="https://github.com/replayio/devtools/assets/9154902/26437619-c657-4172-94f6-494f4333350e">
