### PR TITLE
Testsuites polish: fix error bg in light theme

### DIFF
--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -520,7 +520,7 @@
   --testsuites-capsule-success-bgcolor: var(--testsuites-success-color);
   --testsuites-capsule-success-color: rgb(16, 114, 0);
   --testsuites-error-bgcolor-hover: #591716;
-  --testsuites-error-bgcolor: #4f1615;
+  --testsuites-error-bgcolor: #330c14;
   --testsuites-error-border-color: var(--testsuites-error-icon-bgcolor);
   --testsuites-error-color: #ffe0e0;
   --testsuites-error-icon-bgcolor: rgb(237, 36, 36);
@@ -546,7 +546,7 @@
   --testsuites-v2-success-header: var(--testsuites-success-color);
   --testsuites-v2-success-pill: var(--testsuites-success-color);
   --testsuites-v2-description: #f02d5e;
-  --testsuites-v2-error-bg: #330c14;
+  --testsuites-v2-error-bg: var(--testsuites-error-bgcolor);
 
   --circular-progress-bar-trail-color: var(--testsuites-steps-bgcolor);
 
@@ -1092,8 +1092,7 @@
   --testsuites-v2-success-header: var(--testsuites-success-color);
   --testsuites-v2-success-pill: var(--testsuites-success-color);
   --testsuites-v2-description: #f02d5e;
-  --testsuites-v2-error-bg: #330c14;
-
+  --testsuites-v2-error-bg: var(--testsuites-error-bgcolor);
   --circular-progress-bar-trail-color: var(--testsuites-steps-bgcolor);
 
   /* To organise (Light) */

--- a/src/ui/components/Library/Team/View/NewTestRuns/TestRunSpecDetails.tsx
+++ b/src/ui/components/Library/Team/View/NewTestRuns/TestRunSpecDetails.tsx
@@ -83,9 +83,7 @@ function Errors({ failedTests }: { failedTests: TestRunTestWithRecordings[] }) {
                 <Icon type="warning" className="h-4 w-4" />
                 <span className="font-monospace text-xs">Error</span>
               </div>
-              <div className="font-mono text-xs text-[color:var(--primary-accent-foreground-text)]">
-                {e.split("\n").slice(0, 4).join("\n")}
-              </div>
+              <div className="font-mono text-xs">{e.split("\n").slice(0, 4).join("\n")}</div>
             </div>
           </div>
         ))


### PR DESCRIPTION
**Old:**
<img width="527" alt="image" src="https://github.com/replayio/devtools/assets/9154902/dbf68f69-e807-4265-a474-f1a13c7101c3">

**New:**
<img width="527" alt="image" src="https://github.com/replayio/devtools/assets/9154902/56197a50-875b-4e8e-81fa-a798b619eaf5">

The recent PRs didn't respect light and dark theme, so this puts things back.