### PR TITLE
Update all GH actions versions to the latest and fix other warnings

### DIFF
--- a/.github/workflows/bvaughn-jest.yml
+++ b/.github/workflows/bvaughn-jest.yml
@@ -21,7 +21,7 @@ jobs:
     # Get the yarn cache path.
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+      run: echo "{dir}={$(yarn config get cacheFolder)}" >> $GITHUB_OUTPUT
     - name: Restore yarn cache
       uses: actions/cache@v3
       id: yarn-cache

--- a/.github/workflows/bvaughn-jest.yml
+++ b/.github/workflows/bvaughn-jest.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out repository code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     # Get the yarn cache path.
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path

--- a/.github/workflows/delta.yml
+++ b/.github/workflows/delta.yml
@@ -47,7 +47,7 @@ jobs:
           echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
           node --version
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       # Get the yarn cache path.
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -90,7 +90,7 @@ jobs:
           RECORD_REPLAY_METADATA_TEST_RUN_ID: ${{ needs.generate-test-run-id.outputs.testRunId }}
       - name: Upload Replay recordings
         if: always()
-        uses: replayio/action-upload@v0.4.7
+        uses: replayio/action-upload@v0.5.1
         with:
           api-key: rwk_4mEiT150uOHyLQiQvZfPZiNjmBe4NrOXOm9yG9nS794
           filter: ${{ 'function() { true }' }}

--- a/.github/workflows/delta.yml
+++ b/.github/workflows/delta.yml
@@ -51,7 +51,7 @@ jobs:
       # Get the yarn cache path.
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "{dir}={$(yarn config get cacheFolder)}" >> $GITHUB_OUTPUT
       - name: Restore yarn cache
         uses: actions/cache@v3
         id: yarn-cache

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     name: Trunk Check runner
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       # Get the yarn cache path.
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       # Get the yarn cache path.
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "{dir}={$(yarn config get cacheFolder)}" >> $GITHUB_OUTPUT
       - name: Restore yarn cache
         uses: actions/cache@v3
         id: yarn-cache

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Trunk Check
         uses: trunk-io/trunk-action@v1.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Waiting for 200 from the Vercel Preview
-        uses: patrickedqvist/wait-for-vercel-preview@v1
+        uses: patrickedqvist/wait-for-vercel-preview@v1.3.1
         id: waitFor200
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -81,7 +81,7 @@ jobs:
       # Get the yarn cache path.
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "{dir}={$(yarn config get cacheFolder)}" >> $GITHUB_OUTPUT
       - name: Restore yarn cache
         uses: actions/cache@v3
         id: yarn-cache
@@ -145,7 +145,7 @@ jobs:
       # Get the yarn cache path.
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "{dir}={$(yarn config get cacheFolder)}" >> $GITHUB_OUTPUT
       - name: Restore yarn cache
         uses: actions/cache@v3
         id: yarn-cache
@@ -199,7 +199,7 @@ jobs:
       # Get the yarn cache path.
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "{dir}={$(yarn config get cacheFolder)}" >> $GITHUB_OUTPUT
       - name: Restore yarn cache
         uses: actions/cache@v3
         id: yarn-cache
@@ -231,7 +231,7 @@ jobs:
       # Get the yarn cache path.
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "{dir}={$(yarn config get cacheFolder)}" >> $GITHUB_OUTPUT
       - name: Restore yarn cache
         uses: actions/cache@v3
         id: yarn-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -179,7 +179,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: all-code-coverage-reports_${{ matrix.shard }}
+          name: all-code-coverage-reports_auth
           path: packages/e2e-tests/test-results
           retention-days: 3
       - uses: replayio/action-upload@v0.5.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,7 +126,6 @@ jobs:
         with:
           api-key: ${{ env.RECORD_REPLAY_API_KEY }}
           public: true
-          upload-all: true
   authenticated-e2etest:
     name: Authenticated end-to-end tests (${{ matrix.shard }})
     runs-on: ubuntu-latest
@@ -187,7 +186,6 @@ jobs:
         with:
           api-key: ${{ env.RECORD_REPLAY_API_KEY }}
           public: true
-          upload-all: true
   unit-test:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -252,9 +252,12 @@ jobs:
         with:
           path: test-results
       - name: Merge Monocart reports
-        run: yarn ts-node packages/e2e-tests/scripts/merge-monocart-reports.ts ./test-results
+        id: merge-monocart-reports
+        run: |
+          yarn ts-node packages/e2e-tests/scripts/merge-monocart-reports.ts ./test-results
       - name: Archive merged Playwright report results with code coverage 
         uses: actions/upload-artifact@v4
