### PR TITLE
Fix glob used to select authenticated tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,7 +157,7 @@ jobs:
         run: npx @replayio/playwright install
       - uses: replayio/action-playwright@main
         with:
-          command: npx playwright test --shard ${{ matrix.shard }}/1 --reporter=@replayio/playwright/reporter,line authenticated/**/*.ts
+          command: npx playwright test --shard ${{ matrix.shard }}/1 --reporter=@replayio/playwright/reporter,line authenticated/**/*.ts authenticated/*.ts
           working-directory: ./packages/e2e-tests
           api-key: ${{ env.RECORD_REPLAY_API_KEY }}
           public: true


### PR DESCRIPTION
I'm not sure why the previous pattern doesn't find all the tests but it hasn't been for a while and this pattern seems to improve it.

### Before

<img width="411" alt="image" src="https://github.com/replayio/devtools/assets/788456/9b5a6358-9554-4e94-be1a-cbf63e472484">


### After

<img width="366" alt="image" src="https://github.com/replayio/devtools/assets/788456/e1438edf-08b7-410f-bdc7-751e0146c9b9">
