### PR TITLE
Hardened auth/passport-02 e2e test

### DIFF
--- a/packages/e2e-tests/authenticated/passport-02.test.ts
+++ b/packages/e2e-tests/authenticated/passport-02.test.ts
@@ -1,5 +1,6 @@
 import { openDevToolsTab, startTest } from "../helpers";
 import { E2E_USER_1_API_KEY } from "../helpers/authentication";
+import { showCommentsPanel } from "../helpers/comments";
 import { warpToMessage } from "../helpers/console-panel";
 import {
   activateInspectorTool,
@@ -39,6 +40,10 @@ test(`authenticated/passport-02: Infrared inspection`, async ({
   await waitForElementsToLoad(page);
   await activateInspectorTool(page);
   await inspectCanvasCoordinates(page, 0.05, 0.01);
+
+  // Clicking the canvas will add a comment which can cause timing complications with the passport check below
+  // Easiest way to avoid this is to explicitly wait for the comments panel to be shown before continuing
+  await showCommentsPanel(page);
 
   await waitFor(async () =>
     expect(await isPassportItemCompleted(page, "Inspect UI elements")).toBeTruthy()

--- a/packages/e2e-tests/helpers/passport.ts
+++ b/packages/e2e-tests/helpers/passport.ts
@@ -1,9 +1,12 @@
 import { Page } from "@playwright/test";
 
 export async function showPassport(page: Page) {
-  const passportButton = page.locator(".toolbar-panel-button.passport");
-  const classes = await passportButton.getAttribute("class");
+  const passportTab = page.locator(".toolbar-panel-button.passport");
+  await passportTab.waitFor();
+  const classes = await passportTab.getAttribute("class");
   if (!classes?.includes("active")) {
+    const passportButton = passportTab.locator("button");
+    await passportButton.isEnabled();
     await passportButton.click();
   }
 }


### PR DESCRIPTION
Noticed some recent runs of this test (e.g. [2230adec-8285-4ec8-a6e5-54dc1f3b2657](https://tests.replay.io/recording/authenticatedpassport-02-infrared-inspection--2230adec-8285-4ec8-a6e5-54dc1f3b2657) and [643ce4fd-4a5c-4dda-bd2a-3c1756320829](https://tests.replay.io/recording/authenticatedpassport-02-infrared-inspection--643ce4fd-4a5c-4dda-bd2a-3c1756320829)) seemed to be failing because this button was either clicked too early or not clicked at all.

Added code to hopefully fix that, and while testing it noticed another timing issue (https://go/r/08c74d98-849d-4fa5-9962-30a6fea57991) with the test itself.

This commit addresses both of those and hopefully makes this test less flaky overall. It seems to help based on my locally running the test in headless mode.

**Update** After both changes landed, the [most recent run](https://tests.replay.io/team/dzowNDAyOGMwYS05ZjM1LTQ2ZjktYTkwYi1jNzJkMTIzNzUxOTI=/runs/fbc53389-b9cd-4d3c-890a-65f50860e83a?param=dzowNDAyOGMwYS05ZjM1LTQ2ZjktYTkwYi1jNzJkMTIzNzUxOTI%3D&param=runs&param=4d040f8f-05c9-4b9b-ac63-f75d98469b41) of this branch looks promising:
![Screenshot 2024-01-03 at 3 06 45 PM](https://github.com/replayio/devtools/assets/29597/7d37c65f-9c9d-4fed-a810-aa0da3711fc2)
