### PR TITLE
Remove unused variables from variables.css

### DIFF
--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -63,7 +63,6 @@
   --cool-gray-200: #e5e7eb;
   --cool-gray-300: #d1d5db;
   --cool-gray-400: #9ca3af;
-  --cool-gray-500: #6b7280;
   --green-50: #30e60b;
   --green-60: #12bc00;
   --green-70: #058b00;
@@ -73,7 +72,6 @@
   --grey-10-a30: rgba(249, 249, 250, 0.3);
   --grey-10: #f9f9fa;
   --grey-20: #ededf0;
-  --grey-25: #e0e0e2;
   --grey-30: #d7d7db;
   --grey-40: #b1b1b3;
   --grey-43: #a4a4a4;
@@ -503,9 +501,6 @@
   /* Testsuites (Dark) */
   --test-step-border: var(--theme-base-100);
   --testsuites-active-bgcolor: var(--background-color-current-execution-point);
-  --testsuites-aside-background-color: var(--theme-base-90);
-  --testsuites-aside-color: #fff;
-  --testsuites-aside-border-color: #fdce22;
   --testsuites-capsule-alias-bgcolor: var(--theme-base-90);
   --testsuites-capsule-alias-color: #fff;
   --testsuites-capsule-alias-selected-bgcolor: var(--theme-base-100);
@@ -560,7 +555,6 @@
   --theme-toolbar-background-hover: #232327;
   --theme-toolbar-background: #18181a;
   --theme-toolbar-color: var(--body-color);
-  --theme-toolbar-highlighted-color: var(--green-50);
   --theme-toolbar-hover-active: #252526;
   --theme-toolbar-hover: #232327;
   --theme-toolbar-panel-icon-color: var(--icon-color);
@@ -610,7 +604,6 @@
   --theme-highlight-green: #86de74;
   --theme-highlight-purple: #b98eff;
   --theme-highlight-red: #ff7de9;
-  --theme-highlight-yellow: #fff89e;
 
   /* These theme-highlight color variables have not been photonized. */
   --theme-highlight-bluegrey: #5e88b0;
@@ -1054,9 +1047,6 @@
   /* Testsuites (Light) */
   --test-step-border: rgba(0, 0, 0, 0.05);
   --testsuites-active-bgcolor: var(--background-color-current-execution-point);
-  --testsuites-aside-background-color: rgb(254 243 199);
-  --testsuites-aside-color: var(--body-color);
-  --testsuites-aside-border-color: rgb(253 230 138);
   --testsuites-capsule-alias-bgcolor: var(--theme-base-90);
   --testsuites-capsule-alias-color: var(--body-color);
   --testsuites-capsule-alias-selected-bgcolor: var(--theme-base-100);
@@ -1111,7 +1101,6 @@
   --theme-toolbar-background-hover: rgba(221, 225, 228, 0.66);
   --theme-toolbar-background: var(--grey-10);
   --theme-toolbar-color: var(--body-color);
-  --theme-toolbar-highlighted-color: var(--green-60);
   --theme-toolbar-hover-active: var(--grey-20);
   --theme-toolbar-hover: var(--theme-base-100);
   --theme-toolbar-panel-icon-color: var(--theme-base-60);
@@ -1161,7 +1150,6 @@
   --theme-highlight-green: var(--green-70);
   --theme-highlight-purple: var(--blue-70);
   --theme-highlight-red: var(--magenta-65);
-  --theme-highlight-yellow: #fff89e;
 
   /* These theme-highlight color variables have not been photonized. */
   --theme-highlight-bluegrey: #0072ab;

--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -63,8 +63,6 @@
   --cool-gray-200: #e5e7eb;
   --cool-gray-300: #d1d5db;
   --cool-gray-400: #9ca3af;
-  --green-50: #30e60b;
-  --green-60: #12bc00;
   --green-70: #058b00;
   --grey-10-a15: rgba(249, 249, 250, 0.15);
   --grey-10-a20: rgba(249, 249, 250, 0.2);
@@ -121,15 +119,7 @@
   --z-index-1--timeline-comment: var(--z-index-1);
   --z-index-1--paused-comment: var(--z-index-2);
   --z-index-1--paused-message: var(--z-index-1);
-  --z-index-1--comment-container: var(--z-index-1);
   --z-index-1--tooltip: var(--z-index-1);
-  --z-index-2--hovered-point-secondary: var(--z-index-2);
-  --z-index-3--hovered-point-primary: var(--z-index-3);
-  --z-index-3--hovered-comment-primary: var(--z-index-3);
-  --z-index-4--name: var(--z-index-4);
-  --z-index-5--name: var(--z-index-5);
-  --z-index-6--name: var(--z-index-6);
-  --z-index-7--name: var(--z-index-7);
   --z-index-7--mask: var(--z-index-7);
   --z-index-8--modal: var(--z-index-8);
   --z-index-8--dropdown: var(--z-index-8);
@@ -1242,29 +1232,10 @@
   --context-menu-background-color: var(--context-menu-bgcolor);
   --context-menu-border-color: var(--context-menu-border-color);
   --context-menu-filter: drop-shadow(1px 2px 3px rgba(0, 0, 0, 0.5));
-  --context-menu-font-family: var(--font-family-default);
-  --context-menu-transition-duration: 250ms;
   --context-menu-z-index: 25;
 
   /* menu item styles */
-  --context-menu-item-background-color-hover: var(--context-menu-bgcolor-hover);
-  --context-menu-item-background-color-focus: var(--context-menu-bgcolor-hover);
   --context-menu-item-color: var(--color-default);
-  --context-menu-item-color-disabled: var(--color-dimmer);
-  --context-menu-item-font-size: var(--font-size-regular);
-  --context-menu-item-height: 1.5rem;
-  --context-menu-item-padding: 0.25rem 0.5rem;
-
-  /* category styles */
-  --context-menu-category-color: var(--color-default);
-  --context-menu-category-font-size: var(--font-size-small);
-  --context-menu-category-height: 1rem;
-  --context-menu-category-padding: 0.25rem 0.5rem;
-
-  /* divider styles */
-  --context-menu-divider-color: var(--context-menu-divider);
-  --context-menu-divider-margin: 0.25rem 0;
-  --context-menu-divider-size: 1px;
 }
 
 /* browser specific tweaks */

--- a/src/ui/components/shared/ReplayLogo.tsx
+++ b/src/ui/components/shared/ReplayLogo.tsx
@@ -8,8 +8,8 @@ const logoSizes = {
 };
 const logoColors = {
   white: "#FFF",
-  fuschia: "#F02D5E",
-  gray: "#6b7280)",
+  fuschia: "var(--secondary-accent)",
+  gray: "var(--grey-50)",
 };
 
 const Logo = () => (

--- a/src/ui/components/shared/ReplayLogo.tsx
+++ b/src/ui/components/shared/ReplayLogo.tsx
@@ -9,7 +9,7 @@ const logoSizes = {
 const logoColors = {
   white: "#FFF",
   fuschia: "#F02D5E",
-  gray: "var(--cool-gray-500)",
+  gray: "#6b7280)",
 };
 
 const Logo = () => (


### PR DESCRIPTION
**Background**

I ran a script that finds items in variables.css that aren't used anywhere else in the codebase. Then I went one by one to see if the class could be safely removed. Here's a screenshot of my spreadsheet:

<img width="699" alt="image" src="https://github.com/replayio/devtools/assets/9154902/7c552cf7-833f-4de6-afb7-ef74ad3a8518">

And here's the spreadsheet itself:
[variables-alignment.csv](https://github.com/replayio/devtools/files/13733727/variables-alignment.csv)
