### PR TITLE
Fix scrollbars for recordings and test runs

### DIFF
--- a/src/ui/components/Library/Team/View/NewTestRuns/TestRunList.tsx
+++ b/src/ui/components/Library/Team/View/NewTestRuns/TestRunList.tsx
@@ -38,7 +38,7 @@ export function TestRunList() {
       children={({ height, width }) => (
         <FixedSizeList
           children={TestRunListRow}
-          className="no-scrollbar text-sm"
+          className="text-sm"
           height={height}
           itemCount={itemCount}
           itemData={itemData}

--- a/src/ui/components/Library/Team/View/Recordings/RecordingsPageViewer.tsx
+++ b/src/ui/components/Library/Team/View/Recordings/RecordingsPageViewer.tsx
@@ -33,7 +33,7 @@ export function RecordingsPageViewer({
             isEditing={isEditing}
             setIsEditing={setIsEditing}
           />
-          <div id="recording-list" className="no-scrollbar flex-grow overflow-y-auto">
+          <div id="recording-list" className="flex-grow overflow-y-auto">
             <Recordings
               isEditing={isEditing}
               recordings={recordings}

--- a/src/ui/components/Library/Team/View/TestRuns/TestRunList.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunList.tsx
@@ -39,7 +39,7 @@ export function TestRunList() {
       children={({ height, width }) => (
         <FixedSizeList
           children={TestRunListRow}
-          className="no-scrollbar text-sm"
+          className="text-sm"
           height={height}
           itemCount={itemCount}
           itemData={itemData}


### PR DESCRIPTION
This adds back the scrollbars that were taken away in https://github.com/replayio/devtools/pull/7321

https://www.loom.com/share/aa4c52c554d243c88a342c4bc4eec798