### PR TITLE
Aligning #000 and #FFF more consistently

### DIFF
--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -286,7 +286,7 @@
   --comment-card-source-preview-background-color: var(--background-color-current-execution-point);
   --comment-card-source-preview-background-color-hover: #364052;
   --comment-reply-unpublished-background-color: var(--point-panel-background-color);
-  --comment-reply-unpublished-textfield-background-color: #000;
+  --comment-reply-unpublished-textfield-background-color: var(--theme-base-100);
   --comment-reply-unpublished-textfield-color: #fff;
 
   --object-inspector-bucket-color: #939395;
@@ -323,7 +323,7 @@
 
   --point-panel-background-color: #1f2b43;
   --point-panel-conditional-icon: var(--blue-40);
-  --point-panel-input-background-color: #000000;
+  --point-panel-input-background-color: var(--theme-base-100);
   --point-panel-input-border-color: transparent;
   --point-panel-input-border-color-hover: #273149;
   --point-panel-input-border-color-focus: var(--theme-selection-background);
@@ -335,12 +335,12 @@
   --point-panel-input-disabled-cancel-button-color: #a65858;
   --point-panel-input-disabled-cancel-button-color-hover: #d3aaaa;
   --point-panel-input-disabled-link-color-hover: #fff;
-  --point-panel-timeline-background-color: #000000;
-  --point-panel-timeline-button-background-color: #000000;
+  --point-panel-timeline-background-color: var(--theme-base-100);
+  --point-panel-timeline-button-background-color: var(--theme-base-100);
   --point-panel-timeline-button-color: var(--color-brand);
   --point-panel-timeline-button-color-disabled: #2c4450;
   --point-panel-timeline-button-shadow: 0px 0px 2px 0px hsla(0, 0%, 0%, 0.12);
-  --point-panel-timeline-label-background-color: #000000;
+  --point-panel-timeline-label-background-color: var(--theme-base-100);
   --point-panel-timeline-label-color: var(--color-brand);
   --point-panel-timeline-label-hover-color: #35dfff;
   --point-panel-timeline-label-unselected-color: #747476;
@@ -373,9 +373,9 @@
   --region-loading-color: #69e261;
 
   --search-result-active-background-color: #fffd03;
-  --search-result-active-color: #000000;
+  --search-result-active-color: var(--theme-base-100);
   --search-result-inactive-background-color: #ff9632;
-  --search-result-inactive-color: #000000;
+  --search-result-inactive-color: var(--theme-base-100);
 
   --token-comment-color: #8f8f92;
   --token-definition-color: #fefefe;
@@ -483,7 +483,7 @@
   --unloaded-region-img: url("/images/dotted-mask-dark.svg");
 
   /* Menus (Dark) */
-  --menu-bgcolor: #000;
+  --menu-bgcolor: var(--theme-base-100);
   --menu-color: var(--body-color);
   --menu-hover-bgcolor: #1b2332;
   --menu-hover-color: white;
@@ -507,7 +507,7 @@
   --breakpoint-tip: #fff;
 
   /* Testsuites (Dark) */
-  --test-step-border: #000;
+  --test-step-border: var(--theme-base-100);
   --testsuites-active-bgcolor: var(--background-color-current-execution-point);
   --testsuites-aside-background-color: var(--theme-base-90);
   --testsuites-aside-color: #fff;
@@ -721,7 +721,7 @@
   --body-sub-color: #a9a9b1;
   --buttontext-color: #f4f8fa;
   --checkbox-border: var(--input-border);
-  --checkbox: #fff;
+  --checkbox: var(--theme-base-100);
   --chrome: var(--theme-base-95); /* bg app */
   --dropshadow: 0 4px 6px -1px rgb(100 100 255 / 0.7), 0 2px 4px -2px rgb(0 0 0 / 0.1);
   --icon-color: var(--body-color);
@@ -785,19 +785,19 @@
 
   --color-brand: #05acfd;
   --color-brand-react: #8c65d0;
