### PR TITLE
Add more tests for Playwright panel functionality

### DIFF
--- a/packages/e2e-tests/tests/playwright-01_basic-panel.test.ts
+++ b/packages/e2e-tests/tests/playwright-01_basic-panel.test.ts
@@ -16,6 +16,7 @@ import {
   getTestSuiteResultsSkippedCount,
   getTestSuiteUser,
   openCypressTestPanel,
+  openPlaywrightTestPanel,
 } from "../helpers/testsuites";
 import { waitFor } from "../helpers/utils";
 import test, { expect } from "../testFixtureCloneRecording";
@@ -29,12 +30,7 @@ test("playwright-01: Basic Test Suites panel functionality", async ({
   await startTest(page, recordingId);
   await openDevToolsTab(page);
 
-  await openCypressTestPanel(page);
-
-  const testPanel = getTestSuitePanel(page);
-
-  const isVisible = await testPanel.isVisible();
-  expect(isVisible).toBe(true);
+  await openPlaywrightTestPanel(page);
 
   // These are nested, but at least one should exist
   // on the test suites panel

--- a/packages/e2e-tests/tests/playwright-02_test-step-timelines.test.ts
+++ b/packages/e2e-tests/tests/playwright-02_test-step-timelines.test.ts
@@ -21,11 +21,6 @@ test("playwright-02: Test Step timeline behavior", async ({
 
   await openPlaywrightTestPanel(page);
 
-  const testPanel = getTestSuitePanel(page);
-
-  const isVisible = await testPanel.isVisible();
-  expect(isVisible).toBe(true);
-
   // has 1 test
   const rows = getTestRows(page);
   await waitFor(async () => {

--- a/packages/e2e-tests/tests/playwright-03_test-step-interactions.test.ts
+++ b/packages/e2e-tests/tests/playwright-03_test-step-interactions.test.ts
@@ -25,11 +25,6 @@ test("playwright-03: Test Step interactions", async ({
 
   await openPlaywrightTestPanel(page);
 
-  const testPanel = getTestSuitePanel(page);
-
-  const isVisible = await testPanel.isVisible();
-  expect(isVisible).toBe(true);
-
   // has 1 test
   const rows = getTestRows(page);
   await waitFor(async () => {

--- a/packages/e2e-tests/tests/playwright-04_menu-commands.test.ts
+++ b/packages/e2e-tests/tests/playwright-04_menu-commands.test.ts
@@ -26,11 +26,6 @@ test("playwright-04: Test Step buttons and menu item", async ({
 
   await openPlaywrightTestPanel(page);
 
-  const testPanel = getTestSuitePanel(page);
-
-  const isVisible = await testPanel.isVisible();
-  expect(isVisible).toBe(true);
-
   // has 1 test
   const rows = getTestRows(page);
   await waitFor(async () => {
@@ -81,8 +76,8 @@ test("playwright-04: Test Step buttons and menu item", async ({
   const jumpToSourceMenuItem = page.getByText("Jump to test source");
   expect(await jumpToSourceMenuItem.getAttribute("data-disabled")).toBe("true");
 
-  // click it anyway to hide the context menu
-  await jumpToSourceMenuItem.click({ force: true });
+  // hide the context menu
+  await page.keyboard.press("Escape");
 
   await firstJ2CStep.click();
   const pausedTimelinePercent = await getTimelineCurrentPercent(page);

--- a/packages/e2e-tests/tests/playwright-04_menu-commands.test.ts
+++ b/packages/e2e-tests/tests/playwright-04_menu-commands.test.ts
@@ -1,0 +1,113 @@
+import { Locator } from "@playwright/test";
+
+import { isViewerTabActive, openViewerTab, startTest } from "../helpers";
+import { closeSource, getSelectedLineNumber, waitForSelectedSource } from "../helpers/source-panel";
+import {
+  getSelectedTestCase,
+  getTestCaseSteps,
+  getTestRows,
+  getTestStepBeforeAfterButtons,
+  getTestSuitePanel,
+  getUserActionEventDetails,
+  openPlaywrightTestPanel,
+} from "../helpers/testsuites";
+import { getTimelineCurrentPercent, waitForTimelineAdvanced } from "../helpers/timeline";
+import { getByTestName, waitFor } from "../helpers/utils";
+import test, { expect } from "../testFixtureCloneRecording";
+
+test.use({ exampleKey: "playwright/breakpoints-05" });
+
+test("playwright-04: Test Step buttons and menu item", async ({
+  pageWithMeta: { page, recordingId },
+  exampleKey,
+}) => {
+  await startTest(page, recordingId);
+  await openViewerTab(page);
+
+  await openPlaywrightTestPanel(page);
+
+  const testPanel = getTestSuitePanel(page);
+
+  const isVisible = await testPanel.isVisible();
+  expect(isVisible).toBe(true);
+
+  // has 1 test
+  const rows = getTestRows(page);
+  await waitFor(async () => {
+    await expect(rows).toHaveCount(1);
+  });
+
+  const breakpointsTest = rows
+    .filter({ hasText: "breakpoints-05: Test interaction of breakpoints with debugger statements" })
+    .first();
+
+  // can open tests
+  await breakpointsTest.click();
+  const selectedRow = getSelectedTestCase(page);
+  await waitFor(async () => {
+    expect(await selectedRow.isVisible()).toBe(true);
+    expect(selectedRow).toHaveCount(1);
+  });
+
+  const steps = getTestCaseSteps(selectedRow);
+
+  const stepsWithMaybeJ2C = steps.filter({
+    hasText: /click|press/,
+  });
+
+  // "Jump to Code" button should jump to the right app line
+  const firstJ2CStep = stepsWithMaybeJ2C.nth(0);
+  await firstJ2CStep.hover();
+  const jumpToCodeButton = getByTestName(firstJ2CStep, "JumpToCode");
+  await jumpToCodeButton.hover();
+  await jumpToCodeButton.click();
+
+  await waitForSelectedSource(page, "ViewToggle.tsx");
+  await waitFor(async () => {
+    const lineNumber = await getSelectedLineNumber(page, true);
+    expect(lineNumber).toBe(70);
+  });
+
+  // Avoid "selected line" locator errors by closing this tab first
+  await waitForSelectedSource(page, "ViewToggle.tsx");
+  await closeSource(page, "ViewToggle.tsx");
+
+  // Unlike Cypress, we can't jump to the test source.
+  // Verify that's disabled.
+  await firstJ2CStep.click();
+  const menuButton = getByTestName(firstJ2CStep, "TestSectionRowMenuButton");
+  await menuButton.click();
+
+  const jumpToSourceMenuItem = page.getByText("Jump to test source");
+  expect(await jumpToSourceMenuItem.getAttribute("data-disabled")).toBe("true");
+
+  // click it anyway to hide the context menu
+  await jumpToSourceMenuItem.click({ force: true });
+
+  await firstJ2CStep.click();
+  const pausedTimelinePercent = await getTimelineCurrentPercent(page);
+
+  await menuButton.click();
+  await page.getByText("Play to here").click();
+
+  // Should jump backwards and start playing
+  await waitFor(async () => {
+    const currentTimelinePercent = await getTimelineCurrentPercent(page);
+    expect(currentTimelinePercent).toBeLessThan(pausedTimelinePercent);
+  });
+
+  // And eventually pause at the same spot
+  await waitFor(
+    async () => {
+      const currentTimelinePercent = await getTimelineCurrentPercent(page);
+      expect(currentTimelinePercent).toBe(pausedTimelinePercent);
+    },
+    { timeout: 30000 }
+  );
+
+  await menuButton.click();
+  await page.getByText("Show after").click();
+
+  // Should have gone forward a couple seconds
+  await waitForTimelineAdvanced(page, pausedTimelinePercent);
+});

--- a/packages/e2e-tests/tests/playwright-05_hover-dom-previews.test.ts
+++ b/packages/e2e-tests/tests/playwright-05_hover-dom-previews.test.ts
@@ -1,0 +1,85 @@
+import { openViewerTab, startTest } from "../helpers";
+import {
+  getSelectedTestCase,
+  getTestCaseSteps,
+  getTestRows,
+  getTestSuitePanel,
+  openPlaywrightTestPanel,
+} from "../helpers/testsuites";
+import { waitFor } from "../helpers/utils";
+import test, { expect } from "../testFixtureCloneRecording";
+
+test.use({ exampleKey: "playwright/breakpoints-05" });
+
+test("playwright-05: Test DOM node previews on user action step hover", async ({
+  pageWithMeta: { page, recordingId },
+  exampleKey,
+}) => {
+  await startTest(page, recordingId);
+  await openViewerTab(page);
+
+  await openPlaywrightTestPanel(page);
+
+  const testPanel = getTestSuitePanel(page);
+
+  const isVisible = await testPanel.isVisible();
+  expect(isVisible).toBe(true);
+
+  // has 1 test
+  const rows = getTestRows(page);
+  await waitFor(async () => {
+    await expect(rows).toHaveCount(1);
+  });
+
+  const breakpointsTest = rows
+    .filter({ hasText: "breakpoints-05: Test interaction of breakpoints with debugger statements" })
+    .first();
+
+  await breakpointsTest.click();
+  const selectedRow = getSelectedTestCase(page);
+  await waitFor(async () => {
+    expect(await selectedRow.isVisible()).toBe(true);
+    expect(selectedRow).toHaveCount(1);
+  });
+
+  const steps = getTestCaseSteps(selectedRow);
+  const firstStep = steps.first();
+
+  const userActionSteps = steps.filter({
+    hasText: /click/,
+  });
+
+  // Hovering over a user action step should show a preview of the DOM node
+  const lastClickStep = userActionSteps.last();
+  await lastClickStep.scrollIntoViewIfNeeded();
+
+  // Note that the ID is dynamically generated based on the piece of the box model shown
+  const highlighter = page.locator("#box-model-content");
+
+  await waitFor(
+    async () => {
+      // Repeatedly hover over the first step and then the click step, to force the
+      // `onMouseEnter` handler to keep checking if we have a DOM node entry available.
+      await firstStep.hover({ timeout: 1000 });
+      await lastClickStep.hover({ timeout: 1000 });
+      await highlighter.waitFor({ state: "visible", timeout: 1000 });
+    },
+    // Give the evaluation plenty of time to complete
+    { timeout: 60000 }
+  );
+
+  const pathDefinition = await highlighter.getAttribute("d");
+  // Should have a meaningful SVG path of some kind for the highlighter
+  expect(pathDefinition).toBeTruthy();
+
+  // Select `firstClickStep`
+  await lastClickStep.click();
+  await waitFor(async () => expect(await lastClickStep.getAttribute("data-selected")).toBe("true"));
+  // Make the highlighter go away
+  await firstStep.hover();
+  await highlighter.waitFor({ state: "hidden" });
+
+  // Hover over the selected `firstClickStep` and verify that the highlighter is shown again
+  await lastClickStep.hover();
+  await highlighter.waitFor({ state: "visible" });
+});

--- a/packages/e2e-tests/tests/playwright-05_hover-dom-previews.test.ts
+++ b/packages/e2e-tests/tests/playwright-05_hover-dom-previews.test.ts
@@ -20,11 +20,6 @@ test("playwright-05: Test DOM node previews on user action step hover", async ({
 
   await openPlaywrightTestPanel(page);
 
-  const testPanel = getTestSuitePanel(page);
-
-  const isVisible = await testPanel.isVisible();
-  expect(isVisible).toBe(true);
-
   // has 1 test
   const rows = getTestRows(page);
   await waitFor(async () => {


### PR DESCRIPTION
This PR:

- [x] Adds a Playwright version of `cypress-04` for testing test step list item interactions
- [x] Adds a Playwright version of `cypress-05` for testing DOM node interactions