+        id: upload-coverage-report
         if: always()
         with:
           name: all-code-coverage-reports-merged
@@ -263,3 +266,8 @@ jobs:
             ./test-results/merged-coverage*
             ./test-results/coverage-reports
           retention-days: 14
+      - name: Post coverage summary as a PR comment
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          filePath: ./coverageSummary.md
+          comment_tag: coverage_summary

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Download
         run: wget https://static.replay.io/downloads/macOS-replay-playwright.tar.xz
       - name: Create artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: macOS-replay-playwright
           path: macOS-replay-playwright.tar.xz
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Waiting for 200 from the Vercel Preview
-        uses: patrickedqvist/wait-for-vercel-preview@v1.2.0
+        uses: patrickedqvist/wait-for-vercel-preview@v1
         id: waitFor200
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -73,9 +73,9 @@ jobs:
         shard: ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: "16"
       # Get the yarn cache path.
@@ -115,7 +115,7 @@ jobs:
           AUTOMATED_TEST_SECRET: ${{ secrets.AUTOMATED_TEST_SECRET }}
           AUTHENTICATED_TESTS_WORKSPACE_API_KEY: ${{ secrets.AUTHENTICATED_TESTS_WORKSPACE_API_KEY }}
       - name: Archive Playwright report results with code coverage 
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: all-code-coverage-reports_${{ matrix.shard }}
@@ -138,9 +138,9 @@ jobs:
         shard: ["1"]
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: "16"
       # Get the yarn cache path.
@@ -177,7 +177,7 @@ jobs:
           AUTOMATED_TEST_SECRET: ${{ secrets.AUTOMATED_TEST_SECRET }}
           AUTHENTICATED_TESTS_WORKSPACE_API_KEY: ${{ secrets.AUTHENTICATED_TESTS_WORKSPACE_API_KEY }}
       - name: Archive Playwright report results with code coverage 
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: all-code-coverage-reports_${{ matrix.shard }}
@@ -193,9 +193,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: "16"
       # Get the yarn cache path.
@@ -225,9 +225,9 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: "16"
       # Get the yarn cache path.
@@ -250,13 +250,13 @@ jobs:
           YARN_CHECKSUM_BEHAVIOR: "update"
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
       - name: Download all coverage reports from GitHub Actions Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: test-results
       - name: Merge Monocart reports
         run: yarn ts-node packages/e2e-tests/scripts/merge-monocart-reports.ts ./test-results
       - name: Archive merged Playwright report results with code coverage 
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: all-code-coverage-reports-merged

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -6,7 +6,7 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       # Get the yarn cache path.
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -35,7 +35,7 @@ jobs:
     name: GraphQL schema types
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       # Get the yarn cache path.
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -10,7 +10,7 @@ jobs:
       # Get the yarn cache path.
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "{dir}={$(yarn config get cacheFolder)}" >> $GITHUB_OUTPUT
       - name: Restore yarn cache
         uses: actions/cache@v3
         id: yarn-cache
@@ -39,7 +39,7 @@ jobs:
       # Get the yarn cache path.
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "{dir}={$(yarn config get cacheFolder)}" >> $GITHUB_OUTPUT
       - name: Restore yarn cache
         uses: actions/cache@v3
         id: yarn-cache

--- a/packages/e2e-tests/scripts/merge-monocart-reports.ts
+++ b/packages/e2e-tests/scripts/merge-monocart-reports.ts
@@ -64,6 +64,25 @@ const rootFolder = path.posix.join(currentFolder, "../../..");
 
       onEnd: async (reportData: any) => {
         console.log("Coverage generated: ", reportData.summary);
+        const shortSha = process.env.GITHUB_SHA?.substring(0, 7) ?? "(unknown)";
+
+        // TODO Eventually include the uploaded artifact URL:
+        // https://github.com/actions/upload-artifact/issues/50#issuecomment-1856471599
+
+        fs.writeFileSync(
+          "coverageSummary.md",
+          `
+### Coverage Summary (statements)
+
+- Commit: ${shortSha}
+
+\`\`\`json
+${JSON.stringify(reportData.summary.statements, null, 2)}
+\`\`\`
+
+
+`
+        );
       },
 
       reports: [["html"]],


### PR DESCRIPTION
This PR:

- Updates all of our used GH Actions deps to their latest versions
- Removes a couple of redundant `upload-all` args left over from the switch away from `@replayio/action-playwright`
- Replaces all uses of `set-output`, per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

While working on the E2E code coverage task, I noticed that we had a lot of warnings from our CI jobs:

![image](https://github.com/replayio/devtools/assets/1128784/76194648-68cf-4160-8c6f-b3979e46da37)

Hopefully this will clean those up