-  --color-contrast: #ffffff;
+  --color-contrast: var(--theme-base-100);
   --color-current: #f02d5e;
   --color-default: #223344;
   --color-dim: rgba(135, 135, 137, 0.9);
   --color-dimmer: #aaaaaa;
-  --color-disabled-button: #ffffff;
+  --color-disabled-button: var(--theme-base-100);
   --color-error: #ff0000;
   --color-highlight-change: marktext;
   --color-high-contrast-button: #000000;
   --color-link: var(--color-brand);
-  --color-primary-button: #ffffff;
+  --color-primary-button: var(--theme-base-100);
   --color-search-results: #47628b;
-  --color-secondary-button: #ffffff;
+  --color-secondary-button: var(--theme-base-100);
   --color-warning: #6c5914;
   --color-high-risk-setting: #df4c50;
 
@@ -815,13 +815,13 @@
 
   --color-control-background-active: var(--background-color-primary-button);
   --color-control-background: var(--background-color-inputs);
-  --color-primary-background: #ffffff;
+  --color-primary-background: var(--theme-base-100);
   --color-secondary-background: #eeeeee;
 
   --nag-background-color: #f02d5e;
   --nag-gradient-color-begin: #ff3087;
   --nag-gradient-color-end: #ed265c;
-  --nag-color: #ffffff;
+  --nag-color: var(--theme-base-100);
 
   --collapsible-toggle-color: #868688;
 
@@ -835,7 +835,7 @@
   --comment-card-source-preview-background-color-hover: #e3ecf9;
   --comment-card-source-preview-background-color: var(--background-color-current-execution-point);
   --comment-reply-unpublished-background-color: var(--point-panel-background-color);
-  --comment-reply-unpublished-textfield-background-color: #fff;
+  --comment-reply-unpublished-textfield-background-color: var(--theme-base-100);
   --comment-reply-unpublished-textfield-color: #000;
 
   --object-inspector-bucket-color: #737373;
@@ -872,7 +872,7 @@
 
   --point-panel-background-color: #f0f1f4;
   --point-panel-conditional-icon: var(--blue-60);
-  --point-panel-input-background-color: #ffffff;
+  --point-panel-input-background-color: var(--theme-base-100);
   --point-panel-input-border-color-focus: var(--theme-selection-background);
   --point-panel-input-border-color-hover: #e9ebef;
   --point-panel-input-border-color: transparent;
@@ -884,12 +884,12 @@
   --point-panel-input-disabled-link-color-hover: #b9000d;
   --point-panel-input-edit-button-color-hover: var(--primary-accent);
   --point-panel-input-edit-button-color: var(--color-dimmer);
-  --point-panel-timeline-background-color: #ffffff;
-  --point-panel-timeline-button-background-color: #ffffff;
+  --point-panel-timeline-background-color: var(--theme-base-100);
+  --point-panel-timeline-button-background-color: var(--theme-base-100);
   --point-panel-timeline-button-color-disabled: #e7f7ff;
   --point-panel-timeline-button-color: var(--color-brand);
   --point-panel-timeline-button-shadow: 0px 0px 2px 0px hsla(0, 0%, 0%, 0.12);
-  --point-panel-timeline-label-background-color: #ffffff;
+  --point-panel-timeline-label-background-color: var(--theme-base-100);
   --point-panel-timeline-label-color: var(--color-brand);
   --point-panel-timeline-label-hover-color: #008adb;
   --point-panel-timeline-label-unselected-color: #d1d5db;
@@ -899,15 +899,15 @@
 
   --badge-default-color: rgba(0, 0, 0, 0.08);
   --badge-green-color: #73cc6d;
-  --badge-green-contrast-color: #fff;
+  --badge-green-contrast-color: var(--theme-base-100);
   --badge-orange-color: #da7c04;
