### PR TITLE
Debounce React component details when coming from the Node Picker

### DIFF
--- a/packages/replay-next/components/windowing/GenericListData.ts
+++ b/packages/replay-next/components/windowing/GenericListData.ts
@@ -78,8 +78,10 @@ export abstract class GenericListData<Item> extends EventEmitter<{
   };
 
   setSelectedIndex(value: number | null) {
-    this._selectedIndex = value;
-    this.emit("selectedIndex", value);
+    if (this._selectedIndex !== value) {
+      this._selectedIndex = value;
+      this.emit("selectedIndex", value);
+    }
   }
 
   subscribeToLoading = (callback: (value: boolean) => void) => {

--- a/src/ui/components/SecondaryToolbox/react-devtools/components/ReactDevToolsPanel.tsx
+++ b/src/ui/components/SecondaryToolbox/react-devtools/components/ReactDevToolsPanel.tsx
@@ -2,6 +2,7 @@ import { ExecutionPoint, PauseId } from "@replayio/protocol";
 import {
   KeyboardEvent,
   Suspense,
+  useCallback,
   useContext,
   useLayoutEffect,
   useMemo,
@@ -19,6 +20,7 @@ import AutoSizer from "react-virtualized-auto-sizer";
 
 import ErrorBoundary from "replay-next/components/ErrorBoundary";
 import { PanelLoader } from "replay-next/components/PanelLoader";
+import { useDebounce } from "replay-next/src/hooks/useDebounce";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { InspectButton } from "ui/components/SecondaryToolbox/react-devtools/components/InspectButton";
 import { ReactDevToolsList } from "ui/components/SecondaryToolbox/react-devtools/components/ReactDevToolsList";
@@ -30,13 +32,13 @@ import { useReactDevToolsAnnotations } from "ui/components/SecondaryToolbox/reac
 import { useReplayWall } from "ui/components/SecondaryToolbox/react-devtools/hooks/useReplayWall";
 import { ReactDevToolsListData } from "ui/components/SecondaryToolbox/react-devtools/ReactDevToolsListData";
 import { getDefaultSelectedReactElementId } from "ui/reducers/app";
-import { getRecordingTooLongToSupportRoutines } from "ui/reducers/timeline";
 import { useAppSelector } from "ui/setup/hooks";
 import {
   ParsedReactDevToolsAnnotation,
   reactDevToolsAnnotationsCache,
 } from "ui/suspense/annotationsCaches";
 
+import { ReactElement } from "../types";
 import styles from "./ReactDevToolsPanel.module.css";
 
 export function ReactDevToolsPanel({
@@ -100,6 +102,28 @@ function ReactDevToolsPanelInner({
   );
   const selectedElement =
     listData && selectedIndex != null ? listData.getItemAtIndex(selectedIndex) : null;
+
+  const [debounceElementDetails, setDebounceElementDetails] = useState(false);
+  const selectedElementDebounced = useDebounce(selectedElement, 500);
+  const selectedElementForDetailsPanel = debounceElementDetails
+    ? selectedElementDebounced
+    : selectedElement;
+
+  const selectElementHighPriority = useCallback(
+    (element: ReactElement | null) => {
+      listData.selectElement(element);
+      setDebounceElementDetails(false);
+    },
+    [listData]
+  );
+
+  const selectElementLowPriority = useCallback(
+    (element: ReactElement | null) => {
+      listData.selectElement(element);
+      setDebounceElementDetails(true);
+    },
+    [listData]
+  );
 
   const hasReactMounted = useReactDevToolsAnnotations({
     annotations,
@@ -188,7 +212,8 @@ function ReactDevToolsPanelInner({
                     bridge={bridge}
                     height={height}
                     listData={listData}
-                    pauseId={pauseId}
+                    selectElementHighPriority={selectElementHighPriority}
+                    selectElementLowPriority={selectElementLowPriority}
                     store={store}
                     wall={wall}
                     width={width}
@@ -210,16 +235,21 @@ function ReactDevToolsPanelInner({
           order={2}
           ref={rightPanelRef}
         >
-          {listData && pauseId && selectedElement ? (
+          {listData && pauseId && selectedElementForDetailsPanel ? (
             <ErrorBoundary
-              fallback={<SelectedElementErrorBoundaryFallback element={selectedElement} />}
+              fallback={
+                <SelectedElementErrorBoundaryFallback element={selectedElementForDetailsPanel} />
+              }
               name="ReactDevToolsPanelProperties"
-              resetKey={`${pauseId}:${selectedElement.id}`}
+              resetKey={`${pauseId}:${selectedElementForDetailsPanel.id}`}
             >
-              <Suspense fallback={<SelectedElementLoader element={selectedElement} />}>
+              <Suspense
+                fallback={<SelectedElementLoader element={selectedElementForDetailsPanel} />}
+              >
                 <SelectedElement
                   bridge={bridge}
-                  element={selectedElement}
+                  element={selectedElementForDetailsPanel}
+                  isDebounceDelayed={selectedElementForDetailsPanel.id !== selectedElement?.id}
                   listData={listData}
                   pauseId={pauseId}
                   replayWall={wall}

--- a/src/ui/components/SecondaryToolbox/react-devtools/components/SelectedElement.tsx
+++ b/src/ui/components/SecondaryToolbox/react-devtools/components/SelectedElement.tsx
@@ -40,6 +40,7 @@ import styles from "./SelectedElement.module.css";
 export function SelectedElement({
   bridge,
   element,
+  isDebounceDelayed,
   listData,
   pauseId: defaultPriorityPauseId,
   replayWall,
@@ -47,6 +48,7 @@ export function SelectedElement({
 }: {
   bridge: FrontendBridge;
   element: ReactElement;
+  isDebounceDelayed: boolean;
   listData: ReactDevToolsListData;
   pauseId: PauseId;
   replayWall: ReplayWall;
@@ -64,7 +66,7 @@ export function SelectedElement({
   // Only Suspend at deferred priority
   const deferredElement = useDeferredValue(element);
 
-  const isPending = element !== deferredElement;
+  const isPending = isDebounceDelayed || element !== deferredElement;
 
   const [inspectedElement, [, fiberIdsToNodeIds]] = suspendInParallel(
     () => inspectedElementCache.read(replayClient, bridge, store, replayWall, pauseId, id),

--- a/src/ui/components/SecondaryToolbox/react-devtools/suspense/inspectedElementCache.ts
+++ b/src/ui/components/SecondaryToolbox/react-devtools/suspense/inspectedElementCache.ts
@@ -27,7 +27,7 @@ export const inspectedElementCache = createCache<
   InspectedReactElement
 >({
   config: { immutable: true },
-  debugLabel: "DOMSearchCache",
+  debugLabel: "inspectedElementCache",
   getKey: ([replayClient, bridge, store, replayWall, pauseId, elementId]) =>
     `${pauseId}:${elementId}`,
   load: async ([replayClient, bridge, store, replayWall, pauseId, elementId]) => {


### PR DESCRIPTION
This is a mixture of #9987 and #10000. Like the latter, it reliably detects where a selection change is coming from. But the logic in `ReactDevtoolsPanel` is simpler and doesn't require the new `useDebounceState` hook.