### PR TITLE
Add a buildkite pipeline that can re-record and run the FE tests against a new Chromium build.

### DIFF
--- a/.buildkite/runtime-tests.yml
+++ b/.buildkite/runtime-tests.yml
@@ -1,5 +1,5 @@
 - label: "Runtime e2e tests (linux-x86_64)"
-  key: "static-e2e-tests-linux_x86_64"
+  key: "runtime-fe-e2e-tests-linux_x86_64"
   command: "node ./packages/e2e-tests/scripts/buildkite_run_fe_tests_from_artifact-linux-x86_64.js"
   agents:
     - "deploy=true"

--- a/.buildkite/runtime-tests.yml
+++ b/.buildkite/runtime-tests.yml
@@ -7,6 +7,8 @@
     - seek-oss/aws-sm#v2.3.1:
         region: us-east-2
         env:
+          AUTOMATED_TEST_SECRET: "graphql-automated-test-secret"
+          RECORD_REPLAY_API_KEY: "runtime-record-replay-api-key"
           FLY_API_TOKEN: "prod/fly-api-token"
           BUILDKITE_AGENT_TOKEN: "prod/buildkite-agent-token"
           SSH_PRIVATE_RSA_KEY_B64: "prod/buildkite-ssh-private-key"
@@ -33,6 +35,9 @@
           HASURA_ADMIN_SECRET: HASURA_ADMIN_SECRET
           AWS_SECRET_ACCESS_KEY: BUILD_USER_SECRET_ACCESS_KEY
           AWS_ACCESS_KEY_ID: BUILD_USER_ACCESS_KEY_ID
+          AUTOMATED_TEST_SECRET: AUTOMATED_TEST_SECRET
+          RECORD_REPLAY_API_KEY: RECORD_REPLAY_API_KEY
+
         env:
           DISPLAY: ":1"
           PLAYWRIGHT_HEADLESS: "true"

--- a/.buildkite/runtime-tests.yml
+++ b/.buildkite/runtime-tests.yml
@@ -1,0 +1,39 @@
+- label: "Runtime e2e tests (linux-x86_64)"
+  key: "static-e2e-tests-linux_x86_64"
+  command: "node ./packages/e2e-tests/scripts/buildkite_run_fe_tests_from_artifact-linux-x86_64.js"
+  agents:
+    - "deploy=true"
+  plugins:
+    - seek-oss/aws-sm#v2.3.1:
+        region: us-east-2
+        env:
+          FLY_API_TOKEN: "prod/fly-api-token"
+          BUILDKITE_AGENT_TOKEN: "prod/buildkite-agent-token"
+          SSH_PRIVATE_RSA_KEY_B64: "prod/buildkite-ssh-private-key"
+          TAILSCALE_AUTHKEY: "dev/fly-e2e-test-runner-tailscale-auth-key"
+          HASURA_ADMIN_SECRET: "prod/hasura-admin-secret"
+          BUILD_USER_ACCESS_KEY_ID:
+            secret-id: "prod/build-user"
+            json-key: ".access_key_id"
+          BUILD_USER_SECRET_ACCESS_KEY:
+            secret-id: "prod/build-user"
+            json-key: ".secret_access_key"
+          BUILDEVENT_APIKEY: honeycomb-api-key
+    - "ssh://git@github.com/replayio/fly-buildkite-plugin.git#v0.75":
+        # This image's source code is here https://github.com/replayio/backend-e2e-base-image
+        image: "registry.fly.io/buildkite-backend-e2e-tests:v14"
+        organization: "replay"
+        cpus: 4
+        memory: 4096
+        secrets:
+          BUILDKITE_AGENT_TOKEN: BUILDKITE_AGENT_TOKEN
+          SSH_PRIVATE_RSA_KEY_B64: SSH_PRIVATE_RSA_KEY_B64
+          FLY_API_TOKEN: FLY_API_TOKEN
+          TAILSCALE_AUTHKEY: TAILSCALE_AUTHKEY
+          HASURA_ADMIN_SECRET: HASURA_ADMIN_SECRET
+          AWS_SECRET_ACCESS_KEY: BUILD_USER_SECRET_ACCESS_KEY
+          AWS_ACCESS_KEY_ID: BUILD_USER_ACCESS_KEY_ID
+        env:
+          DISPLAY: ":1"
+          PLAYWRIGHT_HEADLESS: "true"
+          PLAYWRIGHT_CHROMIUM: "true"

