### PR TITLE
Fix toggling of video panel

### DIFF
--- a/packages/e2e-tests/helpers/settings.ts
+++ b/packages/e2e-tests/helpers/settings.ts
@@ -1,6 +1,9 @@
 import { Page } from "@playwright/test";
 
 export async function openSettingsModal(page: Page) {
+  // Don't want to use `showUserOptionsDropdown` here, as it
+  // waits for user settings, and the user may not be logged in
+  // in the auth tests
   await page.locator(".user-options").click();
   await page.locator('.dropdown-container button:has-text("Settings")').click();
 }

--- a/src/ui/components/Viewer.tsx
+++ b/src/ui/components/Viewer.tsx
@@ -31,12 +31,10 @@ const Vertical = ({ toolboxLayout }: { toolboxLayout: ToolboxLayout }) => {
   useLayoutEffect(() => {
     const videoPanel = videoPanelRef.current;
     if (videoPanel) {
-      if (videoPanel.isCollapsed() !== videoPanelCollapsed) {
-        if (videoPanelCollapsed) {
-          videoPanel.collapse();
-        } else {
-          videoPanel.expand();
-        }
+      if (videoPanelCollapsed) {
+        videoPanel.collapse();
+      } else {
+        videoPanel.expand();
       }
     }
   }, [videoPanelCollapsed]);


### PR DESCRIPTION
This PR:

- Updates the logic in `<Video>` to more consistently sync the "is video expanded" state with the resizeable panel
- Adds test logic for the video panel collapsing