### PR TITLE
Debounce React component details when coming from the Node Picker

### DIFF
--- a/packages/e2e-tests/tests/react_devtools-01-basic.test.ts
+++ b/packages/e2e-tests/tests/react_devtools-01-basic.test.ts
@@ -17,7 +17,7 @@ import {
 } from "../helpers/new-react-devtools-panel";
 import { getGetterValue } from "../helpers/object-inspector";
 import { hoverScreenshot } from "../helpers/screenshot";
-import { waitFor } from "../helpers/utils";
+import { delay, waitFor } from "../helpers/utils";
 import test, { expect } from "../testFixtureCloneRecording";
 
 test.use({ exampleKey: "cra/dist/index_chromium.html" });
@@ -78,6 +78,7 @@ test("react_devtools-01: Basic RDT behavior (Chromium)", async ({
   await waitFor(async () => {
     await page.mouse.move(0, 0); // Stop hovering
     await hoverScreenshot(page, x, y);
+
     const actualName = await getComponentName(getSelectedRow(page));
     expect(actualName).toBe("Item");
   });

--- a/packages/replay-next/components/windowing/GenericListData.ts
+++ b/packages/replay-next/components/windowing/GenericListData.ts
@@ -78,8 +78,10 @@ export abstract class GenericListData<Item> extends EventEmitter<{
   };
 
   setSelectedIndex(value: number | null) {
-    this._selectedIndex = value;
-    this.emit("selectedIndex", value);
+    if (this._selectedIndex !== value) {
+      this._selectedIndex = value;
+      this.emit("selectedIndex", value);
+    }
   }
 
   subscribeToLoading = (callback: (value: boolean) => void) => {

--- a/packages/replay-next/src/hooks/useDebounceState.test.tsx
+++ b/packages/replay-next/src/hooks/useDebounceState.test.tsx
@@ -1,0 +1,131 @@
+import { RenderResult, act, render as rtlRender } from "@testing-library/react";
+import { useEffect } from "react";
+
+import useDebounceState, { DebounceState } from "replay-next/src/hooks/useDebounceState";
+
+type Value = string;
+
+describe("useDebounceState", () => {
+  let currentState: DebounceState<Value> = null as any as DebounceState<Value>;
+  let rendered: RenderResult | null = null;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    currentState = null as any as DebounceState<Value>;
+    rendered = null;
+  });
+
+  function Component({ defaultValue, interval }: { defaultValue?: Value; interval?: number }) {
+    const state = useDebounceState(defaultValue, interval);
+
+    useEffect(() => {
+      currentState = state;
+    });
+
+    return null;
+  }
+
+  function render(defaultValue?: Value, interval?: number) {
+    act(() => {
+      if (rendered === null) {
+        rendered = rtlRender(<Component defaultValue={defaultValue} interval={interval} />);
+      } else {
+        rendered.rerender(<Component defaultValue={defaultValue} interval={interval} />);
+      }
+    });
+  }
+
+  it("should not debounce the initial value", async () => {
+    render("initial");
+    expect(currentState.debouncedValue).toEqual("initial");
+    expect(currentState.value).toEqual("initial");
+  });
+
+  it("should correctly update values at high priority", async () => {
+    render("initial");
+
+    act(() => {
+      currentState.setValue("update");
+    });
+    expect(currentState.debouncedValue).toEqual("update");
+    expect(currentState.value).toEqual("update");
+  });
+
+  it("should correctly update values at low-priority", async () => {
+    render("initial");
+
+    act(() => {
+      currentState.setValueDebounced("update");
+    });
+    expect(currentState.debouncedValue).toEqual("initial");
+    expect(currentState.value).toEqual("update");
+
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
+    expect(currentState.debouncedValue).toEqual("initial");
+    expect(currentState.value).toEqual("update");
+
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
+    expect(currentState.debouncedValue).toEqual("update");
+    expect(currentState.value).toEqual("update");
+  });
+
+  it("should replace pending low-priority updates another low-priority update is received", async () => {
+    render("initial");
+
+    act(() => {
+      currentState.setValueDebounced("update one");
+    });
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
+    expect(currentState.debouncedValue).toEqual("initial");
+    expect(currentState.value).toEqual("update one");
+
+    act(() => {
+      currentState.setValueDebounced("update two");
+    });
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
+    expect(currentState.debouncedValue).toEqual("initial");
+    expect(currentState.value).toEqual("update two");
+
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
+    expect(currentState.debouncedValue).toEqual("update two");
+    expect(currentState.value).toEqual("update two");
+  });
+
+  it("should cancel pending low-priority updates when a high-priority update is received", async () => {
+    render("initial");
+
+    act(() => {
+      currentState.setValueDebounced("update one");
+    });
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
+    expect(currentState.debouncedValue).toEqual("initial");
+    expect(currentState.value).toEqual("update one");
+
+    act(() => {
+      currentState.setValue("update two");
+    });
+    expect(currentState.debouncedValue).toEqual("update two");
+    expect(currentState.value).toEqual("update two");
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    expect(currentState.debouncedValue).toEqual("update two");
+    expect(currentState.value).toEqual("update two");
+  });
+});

--- a/packages/replay-next/src/hooks/useDebounceState.ts
+++ b/packages/replay-next/src/hooks/useDebounceState.ts
@@ -1,0 +1,82 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type DebounceState<Type> = {
+  debouncedValue: Type | undefined;
+  value: Type | undefined;
+  setValue: (value: Type) => void;
+  setValueDebounced: (value: Type) => void;
+};
+
+export default function useDebounceState<Type>(
+  defaultValue: Type | undefined,
+  interval: number = 500
+): DebounceState<Type> {
+  const [state, setState] = useState<{
+    debouncedValue: Type | undefined;
+    value: Type | undefined;
+  }>({
+    debouncedValue: defaultValue,
+    value: defaultValue,
+  });
+
+  const ref = useRef<{
+    interval: number;
+    pendingValue: Type | undefined;
+    timeout: NodeJS.Timeout | null;
+  }>({
+    interval,
+    pendingValue: undefined,
+    timeout: null,
+  });
+
+  useEffect(() => {
+    ref.current.interval = interval;
+  });
+
+  const setValueHighPriority = useCallback((value: Type) => {
+    const { timeout } = ref.current;
+
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+
+    ref.current.pendingValue = value;
+    ref.current.timeout = null;
+
+    setState({
+      debouncedValue: value,
+      value: value,
+    });
+  }, []);
+
+  const setValueDebounced = useCallback((value: Type) => {
+    const { interval, pendingValue, timeout } = ref.current;
+
+    if (value === pendingValue) {
+      return;
+    }
+
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+
+    setState(prevState => ({
+      ...prevState,
+      value: value,
+    }));
+
+    ref.current.pendingValue = value;
+    ref.current.timeout = setTimeout(() => {
+      setState(prevState => ({
+        ...prevState,
+        debouncedValue: value,
+      }));
+    }, interval);
+  }, []);
+
+  return {
+    ...state,
+    setValue: setValueHighPriority,
+    setValueDebounced,
+  };
+}

--- a/src/ui/components/SecondaryToolbox/react-devtools/components/SelectedElement.tsx
+++ b/src/ui/components/SecondaryToolbox/react-devtools/components/SelectedElement.tsx
@@ -40,6 +40,7 @@ import styles from "./SelectedElement.module.css";
 export function SelectedElement({
   bridge,
   element,
+  isDebounceDelayed,
   listData,
   pauseId: defaultPriorityPauseId,
   replayWall,
@@ -47,6 +48,7 @@ export function SelectedElement({
 }: {
   bridge: FrontendBridge;
   element: ReactElement;
+  isDebounceDelayed: boolean;
   listData: ReactDevToolsListData;
   pauseId: PauseId;
   replayWall: ReplayWall;
@@ -64,7 +66,7 @@ export function SelectedElement({
   // Only Suspend at deferred priority
   const deferredElement = useDeferredValue(element);
 
-  const isPending = element !== deferredElement;
+  const isPending = isDebounceDelayed || element !== deferredElement;
 
   const [inspectedElement, [, fiberIdsToNodeIds]] = suspendInParallel(
     () => inspectedElementCache.read(replayClient, bridge, store, replayWall, pauseId, id),

--- a/src/ui/components/SecondaryToolbox/react-devtools/suspense/inspectedElementCache.ts
+++ b/src/ui/components/SecondaryToolbox/react-devtools/suspense/inspectedElementCache.ts
@@ -27,7 +27,7 @@ export const inspectedElementCache = createCache<
   InspectedReactElement
 >({
   config: { immutable: true },
-  debugLabel: "DOMSearchCache",
+  debugLabel: "inspectedElementCache",
   getKey: ([replayClient, bridge, store, replayWall, pauseId, elementId]) =>
     `${pauseId}:${elementId}`,
   load: async ([replayClient, bridge, store, replayWall, pauseId, elementId]) => {


### PR DESCRIPTION
- [x] Proposed alternative to #9987; only debounces React element details when the Node Picker is being used.
- [x] Add unit tests for `useDebounceState` hook
