### PR TITLE
Add a caret icon to test suites folder

### DIFF
--- a/src/ui/components/Library/Team/View/NewTestRuns/Overview/RunResults.tsx
+++ b/src/ui/components/Library/Team/View/NewTestRuns/Overview/RunResults.tsx
@@ -216,20 +216,18 @@ function PathNodeRenderer({
             paddingLeft: `${depth * 1}rem`,
           }}
         >
-          <div>
-            <div className="flex items-center gap-2">
-              <div className="flex items-center gap-1 truncate">{formattedNames}/</div>
-              <Icon
-                className={`${
-                  expanded ? "" : "rotate-90"
-                } rotate duration-140 h-4 w-4 transition ease-out`}
-                type="chevron-down"
-              />
-            </div>
-            {!expanded && (
-              <div className="text-xs text-bodySubColor">({pathNode.nestedTestCount} tests)</div>
-            )}
+          <div className="flex items-center gap-2">
+            <div className="flex items-center gap-1 truncate">{formattedNames}/</div>
+            <Icon
+              className={`${
+                expanded ? "" : "rotate-90"
+              } rotate duration-140 h-4 w-4 transition ease-out`}
+              type="chevron-down"
+            />
           </div>
+          {!expanded && (
+            <div className="text-xs text-bodySubColor">({pathNode.nestedTestCount} tests)</div>
+          )}
         </div>
       )}
       <Offscreen mode={expanded ? "visible" : "hidden"}>

--- a/src/ui/components/Library/Team/View/NewTestRuns/Overview/RunResults.tsx
+++ b/src/ui/components/Library/Team/View/NewTestRuns/Overview/RunResults.tsx
@@ -206,9 +206,9 @@ function PathNodeRenderer({
     <>
       {name && (
         <div
-          className={`cursor-pointer truncate rounded py-2 pr-4 ${styles.libraryRow} ${
-            containsSelectedSpec ? styles.libraryRowSelected : ""
-          }`}
+          className={`flex cursor-pointer justify-between truncate rounded py-2 pr-4 ${
+            styles.libraryRow
+          } ${containsSelectedSpec ? styles.libraryRowSelected : ""}`}
           data-test-id="TestRunResult-PathNode"
           data-test-state={expanded ? "expanded" : "collapsed"}
           onClick={onClick}
@@ -216,10 +216,19 @@ function PathNodeRenderer({
             paddingLeft: `${depth * 1}rem`,
           }}
         >
-          <div className="flex items-center gap-1 truncate">{formattedNames}/</div>
-          {!expanded && (
-            <div className="text-xs text-bodySubColor">({pathNode.nestedTestCount} tests)</div>
-          )}
+          <div>
+            <div className="flex items-center gap-1 truncate">{formattedNames}/</div>
+            {!expanded && (
+              <div className="text-xs text-bodySubColor">({pathNode.nestedTestCount} tests)</div>
+            )}
+          </div>
+
+          <Icon
+            className={`${
+              expanded ? "" : "rotate-90"
+            } rotate duration-140 h-4 w-4 transition ease-out`}
+            type="chevron-down"
+          />
         </div>
       )}
       <Offscreen mode={expanded ? "visible" : "hidden"}>

--- a/src/ui/components/Library/Team/View/NewTestRuns/Overview/RunResults.tsx
+++ b/src/ui/components/Library/Team/View/NewTestRuns/Overview/RunResults.tsx
@@ -206,9 +206,9 @@ function PathNodeRenderer({
     <>
       {name && (
         <div
-          className={`flex cursor-pointer justify-between truncate rounded py-2 pr-4 ${
-            styles.libraryRow
-          } ${containsSelectedSpec ? styles.libraryRowSelected : ""}`}
+          className={`cursor-pointer truncate rounded py-2 pr-4 ${styles.libraryRow} ${
+            containsSelectedSpec ? styles.libraryRowSelected : ""
+          }`}
           data-test-id="TestRunResult-PathNode"
           data-test-state={expanded ? "expanded" : "collapsed"}
           onClick={onClick}
@@ -217,18 +217,19 @@ function PathNodeRenderer({
           }}
         >
           <div>
-            <div className="flex items-center gap-1 truncate">{formattedNames}/</div>
+            <div className="flex items-center gap-2">
+              <div className="flex items-center gap-1 truncate">{formattedNames}/</div>
+              <Icon
+                className={`${
+                  expanded ? "" : "rotate-90"
+                } rotate duration-140 h-4 w-4 transition ease-out`}
+                type="chevron-down"
+              />
+            </div>
             {!expanded && (
               <div className="text-xs text-bodySubColor">({pathNode.nestedTestCount} tests)</div>
             )}
           </div>
-
-          <Icon
-            className={`${
-              expanded ? "" : "rotate-90"
-            } rotate duration-140 h-4 w-4 transition ease-out`}
-            type="chevron-down"
-          />
         </div>
       )}
       <Offscreen mode={expanded ? "visible" : "hidden"}>


### PR DESCRIPTION
Closes SCS-1666.

Adds an caret icon to right of folder name to make clear that section is collapsible. https://www.loom.com/share/7ef89c3b5fc34722b98d2e280e68b4a6

@jonbell-lot23 can you please check this looks right before I pass review to frontend team?