### PR TITLE
Redirect gecko recordings to legacy.replay.io

### DIFF
--- a/packages/shared/graphql/generated/GetRecording.ts
+++ b/packages/shared/graphql/generated/GetRecording.ts
@@ -139,6 +139,7 @@ export interface GetRecording_recording_collaboratorRequests {
 export interface GetRecording_recording {
   __typename: "Recording";
   uuid: any;
+  buildId: string | null;
   url: string | null;
   title: string | null;
   duration: number | null;

--- a/packages/shared/graphql/types.ts
+++ b/packages/shared/graphql/types.ts
@@ -204,6 +204,7 @@ export enum RecordingRole {
 }
 
 export interface Recording {
+  buildId?: string | null;
   collaborators?: string[];
   collaboratorRequests?: CollaboratorRequest[] | null;
   comments?: any;

--- a/pages/recording/[[...id]].tsx
+++ b/pages/recording/[[...id]].tsx
@@ -167,6 +167,14 @@ function RecordingPage({
         return;
       }
 
+      if (rec.buildId?.includes("gecko")) {
+        const url = new URL(window.location.href);
+        if (url.hostname === "app.replay.io") {
+          url.hostname = "legacy.replay.io";
+          window.location.replace(url.toString());
+        }
+      }
+
       setRecording(rec);
 
       if (Array.isArray(query.id) && query.id[query.id.length - 1] === "share") {

--- a/src/ui/graphql/recordings.ts
+++ b/src/ui/graphql/recordings.ts
@@ -15,6 +15,7 @@ export const GET_RECORDING = gql`
   query GetRecording($recordingId: UUID!) {
     recording(uuid: $recordingId) {
       uuid
+      buildId
       url
       title
       duration

--- a/src/ui/hooks/recordings.ts
+++ b/src/ui/hooks/recordings.ts
@@ -281,6 +281,7 @@ export function convertRecording(
 ): Recording {
   const recording: Recording = {
     id: rec.uuid,
+    buildId: "buildId" in rec ? rec.buildId : undefined,
     user: "owner" in rec ? rec.owner : undefined,
     userId: "owner" in rec ? rec.owner?.id : undefined,
     // NOTE: URLs are nullable in the database


### PR DESCRIPTION
Doing this in a middleware would have required duplicating a lot of logic, so I added it to `pages/recording/[[...id]].tsx` instead.
Note that this will only redirect if you start at `app.replay.io`. I assumed that otherwise you're a Replay developer and probably know what you're doing.