### PR TITLE
Fixes/docs for running e2e tests against a local backend and chromium.

### DIFF
--- a/packages/e2e-tests/README.md
+++ b/packages/e2e-tests/README.md
@@ -101,6 +101,35 @@ For example, to re-record the _control flow_ test using _node_ you would run:
 ./scripts/save-examples.ts --target=node --example=control_flow
 ```
 
+### How to record and run examples using a custom backend and custom Chromium
+
+This assumes defaults for ports.
+
+#### Record the example
+
+Here we're recording `doc_debugger_statements.html`.
+
+```AUTOMATED_TEST_SECRET=<find me at backend/src/graphql-api/schema.ts!> \
+GRAPHQL_ADDRESS=http://localhost:8087/v1/graphql \
+DISPATCH_ADDRESS=ws://localhost:8000 \
+RECORD_REPLAY_PATH=<parent path to chromium>/chromium/src/out/Release/chrome \
+RECORD_REPLAY_API_KEY=<your api key> \
+./scripts/save-examples.ts --runtime=chromium --project=replay-chromium-local --example=doc_debugger_statements.html
+```
+
+#### Run the test
+
+Here we're running the `breakpoints-05 test`, which depends on the `doc_debugger_statements.html` recording above.
+
+```AUTOMATED_TEST_SECRET=<find me at backend/src/graphql-api/schema.ts!> \
+GRAPHQL_ADDRESS=http://localhost:8087/v1/graphql \
+AUTHENTICATED_TESTS_WORKSPACE_API_KEY=$RECORD_REPLAY_API_KEY \
+DISPATCH_ADDRESS=ws://localhost:8000 \
+RECORD_REPLAY_PATH=~/codedepot/chromium/src/out/Release/chrome \
+RECORD_REPLAY_API_KEY=<your api key> \
+yarn test:debug_local breakpoints-05
+```
+
 ### Updating Other Test Examples
 
 Most of our E2E tests work by having "golden recordings" of the small HTML+JS example files in `public/test`. However, for our Cypress Test Panel E2E tests, we need to work with existing Cypress test recordings as the "golden recordings" that our UI is checked against.

--- a/packages/e2e-tests/config.ts
+++ b/packages/e2e-tests/config.ts
@@ -22,7 +22,8 @@ export default {
   // While thats not great, it's also not the end of the world.
   // If someone does that, we can always change this code to only run in CI in the main repo and have this as a secret.
   // It's a lot easier to hardcode it for now though.
-  replayApiKey: process.env.RECORD_REPLAY_API_KEY || "rwk_7o3q05qOwAXoYHWiVLra5cuOilLIghqDRMWyd8ObPac",
+  replayApiKey:
+    process.env.RECORD_REPLAY_API_KEY || "rwk_7o3q05qOwAXoYHWiVLra5cuOilLIghqDRMWyd8ObPac",
   shouldRecordTest: !process.env.DONT_RECORD_TEST,
   shouldSaveCoverageData: !!process.env.E2E_CODE_COVERAGE,
   updateFixtures: !!process.env.SHOULD_UPDATE_FIXTURES,

--- a/packages/e2e-tests/config.ts
+++ b/packages/e2e-tests/config.ts
@@ -22,7 +22,7 @@ export default {
   // While thats not great, it's also not the end of the world.
   // If someone does that, we can always change this code to only run in CI in the main repo and have this as a secret.
   // It's a lot easier to hardcode it for now though.
-  replayApiKey: "rwk_7o3q05qOwAXoYHWiVLra5cuOilLIghqDRMWyd8ObPac",
+  replayApiKey: process.env.RECORD_REPLAY_API_KEY || "rwk_7o3q05qOwAXoYHWiVLra5cuOilLIghqDRMWyd8ObPac",
   shouldRecordTest: !process.env.DONT_RECORD_TEST,
   shouldSaveCoverageData: !!process.env.E2E_CODE_COVERAGE,
   updateFixtures: !!process.env.SHOULD_UPDATE_FIXTURES,

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -11,6 +11,7 @@
     "test:chromium": "playwright test --project chromium --reporter=@replayio/playwright/reporter,line",
     "test:replay-chromium": "playwright test --project replay-chromium --reporter=@replayio/playwright/reporter,line",
     "test:debug": "playwright test --project chromium --workers 1 --headed",
+    "test:debug_local": "playwright test --project=replay-chromium-custom --workers 1 --headed",
     "test:ui": "playwright test --ui",
     "test:install": "playwright install",
     "ts-node": "ts-node --project ../../tsconfig.json"

--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -5,8 +5,20 @@ const { CI, SLOW_MO, SHARD_NUMBER } = process.env;
 
 const projects = [
   {
+    name: "replay-chromium-custom",
+    use: {
+      launchOptions: {
+        executablePath:
+          process.env["REPLAY_BROWSER_BINARY_PATH"] ||
+          process.env.REPLAY_DIR + "/chromium/src/out/Release/chrome",
+      },
+    },
+  },
+  {
     name: "replay-chromium",
-    use: { ...(replayDevices["Replay Chromium"] as any) },
+    use: {
+      ...(replayDevices["Replay Chromium"] as any),
+    },
   },
   {
     name: "chromium",

--- a/packages/e2e-tests/scripts/record-playwright.ts
+++ b/packages/e2e-tests/scripts/record-playwright.ts
@@ -68,7 +68,7 @@ export async function recordPlaywright(
   }
 }
 
-export async function uploadLastRecording(url: string) : Promise<string> {
+export async function uploadLastRecording(url: string): Promise<string> {
   const list = cli.listAllRecordings();
   const id = findLast(list, rec => rec.metadata.uri === url)?.id;
 

--- a/packages/e2e-tests/scripts/record-playwright.ts
+++ b/packages/e2e-tests/scripts/record-playwright.ts
@@ -28,9 +28,10 @@ export async function recordPlaywright(
   let executablePath: string | undefined = undefined;
   if (config.shouldRecordTest) {
     executablePath = config.browserPath || getExecutablePath(browserName)!;
+    console.log(`Recording with executable at ${executablePath}`);
   }
 
-  const browser = await browserEntry.launch({
+  const browserServer = await browserEntry.launchServer({
     env: {
       ...process.env,
       // @ts-ignore
@@ -43,6 +44,15 @@ export async function recordPlaywright(
     headless: config.headless,
   });
 
+  // Set if you want to see the chromium logs during recording.
+  if (process.env.RECORD_REPLAY_BROWSER_LOG) {
+    const stderr = browserServer.process().stderr;
+    stderr?.addListener("data", data => {
+      console.error(data + "");
+    });
+  }
+
+  const browser = await browserEntry.connect(browserServer.wsEndpoint());
   const context = await browser.newContext({
     ignoreHTTPSErrors: true,
   });
@@ -58,7 +68,7 @@ export async function recordPlaywright(
   }
 }
 
-export async function uploadLastRecording(url: string) {
+export async function uploadLastRecording(url: string) : Promise<string> {
   const list = cli.listAllRecordings();
   const id = findLast(list, rec => rec.metadata.uri === url)?.id;
 

--- a/packages/e2e-tests/scripts/save-examples.ts
+++ b/packages/e2e-tests/scripts/save-examples.ts
@@ -367,11 +367,14 @@ async function saveRecording(example: string, apiKey: string, recordingId: strin
   const buildId = response.data.data.recording.buildId;
 
   const done = logAnimated(`Saving ${chalk.bold(example)} with recording id ${recordingId}`);
-  const id = await uploadRecording(recordingId, {
-    apiKey,
-    server: config.backendUrl,
-    verbose: true,
-  });
+
+  if (!skipUpload) {
+    await uploadRecording(recordingId, {
+      apiKey,
+      server: config.backendUrl,
+      verbose: true,
+    });
+  }
 
   await makeReplayPublic(apiKey, recordingId);
   await updateRecordingTitle(apiKey, recordingId, `E2E Example: ${example}`);
@@ -460,12 +463,14 @@ async function saveBrowserExample({ example }: TestRunCallbackArgs) {
 
   console.log("Recording completed");
   const recordingId = await uploadLastRecording(exampleUrl);
-  console.log("Uploaded recording", recordingId);
+  if (recordingId == null) {
+    throw new Error("Recording not uploaded");
+  }
 
   done();
 
   if (config.useExampleFile && recordingId) {
-    await saveRecording(example.filename, config.replayApiKey, recordingId);
+    await saveRecording(example.filename, config.replayApiKey, recordingId, true);
   }
   if (recordingId) {
     removeRecording(recordingId);

--- a/packages/e2e-tests/scripts/save-examples.ts
+++ b/packages/e2e-tests/scripts/save-examples.ts
@@ -344,7 +344,12 @@ function logAnimated(text: string): () => void {
   };
 }
 
-async function saveRecording(example: string, apiKey: string, recordingId: string, skipUpload?: boolean) {
+async function saveRecording(
+  example: string,
+  apiKey: string,
+  recordingId: string,
+  skipUpload?: boolean
+) {
   const response = await axios({
     url: config.graphqlUrl,
     method: "POST",

--- a/packages/e2e-tests/scripts/save-examples.ts
+++ b/packages/e2e-tests/scripts/save-examples.ts
@@ -389,7 +389,7 @@ async function saveRecording(
   const json: ExamplesData = {
     ...JSON.parse(text),
     [example]: {
-      recording: id,
+      recording: recordingId,
       buildId,
     },
   };

--- a/packages/e2e-tests/scripts/save-examples.ts
+++ b/packages/e2e-tests/scripts/save-examples.ts
@@ -344,7 +344,7 @@ function logAnimated(text: string): () => void {
   };
 }
 
-async function saveRecording(example: string, apiKey: string, recordingId: string) {
+async function saveRecording(example: string, apiKey: string, recordingId: string, skipUpload?: boolean) {
   const response = await axios({
     url: config.graphqlUrl,
     method: "POST",


### PR DESCRIPTION
- Updated README
- Allow replay API key to be set via env-var
- new `test:debug_local` target to run with a custom chromium
- new `replay-chromium-custom` to support the above
- Added chromium log output via `RECORD_REPLAY_BROWSER_LOG` envar
- Avoid trying to upload recording twice
- Throw if the recording wasn't uploaded