### PR TITLE
Fix CSS typo

### DIFF
--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -48,7 +48,7 @@
   --primary-accent: #01acfd;
   --primary-accent-hover: #0194ff;
 
-  --secondary-accent: var(--secondary-accent);
+  --secondary-accent: #d72451;
   --secondary-accent-hover: #d72451;
   --secondary-accent-stroke: var(--secondary-accent);
 


### PR DESCRIPTION
Dumb typo. I had written:

```
--secondary-accent: var(--secondary-accent);
```

Instead of 

```
--secondary-accent: #d72451;
```

