### PR TITLE
[RUN-3033] accept an optional `runId` in workflow_dispatch to later find a specific workflow_run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,17 @@
 name: Run test suites
+run-name: >-
+  ${{ (github.event.inputs.runId && format('Run test suites - run id {0}', github.event.inputs.runId))
+      || (github.event.inputs.linuxBuildFile && format('Run test suites - linux build {0}', github.event.inputs.linuxBuildFile))
+      || '' }}
+
 on:
   pull_request:
   workflow_dispatch:
     inputs:
       linuxBuildFile:
         description: "Linux Chromium Build File (.tar.xz)"
+      runId:
+        description: "Test Run ID, chosen by workflow dispatcher, to make it possible to find the correct run from the api"
   push:
     branches:
       - main


### PR DESCRIPTION
I'd like to be able to start a test run from a different build system, from a completely separate repo[1], then be able to wait for the test run to complete and report the status back to that build.

Unfortunately GH doesn't report back to the dispatcher an ID it can then use to later find the workflow run, so we let the dispatcher choose.  So, from the dispatcher's perspective, here's the flow:

1. generate unique token
2. generate a workflow_dispatch, passing that token for the added `runId` workflow input.  the run name in devtools is changed to a set format, and includes that runId.
3. poll the workflow GH api to locate the workflow run, looking for this set format.  Continue to poll, waiting for `status: "complete"`, then report success/failure based on `conclusion` of the run.

[1] https://github.com/replayio/chromium/pull/1027