### PR TITLE
Wrap <pre> errors better

### DIFF
--- a/src/ui/components/TestSuite/views/TestRecording/TestError.module.css
+++ b/src/ui/components/TestSuite/views/TestRecording/TestError.module.css
@@ -1,6 +1,8 @@
 .Row {
   border-left: 2px solid var(--testsuites-error-border-color);
   padding: 0.5rem 0.75rem;
+  white-space: pre-wrap;
+  word-break: break-all;
 }
 
 .Header {
@@ -21,4 +23,5 @@
   color: var(--testsuites-error-color);
   margin-top: 0.75rem;
   white-space: pre-wrap;
+  word-break: break-all;
 }


### PR DESCRIPTION
By not breaking any characters in our pre content, we end up with blown out widths. This change forces wrapping when the boundary of the div is reached.

**Old:**
<img width="332" alt="image" src="https://github.com/replayio/devtools/assets/9154902/da96e2ae-87e7-4bfa-89ae-5e0105a6a453">

**New:**
<img width="332" alt="image" src="https://github.com/replayio/devtools/assets/9154902/5418911b-7de9-42d5-8fb0-079d88f2cb17">
