### PR TITLE
Add delay before reloading the page

### DIFF
--- a/packages/e2e-tests/authenticated/comments-02.test.ts
+++ b/packages/e2e-tests/authenticated/comments-02.test.ts
@@ -9,6 +9,7 @@ import {
   replyToComment,
 } from "../helpers/comments";
 import { openSource } from "../helpers/source-explorer-panel";
+import { delay } from "../helpers/utils";
 import test, { Page, base } from "../testFixtureCloneRecording";
 
 const url = "authenticated_comments.html";
@@ -55,6 +56,9 @@ test(`authenticated/comments-02: Test shared comments and replies`, async ({
     pageOne = page;
   }
 
+  // Delay so the comment has time to be saved to GraphQL
+  await delay(500);
+
   {
     console.log("User 2: Reply to comment");
 
@@ -75,6 +79,9 @@ test(`authenticated/comments-02: Test shared comments and replies`, async ({
 
     pageTwo = page;
   }
+
+  // Delay so the replay has time to be saved to GraphQL
+  await delay(500);
 
   {
     console.log("User 1: View reply (and delete comment)");


### PR DESCRIPTION
Some recent runs of the comments-02 tests failed ([7814e651-c895-4da0-b13b-dca621a7356d](https://tests.replay.io/recording/authenticatedcomments-02-test-shared-comments-and-replies--7814e651-c895-4da0-b13b-dca621a7356d), [794db301-6f67-4942-b480-11d72bad0f16](https://tests.replay.io/recording/authenticatedcomments-02-test-shared-comments-and-replies--794db301-6f67-4942-b480-11d72bad0f16), [40fbb178-18d6-483e-a58e-604a8278cbff](https://tests.replay.io/recording/authenticatedcomments-02-test-shared-comments-and-replies--40fbb178-18d6-483e-a58e-604a8278cbff), [0cc96e4c-7b65-49de-ae50-33ccf26e8fa8](https://tests.replay.io/recording/authenticatedcomments-02-test-shared-comments-and-replies--0cc96e4c-7b65-49de-ae50-33ccf26e8fa8), [7628f08d-66c7-4fb5-bde3-04f9df7d0ee0](https://tests.replay.io/recording/authenticatedcomments-02-test-shared-comments-and-replies--7628f08d-66c7-4fb5-bde3-04f9df7d0ee0), [f223efab-fd3e-430c-a5f0-d3bdb60a4830](https://tests.replay.io/recording/authenticatedcomments-02-test-shared-comments-and-replies--f223efab-fd3e-430c-a5f0-d3bdb60a4830))

I am not sure why these runs are failing. I speculate maybe they aren't waiting long enough to ensure the newly added comment has been saved to GraphQL (but I don't know how likely that is).

**Edit** Based on the Test Suites run, it doesn't seem like this fixed it. That being said, debugging the flakiness of this test is going to be _hard_ given SCS-1760.