### PR TITLE
Fix showing all replays for a test execution

### DIFF
--- a/src/ui/components/Library/Team/View/Tests/Overview/ReplayList.tsx
+++ b/src/ui/components/Library/Team/View/Tests/Overview/ReplayList.tsx
@@ -21,17 +21,19 @@ export function ReplayList({ executions, label }: { executions: TestExecution[];
   if (!sortedReplays.length) {
     children = <div className={testsuiteStyles.noReplaysFound}>No replays found</div>;
   } else {
-    children = sortedReplays.map((e, i) => (
-      <ReplayListItem
-        recordingId={e.recordings[0]!.id}
-        recordingTitle={e.recordings[0]!.title}
-        isProcessed={e.recordings[0]!.isProcessed}
-        commitTitle={e.commitTitle}
-        date={e.createdAt}
-        key={i}
-        status={e.result}
-      />
-    ));
+    children = sortedReplays.map((e, i) =>
+      e.recordings.map(r => (
+        <ReplayListItem
+          recordingId={r.id}
+          recordingTitle={r.title}
+          isProcessed={r.isProcessed}
+          commitTitle={e.commitTitle}
+          date={e.createdAt}
+          key={i}
+          status={e.result}
+        />
+      ))
+    );
   }
 
   return (


### PR DESCRIPTION
Some test executions can include multiple replays (e.g. comments-02 in the FE tests) but we were only showing the first one previously. Now we'll map over all recordings and show each one.