### PR TITLE
Code cleanup

### DIFF
--- a/packages/e2e-tests/helpers/comments.ts
+++ b/packages/e2e-tests/helpers/comments.ts
@@ -158,11 +158,6 @@ export async function addVisualComment(
     async () => {
       const canvasLocator = page.locator("canvas#graphics");
       await canvasLocator.click({ position: { x, y } });
-
-      await selectContextMenuItem(page, {
-        contextMenuItemTestName: "ContextMenuItem-AddComment",
-        contextMenuTestId: "ContextMenu-Video",
-      });
     },
     "visual",
     text

--- a/packages/e2e-tests/scripts/save-examples.ts
+++ b/packages/e2e-tests/scripts/save-examples.ts
@@ -432,8 +432,10 @@ async function saveBrowserExample({ example }: TestRunCallbackArgs) {
 
   // Shouldn't be "node" by this point
   await recordPlaywright((argv.runtime || example.runtime) as BrowserName, async (page, expect) => {
-    await page.goto(exampleUrl);
-    await playwrightScript(page, expect);
+    const waitForLogPromise = playwrightScript(page, expect);
+    const goToPagePromise = page.goto(exampleUrl);
+
+    await Promise.all([goToPagePromise, waitForLogPromise]);
   });
 
   console.log("Recording completed");


### PR DESCRIPTION
Split a couple of small things off of #9965 that can land early:

- [x] Fixed the `addVisualComment`
- [x] Updated the `saveBrowserExample` helper to fix a race case that caused it to sometimes missed "ExampleFinished" logs