### PR TITLE
Add loaders for new tests and test runs

### DIFF
--- a/src/ui/components/Library/Team/View/NewTestRuns/TestRunsContextRoot.tsx
+++ b/src/ui/components/Library/Team/View/NewTestRuns/TestRunsContextRoot.tsx
@@ -9,6 +9,7 @@ import {
   useMemo,
   useState,
 } from "react";
+import { STATUS_PENDING } from "suspense";
 
 import { TestRun, getTestRunTitle } from "shared/test-suites/TestRun";
 import { useGetTeamRouteParams } from "ui/components/Library/Team/utils";
@@ -26,6 +27,7 @@ type TestRunsContextType = {
   setFilterByStatus: Dispatch<SetStateAction<"all" | "failed">>;
   setFilterByText: Dispatch<SetStateAction<string>>;
   setFilterTestsByText: Dispatch<SetStateAction<string>>;
+  testRunsLoading: boolean;
   testRuns: TestRun[];
   testRunId: string | null;
   testRunIdForDisplay: string | null;
@@ -72,7 +74,7 @@ export function TestRunsFilterContextRoot({ children }: { children: ReactNode })
 export function TestRunsContextRoot({ children }: { children: ReactNode }) {
   const { teamId, testRunId: defaultTestRunId } = useGetTeamRouteParams();
 
-  const testRuns = useTestRuns();
+  const { testRuns, status } = useTestRuns();
 
   const [testRunId, setTestRunId] = useState<string | null>(defaultTestRunId);
 
@@ -159,6 +161,7 @@ export function TestRunsContextRoot({ children }: { children: ReactNode }) {
         setFilterTestsByText,
         testRunId: deferredTestRunId,
         testRunIdForDisplay: testRunId,
+        testRunsLoading: status === STATUS_PENDING,
         testRuns: filteredTestRuns,
         spec,
         setSpec,

--- a/src/ui/components/Library/Team/View/NewTestRuns/TestRunsPage.tsx
+++ b/src/ui/components/Library/Team/View/NewTestRuns/TestRunsPage.tsx
@@ -37,6 +37,7 @@ function TestRunsContent() {
     setFilterByBranch,
     setFilterByStatus,
     setFilterByText,
+    testRunsLoading,
   } = useContext(TestRunsContext);
   const { filterByTime, setFilterByTime } = useContext(TestRunsFilterContext);
 
@@ -144,9 +145,13 @@ function TestRunsContent() {
               data-filtered-by-text={filterByText}
               data-test-id="TestRunList"
             >
-              <Suspense fallback={<LibrarySpinner />}>
+              {testRunsLoading ? (
+                <div className="flex h-full items-center justify-center">
+                  <LibrarySpinner />
+                </div>
+              ) : (
                 <TestRunList />
-              </Suspense>
+              )}
             </div>
           </div>
         </Panel>

--- a/src/ui/components/Library/Team/View/NewTestRuns/hooks/useTestRuns.ts
+++ b/src/ui/components/Library/Team/View/NewTestRuns/hooks/useTestRuns.ts
@@ -1,5 +1,5 @@
 import { useContext, useMemo } from "react";
-import { useImperativeIntervalCacheValues } from "suspense";
+import { Status, useImperativeIntervalCacheValues } from "suspense";
 
 import { GraphQLClientContext } from "replay-next/src/contexts/GraphQLClientContext";
 import { TestRun } from "shared/test-suites/TestRun";
@@ -11,14 +11,14 @@ import { TestRunsFilterContext } from "../../NewTestRuns/TestRunsContextRoot";
 
 const EMPTY_ARRAY: any[] = [];
 
-export function useTestRuns(): TestRun[] {
+export function useTestRuns(): { testRuns: TestRun[]; status: Status } {
   const graphQLClient = useContext(GraphQLClientContext);
   const { teamId } = useContext(TeamContext);
   const { startTime, endTime } = useContext(TestRunsFilterContext);
 
   const accessToken = useToken();
 
-  const { value = EMPTY_ARRAY } = useImperativeIntervalCacheValues(
+  const { value = EMPTY_ARRAY, status } = useImperativeIntervalCacheValues(
     testRunsIntervalCache,
     startTime.getTime(),
     endTime.getTime(),
@@ -27,7 +27,7 @@ export function useTestRuns(): TestRun[] {
     teamId
   );
 
-  const testRunsDesc = useMemo(() => [...value].reverse(), [value]);
+  const testRuns = useMemo(() => [...value].reverse(), [value]);
 
-  return testRunsDesc;
+  return { testRuns, status };
 }

--- a/src/ui/components/Library/Team/View/Tests/TestContextRoot.tsx
+++ b/src/ui/components/Library/Team/View/Tests/TestContextRoot.tsx
@@ -7,6 +7,7 @@ import {
   useMemo,
   useState,
 } from "react";
+import { STATUS_PENDING } from "suspense";
 
 import { Test } from "shared/test-suites/TestRun";
 
@@ -24,13 +25,14 @@ type TestsContextType = {
   testId: string | null;
   testIdForDisplay: string | null;
   selectedTest: Test | null;
+  testsLoading: boolean;
   tests: Test[];
 };
 
 export const TestContext = createContext<TestsContextType>(null as any);
 
 export function TestsContextRoot({ children }: { children: ReactNode }) {
-  const tests = useTests();
+  const { tests, status } = useTests();
 
   const [testId, setTestId] = useState<string | null>(null);
 
@@ -72,9 +74,19 @@ export function TestsContextRoot({ children }: { children: ReactNode }) {
       testId: deferredTestId,
       testIdForDisplay: testId,
       selectedTest: testId ? tests.find(t => t.testId === testId) ?? null : null,
+      testsLoading: status === STATUS_PENDING,
       tests: filteredTests,
     };
-  }, [filterByTime, sortBy, filterByText, filterByTextDeferred, deferredTestId, testId, tests]);
+  }, [
+    filterByTime,
+    sortBy,
+    filterByText,
+    filterByTextDeferred,
+    deferredTestId,
+    testId,
+    status,
+    tests,
+  ]);
 
   return <TestContext.Provider value={value}>{children}</TestContext.Provider>;
 }

--- a/src/ui/components/Library/Team/View/Tests/TestsPage.tsx
+++ b/src/ui/components/Library/Team/View/Tests/TestsPage.tsx
@@ -28,6 +28,7 @@ function TestsContent() {
     filterByTextForDisplay,
     sortBy,
     setSortBy,
+    testsLoading,
   } = useContext(TestContext);
 
   const {
@@ -100,9 +101,13 @@ function TestsContent() {
             </div>
 
             <div className="grow" data-filtered-by-text={filterByText} data-test-id="TestList">
-              <Suspense fallback={<LibrarySpinner />}>
+              {testsLoading ? (
+                <div className="flex h-full items-center justify-center">
+                  <LibrarySpinner />
+                </div>
+              ) : (
                 <TestList />
-              </Suspense>
+              )}
             </div>
           </div>
         </Panel>

--- a/src/ui/components/Library/Team/View/Tests/hooks/useTests.ts
+++ b/src/ui/components/Library/Team/View/Tests/hooks/useTests.ts
@@ -1,5 +1,5 @@
 import { useContext } from "react";
-import { useImperativeCacheValue } from "suspense";
+import { Status, useImperativeCacheValue } from "suspense";
 
 import { GraphQLClientContext } from "replay-next/src/contexts/GraphQLClientContext";
 import { Test } from "shared/test-suites/TestRun";
@@ -10,17 +10,17 @@ import { testsCache } from "../../TestRuns/suspense/TestsCache";
 
 const EMPTY_ARRAY: any[] = [];
 
-export function useTests(): Test[] {
+export function useTests(): { tests: Test[]; status: Status } {
   const graphQLClient = useContext(GraphQLClientContext);
   const { teamId } = useContext(TeamContext);
 
   const accessToken = useToken();
 
-  const { value = EMPTY_ARRAY } = useImperativeCacheValue(
+  const { value = EMPTY_ARRAY, status } = useImperativeCacheValue(
     testsCache,
     graphQLClient,
     accessToken?.token ?? null,
     teamId
   );
-  return value;
+  return { tests: value, status };
 }


### PR DESCRIPTION
Closes SCS-1624.

Adds loader for both new tests and test runs view.

Tests: https://www.loom.com/share/bcdd5da730144d828372f9d3d441ac3b
Test Runs: https://www.loom.com/share/a17af943103543d4893c328e98621e41 (Notice the loader is little lower than other panel's loader. This is because first panel always has input/filter at top available, this changes vertical offset a bit. I'm open to suggestions if we can improve this, cc: @jonbell-lot23)