### PR TITLE
Turn on new runs view by default

### DIFF
--- a/packages/shared/user-data/LocalStorage/config.ts
+++ b/packages/shared/user-data/LocalStorage/config.ts
@@ -10,6 +10,6 @@ export const config = {
   reactDevToolsStateExpanded: Boolean(true),
   replayNextCurrentPanel: "sources" as ReplayNextCurrentPanel,
   replayVideoPanelCollapsed: false,
-  enableTestSuitesNewRunsView: false,
+  enableTestSuitesNewRunsView: true,
   enableTestSuitesTestsView: false,
 };


### PR DESCRIPTION
This just turns the flag on by default.

Technically since this is a separate branch we should be able to just get rid of the old test runs view, and just have the new one. But let's make sure it's stable first before we delete any code.