### PR TITLE
Remove and consolidate one-off css colors

### DIFF
--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -63,7 +63,6 @@
   --cool-gray-200: #e5e7eb;
   --cool-gray-300: #d1d5db;
   --cool-gray-400: #9ca3af;
-  --cool-gray-500: #6b7280;
   --green-50: #30e60b;
   --green-60: #12bc00;
   --green-70: #058b00;
@@ -73,7 +72,6 @@
   --grey-10-a30: rgba(249, 249, 250, 0.3);
   --grey-10: #f9f9fa;
   --grey-20: #ededf0;
-  --grey-25: #e0e0e2;
   --grey-30: #d7d7db;
   --grey-40: #b1b1b3;
   --grey-43: #a4a4a4;
@@ -503,9 +501,6 @@
   /* Testsuites (Dark) */
   --test-step-border: var(--theme-base-100);
   --testsuites-active-bgcolor: var(--background-color-current-execution-point);
-  --testsuites-aside-background-color: var(--theme-base-90);
-  --testsuites-aside-color: #fff;
-  --testsuites-aside-border-color: #fdce22;
   --testsuites-capsule-alias-bgcolor: var(--theme-base-90);
   --testsuites-capsule-alias-color: #fff;
   --testsuites-capsule-alias-selected-bgcolor: var(--theme-base-100);
@@ -560,7 +555,6 @@
   --theme-toolbar-background-hover: #232327;
   --theme-toolbar-background: #18181a;
   --theme-toolbar-color: var(--body-color);
-  --theme-toolbar-highlighted-color: var(--green-50);
   --theme-toolbar-hover-active: #252526;
   --theme-toolbar-hover: #232327;
   --theme-toolbar-panel-icon-color: var(--icon-color);
@@ -610,7 +604,6 @@
   --theme-highlight-green: #86de74;
   --theme-highlight-purple: #b98eff;
   --theme-highlight-red: #ff7de9;
-  --theme-highlight-yellow: #fff89e;
 
   /* These theme-highlight color variables have not been photonized. */
   --theme-highlight-bluegrey: #5e88b0;
@@ -1054,9 +1047,6 @@
   /* Testsuites (Light) */
   --test-step-border: rgba(0, 0, 0, 0.05);
   --testsuites-active-bgcolor: var(--background-color-current-execution-point);
-  --testsuites-aside-background-color: rgb(254 243 199);
-  --testsuites-aside-color: var(--body-color);
-  --testsuites-aside-border-color: rgb(253 230 138);
   --testsuites-capsule-alias-bgcolor: var(--theme-base-90);
   --testsuites-capsule-alias-color: var(--body-color);
   --testsuites-capsule-alias-selected-bgcolor: var(--theme-base-100);
@@ -1111,7 +1101,6 @@
   --theme-toolbar-background-hover: rgba(221, 225, 228, 0.66);
   --theme-toolbar-background: var(--grey-10);
   --theme-toolbar-color: var(--body-color);
-  --theme-toolbar-highlighted-color: var(--green-60);
   --theme-toolbar-hover-active: var(--grey-20);
   --theme-toolbar-hover: var(--theme-base-100);
   --theme-toolbar-panel-icon-color: var(--theme-base-60);
@@ -1161,7 +1150,6 @@
   --theme-highlight-green: var(--green-70);
   --theme-highlight-purple: var(--blue-70);
   --theme-highlight-red: var(--magenta-65);
-  --theme-highlight-yellow: #fff89e;
 
   /* These theme-highlight color variables have not been photonized. */
   --theme-highlight-bluegrey: #0072ab;

--- a/src/ui/components/shared/ReplayLogo.tsx
+++ b/src/ui/components/shared/ReplayLogo.tsx
@@ -8,8 +8,8 @@ const logoSizes = {
 };
 const logoColors = {
   white: "#FFF",
-  fuschia: "#F02D5E",
-  gray: "#6b7280)",
+  fuschia: "var(--secondary-accent)",
+  gray: "var(--grey-50)",
 };
 
 const Logo = () => (

--- a/src/ui/components/shared/ReplayLogo.tsx
+++ b/src/ui/components/shared/ReplayLogo.tsx
@@ -9,7 +9,7 @@ const logoSizes = {
 const logoColors = {
   white: "#FFF",
   fuschia: "#F02D5E",
-  gray: "var(--cool-gray-500)",
+  gray: "#6b7280)",
 };
 
 const Logo = () => (


### PR DESCRIPTION
**Sketch I used to track this**
<img width="1071" alt="one-offs" src="https://github.com/replayio/devtools/assets/9154902/9511baad-b37f-45a7-87c6-3b4b65f0e7d2">

**Summary**

There are some strange colors we're only using once. This PR cleaned up a bunch of them and figured out the justification for other ones.

**Removed, usually because they're not used anywhere**

1. cool-gray-500
2. theme-toolbar-highlighted-color (also green-50 and green-60)
3. grey-25
4. testsuites-aside-background-color, testsuites-aside-color, testsuites-aside-border-color
5. theme-highlight-yellow

**Kept**

1. purple-50 – this is our standard purple for the playhead. Maybe we need a better name for this. I don't want purple-50 used willy-nilly other than on the playhead
2. green-70 — I want to see if I can find a more unified green for the whole system
3. A bunch of grays (we need a broader gray audit to do this right)
4. magenta-65 is actually used in a ton of places
5. yellow-65 -- stay tuned