### PR TITLE
Add explicit error fallback if log point panel hits fail to load

### DIFF
--- a/packages/replay-next/components/sources/SourceListRowMouseEvents.tsx
+++ b/packages/replay-next/components/sources/SourceListRowMouseEvents.tsx
@@ -1,5 +1,6 @@
 import { UIEvent, useContext, useLayoutEffect, useRef, useState } from "react";
 
+import ErrorBoundary from "replay-next/components/ErrorBoundary";
 import useGetDefaultLogPointContent from "replay-next/components/sources/hooks/useGetDefaultLogPointContent";
 import HoverButton from "replay-next/components/sources/HoverButton";
 import useSourceContextMenu from "replay-next/components/sources/useSourceContextMenu";
@@ -233,17 +234,19 @@ export function SourceListRowMouseEvents({
       )}
 
       {!isLineNumberHovered && isRowHovered && (
-        <HoverButton
-          addPoint={addPoint}
-          deletePoints={deletePoints}
-          editPendingPointText={editPendingPointText}
-          editPointBehavior={editPointBehavior}
-          lineHitCounts={lineHitCounts}
-          lineNumber={lineNumber}
-          point={pointForDefaultPriority}
-          pointBehavior={pointBehavior}
-          source={source}
-        />
+        <ErrorBoundary name="SourceListRowMouseEvents-HoverButton" fallback={null}>
+          <HoverButton
+            addPoint={addPoint}
+            deletePoints={deletePoints}
+            editPendingPointText={editPendingPointText}
+            editPointBehavior={editPointBehavior}
+            lineHitCounts={lineHitCounts}
+            lineNumber={lineNumber}
+            point={pointForDefaultPriority}
+            pointBehavior={pointBehavior}
+            source={source}
+          />
+        </ErrorBoundary>
       )}
 
       {contextMenu}

--- a/packages/replay-next/components/sources/log-point-panel/LogPointPanel.module.css
+++ b/packages/replay-next/components/sources/log-point-panel/LogPointPanel.module.css
@@ -1,5 +1,6 @@
 .Panel,
-.Loader {
+.Loader,
+.ErrorFallback {
   position: absolute;
   top: var(--line-height);
   left: var(--source-line-number-offset);
@@ -26,13 +27,22 @@
   color: var(--point-panel-input-disabled-link-color-hover);
 }
 
-.Loader {
-  background-color: var(--point-panel-background-color);
+.Loader,
+.ErrorFallback {
   padding: 0.5rem;
   display: flex;
   align-items: center;
   justify-content: center;
   color: var(--color-dimmer);
+}
+.Loader {
+  background-color: var(--point-panel-background-color);
+}
+.ErrorFallback {
+  background-color: var(--background-color-error);
+  color: var(--color-error);
+  border-top: 1px solid var(--border-color-error);
+  border-bottom: 1px solid var(--border-color-error);
 }
 
 .EditableContentWrapperRow,

--- a/packages/replay-next/components/sources/log-point-panel/LogPointPanel.tsx
+++ b/packages/replay-next/components/sources/log-point-panel/LogPointPanel.tsx
@@ -11,6 +11,7 @@ import {
 
 import { assert } from "protocol/utils";
 import AvatarImage from "replay-next/components/AvatarImage";
+import ErrorBoundary from "replay-next/components/ErrorBoundary";
 import Icon from "replay-next/components/Icon";
 import CodeEditor from "replay-next/components/lexical/CodeEditor";
 import {
@@ -88,10 +89,25 @@ export default function PointPanelWrapper(props: ExternalProps) {
     return loader;
   }
 
+  const errorFallback = (
+    <div
+      className={`${styles.ErrorFallback} ${className}`}
+      style={{
+        height: pointWithPendingEdits.condition
+          ? "var(--point-panel-with-conditional-height)"
+          : "var(--point-panel-height)",
+      }}
+    >
+      Could not load hit points
+    </div>
+  );
+
   return (
-    <Suspense fallback={loader}>
-      <PointPanel {...props} focusRange={focusRange} pointForSuspense={pointForSuspense} />
-    </Suspense>
+    <ErrorBoundary name="LogPointPanel" fallback={errorFallback}>
+      <Suspense fallback={loader}>
+        <PointPanel {...props} focusRange={focusRange} pointForSuspense={pointForSuspense} />
+      </Suspense>
+    </ErrorBoundary>
   );
 }
 


### PR DESCRIPTION
To test this, I modified the `hitPointsForLocationCache` to throw an error.

https://github.com/replayio/devtools/assets/29597/0b225cc6-fd38-4dbe-b250-526a7c63a566

