### PR TITLE
Consolidating font-size css variables

### DIFF
--- a/packages/replay-next/components/elements-new/ElementReactDetails.module.css
+++ b/packages/replay-next/components/elements-new/ElementReactDetails.module.css
@@ -15,7 +15,7 @@
   color: var(--tab-color);
   border-top: 0.25rem solid var(--chrome);
   font-family: var(--monospace-font-family);
-  font-size: var(--theme-code-font-size);
+  font-size: var(--font-size-regular-monospace);
 }
 .Details:hover .ComponentName {
   text-decoration: underline;

--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -1,4 +1,4 @@
-/* Text sizes */
+/* Core font sizes */
 :root,
 :root.prefers-default-font-size {
   --font-size-large: 16px;
@@ -24,7 +24,7 @@
   --theme-focus-border-color-textbox: #0675d3;
   --theme-textbox-box-shadow: rgba(97, 181, 255, 0.75);
 
-  /* Other text sizes */
+  /* Other font sizes */
   --root-font-size: 16px;
   --theme-code-line-height: calc(15 / 11);
   --theme-tab-font-size: var(--font-size-large);

--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -9,10 +9,10 @@
   --theme-textbox-box-shadow: rgba(97, 181, 255, 0.75);
 
   /* Text sizes */
-  --devtools-base-font-size: 12px;
+  —font-size-regular: 12px;
   --root-font-size: 16px;
-  --theme-body-font-size: 12px;
-  --theme-code-font-size: 11px;
+  --font-size-regular: 12px;
+  --font-size-regular-monospace: 11px;
   --theme-code-line-height: calc(15 / 11);
   --theme-tab-font-size: var(--font-size-large);
 

--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -1,18 +1,31 @@
+/* Text sizes */
+:root,
+:root.prefers-default-font-size {
+  --font-size-large: 16px;
+  --font-size-regular: 12px;
+  --font-size-regular-monospace: 11px;
+  --font-size-small: 10px;
+  --font-size-tiny: 8px;
+}
+
+:root.prefers-large-font-size {
+  --font-size-large: 20px;
+  --font-size-regular: 14px;
+  --font-size-regular-monospace: 13px;
+  --font-size-small: 12px;
+  --font-size-tiny: 10px;
+}
+
 :root {
   --font-family-default: Inter, sans-serif;
   --font-family-monospace: Menlo, ui-monospace, SFMono-Regular, Monaco, Consolas, Liberation Mono,
     Courier New, monospace;
 
-  /* Migration note: everyone below this was removed from src/devtools/client/themes/variables.css */
-
   --theme-focus-border-color-textbox: #0675d3;
   --theme-textbox-box-shadow: rgba(97, 181, 255, 0.75);
 
-  /* Text sizes */
-  —font-size-regular: 12px;
+  /* Other text sizes */
   --root-font-size: 16px;
-  --font-size-regular: 12px;
-  --font-size-regular-monospace: 11px;
   --theme-code-line-height: calc(15 / 11);
   --theme-tab-font-size: var(--font-size-large);
 
@@ -122,23 +135,6 @@
   --z-index-7--mask: var(--z-index-7);
   --z-index-8--modal: var(--z-index-8);
   --z-index-8--dropdown: var(--z-index-8);
-}
-
-:root,
-:root.prefers-default-font-size {
-  --font-size-large: 16px;
-  --font-size-regular: 12px;
-  --font-size-regular-monospace: 11px;
-  --font-size-small: 10px;
-  --font-size-tiny: 8px;
-}
-
-:root.prefers-large-font-size {
-  --font-size-large: 20px;
-  --font-size-regular: 14px;
-  --font-size-regular-monospace: 13px;
-  --font-size-small: 12px;
-  --font-size-tiny: 10px;
 }
 
 :root,

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.css
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.css
@@ -78,7 +78,7 @@
   color: var(--theme-toolbar-color);
   display: flex;
   font-family: var(--monospace-font-family);
-  font-size: var(--theme-code-font-size);
+  font-size: var(--font-size-regular-monospace);
   width: 100%;
   min-height: 28px;
   padding-top: 2px;

--- a/src/devtools/client/debugger/src/components/Editor/Editor.css
+++ b/src/devtools/client/debugger/src/components/Editor/Editor.css
@@ -85,7 +85,7 @@ html[dir="rtl"] .editor-mount {
 .editor-wrapper .editor-mount {
   width: 100%;
   background-color: var(--body-bgcolor);
-  font-size: var(--theme-code-font-size);
+  font-size: var(--font-size-regular-monospace);
   line-height: var(--theme-code-line-height);
 }
 

--- a/src/devtools/client/debugger/src/components/Editor/EditorPane.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/EditorPane.tsx
@@ -27,9 +27,9 @@ export const EditorPane = () => {
   useLayoutEffect(() => {
     const root = document.querySelector<HTMLElement>(":root")!;
     if (enableLargeText) {
-      root.style.setProperty("--theme-code-font-size", "14px");
+      root.style.setProperty("--font-size-regular-monospace", "14px");
     } else {
-      root.style.setProperty("--theme-code-font-size", "11px");
+      root.style.setProperty("--font-size-regular-monospace", "11px");
     }
   }, [enableLargeText]);
 

--- a/src/devtools/client/debugger/src/components/Editor/EditorPane.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/EditorPane.tsx
@@ -23,16 +23,6 @@ export const EditorPane = () => {
 
   const nodeWidth = useWidthObserver(panelEl);
 
-  // ExperimentFeature: LargeText Logic
-  useLayoutEffect(() => {
-    const root = document.querySelector<HTMLElement>(":root")!;
-    if (enableLargeText) {
-      root.style.setProperty("--font-size-regular-monospace", "14px");
-    } else {
-      root.style.setProperty("--font-size-regular-monospace", "11px");
-    }
-  }, [enableLargeText]);
-
   return (
     <div
       className={classNames("editor-pane overflow-hidden ", {

--- a/src/devtools/client/debugger/src/components/shared/Accordion.css
+++ b/src/devtools/client/debugger/src/components/shared/Accordion.css
@@ -70,7 +70,7 @@
 }
 
 .accordion ._content {
-  font-size: var(--theme-body-font-size);
+  font-size: var(--font-size-regular);
   overflow-y: auto;
   background-color: var(--body-bgcolor);
 }

--- a/src/devtools/client/debugger/src/components/shared/Popover.module.css
+++ b/src/devtools/client/debugger/src/components/shared/Popover.module.css
@@ -11,7 +11,7 @@
   max-height: 400px;
   height: auto;
   overflow: auto;
-  font-size: var(--theme-code-font-size);
+  font-size: var(--font-size-regular-monospace);
   background-color: var(--color-primary-background);
   border: 1px solid var(--body-color);
 }

--- a/src/devtools/client/themes/common.css
+++ b/src/devtools/client/themes/common.css
@@ -37,11 +37,11 @@
 }
 
 .theme-body-font-size {
-  font-size: var(--theme-body-font-size);
+  font-size: var(--font-size-regular);
 }
 
 .theme-code-font-size {
-  font-size: var(--theme-code-font-size);
+  font-size: var(--font-size-regular-monospace);
 }
 
 .theme-tab-font-size {
@@ -77,7 +77,7 @@
 
 .devtools-monospace {
   font-family: var(--monospace-font-family);
-  font-size: var(--theme-code-font-size);
+  font-size: var(--font-size-regular-monospace);
 }
 
 /**

--- a/src/devtools/client/themes/markup.css
+++ b/src/devtools/client/themes/markup.css
@@ -151,7 +151,7 @@ ul.children + .tag-line::before {
 /* A tag line should have a height of 16px, with a line-height of 14px,
  * (assuming a font-size of 11px). */
 .tag-line {
-  font-size: var(--theme-code-font-size);
+  font-size: var(--font-size-regular-monospace);
   min-height: 1.2727em;
   line-height: 1.2727em;
   padding-block: 1px;

--- a/src/devtools/client/themes/tooltips.css
+++ b/src/devtools/client/themes/tooltips.css
@@ -68,7 +68,7 @@ strong {
 }
 
 .tooltip-container {
-  font-size: var(—font-size-regular);
+  font-size: var(--font-size-regular);
   display: none;
   position: fixed;
   z-index: 9999;
@@ -351,7 +351,7 @@ strong {
 }
 
 .tooltip-container[type="doorhanger"] .menuitem > .command {
-  font-size: var(—font-size-regular);
+  font-size: var(--font-size-regular);
   display: flex;
   align-items: baseline;
   margin: 0;

--- a/src/devtools/client/themes/tooltips.css
+++ b/src/devtools/client/themes/tooltips.css
@@ -68,7 +68,7 @@ strong {
 }
 
 .tooltip-container {
-  font-size: var(--devtools-base-font-size);
+  font-size: var(—font-size-regular);
   display: none;
   position: fixed;
   z-index: 9999;
@@ -351,7 +351,7 @@ strong {
 }
 
 .tooltip-container[type="doorhanger"] .menuitem > .command {
-  font-size: var(--devtools-base-font-size);
+  font-size: var(—font-size-regular);
   display: flex;
   align-items: baseline;
   margin: 0;

--- a/src/devtools/client/themes/webconsole.css
+++ b/src/devtools/client/themes/webconsole.css
@@ -118,7 +118,7 @@
    * Note: on hover we show a 3px pseudo-border on top of the left padding. */
   padding-inline-start: 4px;
   padding-inline-end: 8px;
-  font-size: var(--theme-code-font-size);
+  font-size: var(--font-size-regular-monospace);
   line-height: var(--console-output-line-height);
   color: var(--console-message-color);
 }
@@ -424,7 +424,7 @@ html #webconsole-notificationbox {
   align-items: center;
   max-width: 100%;
   font-family: var(--monospace-font-family);
-  font-size: var(--theme-code-font-size);
+  font-size: var(--font-size-regular-monospace);
   line-height: var(--console-output-line-height);
   background-color: var(--theme-console-input-bgcolor);
 }

--- a/src/ui/components/Comments/CommentCardsList.module.css
+++ b/src/ui/components/Comments/CommentCardsList.module.css
@@ -54,7 +54,7 @@
 
 .NoComments p {
   margin-top: 1rem;
-  font-size: var(—font-size-regular);
+  font-size: var(--font-size-regular);
 }
 
 .NoCommentsIcon {

--- a/src/ui/components/Comments/CommentCardsList.module.css
+++ b/src/ui/components/Comments/CommentCardsList.module.css
@@ -54,7 +54,7 @@
 
 .NoComments p {
   margin-top: 1rem;
-  font-size: var(--devtools-base-font-size);
+  font-size: var(—font-size-regular);
 }
 
 .NoCommentsIcon {

--- a/src/ui/components/Library/Team/View/TestSuitePanelMessage.module.css
+++ b/src/ui/components/Library/Team/View/TestSuitePanelMessage.module.css
@@ -13,7 +13,7 @@
   background-color: var(--theme-base-90);
   padding: 0.5rem 0.75rem;
   text-align: center;
-  font-size: var(--theme-body-font-size);
+  font-size: var(--font-size-regular);
   width: fit-content;
   margin: 0 auto;
 }

--- a/src/ui/components/Timeline/Capsule.module.css
+++ b/src/ui/components/Timeline/Capsule.module.css
@@ -60,7 +60,7 @@
   color: var(--theme-text-color-strong);
   padding: 0.5rem;
   border-radius: 0.5rem;
-  font-size: var(--theme-body-font-size);
+  font-size: var(--font-size-regular);
   text-align: center;
 }
 


### PR DESCRIPTION
Addresses https://linear.app/replay/issue/DES-1045/fix-our-font-sizes-in-variablescss

<img width="746" alt="image" src="https://github.com/replayio/devtools/assets/9154902/c09d2b93-493f-4e72-a020-2c8d53f386a8">

We have a few straggler css variables that should use more standardised naming, so this PR does that.