### PR TITLE
Node picker explicit error state

### DIFF
--- a/src/ui/components/App.css
+++ b/src/ui/components/App.css
@@ -79,6 +79,9 @@ h2 {
 #command-button-pick.active::before {
   background-color: var(--primary-accent);
 }
+#command-button-pick.errored::before {
+  background-color: var(--theme-icon-error-color);
+}
 
 .app-mask {
   height: 100%;

--- a/src/ui/components/NodePicker.tsx
+++ b/src/ui/components/NodePicker.tsx
@@ -22,14 +22,19 @@ export function NodePicker() {
 
   const { pauseId } = useMostRecentLoadedPause() ?? {};
 
-  const active = (status === "initializing" || status === "active") && type === "domElement";
+  const isActive = (status === "initializing" || status === "active") && type === "domElement";
+  const didError = status === "error" && type === "domElement";
+
+  const title = didError
+    ? "Something went wrong initializing this component"
+    : "Select an element in the video to inspect it";
 
   const onClick = () => {
     if (shouldShow) {
       dismissInspectElementNag();
     }
 
-    if (!active) {
+    if (!isActive) {
       if (pauseId == null) {
         console.warn("NodePicker enabled before PauseId is available");
         return;
@@ -53,12 +58,13 @@ export function NodePicker() {
   return (
     <button
       className={classnames("devtools-button toolbar-panel-button tab", {
-        active,
+        active: isActive,
+        errored: didError,
       })}
       data-status={status}
       id="command-button-pick"
       onClick={onClick}
-      title="Select an element in the video to inspect it"
+      title={title}
     />
   );
 }

--- a/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
+++ b/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
@@ -1,6 +1,5 @@
 import { ObjectId, Object as ProtocolObject } from "@replayio/protocol";
 import { createBridge, createStore, initialize } from "@replayio/react-devtools-inline/frontend";
-import { bool } from "prop-types";
 import { useContext, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useImperativeCacheValue } from "suspense";
 
@@ -27,7 +26,7 @@ import {
 } from "ui/components/SecondaryToolbox/react-devtools/ReplayWall";
 import { getPreferredLocation } from "ui/reducers/sources";
 import { getRecordingTooLongToSupportRoutines } from "ui/reducers/timeline";
-import { useAppDispatch, useAppSelector, useAppStore } from "ui/setup/hooks";
+import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import {
   ParsedReactDevToolsAnnotation,
   reactDevToolsAnnotationsCache,

--- a/src/ui/components/SecondaryToolbox/react-devtools/components/InspectButton.module.css
+++ b/src/ui/components/SecondaryToolbox/react-devtools/components/InspectButton.module.css
@@ -20,3 +20,6 @@
 .Icon[data-active] {
   color: var(--primary-accent);
 }
+.Icon[data-errored] {
+  color: var(--theme-icon-error-color);
+}

--- a/src/ui/components/SecondaryToolbox/react-devtools/components/InspectButton.tsx
+++ b/src/ui/components/SecondaryToolbox/react-devtools/components/InspectButton.tsx
@@ -10,7 +10,26 @@ import styles from "./InspectButton.module.css";
 export function InspectButton({ wall }: { wall: ReplayWall }) {
   const { status, type } = useContext(NodePickerContext);
 
-  const isActive = (status === "active" || status === "initializing") && type === "reactComponent";
+  let isActive = false;
+  let didError = false;
+  let state = "inactive";
+  let title = undefined;
+  if (type === "reactComponent") {
+    switch (status) {
+      case "active":
+      case "initializing": {
+        isActive = true;
+        state = "active";
+        break;
+      }
+      case "error": {
+        didError = true;
+        state = "error";
+        title = "Something went wrong initializing this component";
+        break;
+      }
+    }
+  }
 
   const onClick = (event: MouseEvent) => {
     event.preventDefault();
@@ -26,12 +45,18 @@ export function InspectButton({ wall }: { wall: ReplayWall }) {
   return (
     <button
       className={styles.Button}
-      data-state={isActive ? "active" : "inactive"}
+      data-state={state}
       data-test-id="ReactDevTools-InspectButton"
       disabled={wall === null}
       onClick={onClick}
+      title={title}
     >
-      <Icon className={styles.Icon} data-active={isActive || undefined} type="inspect" />
+      <Icon
+        className={styles.Icon}
+        data-active={isActive || undefined}
+        data-errored={didError || undefined}
+        type="inspect"
+      />
     </button>
   );
 }


### PR DESCRIPTION
![Screenshot 2023-12-26 at 2 28 31 PM](https://github.com/replayio/devtools/assets/29597/81ddcdf1-224e-488c-bfe1-1d16e6933e6b)

![Screenshot 2023-12-26 at 2 35 02 PM](https://github.com/replayio/devtools/assets/29597/5b90dd7b-ee2c-4db0-b985-0ff227572bef)

Note that all e2e tests passed for this PR except `logpoints-03` (which also fails on main); see [test run](https://tests.replay.io/team/dzowNDAyOGMwYS05ZjM1LTQ2ZjktYTkwYi1jNzJkMTIzNzUxOTI=/runs/3257ec32-0444-4c5a-9c1e-8d6c4747bddf).

Note this PR does not update the legacy React DevTools node picker UI because that component has been deprecated and will be removed soon (once we drop support for Gecko recordings).