### PR TITLE
Improve logic for showing test title and error

### DIFF
--- a/src/ui/components/TestSuite/views/GroupedTestCases/TestRecordingTreeRow.tsx
+++ b/src/ui/components/TestSuite/views/GroupedTestCases/TestRecordingTreeRow.tsx
@@ -20,12 +20,15 @@ export default function TestRecordingTreeRow({
 
   const onClick = () => startTransition(onClickProp);
 
-  const { attempt, error, id, result, source } = testRecording;
+  const { attempt, error, id, result, source, testRunnerName } = testRecording;
   const { title } = source;
 
   const isFlaky = flakyTestIds.has(id);
-  // TODO [SCS-1268] Remove undefined check
-  const showTitle = isFlaky ? result === "passed" : attempt === undefined || attempt === 1;
+
+  let showTitleAndError = true;
+  if (testRunnerName === "cypress") {
+    showTitleAndError = isFlaky ? result === "passed" : attempt === 1;
+  }
 
   let attemptLabel;
   switch (result) {
@@ -46,12 +49,12 @@ export default function TestRecordingTreeRow({
       data-test-name="TestRecordingTreeRow"
       onClick={onClick}
     >
-      {showTitle || <Icon className={styles.NestedIcon} type="arrow-nested" />}
+      {showTitleAndError || <Icon className={styles.NestedIcon} type="arrow-nested" />}
       <TestResultIcon result={result} />
       <div className={styles.Column}>
         <div className={styles.HeaderRow}>
           <div className={styles.Title}>
-            {showTitle ? (
+            {showTitleAndError ? (
               title
             ) : (
               <>
@@ -62,7 +65,7 @@ export default function TestRecordingTreeRow({
           </div>
           <MaterialIcon className={styles.Chevron}>chevron_right</MaterialIcon>
         </div>
-        {showTitle && error && (
+        {showTitleAndError && error && (
           <div className={styles.Error}>
             <span className={styles.ErrorTitle}>Error:</span> {error.message}
           </div>


### PR DESCRIPTION
I think this logic was originally intended for scenarios where we show multiple attempts in the same recording (Cypress?) and does not work or make sense when we show only one (Playwright). See discussion on SCS-1743 for more...

[Test Suite run](https://app.replay.io/team/dzowNDAyOGMwYS05ZjM1LTQ2ZjktYTkwYi1jNzJkMTIzNzUxOTI=/runs/075b0376-4620-4a2e-b295-dc90601759c9?param=dzowNDAyOGMwYS05ZjM1LTQ2ZjktYTkwYi1jNzJkMTIzNzUxOTI%3D&param=runs&param=66806e57-f80f-4b59-84a9-cbf20e9a826a) shows 3 failures, none of which seem related to this change 😞
- cypress-05 (seems to be about box highlighting which is unrelated to this change, and this test passed for me locally)
- logpoints-03 (this is expected because it also fails on main)
- playwright-05 (seems to be about box highlighting which is unrelated to this change, and this test passed for me locally)