### PR TITLE
Standardise on "color-default" rather than "body-color"

### DIFF
--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -780,7 +780,7 @@
   --color-brand-react: #8c65d0;
   --color-contrast: var(--theme-base-100);
   --color-current: var(--secondary-accent);
-  --color-default: #38383d;
+  --color-default: #223344;
   --color-dim: rgba(135, 135, 137, 0.9);
   --color-dimmer: #aaaaaa;
   --color-disabled-button: var(--theme-base-100);

--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -232,7 +232,7 @@
   --color-brand-react: #ae87f2;
   --color-contrast: var(--chrome);
   --color-current: var(--secondary-accent);
-  --color-default: #ffffff;
+  --color-default: green;
   --color-dim: #aaaaaa;
   --color-dimmer: #5f6977;
   --color-error: #ffb3d2;
@@ -582,7 +582,7 @@
   /* Selection (Dark) */
   --theme-selection-background-hover: #353b48;
   --theme-selection-background: var(--primary-accent);
-  --theme-selection-color: #ffffff;
+  --theme-selection-color: #fff;
   --theme-selection-focus-background: var(--grey-60);
   --theme-selection-focus-color: var(--grey-30);
   --theme-table-selection-background-hover: var(--theme-toolbar-background);
@@ -780,7 +780,7 @@
   --color-brand-react: #8c65d0;
   --color-contrast: var(--theme-base-100);
   --color-current: var(--secondary-accent);
-  --color-default: #223344;
+  --color-default: orange;
   --color-dim: rgba(135, 135, 137, 0.9);
   --color-dimmer: #aaaaaa;
   --color-disabled-button: var(--theme-base-100);

--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -48,7 +48,7 @@
   --primary-accent: #01acfd;
   --primary-accent-hover: #0194ff;
 
-  --secondary-accent: var(--secondary-accent);
+  --secondary-accent: #d72451;
   --secondary-accent-hover: #d72451;
   --secondary-accent-stroke: var(--secondary-accent);
 
@@ -166,7 +166,7 @@
 
   /* Core classes (Dark) */
   --body-bgcolor: var(--theme-base-95);
-  --body-color: var(--grey-30);
+  --body-color: var(--color-default);
   --body-sub-color: var(--grey-40);
   --buttontext-color: #f4f8fa;
   --checkbox-border: var(--input-border);
@@ -711,7 +711,7 @@
 
   /* Core classes (Light) */
   --body-bgcolor: var(--theme-base-100); /* bg text */
-  --body-color: #38383d;
+  --body-color: var(--color-default);
   --body-sub-color: #a9a9b1;
   --buttontext-color: #f4f8fa;
   --checkbox-border: var(--input-border);

--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -232,7 +232,7 @@
   --color-brand-react: #ae87f2;
   --color-contrast: var(--chrome);
   --color-current: var(--secondary-accent);
-  --color-default: green;
+  --color-default: #d7d7db;
   --color-dim: #aaaaaa;
   --color-dimmer: #5f6977;
   --color-error: #ffb3d2;
@@ -780,7 +780,7 @@
   --color-brand-react: #8c65d0;
   --color-contrast: var(--theme-base-100);
   --color-current: var(--secondary-accent);
-  --color-default: orange;
+  --color-default: #38383d;
   --color-dim: rgba(135, 135, 137, 0.9);
   --color-dimmer: #aaaaaa;
   --color-disabled-button: var(--theme-base-100);


### PR DESCRIPTION
**Background**

bvaughn added the concept of a three-colour ramp a while back:

color-default
color-dim
color-dimmer

(as well as a ton of other colors in this namespace, like color-current, color-contrast, etc)

Before that, we had a different naming convention that pivoted on color vs bgcolor:

body-color
body-bgcolor


But of course this method doesn't easily incorporate variations like dimming. So in this example, I'm pointing the legacy body-color stuff to the newer colour-default stuff.

In the future, we can find/replace all the old legacy stuff, but for now a re-route will work well.