### PR TITLE
Testsuites polish: handling <pre> better in errors

### DIFF
--- a/src/ui/components/Library/Team/View/NewTestRuns/TestRunSpecDetails.tsx
+++ b/src/ui/components/Library/Team/View/NewTestRuns/TestRunSpecDetails.tsx
@@ -24,7 +24,7 @@ export function TestRunSpecDetails() {
   if (!spec) {
     return (
       <div className="flex h-full w-full items-center justify-center p-2">
-        <div className="rounded-md bg-chrome py-2 px-3 text-center">
+        <div className="rounded-md bg-chrome px-3 py-2 text-center">
           Select a test to see its details here
         </div>
       </div>
@@ -79,7 +79,7 @@ function Errors({ failedTests }: { failedTests: TestRunTestWithRecordings[] }) {
             key={`${t.id}-${i}`}
             className="w-full overflow-x-auto rounded-md bg-[color:var(--testsuites-v2-error-bg)] px-3 py-4"
           >
-            <div className="flex flex-col gap-4 whitespace-pre border-l-2 border-[color:var(--testsuites-v2-failed-header)] px-3">
+            <div className="flex flex-col gap-4 whitespace-pre-wrap break-words border-l-2 border-[color:var(--testsuites-v2-failed-header)] px-3">
               <div className="mb-2 flex cursor-default select-none flex-row items-center gap-2 text-[color:var(--testsuites-v2-failed-header)]">
                 <Icon type="warning" className="h-4 w-4" />
                 <span className="font-monospace text-xs">Error</span>

--- a/src/ui/components/Library/Team/View/NewTestRuns/TestRunSpecDetails.tsx
+++ b/src/ui/components/Library/Team/View/NewTestRuns/TestRunSpecDetails.tsx
@@ -25,7 +25,7 @@ export function TestRunSpecDetails() {
   if (!spec) {
     return (
       <div className="flex h-full w-full items-center justify-center p-2">
-<div className={styles.standardMessaging}>Select a test to see its details here</div>
+        <div className={styles.standardMessaging}>Select a test to see its details here</div>
       </div>
     );
   } else if (groupedTests === null || selectedTest == null) {


### PR DESCRIPTION
**Old:**
<img width="548" alt="image" src="https://github.com/replayio/devtools/assets/9154902/a957b555-8593-4a7d-86f2-798d620d3fd4">

**New:**
<img width="548" alt="image" src="https://github.com/replayio/devtools/assets/9154902/0444fe9e-9e22-48f0-b298-4b4ed8346f57">

Our pre was acting up. Fixed.