### PR TITLE
Fix Elements CSS rules panel empty  message

### DIFF
--- a/src/devtools/client/inspector/markup/components/rules/RulesPanel.tsx
+++ b/src/devtools/client/inspector/markup/components/rules/RulesPanel.tsx
@@ -66,7 +66,11 @@ export function RulesPanelSuspends() {
           {({ height }: { height: number }) => (
             <RulesList
               height={height}
-              noContentFallback={<div className={styles.NoStyles}>No styles to display</div>}
+              noContentFallback={
+                <div className={styles.NoStyles}>
+                  {selectedNodeId ? "No styles to display" : "No element selected"}
+                </div>
+              }
               rules={cachedStyles?.rules ?? NO_RULES_AVAILABLE}
               searchText={searchText}
             />


### PR DESCRIPTION
Don't say "no styles to display" unless an element has actually been selected.

https://github.com/replayio/devtools/assets/29597/3344930f-ba72-4040-a748-f54b57455c58

