### PR TITLE
Testsuites polish: adjusting header

### DIFF
--- a/src/ui/components/Library/Team/View/NewTestRuns/TestRunSpecDetails.tsx
+++ b/src/ui/components/Library/Team/View/NewTestRuns/TestRunSpecDetails.tsx
@@ -24,7 +24,7 @@ export function TestRunSpecDetails() {
   if (!spec) {
     return (
       <div className="flex h-full w-full items-center justify-center p-2">
-        <div className="rounded-md bg-chrome py-2 px-3 text-center">
+        <div className="rounded-md bg-chrome px-3 py-2 text-center">
           Select a test to see its details here
         </div>
       </div>
@@ -37,7 +37,7 @@ export function TestRunSpecDetails() {
 
   return (
     <div className="flex h-full w-full flex-col justify-start text-sm">
-      <div className="mt-10 flex flex-grow flex-col gap-3 overflow-y-auto border-t border-themeBorder py-3">
+      <div className="flex flex-grow flex-col gap-3 overflow-y-auto py-3">
         <div className="flex flex-col gap-2 px-3">
           <div className="overflow-hidden overflow-ellipsis whitespace-nowrap text-lg font-semibold">
             Replays


### PR DESCRIPTION
**Old:**
<img width="678" alt="image" src="https://github.com/replayio/devtools/assets/9154902/92b6fca7-4b59-4bc8-ab58-973402003bf7">

**New:**
<img width="678" alt="image" src="https://github.com/replayio/devtools/assets/9154902/906442e5-08c8-4bf9-80c4-72c8ea2442b2">

Addresses https://linear.app/replay/issue/DES-1019/unexpected-marginpadding-at-the-top-of-the-3rd-test-column