### PR TITLE
Add pending state for step details and extract Cypress details wrapper

### DIFF
--- a/packages/replay-next/components/errors/InlineErrorBoundary.tsx
+++ b/packages/replay-next/components/errors/InlineErrorBoundary.tsx
@@ -29,6 +29,8 @@ export function InlineErrorBoundary({
 }: Omit<ErrorBoundaryProps, "fallback" | "fallbackRender" | "FallbackComponent" | "resetKeys"> & {
   fallback?: ReactElement | null;
 
+  children: React.ReactNode;
+
   // Uniquely identifies this error boundary; logged to Sentry.
   name: string;
 

--- a/src/ui/components/TestSuite/views/TestRecording/TestEventDetails.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestEventDetails.tsx
@@ -4,12 +4,12 @@ import { InlineErrorBoundary } from "replay-next/components/errors/InlineErrorBo
 import { isUserActionTestEvent } from "shared/test-suites/RecordingTestMetadata";
 import { TestSuiteContext } from "ui/components/TestSuite/views/TestSuiteContext";
 
+import { CypressUserActionStepDetails } from "./TestEventStepDetails/CypressUserActionStepDetails";
 import { PlaywrightUserActionEventDetails } from "./TestEventStepDetails/PlaywrightUserActionEventDetails";
-import { UserActionEventPropsInspector } from "./TestEventStepDetails/UserActionEventPropsInspector";
 import styles from "./TestEventStepDetails/TestEventDetails.module.css";
 
 export default function TestEventDetails({ collapsed }: { collapsed: boolean }) {
-  const { testEvent } = useContext(TestSuiteContext);
+  const { testEvent, testEventPending } = useContext(TestSuiteContext);
 
   if (collapsed) {
     return null;
@@ -21,11 +21,11 @@ export default function TestEventDetails({ collapsed }: { collapsed: boolean }) 
   const UserEventDetailsComponent =
     testRunnerName === "playwright"
       ? PlaywrightUserActionEventDetails
-      : UserActionEventPropsInspector;
+      : CypressUserActionStepDetails;
 
   return (
     <InlineErrorBoundary name="TestEventDetails">
-      <UserEventDetailsComponent testEvent={testEvent} />
+      <UserEventDetailsComponent testEvent={testEvent} testEventPending={testEventPending} />
     </InlineErrorBoundary>
   );
 }

--- a/src/ui/components/TestSuite/views/TestRecording/TestEventStepDetails/CypressUserActionStepDetails.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestEventStepDetails/CypressUserActionStepDetails.tsx
@@ -1,0 +1,27 @@
+import { UserActionEvent } from "shared/test-suites/RecordingTestMetadata";
+
+import { LoadingFailedMessage } from "./TestEventDetailsLoadingMessages";
+import { UserActionEventPropsInspector } from "./UserActionEventPropsInspector";
+import styles from "./TestEventDetails.module.css";
+
+export function CypressUserActionStepDetails({
+  testEvent,
+  testEventPending,
+}: {
+  testEvent: UserActionEvent;
+  testEventPending?: boolean;
+}) {
+  return (
+    <div
+      className={styles.UserActionEventDetails}
+      data-test-name="UserActionEventDetails"
+      data-is-pending={testEventPending || undefined}
+    >
+      {testEvent.data.timeStampedPoints.result ? (
+        <UserActionEventPropsInspector testEvent={testEvent} />
+      ) : (
+        <LoadingFailedMessage />
+      )}
+    </div>
+  );
+}

--- a/src/ui/components/TestSuite/views/TestRecording/TestEventStepDetails/PlaywrightUserActionEventDetails.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestEventStepDetails/PlaywrightUserActionEventDetails.tsx
@@ -19,7 +19,13 @@ import { LoadingFailedMessage } from "./TestEventDetailsLoadingMessages";
 import { UserActionEventPropsInspector } from "./UserActionEventPropsInspector";
 import styles from "./TestEventDetails.module.css";
 
-export function PlaywrightUserActionEventDetails({ testEvent }: { testEvent: UserActionEvent }) {
+export function PlaywrightUserActionEventDetails({
+  testEvent,
+  testEventPending,
+}: {
+  testEvent: UserActionEvent;
+  testEventPending?: boolean;
+}) {
   const [selectedTab, selectTab] = useLocalStorageUserData("playwrightStepSelectedTab");
 
   return (
@@ -41,7 +47,11 @@ export function PlaywrightUserActionEventDetails({ testEvent }: { testEvent: Use
         </button>
       </div>
 
-      <div className={styles.UserActionEventDetails}>
+      <div
+        className={styles.UserActionEventDetails}
+        data-test-name="UserActionEventDetails"
+        data-is-pending={testEventPending || undefined}
+      >
         <Offscreen mode={selectedTab === "elements" ? "visible" : "hidden"}>
           {testEvent.data.timeStampedPoints.result ? (
             <UserActionEventPropsInspector testEvent={testEvent} />

--- a/src/ui/components/TestSuite/views/TestRecording/TestEventStepDetails/TestEventDetails.module.css
+++ b/src/ui/components/TestSuite/views/TestRecording/TestEventStepDetails/TestEventDetails.module.css
@@ -25,6 +25,10 @@
   padding-bottom: 0.5rem;
 }
 
+.UserActionEventDetails[data-is-pending] {
+  opacity: 0.5;
+}
+
 .DetailsTitle {
   font-size: var(--font-size-small);
   color: var(--color-dimmer);

--- a/src/ui/components/TestSuite/views/TestRecording/TestEventStepDetails/UserActionEventPropsInspector.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestEventStepDetails/UserActionEventPropsInspector.tsx
@@ -11,7 +11,6 @@ import {
 } from "ui/components/TestSuite/suspense/TestEventDetailsCache";
 
 import { LoadingFailedMessage, LoadingInProgress } from "./TestEventDetailsLoadingMessages";
-import styles from "./TestEventDetails.module.css";
 
 export function UserActionEventPropsInspector({ testEvent }: { testEvent: UserActionEvent }) {
   // Parent ensures this exists
@@ -40,10 +39,8 @@ export function UserActionEventPropsInspector({ testEvent }: { testEvent: UserAc
   }
 
   return (
-    <div className={styles.UserActionEventDetails} data-test-name="UserActionEventDetails">
-      <InspectableTimestampedPointContext.Provider value={context}>
-        <PropertiesRenderer pauseId={value.pauseId} object={value.props} hidePrototype={true} />
-      </InspectableTimestampedPointContext.Provider>
-    </div>
+    <InspectableTimestampedPointContext.Provider value={context}>
+      <PropertiesRenderer pauseId={value.pauseId} object={value.props} hidePrototype={true} />
+    </InspectableTimestampedPointContext.Provider>
   );
 }

--- a/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
@@ -51,13 +51,12 @@ export function TestSectionRow({
     setTestEvent,
     testEvent: selectedTestEvent,
     testRecording,
+    testEventPending,
   } = useContext(TestSuiteContext);
 
   const isSelected = testEvent === selectedTestEvent;
 
   const dispatch = useAppDispatch();
-
-  const [isPending, startTransition] = useTransition();
 
   const { contextMenu, onContextMenu } = useTestEventContextMenu(testEvent);
 
@@ -125,9 +124,7 @@ export function TestSectionRow({
   }
 
   const onClick = async () => {
-    startTransition(() => {
-      setTestEvent(testEvent);
-    });
+    setTestEvent(testEvent);
 
     let executionPoint: ExecutionPoint | null = null;
     let time: number | null = null;
@@ -217,7 +214,7 @@ export function TestSectionRow({
     <div
       className={styles.Row}
       data-context-menu-active={contextMenu !== null || undefined}
-      data-is-pending={isPending || undefined}
+      data-is-pending={testEventPending || undefined}
       data-position={position}
       data-selected={isSelected || undefined}
       data-status={status}

--- a/src/ui/components/TestSuite/views/TestSuiteContext.tsx
+++ b/src/ui/components/TestSuite/views/TestSuiteContext.tsx
@@ -5,6 +5,7 @@ import {
   useContext,
   useMemo,
   useState,
+  useTransition,
 } from "react";
 
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
@@ -17,6 +18,7 @@ type TestSuiteContextType = {
   setTestEvent: (value: TestEvent | null) => void;
   testEvent: TestEvent | null;
   testRecording: TestRecording | null;
+  testEventPending: boolean;
 };
 
 export const TestSuiteContext = createContext<TestSuiteContextType>(null as any);
@@ -28,6 +30,13 @@ export function TestSuiteContextRoot({ children }: PropsWithChildren) {
 
   const [testEvent, setTestEvent] = useState<TestEvent | null>(null);
   const [testRecording, setTestRecording] = useState<TestRecording | null>(null);
+  const [testEventPending, startTestEventTransition] = useTransition();
+
+  const setTestEventWrapper = useCallback((testEvent: TestEvent | null) => {
+    startTestEventTransition(() => {
+      setTestEvent(testEvent);
+    });
+  }, []);
 
   const setTestRecordingWrapper = useCallback(
     async (testRecording: TestRecording | null) => {
@@ -62,12 +71,13 @@ export function TestSuiteContextRoot({ children }: PropsWithChildren) {
 
   const value = useMemo(
     () => ({
-      setTestEvent,
+      setTestEvent: setTestEventWrapper,
       setTestRecording: setTestRecordingWrapper,
       testEvent,
       testRecording,
+      testEventPending,
     }),
-    [setTestRecordingWrapper, testEvent, testRecording]
+    [setTestRecordingWrapper, setTestEventWrapper, testEvent, testRecording, testEventPending]
   );
 
   return <TestSuiteContext.Provider value={value}>{children}</TestSuiteContext.Provider>;


### PR DESCRIPTION
This PR:

- Moves the `useTransition` for "current selected test event" into `TestSuiteContext`
  - Wraps the setter in a `startTransition`
  - adds the pending flag to the context
- Updates `TestSectionRow` and `TestStepDetails` to use that pending flag from context
- Extracts a `CypressUserActionStepDetails` component, to better match the wrapping structure for the Playwright version
- Uses the pending flag to dim opacity for the step details panel
- Fills in a seemingly missing `children` prop type for `<InlineErrorBoundary>` (TS was claiming it couldn't accept children)

![image](https://github.com/replayio/devtools/assets/1128784/4261b5ab-d76d-4eab-9c91-df6d61b77772)
