### PR TITLE
Reconcile our two color ramps (grey-x and theme-base-x)

### DIFF
--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -65,17 +65,19 @@
   --grey-10-a20: rgba(249, 249, 250, 0.2);
   --grey-10-a25: rgba(249, 249, 250, 0.25);
   --grey-10-a30: rgba(249, 249, 250, 0.3);
-  --grey-10: #f9f9fa;
-  --grey-20: #ededf0;
-  --grey-30: #d7d7db;
+
+  --grey-10: #f2f2f2;
+  --grey-20: #e6e6e6;
+  --grey-30: #d9d9d9;
   --grey-40: #b1b1b3;
   --grey-50: #737373;
-  --grey-55: #5c5c5f;
-  --grey-60: #4a4a4f;
-  --grey-70: #38383d;
+  --grey-60: #3e434b;
+  --grey-70: #3d4552;
+  --grey-70: none;
+  --grey-90: #192230;
+
   --grey-90-a10: rgba(12, 12, 13, 0.1);
   --grey-90-a30: rgba(12, 12, 13, 0.3);
-  --grey-90: #0c0c0d;
   --magenta-65: #dd00a9;
   --purple-50: #9400ff;
   --red-20: #ffb3d2;
@@ -130,9 +132,9 @@
 
   /* Color ramp (Dark) */
   --theme-base-100: #000; /* background chrome */
-  --theme-base-95: #192230; /* tab bars */
-  --theme-base-90: #3d4552; /* editor and selected tab */
-  --theme-base-85: #3e434b; /* textfields */
+  --theme-base-95: var(--grey-90); /* tab bars */
+  --theme-base-90: var(--grey-70); /* editor and selected tab */
+  --theme-base-85: var(--grey-60); /* textfields */
   --theme-base-80: #797d81;
   --theme-base-70: #a2a6a8;
   --theme-base-60: #c3c6c8;
@@ -670,9 +672,9 @@
 
   /* Color ramp (Light) */
   --theme-base-100: hsl(0, 0%, 100%);
-  --theme-base-95: hsl(0, 0%, 95%);
-  --theme-base-90: hsl(0, 0%, 90%);
-  --theme-base-85: hsl(0, 0%, 85%);
+  --theme-base-95: var(--grey-10);
+  --theme-base-90: var(--grey-20);
+  --theme-base-85: var(--grey-30);
   --theme-base-80: hsl(0, 0%, 80%);
   --theme-base-70: hsl(0, 0%, 70%);
   --theme-base-60: hsl(0, 0%, 60%);


### PR DESCRIPTION
### Notes for Brian

There are a lot of notes below to get into all of the details, but the high level summary is that I'm aligning our different shades of grey. It's good and correct to have a color ramp for grey-10, grey-20, etc and have a seperate color ramp that's more semantically tied to the needs of the theme (theme-base-90, theme-base-80, etc) ... the issue is when these greys aren't lined up. So this ticket takes another step forward towards aligning.


### More details:

This is copied from [my Notion page](https://www.notion.so/replayio/Aligning-our-color-ramps-ae78f410bdb74720b4a8b89b54f9aa5f?pvs=4):

From the [Linear ticket](https://linear.app/replay/issue/DES-1066/create-simplified-grays-ramp-for-our-design-system):

My previous 9 PRs in the [[Design System Alignment Project](https://www.notion.so/Design-System-Alignment-Project-87afabecf50d4badb2522b65922fb608?pvs=21)](https://www.notion.so/Design-System-Alignment-Project-87afabecf50d4badb2522b65922fb608?pvs=21) have been leading up to this: now that I have a more aligned set of colors for our shades of grey, I can make a better spectrum of greys for us to use.

**Some background:**

We already have our base-theme-x ramp, where base-theme-100 is black in dark theme and white in white theme. These gradations provide the foundation of our color scheme.

Separately, we have the standard grey-x ramp. The reason you shouldn't build a UI with these colors alone is because then everything is special-cased, with no higher-level consistency. The key is to combine both of these ramps so they can share a finite number of colors in a consistent way.

**Next steps:**

1. Reconcile the base-theme-x colors with the grey-x colors (many are similar but different)
2. Make each base-theme-x color point directly to a grey-x variable (right now they're all hand-coded, which leads to inconsistency)
3. Test and verify

### Notes

Here’s my first visual comparison:

![image](https://github.com/replayio/devtools/assets/9154902/a7f52b73-dee5-48fe-bd1c-d5dea77fb33a)

The two colored boxes on the left show a comparison between our theme-base-x ramp versus our grey-x ramp. From this, a few insights shake out:

1. The grey-x ramp is quite flat, since it’s just showing greys, whereas our theme-base one has more blues and warmth, because it’s not strictly trying to be grey.
2. We could align our theme-base to something more strictly grey, but we tried that and the app looked uninviting. Better is to go in the other direction: give our grey ramp some flavour by taking the colors from theme-base and applying them to our grey ramp.
3. Notice the big gap we have here — between grey 30 and grey 60, we don’t define anything … yet our theme-base does. So we need to do something to address those.
4. I’m going to address the gap later. For now, I am going to simply move our greys over to the theme-base-x colors we’re using, then switch our theme-base-x colors to using the grey-x ramp

**Changes (for now)**

—grey-90 change from 0C0C0D to 192230

—grey-70 change from 38383D to 3D4552

—grey-60 change from 4A4A4F to 3E434B

—grey-30 change from D7D7DB to D9D9D9

—grey-20 change from EDEDF0 to E6E6E6

—grey-10 change from F9F9FA to F2F2F2

**How I tested**

I swapped out the grey-x ramp with different shades of red and clicked all through the app. We don't actually use these hard-coded values very often, so the visible changes are pretty minimal. There are some slight hue differences, but I spent time making sure even when they're different they're nearly indistinguishable after the change.