### PR TITLE
Aligning our secondary-accent color

### DIFF
--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -35,9 +35,9 @@
   --primary-accent: #01acfd;
   --primary-accent-hover: #0194ff;
 
-  --secondary-accent: #f02d5e;
+  --secondary-accent: orange;
   --secondary-accent-hover: #d72451;
-  --secondary-accent-stroke: #f02d5e;
+  --secondary-accent-stroke: var(--secondary-accent);
 
   /* used in our codebase, to be refactored */
   --blue-30: #75baff;
@@ -221,7 +221,7 @@
   --background-color-primary-button-disabled: #17527b;
   --background-color-primary-button: #02acfd;
   --background-color-resize-handle: #242e3d;
-  --background-color-secondary-button: #f02d5e;
+  --background-color-secondary-button: var(--secondary-accent);
   --background-color-source-search: #25364e;
   --background-color-warning: #42381f;
   --background-color-high-risk-setting: #310f21;
@@ -237,7 +237,7 @@
   --color-brand: #02acfd;
   --color-brand-react: #ae87f2;
   --color-contrast: #081121;
-  --color-current: #f02d5e;
+  --color-current: var(--secondary-accent);
   --color-default: #ffffff;
   --color-dim: #aaaaaa;
   --color-dimmer: #5f6977;
@@ -344,7 +344,7 @@
   --point-panel-timeline-label-color: var(--color-brand);
   --point-panel-timeline-label-hover-color: #35dfff;
   --point-panel-timeline-label-unselected-color: #747476;
-  --point-panel-timeline-label-selected-color: #f02d5e;
+  --point-panel-timeline-label-selected-color: var(--secondary-accent);
   --point-panel-timeline-label-edit-hover-background-color: #434343;
   --point-panel-timeline-label-edit-color: #fff;
 
@@ -529,7 +529,7 @@
   --testsuites-steps-bgcolor: transparent;
   --testsuites-steps-toggle-bgcolor: #191f2a;
   --testsuites-success-color: #31d710;
-  --testsuites-failed-color: #f02d5e;
+  --testsuites-failed-color: var(--secondary-accent);
   --testsuites-flaky-color: #fdba00;
   --testsuites-skipped-color: var(--theme-base-70);
   --testsuites-unresolved-color: var(--background-color-contrast-1);
@@ -546,7 +546,7 @@
   --testsuites-v2-success-icon: var(--testsuites-success-color);
   --testsuites-v2-success-header: var(--testsuites-success-color);
   --testsuites-v2-success-pill: var(--testsuites-success-color);
-  --testsuites-v2-description: #f02d5e;
+  --testsuites-v2-description: var(--secondary-accent);
   --testsuites-v2-error-bg: var(--testsuites-error-bgcolor);
 
   --circular-progress-bar-trail-color: var(--testsuites-steps-bgcolor);
@@ -764,7 +764,7 @@
   --background-color-light: #f9f9fa;
   --background-color-primary-button-disabled: #d2d2d2;
   --background-color-primary-button: #05acfd;
-  --background-color-secondary-button: #f02d5e;
+  --background-color-secondary-button: var(--secondary-accent);
 
   --background-color-current-execution-point: #eaf3ff;
   --background-color-current-execution-point-column: #b8d7ff;
@@ -786,7 +786,7 @@
   --color-brand: #05acfd;
   --color-brand-react: #8c65d0;
   --color-contrast: #ffffff;
-  --color-current: #f02d5e;
+  --color-current: var(--secondary-accent);
   --color-default: #223344;
   --color-dim: rgba(135, 135, 137, 0.9);
   --color-dimmer: #aaaaaa;
@@ -818,7 +818,7 @@
   --color-primary-background: #ffffff;
   --color-secondary-background: #eeeeee;
 
-  --nag-background-color: #f02d5e;
+  --nag-background-color: var(--secondary-accent);
   --nag-gradient-color-begin: #ff3087;
   --nag-gradient-color-end: #ed265c;
   --nag-color: #ffffff;