--- a/packages/e2e-tests/scripts/aws_secrets.js
+++ b/packages/e2e-tests/scripts/aws_secrets.js
@@ -1,3 +1,5 @@
+/* Copyright 2024 Record Replay Inc. */
+
 const { execSync } = require("child_process");
 
 function getSecret(key, region) {

--- a/packages/e2e-tests/scripts/aws_secrets.js
+++ b/packages/e2e-tests/scripts/aws_secrets.js
@@ -1,0 +1,12 @@
+const { execSync } = require("child_process");
+
+function getSecret(key, region) {
+  return execSync(
+    `aws secretsmanager get-secret-value --secret-id "${key}" --region ${region} --output json --query "SecretString"`
+  )
+    .toString()
+    .trim()
+    .replaceAll('"', "");
+}
+
+module.exports = getSecret;

--- a/packages/e2e-tests/scripts/build_id_from_artifact.js
+++ b/packages/e2e-tests/scripts/build_id_from_artifact.js
@@ -1,4 +1,4 @@
-/* Copyright 2023 Record Replay Inc. */
+/* Copyright 2024 Record Replay Inc. */
 
 const fs = require("fs");
 const path = require("path");

--- a/packages/e2e-tests/scripts/build_id_from_artifact.js
+++ b/packages/e2e-tests/scripts/build_id_from_artifact.js
@@ -1,0 +1,18 @@
+/* Copyright 2023 Record Replay Inc. */
+
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+function build_id_from_artifact(os, arch) {
+  const buildIdPath = path.join("build_id", os, arch, "build_id");
+
+  execSync(
+    `buildkite-agent artifact download ${buildIdPath} . --build ` +
+      process.env.BUILDKITE_TRIGGERED_FROM_BUILD_ID
+  );
+
+  return fs.readFileSync(buildIdPath, "utf8").trim();
+}
+
+module.exports = build_id_from_artifact;

--- a/packages/e2e-tests/scripts/build_products.js
+++ b/packages/e2e-tests/scripts/build_products.js
@@ -9,7 +9,7 @@ function install_build_products(RUNTIME_BUILD_ID, PLATFORM, ARCHITECTURE) {
   let ARCH_SUFFIX = "";
   if (PLATFORM === "win32") {
     BUILD_FILE = `${RUNTIME_BUILD_ID}.zip`;
-  } else if (ARCHITECTURE === "x64") {
+  } else if (ARCHITECTURE === "x86_64") {
     BUILD_FILE = `${RUNTIME_BUILD_ID}.tar.xz`;
   } else if (ARCHITECTURE === "arm64") {
     BUILD_FILE = `${RUNTIME_BUILD_ID}-arm.tar.xz`;

--- a/packages/e2e-tests/scripts/build_products.js
+++ b/packages/e2e-tests/scripts/build_products.js
@@ -1,3 +1,5 @@
+/* Copyright 2024 Record Replay Inc. */
+
 const fs = require("fs");
 const path = require("path");
 const os = require("os");

--- a/packages/e2e-tests/scripts/build_products.js
+++ b/packages/e2e-tests/scripts/build_products.js
@@ -1,0 +1,65 @@
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const { execSync } = require("child_process");
+
+function install_build_products(RUNTIME_BUILD_ID, PLATFORM, ARCHITECTURE) {
+  // Set BUILD_FILE based on ARCHITECTURE and PLATFORM
+  let BUILD_FILE;
+  let ARCH_SUFFIX = "";
+  if (PLATFORM === "win32") {
+    BUILD_FILE = `${RUNTIME_BUILD_ID}.zip`;
+  } else if (ARCHITECTURE === "x64") {
+    BUILD_FILE = `${RUNTIME_BUILD_ID}.tar.xz`;
+  } else if (ARCHITECTURE === "arm64") {
+    BUILD_FILE = `${RUNTIME_BUILD_ID}-arm.tar.xz`;
+    ARCH_SUFFIX = "-arm";
+  } else {
+    throw new Error(`Unsupported platform: ${PLATFORM} ${ARCHITECTURE}`);
+  }
+
+  const TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "buildkite_run_test"));
+  process.on("exit", () => fs.rmdirSync(TMP_DIR, { recursive: true }));
+
+  // Download build
+  const buildUrl = `https://static.replay.io/downloads/${BUILD_FILE}`;
+  console.log(`Downloading build from ${buildUrl}`);
+  execSync(`curl ${buildUrl} -o ${path.join(TMP_DIR, BUILD_FILE)}`);
+
+  // Extract build
+  fs.mkdirSync(path.join(TMP_DIR, "build"));
+  execSync(`tar xf ${path.join(TMP_DIR, BUILD_FILE)} -C ${path.join(TMP_DIR, "build")}`);
+
+  // Download and extract symbols
+  // Don't do this for now--we only need this if we're trying to symbolify the chromium output, which
+  // we can't easily do (yet).
+
+  // const SYMBOL_FILE = `${RUNTIME_BUILD_ID}${ARCH_SUFFIX}.symbols.tgz`;
+  // const symbolUrl = `s3://recordreplay-us-east-2-dev/symbols/${SYMBOL_FILE}`;
+  // console.log(`Downloading symbols from ${symbolUrl}`);
+  // execSync(`aws s3 cp ${symbolUrl} ${path.join(TMP_DIR, SYMBOL_FILE)}`);
+  // fs.mkdirSync(SYMBOLS_DIR, { recursive: true });
+  // execSync(`tar xf ${path.join(TMP_DIR, SYMBOL_FILE)} -C ${SYMBOLS_DIR}`);
+
+  // Set Chrome binary path based on OS
+  let CHROME_BINARY;
+  if (PLATFORM === "linux") {
+    CHROME_BINARY = path.join(TMP_DIR, "build", "replay-chromium", "chrome");
+  } else if (PLATFORM === "darwin") {
+    CHROME_BINARY = path.join(
+      TMP_DIR,
+      "build",
+      "Replay-Chromium.app",
+      "Contents",
+      "MacOS",
+      "Chromium"
+    );
+  } else if (PLATFORM === "win32") {
+    CHROME_BINARY = path.join(TMP_DIR, "build", "replay-chromium", "chrome.exe");
+  } else {
+    throw new Error(`Unsupported platform: ${PLATFORM}`);
+  }
+  return CHROME_BINARY;
+}
+
+module.exports = install_build_products;

--- a/packages/e2e-tests/scripts/buildkite_run_fe_tests.js
+++ b/packages/e2e-tests/scripts/buildkite_run_fe_tests.js
@@ -17,6 +17,10 @@ function run_fe_tests(CHROME_BINARY_PATH) {
     stdio: "inherit",
   });
 
