### PR TITLE
General code cleanup

### DIFF
--- a/packages/e2e-tests/authenticated/comments-01.test.ts
+++ b/packages/e2e-tests/authenticated/comments-01.test.ts
@@ -1,11 +1,6 @@
 import { openDevToolsTab, startTest } from "../helpers";
 import { E2E_USER_1_API_KEY } from "../helpers/authentication";
-import {
-  addSourceCodeComment,
-  deleteAllComments,
-  deleteComment,
-  editComment,
-} from "../helpers/comments";
+import { addSourceCodeComment, deleteComment, editComment } from "../helpers/comments";
 import { openSource } from "../helpers/source-explorer-panel";
 import test from "../testFixtureCloneRecording";
 
@@ -21,10 +16,6 @@ test(`authenticated/comments-01: Test add, edit, and delete comment functionalit
   await startTest(page, recordingId, E2E_USER_1_API_KEY);
   await openDevToolsTab(page);
   await openSource(page, exampleKey);
-
-  // Clean up from previous tests
-  // TODO [SCS-1066] Ideally we would create a fresh recording for each test run
-  await deleteAllComments(page);
 
   let commentLocator = await addSourceCodeComment(page, {
     text: "This is a test comment",

--- a/packages/e2e-tests/authenticated/comments-02.test.ts
+++ b/packages/e2e-tests/authenticated/comments-02.test.ts
@@ -38,10 +38,6 @@ test(`authenticated/comments-02: Test shared comments and replies`, async ({
     const page = await context.newPage();
     await load(page, recordingId, E2E_USER_1_API_KEY);
 
-    // Clean up from previous tests
-    // TODO [SCS-1066] Ideally we would create a fresh recording for each test run
-    await deleteAllComments(page);
-
     await addSourceCodeComment(page, {
       text: "This is a test comment from user 1",
       lineNumber: 3,

--- a/packages/e2e-tests/authenticated/comments-03.test.ts
+++ b/packages/e2e-tests/authenticated/comments-03.test.ts
@@ -24,10 +24,6 @@ test(`authenticated/comments-03: Comment previews`, async ({
   await startTest(page, recordingId, E2E_USER_1_API_KEY);
   await openDevToolsTab(page);
 
-  // Clean up from previous tests
-  // TODO [SCS-1066] Ideally we would create a fresh recording for each test run
-  await deleteAllComments(page);
-
   // Add and verify source code comment previews
   await openSource(page, url);
   const sourceCodeComment = await addSourceCodeComment(page, {

--- a/packages/e2e-tests/authenticated/logpoints-01.test.ts
+++ b/packages/e2e-tests/authenticated/logpoints-01.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../helpers/pause-information-panel";
 import { openSource } from "../helpers/source-explorer-panel";
 import { addLogpoint, editLogPoint, removeAllLogpoints } from "../helpers/source-panel";
+import { waitForRecordingToFinishIndexing } from "../helpers/utils";
 import test, { Page, expect } from "../testFixtureCloneRecording";
 
 // Each authenticated e2e test must use a unique recording id;
@@ -43,10 +44,6 @@ test(`authenticated/logpoints-01: Shared logpoints functionality`, async ({
     const context = await browser.newContext();
     const page = await context.newPage();
     await load(page, recordingId, E2E_USER_1_API_KEY);
-
-    // Clean up from previous tests
-    // TODO [SCS-1066] Ideally we would create a fresh recording for each test run
-    await removeAllLogpoints(page);
 
     // Add log point (will be shared, since we're authenticated)
     await addLogpoint(page, {
@@ -88,6 +85,8 @@ test(`authenticated/logpoints-01: Shared logpoints functionality`, async ({
     const page = pageOne;
     await page.reload();
 
+    await waitForRecordingToFinishIndexing(page);
+
     // Verify log point is still present and not affected by user 2
     await verifyConsoleMessage(page, "initial:", "log-point", 10);
 
@@ -106,6 +105,8 @@ test(`authenticated/logpoints-01: Shared logpoints functionality`, async ({
     // User 2
     const page = pageTwo;
     await page.reload();
+
+    await waitForRecordingToFinishIndexing(page);
 
     // Point should show updated content
     await verifyConsoleMessage(page, "updated:", "log-point", 10);

--- a/packages/replay-next/components/elements-new/ElementsListData.test.ts
+++ b/packages/replay-next/components/elements-new/ElementsListData.test.ts
@@ -196,7 +196,7 @@ describe("ElementsListData", () => {
           <script type=\\"text/javascript\\">
             // Line of text
           </script>
-          <link rel=\\"stylesheet\\" href=\\"index.css\\" />
+          <link href=\\"index.css\\" rel=\\"stylesheet\\" />
         </head>
         <body>
           <ul>
@@ -220,7 +220,7 @@ describe("ElementsListData", () => {
           <script type=\\"text/javascript\\">
             // Line of text
           </script>
-          <link rel=\\"stylesheet\\" href=\\"index.css\\" />
+          <link href=\\"index.css\\" rel=\\"stylesheet\\" />
         </head>
         <body>
           <ul>…</ul>
@@ -237,7 +237,7 @@ describe("ElementsListData", () => {
           <script type=\\"text/javascript\\">
             // Line of text
           </script>
-          <link rel=\\"stylesheet\\" href=\\"index.css\\" />
+          <link href=\\"index.css\\" rel=\\"stylesheet\\" />
         </head>
         <body>…</body>
       </html>"
@@ -252,7 +252,7 @@ describe("ElementsListData", () => {
           <script type=\\"text/javascript\\">
             // Line of text
           </script>
-          <link rel=\\"stylesheet\\" href=\\"index.css\\" />
+          <link href=\\"index.css\\" rel=\\"stylesheet\\" />
         </head>
         <body>
           <ul>…</ul>

--- a/packages/replay-next/components/elements-new/ElementsListItem.module.css
+++ b/packages/replay-next/components/elements-new/ElementsListItem.module.css
@@ -64,7 +64,6 @@
 .HtmlAttribute {
   display: inline;
   color: var(--value-type-html-attribute-name);
-  padding-left: 1ch;
 }
 .HtmlAttribute:focus {
   outline: none;

--- a/packages/replay-next/components/elements-new/ElementsListItem.tsx
+++ b/packages/replay-next/components/elements-new/ElementsListItem.tsx
@@ -202,6 +202,7 @@ function HTMLNodeRenderer({
 }) {
   let renderedAttributes: ReactNode[] = [];
   for (let key in attributes) {
+    renderedAttributes.push(" ");
     renderedAttributes.push(<HtmlAttributeRenderer key={key} name={key} value={attributes[key]} />);
   }
 

--- a/packages/replay-next/components/elements-new/utils/serialization.test.ts
+++ b/packages/replay-next/components/elements-new/utils/serialization.test.ts
@@ -123,7 +123,7 @@ describe("serializeDOM", () => {
       expect(listData.toString()).toMatchInlineSnapshot(`
         "<html>
           <head>
-            <link rel=\\"stylesheet\\" href=\\"https://example.com/style.css\\" />
+            <link href=\\"https://example.com/style.css\\" rel=\\"stylesheet\\" />
             <script src=\\"https://example.com/script.js\\" />
           </head>
           <body>

--- a/packages/replay-next/components/elements-new/utils/serialization.ts
+++ b/packages/replay-next/components/elements-new/utils/serialization.ts
@@ -191,6 +191,7 @@ export function serializeDOM(rootNode: Document): number[] {
 
     if (typeof domNodeOrText.getAttributeNames === "function") {
       const attributeNames = domNodeOrText.getAttributeNames();
+      attributeNames.sort();
       attributeNames.forEach(name => {
         const value = domNodeOrText.getAttribute(name);
         if (value) {

--- a/src/ui/components/NodePicker.tsx
+++ b/src/ui/components/NodePicker.tsx
@@ -1,4 +1,3 @@
-import { NodeBounds } from "@replayio/protocol";
 import classnames from "classnames";
 import React, { useCallback, useLayoutEffect, useRef, useState } from "react";
 
@@ -25,11 +24,6 @@ import { NodePicker as NodePickerClass } from "ui/utils/nodePicker";
 interface Position {
   x: number;
   y: number;
-}
-
-interface GlobalNodePickerTestMethods {
-  clickNodePickerButton: () => Promise<void>;
-  nodePickerMouseClickInCanvas: (pos: Position | null) => Promise<void>;
 }
 
 const nodePickerInstance = new NodePickerClass();
@@ -72,24 +66,6 @@ export function NodePicker() {
       dispatch(selectNode(nodeId));
     },
     [dispatch]
-  );
-
-  const nodePickerMouseClickInCanvas = useCallback(
-    async function nodePickerMouseClickInCanvas(pos: Position | null) {
-      setGlobalNodePickerActive(false);
-      nodePickerRemoveTime.current = Date.now();
-      let nodeBounds: NodeBounds | null = null;
-      if (pos) {
-        const boundingRects = await dispatch(fetchMouseTargetsForPause());
-        nodeBounds = getMouseTarget(boundingRects ?? [], pos.x, pos.y);
-      }
-      if (nodeBounds) {
-        handleNodeSelected(nodeBounds.node);
-      } else {
-        dispatch(unhighlightNode());
-      }
-    },
-    [dispatch, handleNodeSelected]
   );
 
   useLayoutEffect(() => {


### PR DESCRIPTION
Split a few things off of #9965 that aren't blocked by the Gecko to Chromium migration. That PR may take a long time to land, due to RUN blockers, and it seems worth landing these changes earlier if possible.

- [x] Deleted some outdated "TODO" comments in our authenticated tests
- [x] Updated our `waitFor` helper to be less noisy while a test is running
- [x] Deleted some dead code in `NodePicker`
- [x] Updated the new Elements list to alpha-sort attribute names (to match the old Elements panel?)
- [x] Updated the way the new Elements list renderers attributes to add an actual space in between them rather than margins