@@ -893,7 +893,7 @@
   --point-panel-timeline-label-color: var(--color-brand);
   --point-panel-timeline-label-hover-color: #008adb;
   --point-panel-timeline-label-unselected-color: #d1d5db;
-  --point-panel-timeline-label-selected-color: #f02d5e;
+  --point-panel-timeline-label-selected-color: var(--secondary-accent);
   --point-panel-timeline-label-edit-hover-background-color: #f5f5f5;
   --point-panel-timeline-label-edit-color: #223344;
 
@@ -1072,13 +1072,13 @@
   --testsuites-error-bgcolor-hover: #ffe0e0;
   --testsuites-error-bgcolor: #ffe9e9;
   --testsuites-error-border-color: var(--testsuites-error-icon-bgcolor);
-  --testsuites-error-color: #f02d5e;
+  --testsuites-error-color: var(--secondary-accent);
   --testsuites-error-icon-bgcolor: rgb(203, 0, 0);
   --testsuites-steps-bgcolor-hover: #f7f7f7;
   --testsuites-steps-bgcolor: #fff;
   --testsuites-steps-toggle-bgcolor: #fff;
   --testsuites-success-color: #058b00;
-  --testsuites-failed-color: #f02d5e;
+  --testsuites-failed-color: var(--secondary-accent);
   --testsuites-flaky-color: #fdba00;
   --testsuites-skipped-color: var(--theme-base-70);
   --testsuites-unresolved-color: var(--background-color-contrast-1);
@@ -1095,7 +1095,7 @@
   --testsuites-v2-success-icon: var(--testsuites-success-color);
   --testsuites-v2-success-header: var(--testsuites-success-color);
   --testsuites-v2-success-pill: var(--testsuites-success-color);
-  --testsuites-v2-description: #f02d5e;
+  --testsuites-v2-description: var(--secondary-accent);
   --testsuites-v2-error-bg: var(--testsuites-error-bgcolor);
   --circular-progress-bar-trail-color: var(--testsuites-steps-bgcolor);
 

--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -233,10 +233,9 @@
   --border-color-warning: #6f5920;
   --border-color: #e1e6ed;
   --border-color-elements-subtree: var(--background-color-contrast-1);
-
   --color-brand: #02acfd;
   --color-brand-react: #ae87f2;
-  --color-contrast: #081121;
+  --color-contrast: var(--chrome);
   --color-current: var(--secondary-accent);
   --color-default: #ffffff;
   --color-dim: #aaaaaa;
@@ -785,7 +784,7 @@
 
   --color-brand: #05acfd;
   --color-brand-react: #8c65d0;
-  --color-contrast: #ffffff;
+  --color-contrast: var(--theme-base-100);
   --color-current: var(--secondary-accent);
   --color-default: #223344;
   --color-dim: rgba(135, 135, 137, 0.9);

--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -35,7 +35,7 @@
   --primary-accent: #01acfd;
   --primary-accent-hover: #0194ff;
 
-  --secondary-accent: orange;
+  --secondary-accent: var(--secondary-accent);
   --secondary-accent-hover: #d72451;
   --secondary-accent-stroke: var(--secondary-accent);
 


### PR DESCRIPTION
**Background**

From my [Design System Alignment Project](https://www.notion.so/replayio/Design-System-Alignment-Project-87afabecf50d4badb2522b65922fb608?pvs=4) doc: Our variables.css file uses a lot of different colors that are very similar, but not quite. This is a broad project to help us pull our variables.css document into alignment with our Figma and make a system that is less likely to have small visual regressions and inconsistencies.

**Summary of these changes**

<img width="668" alt="image" src="https://github.com/replayio/devtools/assets/9154902/bf59107a-42ca-4374-9570-f83e57bf1c58">

We have a bunch of hard-coded values in our system that should be referring to a single variable. This can lead to inconsistencies and misalignments. I made changes in these locations: 

1. testsuites-failed-color
2. secondary-accent-stroke
3. background-color-secondary-button
4. color-current
5. point-panel-timeline-label-selected-color
6. testsuites-v2-description
7. nag-background-color
8. testsuites-error-color