### PR TITLE
Use launchdarkly to target specific workspaces with the new test runs view

### DIFF
--- a/packages/shared/user-data/LocalStorage/config.ts
+++ b/packages/shared/user-data/LocalStorage/config.ts
@@ -10,6 +10,5 @@ export const config = {
   reactDevToolsStateExpanded: Boolean(true),
   replayNextCurrentPanel: "sources" as ReplayNextCurrentPanel,
   replayVideoPanelCollapsed: false,
-  enableTestSuitesNewRunsView: false,
   enableTestSuitesTestsView: false,
 };

--- a/src/ui/components/Library/Team/TeamPage.tsx
+++ b/src/ui/components/Library/Team/TeamPage.tsx
@@ -1,6 +1,7 @@
-import { useContext } from "react";
+import { useContext, useEffect } from "react";
 
 import { useGetTeamRouteParams } from "ui/components/Library/Team/utils";
+import { refreshLaunchDarklyContext } from "ui/utils/launchdarkly";
 
 import { ParamHandler } from "./ParamHandlers/ParamHandler";
 import {
@@ -13,6 +14,10 @@ import { ViewPage } from "./View/ViewPage";
 
 export function TeamPage() {
   const { teamId } = useGetTeamRouteParams();
+
+  useEffect(() => {
+    refreshLaunchDarklyContext(teamId);
+  }, [teamId]);
 
   if (teamId === MY_LIBRARY_TEAM.id) {
     return (

--- a/src/ui/components/Library/Team/View/ViewPage.tsx
+++ b/src/ui/components/Library/Team/View/ViewPage.tsx
@@ -1,6 +1,6 @@
 import { useContext } from "react";
 
-import useLocalStorageUserData from "shared/user-data/LocalStorage/useLocalStorageUserData";
+import { useLaunchDarkly } from "ui/utils/launchdarkly";
 
 import { FilterBarContainer } from "./FilterBarContainer";
 import { TestRunsPage as NewTestRunsPage } from "./NewTestRuns/TestRunsPage";
@@ -17,9 +17,20 @@ export function ViewPage({ defaultView }: { defaultView: string }) {
   );
 }
 
+function TestRunsView() {
+  const { getFeatureFlag, ready } = useLaunchDarkly();
+  const enableTestSuitesNewRunsView = getFeatureFlag("enable-new-test-run-view");
+
+  if (!ready) {
+    return null;
+  }
+
+  return enableTestSuitesNewRunsView ? <NewTestRunsPage /> : <TestRunsPage />;
+}
+
 export function ViewPageContent() {
   const { view } = useContext(ViewContext);
-  const [enableTestSuitesNewRunsView] = useLocalStorageUserData("enableTestSuitesNewRunsView");
+
   return (
     <div className="flex flex-grow flex-col overflow-hidden">
       <FilterBarContainer />
@@ -27,11 +38,7 @@ export function ViewPageContent() {
         {view === "recordings" ? (
           <RecordingsPage />
         ) : view === "runs" ? (
-          enableTestSuitesNewRunsView ? (
-            <NewTestRunsPage />
-          ) : (
-            <TestRunsPage />
-          )
+          <TestRunsView />
         ) : view === "tests" ? (
           <TestsPage />
         ) : null}

--- a/src/ui/setup/index.ts
+++ b/src/ui/setup/index.ts
@@ -190,9 +190,10 @@ export async function bootstrapApp() {
 
       setTelemetryContext(userInfo);
       maybeSetMixpanelContext({ ...userInfo, workspaceId, role, isTest: rec?.isTest });
+      initLaunchDarkly(workspaceId);
+    } else {
+      initLaunchDarkly();
     }
-
-    initLaunchDarkly();
   });
 
   return store;


### PR DESCRIPTION
This switches us to using launchdarkly so we can incrementally (and specifically) roll out the new runs view to teams.

https://www.loom.com/share/3553874012784d01b3ec93bfc3a07983