### PR TITLE
Add error boundaries for new test suite pages

### DIFF
--- a/src/ui/components/Library/Team/View/NewTestRuns/TestRunsPage.tsx
+++ b/src/ui/components/Library/Team/View/NewTestRuns/TestRunsPage.tsx
@@ -1,11 +1,13 @@
-import { Suspense, useContext } from "react";
+import { ReactNode, Suspense, useContext } from "react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { ContextMenuItem, useContextMenu } from "use-context-menu";
 
+import ErrorBoundary from "replay-next/components/ErrorBoundary";
 import Icon from "replay-next/components/Icon";
 import { IndeterminateProgressBar } from "replay-next/components/IndeterminateLoader";
 import { LibrarySpinner } from "ui/components/Library/LibrarySpinner";
 
+import { TestSuitePanelMessage } from "../TestSuitePanelMessage";
 import { TimeFilterContext, TimeFilterContextRoot } from "../TimeFilterContextRoot";
 import { FilterField } from "./FilterField";
 import { TestRunOverviewPage } from "./Overview/TestRunOverviewContextRoot";
@@ -15,13 +17,23 @@ import { TestRunSpecDetails } from "./TestRunSpecDetails";
 import styles from "../../../Library.module.css";
 import dropdownStyles from "./Dropdown.module.css";
 
+function ErrorFallback() {
+  return (
+    <TestSuitePanelMessage>
+      Failed to load test runs. Refresh page to try again.
+    </TestSuitePanelMessage>
+  );
+}
+
 export function TestRunsPage() {
   return (
-    <TimeFilterContextRoot>
-      <TestRunsContextRoot>
-        <TestRunsContent />
-      </TestRunsContextRoot>
-    </TimeFilterContextRoot>
+    <ErrorBoundary name="TestRunsPageErrorBoundary" fallback={<ErrorFallback />}>
+      <TimeFilterContextRoot>
+        <TestRunsContextRoot>
+          <TestRunsContent />
+        </TestRunsContextRoot>
+      </TimeFilterContextRoot>
+    </ErrorBoundary>
   );
 }
 

--- a/src/ui/components/Library/Team/View/Tests/TestsPage.tsx
+++ b/src/ui/components/Library/Team/View/Tests/TestsPage.tsx
@@ -2,10 +2,12 @@ import { Suspense, useContext } from "react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { ContextMenuItem, useContextMenu } from "use-context-menu";
 
+import ErrorBoundary from "replay-next/components/ErrorBoundary";
 import Icon from "replay-next/components/Icon";
 import LibraryDropdownTrigger from "ui/components/Library/LibraryDropdownTrigger";
 import { LibrarySpinner } from "ui/components/Library/LibrarySpinner";
 
+import { TestSuitePanelMessage } from "../TestSuitePanelMessage";
 import {
   TimeFilterContext,
   TimeFilterContextRoot,
@@ -18,11 +20,19 @@ import styles from "./TestsPage.module.css";
 
 export function TestsPage() {
   return (
-    <TimeFilterContextRoot>
-      <TestsContextRoot>
-        <TestsContent />
-      </TestsContextRoot>
-    </TimeFilterContextRoot>
+    <ErrorBoundary name="TestsPageErrorBoundary" fallback={<ErrorFallback />}>
+      <TimeFilterContextRoot>
+        <TestsContextRoot>
+          <TestsContent />
+        </TestsContextRoot>
+      </TimeFilterContextRoot>
+    </ErrorBoundary>
+  );
+}
+
+function ErrorFallback() {
+  return (
+    <TestSuitePanelMessage>Failed to load tests. Refresh page to try again.</TestSuitePanelMessage>
   );
 }
 


### PR DESCRIPTION
Closes SCS-1720.

@jonbell-lot23 Can I ask for your help here? Here's the how error message would look for:

Test Runs:
<img width="1913" alt="Screenshot 2023-12-14 at 6 17 20 PM" src="https://github.com/replayio/devtools/assets/2629902/37e328e6-827e-44c5-8e12-c40e50a1ed1b">


Tests:
<img width="1911" alt="Screenshot 2023-12-14 at 6 17 37 PM" src="https://github.com/replayio/devtools/assets/2629902/636dbdff-dd86-42b0-a9fd-3a53b4572394">

Thoughts?