### PR TITLE
Fix regression that broke the modal asking the user to sign in

### DIFF
--- a/src/ui/components/Errors/RootErrorBoundary.tsx
+++ b/src/ui/components/Errors/RootErrorBoundary.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from "next/router";
 import { ErrorInfo } from "react";
 import { ErrorBoundary, ErrorBoundaryProps } from "react-error-boundary";
 
@@ -20,6 +21,7 @@ export function RootErrorBoundary({
 }: Omit<ErrorBoundaryProps, "fallback" | "fallbackRender" | "FallbackComponent" | "resetKeys"> & {
   name: string;
 }) {
+  const { pathname } = useRouter();
   const expectedError = useAppSelector(getExpectedError);
   const unexpectedError = useAppSelector(getUnexpectedError);
   const dispatch = useAppDispatch();
@@ -44,10 +46,10 @@ export function RootErrorBoundary({
     }
   };
 
-  if (expectedError) {
+  if (expectedError && pathname !== "/login") {
     return (
       <ExpectedErrorModal
-        action="refresh"
+        action={expectedError.action ?? "refresh"}
         details={expectedError.content ?? ""}
         title={expectedError.message ?? "Error"}
       />


### PR DESCRIPTION
`expectedError.action` was not passed to `<ExpectedErrorModal>` so it showed a refresh button instead of the sign in button.
Another problem was that the `expectedError` is cleared in an effect in the login page, but that page is not displayed as long as `expectedError` is set because the new `<RootErrorBoundary>` would not mount the app in that case.
I tried to clear `expectedError` in the `onClick` handler of the `<SignInButton>` but that didn't work either: clearing `expectedError` would remount the app immediately (*before* switching to the `/login` route), which would set `expectedError` again (see my comments in [13c40380-f810-4e2e-bb83-63367811d99d](https://app.replay.io/recording/cant-clear-expectederror--13c40380-f810-4e2e-bb83-63367811d99d)). So I added a special case for the `/login` route to `<RootErrorBoundary>`. That feels a bit hacky but I couldn't think of a cleaner way to fix this.
@markerikson tagging you as reviewer because Brian is out for the next couple of days.
@bvaughn I think you may want to look at this when you're back - perhaps you find a cleaner way to clear `expectedError`