+  execSync("npx playwright install chromium", {
+    stdio: "inherit",
+  })
+
   // Start the webserver.
   let webProc = exec("yarn dev", (error, stdout, stderr) => {
     if (error) {

--- a/packages/e2e-tests/scripts/buildkite_run_fe_tests.js
+++ b/packages/e2e-tests/scripts/buildkite_run_fe_tests.js
@@ -79,7 +79,7 @@ function run_fe_tests(CHROME_BINARY_PATH) {
     "react_devtools-03-multiple-versions",
   ];
 
-  execSync(`xvfb-run yarn test:debug_local ${testNames.join(" ")}`, {
+  execSync(`xvfb-run yarn test:debug ${testNames.join(" ")}`, {
     stdio: "inherit",
     stderr: "inherit",
   });

--- a/packages/e2e-tests/scripts/buildkite_run_fe_tests.js
+++ b/packages/e2e-tests/scripts/buildkite_run_fe_tests.js
@@ -48,10 +48,12 @@ function run_fe_tests(CHROME_BINARY_PATH) {
     "doc_rr_preview.html",
     "doc_rr_region_loading.html",
     "doc_stacking_chromium.html",
-    "rdt-react-versions/dist/index.html"
+    "rdt-react-versions/dist/index.html",
   ];
   execSync(
-    `xvfb-run ./packages/e2e-tests/scripts/save-examples.ts --runtime=chromium --project=replay-chromium-local --example=${htmlFiles.join(',')}`,
+    `xvfb-run ./packages/e2e-tests/scripts/save-examples.ts --runtime=chromium --project=replay-chromium-local --example=${htmlFiles.join(
+      ","
+    )}`,
     { stdio: "inherit" }
   );
 
@@ -61,9 +63,9 @@ function run_fe_tests(CHROME_BINARY_PATH) {
   // Run the known-passind tests.
   const testNames = [
     "comments-01",
-    "comments-02",
-    "comments-03", 
-    "logpoints-01", 
+    //"comments-02",
+    "comments-03",
+    "logpoints-01",
     "stepping-05_chromium",
     "scopes_renderer",
     "passport-01",
@@ -71,12 +73,15 @@ function run_fe_tests(CHROME_BINARY_PATH) {
     "passport-04",
     "object_preview-03",
     "focus_mode-01",
-    "elements-search", 
+    "elements-search",
     "stacking_chromium",
-    "react_devtools-03-multiple-versions"
-  ]
+    "react_devtools-03-multiple-versions",
+  ];
 
-  execSync(`xvfb-run yarn test:debug_local ${testNames.join(' ')}`, { stdio: "inherit", stderr: "inherit" });
+  execSync(`xvfb-run yarn test:debug_local ${testNames.join(" ")}`, {
+    stdio: "inherit",
+    stderr: "inherit",
+  });
 
   // Make sure the web server shuts down.
   webProc.kill("SIGKILL");

--- a/packages/e2e-tests/scripts/buildkite_run_fe_tests.js
+++ b/packages/e2e-tests/scripts/buildkite_run_fe_tests.js
@@ -34,9 +34,7 @@ function run_fe_tests(CHROME_BINARY_PATH) {
 
   process.env.RECORD_REPLAY_DISPATCH_SERVER = "wss://dispatch.replay.io";
   process.env.REPLAY_BROWSER_BINARY_PATH = CHROME_BINARY_PATH;
-  process.env.RECORD_REPLAY_API_KEY = "rwk_b6mnJ00rI4pzlwkYmggmmmV1TVQXA0AUktRHoo4vGl9";
   process.env.AUTHENTICATED_TESTS_WORKSPACE_API_KEY = process.env.RECORD_REPLAY_API_KEY;
-  process.env.AUTOMATED_TEST_SECRET = "c2MjW2nnut4vqpntvD@P3f46Edf-86eb";
 
   // Generate new recordings with the new chromium build.
   execSync(

--- a/packages/e2e-tests/scripts/buildkite_run_fe_tests.js
+++ b/packages/e2e-tests/scripts/buildkite_run_fe_tests.js
@@ -1,3 +1,5 @@
+/* Copyright 2024 Record Replay Inc. */
+
 const { execSync, exec } = require("child_process");
 const getSecret = require("./aws_secrets");
 

--- a/packages/e2e-tests/scripts/buildkite_run_fe_tests.js
+++ b/packages/e2e-tests/scripts/buildkite_run_fe_tests.js
@@ -37,6 +37,7 @@ function run_fe_tests(CHROME_BINARY_PATH) {
   process.env.RECORD_REPLAY_DISPATCH_SERVER = "wss://dispatch.replay.io";
   process.env.REPLAY_BROWSER_BINARY_PATH = CHROME_BINARY_PATH;
   process.env.AUTHENTICATED_TESTS_WORKSPACE_API_KEY = process.env.RECORD_REPLAY_API_KEY;
+  process.env.PLAYWRIGHT_TEST_BASE_URL = "https://app.replay.io";
 
   // Generate new recordings for known-passing tests with the new chromium build.
   const htmlFiles = [

--- a/packages/e2e-tests/scripts/buildkite_run_fe_tests.js
+++ b/packages/e2e-tests/scripts/buildkite_run_fe_tests.js
@@ -38,17 +38,45 @@ function run_fe_tests(CHROME_BINARY_PATH) {
   process.env.REPLAY_BROWSER_BINARY_PATH = CHROME_BINARY_PATH;
   process.env.AUTHENTICATED_TESTS_WORKSPACE_API_KEY = process.env.RECORD_REPLAY_API_KEY;
 
-  // Generate new recordings with the new chromium build.
+  // Generate new recordings for known-passing tests with the new chromium build.
+  const htmlFiles = [
+    "authenticated_comments.html",
+    "authenticated_logpoints.html",
+    "doc_minified_chromium.html",
+    "doc_recursion.html",
+    "doc_rr_console.html",
+    "doc_rr_preview.html",
+    "doc_rr_region_loading.html",
+    "doc_stacking_chromium.html",
+    "rdt-react-versions/dist/index.html"
+  ];
   execSync(
-    `xvfb-run ./packages/e2e-tests/scripts/save-examples.ts --runtime=chromium --project=replay-chromium-local --example=authenticated_comments_1.html`,
+    `xvfb-run ./packages/e2e-tests/scripts/save-examples.ts --runtime=chromium --project=replay-chromium-local --example=${htmlFiles.join(',')}`,
     { stdio: "inherit" }
   );
 
   // Without the wait, the next xvfb-run command can fail.
   execSync("sleep 5");
 
-  // Run the tests.
-  execSync(`xvfb-run yarn test:debug_local comments-01`, { stdio: "inherit", stderr: "inherit" });
+  // Run the known-passind tests.
+  const testNames = [
+    "comments-01",
+    "comments-02",
+    "comments-03", 
+    "logpoints-01", 
+    "stepping-05_chromium",
+    "scopes_renderer",
+    "passport-01",
+    "passport-03",
+    "passport-04",
+    "object_preview-03",
+    "focus_mode-01",
+    "elements-search", 
+    "stacking_chromium",
+    "react_devtools-03-multiple-versions"
+  ]
+
+  execSync(`xvfb-run yarn test:debug_local ${testNames.join(' ')}`, { stdio: "inherit", stderr: "inherit" });
 
   // Make sure the web server shuts down.
   webProc.kill("SIGKILL");

--- a/packages/e2e-tests/scripts/buildkite_run_fe_tests.js
+++ b/packages/e2e-tests/scripts/buildkite_run_fe_tests.js
@@ -19,7 +19,7 @@ function run_fe_tests(CHROME_BINARY_PATH) {
 
   execSync("npx playwright install chromium", {
     stdio: "inherit",
-  })
+  });
 
   // Start the webserver.
   let webProc = exec("yarn dev", (error, stdout, stderr) => {

--- a/packages/e2e-tests/scripts/buildkite_run_fe_tests.js
+++ b/packages/e2e-tests/scripts/buildkite_run_fe_tests.js
@@ -1,0 +1,62 @@
+const { execSync, exec } = require("child_process");
+const getSecret = require("./aws_secrets");
+
+function run_fe_tests(CHROME_BINARY_PATH) {
+  // Install node deps
+  execSync("npm i -g yarn", {
+    stdio: "inherit",
+  });
+
+  execSync("yarn install", {
+    stdio: "inherit",
+  });
+
+  execSync("cp .env.sample .env", {
+    stdio: "inherit",
+  });
+
+  // Start the webserver.
+  let webProc = exec("yarn dev", (error, stdout, stderr) => {
+    if (error) {
+      console.error(`exec error: ${error}`);
+      return;
+    }
+    console.error(`yarn dev stdout: ${stdout}`);
+    console.error(`yarn dev stderr: ${stderr}`);
+  });
+
+  // Wait a little, to let the yarn dev server start up.
+  execSync("sleep 5");
+
+  if (!process.env.HASURA_ADMIN_SECRET) {
+    process.env.HASURA_ADMIN_SECRET = getSecret("prod/hasura-admin-secret", "us-east-2");
+  }
+
+  process.env.RECORD_REPLAY_DISPATCH_SERVER = "wss://dispatch.replay.io";
+  process.env.REPLAY_BROWSER_BINARY_PATH = CHROME_BINARY_PATH;
+  process.env.RECORD_REPLAY_API_KEY = "rwk_b6mnJ00rI4pzlwkYmggmmmV1TVQXA0AUktRHoo4vGl9";
+  process.env.AUTHENTICATED_TESTS_WORKSPACE_API_KEY = process.env.RECORD_REPLAY_API_KEY;
+  process.env.AUTOMATED_TEST_SECRET = "c2MjW2nnut4vqpntvD@P3f46Edf-86eb";
+
+  // Generate new recordings with the new chromium build.
+  execSync(
+    `xvfb-run ./packages/e2e-tests/scripts/save-examples.ts --runtime=chromium --project=replay-chromium-local --example=authenticated_comments_1.html`,
+    { stdio: "inherit" }
+  );
+
+  // Without the wait, the next xvfb-run command can fail.
+  execSync("sleep 5");
+
+  // Run the tests.
+  execSync(`xvfb-run yarn test:debug_local comments-01`, { stdio: "inherit", stderr: "inherit" });
+
+  // Make sure the web server shuts down.
+  webProc.kill("SIGKILL");
+
+  console.error("Done tests.");
+
+  // Without this, we can hang--no idea why.
+  process.exit(0);
+}
+
+module.exports = run_fe_tests;

--- a/packages/e2e-tests/scripts/buildkite_run_fe_tests_from_artifact-linux-x86_64.js
+++ b/packages/e2e-tests/scripts/buildkite_run_fe_tests_from_artifact-linux-x86_64.js
@@ -1,3 +1,3 @@
 const run_fe_tests_from_artifact = require("./buildkite_run_fe_tests_from_artifact");
 
-run_fe_tests_from_artifact("linux", "x64");
+run_fe_tests_from_artifact("linux", "x86_64");

--- a/packages/e2e-tests/scripts/buildkite_run_fe_tests_from_artifact-linux-x86_64.js
+++ b/packages/e2e-tests/scripts/buildkite_run_fe_tests_from_artifact-linux-x86_64.js
@@ -1,3 +1,5 @@
+/* Copyright 2024 Record Replay Inc. */
+
 const run_fe_tests_from_artifact = require("./buildkite_run_fe_tests_from_artifact");
 
 run_fe_tests_from_artifact("linux", "x86_64");

--- a/packages/e2e-tests/scripts/buildkite_run_fe_tests_from_artifact-linux-x86_64.js
+++ b/packages/e2e-tests/scripts/buildkite_run_fe_tests_from_artifact-linux-x86_64.js
@@ -1,0 +1,3 @@
+const run_fe_tests_from_artifact = require("./buildkite_run_fe_tests_from_artifact");
+
+run_fe_tests_from_artifact("linux", "x64");

--- a/packages/e2e-tests/scripts/buildkite_run_fe_tests_from_artifact.js
+++ b/packages/e2e-tests/scripts/buildkite_run_fe_tests_from_artifact.js
@@ -1,3 +1,5 @@
+/* Copyright 2024 Record Replay Inc. */
+
 const build_id_from_artifact = require("./build_id_from_artifact");
 const install_build_products = require("./build_products");
 const run_fe_tests = require("./buildkite_run_fe_tests");

--- a/packages/e2e-tests/scripts/buildkite_run_fe_tests_from_artifact.js
+++ b/packages/e2e-tests/scripts/buildkite_run_fe_tests_from_artifact.js
@@ -1,0 +1,12 @@
+const build_id_from_artifact = require("./build_id_from_artifact");
+const install_build_products = require("./build_products");
+const run_fe_tests = require("./buildkite_run_fe_tests");
+
+function run_fe_tests_from_artifact(PLATFORM, ARCH) {
+  let RUNTIME_BUILD_ID = build_id_from_artifact(PLATFORM, ARCH);
+  let CHROME_BINARY_PATH = install_build_products(RUNTIME_BUILD_ID, PLATFORM, ARCH);
+
+  run_fe_tests(CHROME_BINARY_PATH);
+}
+
+module.exports = run_fe_tests_from_artifact;

--- a/packages/e2e-tests/scripts/save-examples.ts
+++ b/packages/e2e-tests/scripts/save-examples.ts
@@ -28,7 +28,7 @@ type Target = "all" | "browser" | "node";
 const argv = yargs
   .option("example", {
     alias: "e",
-    description: "Only re-generate tests for this specific example file",
+    description: "Only re-generate tests for a single file, or a comma-separated list of files",
     type: "string",
   })
   .option("runtime", {
@@ -423,10 +423,10 @@ async function saveExamples(
 ) {
   let examplesToRun = knownExamples.filter(example => example.category === examplesTarget);
 
-  const specificExample = argv.example;
+  const specificExamples = argv.example.split(',').filter(s => s.length > 0);
 
-  if (specificExample) {
-    examplesToRun = examplesToRun.filter(example => example.filename === specificExample);
+  if (specificExamples) {
+    examplesToRun = examplesToRun.filter(example => specificExamples.includes(example.filename));
   }
 
   console.log(

--- a/packages/e2e-tests/scripts/save-examples.ts
+++ b/packages/e2e-tests/scripts/save-examples.ts
@@ -423,7 +423,7 @@ async function saveExamples(
 ) {
   let examplesToRun = knownExamples.filter(example => example.category === examplesTarget);
 
-  const specificExamples = argv.example.split(',').filter(s => s.length > 0);
+  const specificExamples = argv.example.split(",").filter(s => s.length > 0);
 
   if (specificExamples) {
     examplesToRun = examplesToRun.filter(example => specificExamples.includes(example.filename));


### PR DESCRIPTION
Introduce a buildkite pipeline that records and runs the fe tests, triggerable via the runtime build.  Some limitations for the moment as we roll out:
- No symbolication for recording errors. (And, no recording log output....)
- some secrets in JS ("but we do it elsewhere!")
- code duplication between fe and be :(
- some magic incantations (sleep statements, process suicide) to get around issues I can't diagnose.)