### PR TITLE
Revert context menu regression

### DIFF
--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -1235,7 +1235,24 @@
   --context-menu-z-index: 25;
 
   /* menu item styles */
+  --context-menu-item-background-color-hover: var(--context-menu-bgcolor-hover);
+  --context-menu-item-background-color-focus: var(--context-menu-bgcolor-hover);
   --context-menu-item-color: var(--color-default);
+  --context-menu-item-color-disabled: var(--color-dimmer);
+  --context-menu-item-font-size: var(--font-size-regular);
+  --context-menu-item-height: 1.5rem;
+  --context-menu-item-padding: 0.25rem 0.5rem;
+
+  /* category styles */
+  --context-menu-category-color: var(--color-default);
+  --context-menu-category-font-size: var(--font-size-regular);
+  --context-menu-category-height: 1rem;
+  --context-menu-category-padding: 0.25rem 0.5rem;
+
+  /* divider styles */
+  --context-menu-divider-color: var(--context-menu-divider);
+  --context-menu-divider-margin: 0.25rem 0;
+  --context-menu-divider-size: 1px;
 }
 
 /* browser specific tweaks */


### PR DESCRIPTION
A few weeks ago we lost some CSS variables that broke our context menus. This is reverting that change so things look right again.

Old:
<img width="190" alt="image" src="https://github.com/replayio/devtools/assets/9154902/979b270e-e773-4486-8547-433307e61e40">

New:
<img width="148" alt="image" src="https://github.com/replayio/devtools/assets/9154902/34688d77-b0b1-4147-89a1-9e973aa4a426">

Note to @bvaughn -- this is my bad, when I search for variables like "context-menu-item-padding", it returns zero results other than the one in variables.css. I use that as a signal that something isn't used, but clearly that didn't work here. Can you help me understand how to make sure I find any uses of a variable that a simple search may miss?