-  --badge-orange-contrast-color: #fff;
+  --badge-orange-contrast-color: var(--theme-base-100);
   --badge-picker-background-color: #f9f9fa;
   --badge-picker-invalid-background-color: #f4d8d8;
   --badge-purple-color: #a973cd;
-  --badge-purple-contrast-color: #fff;
+  --badge-purple-contrast-color: var(--theme-base-100);
   --badge-unicorn-color: #ff6ddf;
-  --badge-unicorn-contrast-color: #fff;
+  --badge-unicorn-contrast-color: var(--theme-base-100);
   --badge-yellow-color: #e4cd00;
   --badge-yellow-contrast-color: rgb(99, 79, 5);
 
@@ -1066,17 +1066,17 @@
   --testsuites-capsule-alias-selected-bgcolor: var(--theme-base-100);
   --testsuites-capsule-alias-selected-color: var(--body-color);
   --testsuites-capsule-error-bgcolor: rgb(203, 0, 0);
-  --testsuites-capsule-error-color: #fff;
+  --testsuites-capsule-error-color: var(--theme-base-100);
   --testsuites-capsule-success-bgcolor: var(--testsuites-success-color);
-  --testsuites-capsule-success-color: #ffffff;
+  --testsuites-capsule-success-color: var(--theme-base-100);
   --testsuites-error-bgcolor-hover: #ffe0e0;
   --testsuites-error-bgcolor: #ffe9e9;
   --testsuites-error-border-color: var(--testsuites-error-icon-bgcolor);
   --testsuites-error-color: #f02d5e;
   --testsuites-error-icon-bgcolor: rgb(203, 0, 0);
   --testsuites-steps-bgcolor-hover: #f7f7f7;
-  --testsuites-steps-bgcolor: #fff;
-  --testsuites-steps-toggle-bgcolor: #fff;
+  --testsuites-steps-bgcolor: var(--theme-base-100);
+  --testsuites-steps-toggle-bgcolor: var(--theme-base-100);
   --testsuites-success-color: #058b00;
   --testsuites-failed-color: #f02d5e;
   --testsuites-flaky-color: #fdba00;
@@ -1117,7 +1117,7 @@
   --theme-toolbar-color: var(--body-color);
   --theme-toolbar-highlighted-color: var(--green-60);
   --theme-toolbar-hover-active: var(--grey-20);
-  --theme-toolbar-hover: #fff;
+  --theme-toolbar-hover: var(--theme-base-100);
   --theme-toolbar-panel-icon-color: var(--theme-base-60);
   --theme-toolbar-selected-color: var(--body-color);
   --theme-toolbar-separator: var(--grey-90-a10);
@@ -1137,7 +1137,7 @@
   /* Selection (Light) */
   --theme-selection-background-hover: #f0f9fe;
   --theme-selection-background: var(--primary-accent);
-  --theme-selection-color: #ffffff;
+  --theme-selection-color: var(--theme-base-100);
   --theme-selection-focus-background: var(--toolbarbutton-hover-background);
   --theme-selection-focus-color: var(--grey-70);
   --theme-table-selection-background-hover: var(--theme-toolbar-background);
@@ -1215,7 +1215,7 @@
   --loading-boxes: white;
 
   /* Tour */
-  --tour-body-color: #fff;
+  --tour-body-color: var(--theme-base-100);
   --tour-callout-body-color: #ff0;
 
   /* Focus mode editor (light) */


### PR DESCRIPTION
We’re hard-coding #000 in a lot of places in dark theme:

<img width="1293" alt="image" src="https://github.com/replayio/devtools/assets/9154902/e3f42f8c-ddfb-4304-8d4a-6ef779e68bde">

There’s nothing wrong about using a lot of different css variables for different parts of the system, but they shouldn’t be hard-coded when they’re part of a broader system. In dark theme, we don’t use #000, we use theme-base-100.

—

The same is true with using #FFF versus theme-base-100. If we decide that our #fff or #000 is too aggressive at some point in the future, we need a single place to adjust the whole UI instead of needing to track it down everywhere.