### PR TITLE
Handle Cypress elements data nested in a .props field, and highlight multiple nodes per test step

### DIFF
--- a/packages/e2e-tests/tests/cypress-05_hover-dom-previews.test.ts
+++ b/packages/e2e-tests/tests/cypress-05_hover-dom-previews.test.ts
@@ -83,4 +83,32 @@ test("cypress-05: Test DOM node preview on user action step hover", async ({
   // Hover over the selected `firstClickStep` and verify that the highlighter is shown again
   await firstClickStep.hover();
   await highlighter.waitFor({ state: "visible" });
+
+  // Should also handle multiple found DOM nodes
+  const stepWithMultipleNodes = steps
+    .filter({
+      hasText: "[data-test*=bankaccount-list-item]",
+    })
+    .first();
+
+  // There should now be 2 highlighters in the page,
+  // one per found list item DOM node
+
+  await waitFor(
+    async () => {
+      // Repeatedly hover over the first step and then the actual step, to force the
+      // `onMouseEnter` handler to keep checking if we have a DOM node entry available.
+      await firstStep.hover({ timeout: 1000 });
+      await stepWithMultipleNodes.hover({ timeout: 1000 });
+      const count = await highlighter.count();
+      await highlighter.first().waitFor({ state: "visible", timeout: 1000 });
+      expect(count).toBe(2);
+    },
+    // Give the evaluation plenty of time to complete
+    { timeout: 30000 }
+  );
+
+  const badge = stepWithMultipleNodes.locator(`[class*="SelectedBadge"]`);
+  const badgeText = await badge.innerText();
+  expect(badgeText).toBe("2");
 });

--- a/packages/e2e-tests/tests/cypress-05_hover-dom-previews.test.ts
+++ b/packages/e2e-tests/tests/cypress-05_hover-dom-previews.test.ts
@@ -6,7 +6,7 @@ import {
   getTestSuitePanel,
   openCypressTestPanel,
 } from "../helpers/testsuites";
-import { waitFor } from "../helpers/utils";
+import { debugPrint, waitFor } from "../helpers/utils";
 import test, { expect } from "../testFixtureCloneRecording";
 
 test.use({ exampleKey: "cypress-realworld/bankaccounts.spec.js" });
@@ -50,6 +50,8 @@ test("cypress-05: Test DOM node preview on user action step hover", async ({
     hasText: /click|type/,
   });
 
+  debugPrint(page, "Checking highlighting for one node");
+
   // Hovering over a user action step should show a preview of the DOM node
   const firstClickStep = userActionSteps.first();
 
@@ -84,6 +86,8 @@ test("cypress-05: Test DOM node preview on user action step hover", async ({
   await firstClickStep.hover();
   await highlighter.waitFor({ state: "visible" });
 
+  debugPrint(page, "Checking highlighting for multiple nodes");
+
   // Should also handle multiple found DOM nodes
   const stepWithMultipleNodes = steps
     .filter({
@@ -108,6 +112,10 @@ test("cypress-05: Test DOM node preview on user action step hover", async ({
     { timeout: 30000 }
   );
 
+  debugPrint(page, "Checking found nodes badge");
+
+  // Badge doesn't show up until the step is selected
+  await stepWithMultipleNodes.click();
   const badge = stepWithMultipleNodes.locator(`[class*="SelectedBadge"]`);
   const badgeText = await badge.innerText();
   expect(badgeText).toBe("2");

--- a/packages/e2e-tests/tests/playwright-05_hover-dom-previews.test.ts
+++ b/packages/e2e-tests/tests/playwright-05_hover-dom-previews.test.ts
@@ -6,7 +6,7 @@ import {
   getTestSuitePanel,
   openPlaywrightTestPanel,
 } from "../helpers/testsuites";
-import { waitFor } from "../helpers/utils";
+import { debugPrint, waitFor } from "../helpers/utils";
 import test, { expect } from "../testFixtureCloneRecording";
 
 test.use({ exampleKey: "playwright/breakpoints-05" });
@@ -44,6 +44,8 @@ test("playwright-05: Test DOM node previews on user action step hover", async ({
     hasText: /click/,
   });
 
+  debugPrint(page, "Checking highlighting for one node");
+
   // Hovering over a user action step should show a preview of the DOM node
   const lastClickStep = userActionSteps.last();
   await lastClickStep.scrollIntoViewIfNeeded();
@@ -78,6 +80,8 @@ test("playwright-05: Test DOM node previews on user action step hover", async ({
   await lastClickStep.hover();
   await highlighter.waitFor({ state: "visible" });
 
+  debugPrint(page, "Checking highlighting for multiple nodes");
+
   // Should also handle multiple found DOM nodes
   const stepWithMultipleNodes = steps
     .filter({
@@ -102,6 +106,11 @@ test("playwright-05: Test DOM node previews on user action step hover", async ({
     { timeout: 30000 }
   );
 
-  // We don't have badges shown for Playwright test steps,
-  // so skip that unlike the Cypress test
+  debugPrint(page, "Checking found nodes badge");
+
+  // Badge doesn't show up until the step is selected
+  await stepWithMultipleNodes.click();
+  const badge = stepWithMultipleNodes.locator(`[class*="SelectedBadge"]`);
+  const badgeText = await badge.innerText();
+  expect(badgeText).toBe("4");
 });

--- a/packages/e2e-tests/tests/playwright-05_hover-dom-previews.test.ts
+++ b/packages/e2e-tests/tests/playwright-05_hover-dom-previews.test.ts
@@ -77,4 +77,31 @@ test("playwright-05: Test DOM node previews on user action step hover", async ({
   // Hover over the selected `firstClickStep` and verify that the highlighter is shown again
   await lastClickStep.hover();
   await highlighter.waitFor({ state: "visible" });
+
+  // Should also handle multiple found DOM nodes
+  const stepWithMultipleNodes = steps
+    .filter({
+      hasText: `[data-test-name="ScopesList"] >> [data-test-name="Expandable"]`,
+    })
+    .last();
+
+  // There should now be 4 highlighters in the page,
+  // one per found expandable scope DOM node
+
+  await waitFor(
+    async () => {
+      // Repeatedly hover over the first step and then the actual step, to force the
+      // `onMouseEnter` handler to keep checking if we have a DOM node entry available.
+      await firstStep.hover({ timeout: 1000 });
+      await stepWithMultipleNodes.hover({ timeout: 1000 });
+      const count = await highlighter.count();
+      await highlighter.first().waitFor({ state: "visible", timeout: 1000 });
+      expect(count).toBe(4);
+    },
+    // Give the evaluation plenty of time to complete
+    { timeout: 30000 }
+  );
+
+  // We don't have badges shown for Playwright test steps,
+  // so skip that unlike the Cypress test
 });

--- a/src/devtools/client/inspector/markup/reducers/markup.ts
+++ b/src/devtools/client/inspector/markup/reducers/markup.ts
@@ -44,7 +44,8 @@ const markupSlice = createSlice({
       },
     },
     nodesHighlighted(state, action: PayloadAction<string[]>) {
-      state.highlightedNodes = action.payload;
+      const uniqueNodeIds = [...new Set(action.payload)];
+      state.highlightedNodes = uniqueNodeIds;
     },
     nodeBoxModelsLoaded(state, action: PayloadAction<BoxModel[]>) {
       boxModelAdapter.setAll(state.nodeBoxModels, action);

--- a/src/ui/components/TestSuite/suspense/TestEventDetailsCache.ts
+++ b/src/ui/components/TestSuite/suspense/TestEventDetailsCache.ts
@@ -289,8 +289,10 @@ async function fetchAndCachePossibleCypressDomNode(
     findProtocolObjectProperty(sanitized, propName)
   );
 
-  // Grab the first one that exists, if any
-  const firstPropWithPotentialElements = propsWithPotentialElements.find(Boolean);
+  // Grab the first prop field that points to some object (DOM node or array).
+  // As an example, if there's `"Yielded": undefined`, we would skip that
+  // and fall back to `"Applied To"` if that has something.
+  const firstPropWithPotentialElements = propsWithPotentialElements.find(prop => prop?.object);
 
   let possibleDomNodes: ProtocolObject[] = [];
 

--- a/src/ui/components/TestSuite/suspense/TestEventDetailsCache.ts
+++ b/src/ui/components/TestSuite/suspense/TestEventDetailsCache.ts
@@ -346,8 +346,17 @@ async function cacheDomNodeEntry(
       })
     );
 
-    // Only want to show elements that are actually in the page
-    elements = elements.filter(e => e.node.isConnected);
+    const uniqueDomNodeIds = new Set<string>();
+
+    // Only want to show elements that are actually in the page,
+    // and remove any duplicates
+    elements = elements.filter(e => {
+      if (e.node.isConnected && !uniqueDomNodeIds.has(e.id)) {
+        uniqueDomNodeIds.add(e.id);
+        return true;
+      }
+      return false;
+    });
   }
 
   const domNodeDetails: TestEventDomNodeDetails = {

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
@@ -12,6 +12,7 @@ import {
   RecordingTestMetadataV3,
   TestSectionName,
   UserActionEvent,
+  getUserActionTestEventResultPoint,
   isUserActionTestEvent,
 } from "shared/test-suites/RecordingTestMetadata";
 import { jumpToKnownEventListenerHit } from "ui/actions/eventListeners/jumpToCode";
@@ -55,8 +56,9 @@ export default memo(function UserActionEventRow({
   userActionEvent: UserActionEvent;
 }) {
   const { data } = userActionEvent;
-  const { command, error, parentId, timeStampedPoints, resultVariable } = data;
-  const { result: resultTimeStampedPoint } = timeStampedPoints;
+  const testRunnerName = groupedTestCases.environment.testRunner.name;
+  const { command, error, parentId } = data;
+  const resultPoint = getUserActionTestEventResultPoint(userActionEvent, testRunnerName);
 
   const replayClient = useContext(ReplayClientContext);
 
@@ -112,11 +114,7 @@ export default memo(function UserActionEventRow({
     dispatch(jumpToKnownEventListenerHit(onSeek, jumpToCodeAnnotation));
   };
 
-  const showBadge =
-    isSelected &&
-    command.name === "get" &&
-    resultVariable != null &&
-    resultTimeStampedPoint !== null;
+  const showBadge = isSelected && resultPoint !== null;
   const showJumpToCode = (isHovered || isSelected) && canShowJumpToCode;
 
   let jumpToCodeStatus: JumpToCodeStatus = "loading";
@@ -172,7 +170,7 @@ export default memo(function UserActionEventRow({
       </div>
       {showBadge && (
         <Suspense fallback={<Loader />}>
-          <Badge isSelected={isSelected} timeStampedPoint={resultTimeStampedPoint} />
+          <Badge isSelected={isSelected} timeStampedPoint={resultPoint} />
         </Suspense>
       )}
       {showJumpToCode && jumpToCodeAnnotation && (

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
@@ -12,7 +12,6 @@ import {
   RecordingTestMetadataV3,
   TestSectionName,
   UserActionEvent,
-  getUserActionTestEventResultPoint,
   isUserActionTestEvent,
 } from "shared/test-suites/RecordingTestMetadata";
 import { jumpToKnownEventListenerHit } from "ui/actions/eventListeners/jumpToCode";
@@ -58,7 +57,7 @@ export default memo(function UserActionEventRow({
   const { data } = userActionEvent;
   const testRunnerName = groupedTestCases.environment.testRunner.name;
   const { command, error, parentId } = data;
-  const resultPoint = getUserActionTestEventResultPoint(userActionEvent, testRunnerName);
+  const resultPoint = userActionEvent.data.timeStampedPoints.result;
 
   const replayClient = useContext(ReplayClientContext);
 

--- a/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
@@ -199,13 +199,20 @@ export function TestSectionRow({
         return;
       }
 
-      const firstDomNodeDetails = testEventDomNodeCache.getValueIfCached(point.point);
+      const domNodesDetails = testEventDomNodeCache.getValueIfCached(point.point);
 
-      if (firstDomNodeDetails?.domNode?.node.isConnected) {
-        const { domNode, pauseId } = firstDomNodeDetails;
-        // Highlight using bounding rects, which we should have pre-cached already
-        dispatch(highlightNodes([domNode.id], pauseId, false));
+      if (!domNodesDetails) {
+        return;
       }
+
+      const { pauseId, domNodes } = domNodesDetails;
+      // Highlight using bounding rects, which we should have pre-cached already
+      dispatch(
+        highlightNodes(
+          domNodes.map(d => d.id),
+          pauseId
+        )
+      );
     }
   };
 

--- a/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
@@ -178,42 +178,31 @@ export function TestSectionRow({
 
   const onMouseEnter = async () => {
     dispatch(setHoverTime(getTestEventTime(testEvent)));
-
-    if (isUserActionTestEvent(testEvent)) {
-      // We hope to have details on the relevant DOM node cached by now.
-      // If we do, go ahead and read that synchronously so we can highlight the node.
-      // Otherwise, nothing to do here.
-      let point: TimeStampedPoint | null = null;
-      switch (testRunnerName) {
-        case "cypress": {
-          point = testEvent.data.timeStampedPoints.result ?? null;
-          break;
-        }
-        default: {
-          point = testEvent.data.timeStampedPoints.beforeStep ?? null;
-          break;
-        }
-      }
-
-      if (!point) {
-        return;
-      }
-
-      const domNodesDetails = testEventDomNodeCache.getValueIfCached(point.point);
-
-      if (!domNodesDetails) {
-        return;
-      }
-
-      const { pauseId, domNodes } = domNodesDetails;
-      // Highlight using bounding rects, which we should have pre-cached already
-      dispatch(
-        highlightNodes(
-          domNodes.map(d => d.id),
-          pauseId
-        )
-      );
+    if (!isUserActionTestEvent(testEvent)) {
+      return;
     }
+
+    // We hope to have details on the relevant DOM node cached by now.
+    // If we do, go ahead and read that synchronously so we can highlight the node.
+    const resultPoint = testEvent.data.timeStampedPoints.result;
+    if (!resultPoint) {
+      return;
+    }
+
+    const domNodesDetails = testEventDomNodeCache.getValueIfCached(resultPoint.point);
+
+    if (!domNodesDetails) {
+      return;
+    }
+
+    const { pauseId, domNodes } = domNodesDetails;
+    // Highlight using bounding rects, which we should have pre-cached already
+    dispatch(
+      highlightNodes(
+        domNodes.map(d => d.id),
+        pauseId
+      )
+    );
   };
 
   const onMouseLeave = () => {


### PR DESCRIPTION
This PR:

- Updates the Cypress step details logic to handle looking for DOM nodes in cases where they are nested inside a `stepDetails.props` field, instead of being at the top level of the `stepDetails` object ( FE-2139 )
- Updates the step details cache to store all found DOM nodes for a step and updates the step row to highlight all of them, instead of just highlighting the first ( FE-2137 )
- Updates the user action row to show count badges for both Cypress and Playwright
- Updates the highlight tests to check for the multiple-DOM-node case

Working for Cypress:

![image](https://github.com/replayio/devtools/assets/1128784/7253e38b-b01f-4933-9544-449268c4a11c)

and Playwright:

![image](https://github.com/replayio/devtools/assets/1128784/33b8c61d-9e60-4894-accc-336e689f799e)
