### PR TITLE
Add messaging when no test run is selected

### DIFF
--- a/src/ui/components/Library/Team/View/NewTestRuns/Overview/TestRunOverviewContent.tsx
+++ b/src/ui/components/Library/Team/View/NewTestRuns/Overview/TestRunOverviewContent.tsx
@@ -9,15 +9,8 @@ import { RunSummary } from "./RunSummary";
 import styles from "../../../../Library.module.css";
 
 export function TestRunOverviewContent() {
-  const {
-    filterByStatus,
-    filterByText,
-    testRunId,
-    testRunIdForDisplay,
-    testRuns,
-    filterTestsByText,
-    setFilterTestsByText,
-  } = useContext(TestRunsContext);
+  const { testRunId, testRunIdForDisplay, testRuns, filterTestsByText, setFilterTestsByText } =
+    useContext(TestRunsContext);
 
   const { recordings, durationMs } = useTestRunDetailsSuspends(testRunId);
   const [filterCurrentRunByStatus, setFilterCurrentRunByStatus] = useState<
@@ -26,11 +19,10 @@ export function TestRunOverviewContent() {
 
   const isPending = testRunId !== testRunIdForDisplay;
 
-  const hasFilters = filterByStatus !== "all" || filterByText !== "";
   const testRun = testRuns.find(testRun => testRun.id === testRunId);
 
   let children = null;
-  if (testRun && recordings && !hasFilters) {
+  if (testRun && recordings?.length) {
     children = (
       <>
         <RunSummary

--- a/src/ui/components/Library/Team/View/NewTestRuns/Overview/TestRunOverviewContent.tsx
+++ b/src/ui/components/Library/Team/View/NewTestRuns/Overview/TestRunOverviewContent.tsx
@@ -4,6 +4,7 @@ import { RunResults } from "ui/components/Library/Team/View/NewTestRuns/Overview
 import { TestRunsContext } from "ui/components/Library/Team/View/NewTestRuns/TestRunsContextRoot";
 import { useTestRunDetailsSuspends } from "ui/components/Library/Team/View/TestRuns/hooks/useTestRunDetailsSuspends";
 
+import { TestSuitePanelMessage } from "../../TestSuitePanelMessage";
 import { RunSummary } from "./RunSummary";
 import styles from "../../../../Library.module.css";
 
@@ -29,27 +30,27 @@ export function TestRunOverviewContent() {
   const testRun = testRuns.find(testRun => testRun.id === testRunId);
 
   let children = null;
-  if (testRun && recordings) {
-    if (!hasFilters || testRuns.find(testRun => testRun.id === testRunId)) {
-      children = (
-        <>
-          <RunSummary
-            isPending={isPending}
-            testRun={testRun}
-            durationMs={durationMs}
-            setTestFilterByText={setFilterTestsByText}
-            testFilterByText={filterTestsByText}
-            setFilterCurrentRunByStatus={setFilterCurrentRunByStatus}
-            filterCurrentRunByStatus={filterCurrentRunByStatus}
-          />
-          <RunResults
-            isPending={isPending}
-            testFilterByText={filterTestsByText}
-            filterCurrentRunByStatus={filterCurrentRunByStatus}
-          />
-        </>
-      );
-    }
+  if (testRun && recordings && !hasFilters) {
+    children = (
+      <>
+        <RunSummary
+          isPending={isPending}
+          testRun={testRun}
+          durationMs={durationMs}
+          setTestFilterByText={setFilterTestsByText}
+          testFilterByText={filterTestsByText}
+          setFilterCurrentRunByStatus={setFilterCurrentRunByStatus}
+          filterCurrentRunByStatus={filterCurrentRunByStatus}
+        />
+        <RunResults
+          isPending={isPending}
+          testFilterByText={filterTestsByText}
+          filterCurrentRunByStatus={filterCurrentRunByStatus}
+        />
+      </>
+    );
+  } else {
+    children = <TestSuitePanelMessage>Select a run to see its details here</TestSuitePanelMessage>;
   }
 
   return (

--- a/src/ui/components/Library/Team/View/NewTestRuns/TestRunList.tsx
+++ b/src/ui/components/Library/Team/View/NewTestRuns/TestRunList.tsx
@@ -6,7 +6,6 @@ import { TestRun } from "shared/test-suites/TestRun";
 import { TestRunListItem } from "ui/components/Library/Team/View/NewTestRuns/TestRunListItem";
 import { SecondaryButton } from "ui/components/shared/Button";
 
-import { TestSuitePanelMessage } from "../TestSuitePanelMessage";
 import { TestRunsContext } from "./TestRunsContextRoot";
 
 const PAGE_SIZE = 50;

--- a/src/ui/components/Library/Team/View/NewTestRuns/TestRunList.tsx
+++ b/src/ui/components/Library/Team/View/NewTestRuns/TestRunList.tsx
@@ -6,6 +6,7 @@ import { TestRun } from "shared/test-suites/TestRun";
 import { TestRunListItem } from "ui/components/Library/Team/View/NewTestRuns/TestRunListItem";
 import { SecondaryButton } from "ui/components/shared/Button";
 
+import { TestSuitePanelMessage } from "../TestSuitePanelMessage";
 import { TestRunsContext } from "./TestRunsContextRoot";
 
 const PAGE_SIZE = 50;

--- a/src/ui/components/Library/Team/View/NewTestRuns/TestRunSpecDetails.tsx
+++ b/src/ui/components/Library/Team/View/NewTestRuns/TestRunSpecDetails.tsx
@@ -4,9 +4,9 @@ import Icon from "replay-next/components/Icon";
 import { TestRunTestWithRecordings } from "shared/test-suites/TestRun";
 
 import { useTestRunDetailsSuspends } from "../TestRuns/hooks/useTestRunDetailsSuspends";
+import { TestSuitePanelMessage } from "../TestSuitePanelMessage";
 import { TestResultListItem } from "./Overview/TestResultListItem";
 import { TestRunsContext } from "./TestRunsContextRoot";
-import styles from "../../../Testsuites.module.css";
 
 export function TestRunSpecDetails() {
   const { spec, filterTestsByText } = useContext(TestRunsContext);
@@ -23,11 +23,7 @@ export function TestRunSpecDetails() {
   const selectedTest = selectedSpecTests?.[0];
 
   if (!spec) {
-    return (
-      <div className="flex h-full w-full items-center justify-center p-2">
-        <div className={styles.standardMessaging}>Select a test to see its details here</div>
-      </div>
-    );
+    return <TestSuitePanelMessage>Select a test to see its details here</TestSuitePanelMessage>;
   } else if (groupedTests === null || selectedTest == null) {
     return null;
   }

--- a/src/ui/components/Library/Team/View/TestSuitePanelMessage.module.css
+++ b/src/ui/components/Library/Team/View/TestSuitePanelMessage.module.css
@@ -1,4 +1,14 @@
-.standardMessaging {
+.panelMessage {
+  height: 100%;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 0.5rem;
+  line-height: 1.25rem;
+}
+
+.content {
   border-radius: 0.375rem;
   background-color: var(--theme-base-90);
   padding: 0.5rem 0.75rem;

--- a/src/ui/components/Library/Team/View/TestSuitePanelMessage.module.css
+++ b/src/ui/components/Library/Team/View/TestSuitePanelMessage.module.css
@@ -1,5 +1,4 @@
-.standardMessaging,
-.noReplaysFound {
+.standardMessaging {
   border-radius: 0.375rem;
   background-color: var(--theme-base-90);
   padding: 0.5rem 0.75rem;
@@ -7,8 +6,4 @@
   font-size: var(--theme-body-font-size);
   width: fit-content;
   margin: 0 auto;
-}
-
-.noReplaysFound {
-  margin-top: 3rem;
 }

--- a/src/ui/components/Library/Team/View/TestSuitePanelMessage.tsx
+++ b/src/ui/components/Library/Team/View/TestSuitePanelMessage.tsx
@@ -1,0 +1,9 @@
+import styles from "./TestSuitePanelMessage.module.css";
+
+export function TestSuitePanelMessage({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex h-full w-full items-center justify-center p-2">
+      <div className={styles.standardMessaging}>{children}</div>
+    </div>
+  );
+}

--- a/src/ui/components/Library/Team/View/TestSuitePanelMessage.tsx
+++ b/src/ui/components/Library/Team/View/TestSuitePanelMessage.tsx
@@ -2,8 +2,8 @@ import styles from "./TestSuitePanelMessage.module.css";
 
 export function TestSuitePanelMessage({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex h-full w-full items-center justify-center p-2">
-      <div className={styles.standardMessaging}>{children}</div>
+    <div className={styles.panelMessage}>
+      <div className={styles.content}>{children}</div>
     </div>
   );
 }

--- a/src/ui/components/Library/Team/View/Tests/Overview/ReplayList.tsx
+++ b/src/ui/components/Library/Team/View/Tests/Overview/ReplayList.tsx
@@ -6,8 +6,8 @@ import Icon from "replay-next/components/Icon";
 import { TestExecution } from "shared/test-suites/TestRun";
 
 import { getTruncatedRelativeDate } from "../../Recordings/RecordingListItem/RecordingListItem";
+import { TestSuitePanelMessage } from "../../TestSuitePanelMessage";
 import styles from "../../../../Library.module.css";
-import testsuiteStyles from "../../../../Testsuites.module.css";
 
 export function ReplayList({ executions, label }: { executions: TestExecution[]; label: string }) {
   const sortedReplays = orderBy(
@@ -19,7 +19,7 @@ export function ReplayList({ executions, label }: { executions: TestExecution[];
   let children = null;
 
   if (!sortedReplays.length) {
-    children = <div className={testsuiteStyles.noReplaysFound}>No replays found</div>;
+    children = <TestSuitePanelMessage>No replays found</TestSuitePanelMessage>;
   } else {
     children = sortedReplays.map((e, i) =>
       e.recordings.map(r => (

--- a/src/ui/components/Library/Team/View/Tests/Overview/TestOverviewContent.tsx
+++ b/src/ui/components/Library/Team/View/Tests/Overview/TestOverviewContent.tsx
@@ -2,11 +2,11 @@ import { useContext } from "react";
 
 import { LibrarySpinner } from "ui/components/Library/LibrarySpinner";
 
+import { TestSuitePanelMessage } from "../../TestSuitePanelMessage";
 import { useTest } from "../hooks/useTest";
 import { TestContext } from "../TestContextRoot";
 import { TestDetails } from "./TestDetails";
 import libraryStyles from "../../../../Library.module.css";
-import styles from "../../../../Testsuites.module.css";
 
 export function TestOverviewContent() {
   const { testId } = useContext(TestContext);
@@ -16,11 +16,7 @@ export function TestOverviewContent() {
   if (testId) {
     children = <TestOverview testId={testId} />;
   } else {
-    children = (
-      <div className="flex h-full items-center justify-center p-2">
-        <div className={styles.standardMessaging}>Select a test to see its details here</div>
-      </div>
-    );
+    children = <TestSuitePanelMessage>Select a test to see its details here</TestSuitePanelMessage>;
   }
 
   return (


### PR DESCRIPTION
* Adds messaging to center pane; when no test run is selected
* Refactors "standard messaging" into a new `TestSuitesPanelMessage` component

<img width="906" alt="image" src="https://github.com/replayio/devtools/assets/788456/a351d8a5-fdbd-42f4-a91f-90d3dabf6b15">
