### PR TITLE
Ensure unique keys for test suite recording items

### DIFF
--- a/src/ui/components/Library/Team/View/TestRuns/Overview/RunResults.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/Overview/RunResults.tsx
@@ -171,7 +171,7 @@ const FileNodeRenderer = memo(function FileNodeRenderer({
                 <TestResultListItem
                   depth={depth + 1}
                   filterByText={filterByText}
-                  key={recording.id}
+                  key={test.id + recording.id}
                   label={execution.result}
                   recording={recording}
                   test={test}


### PR DESCRIPTION
## Issue

When the backend changes to group by test instead of spec file, it may return multiple tests entries for the same recording. Since the previous `key` value was the recording id, we had some odd rendering when switching to a run that had a spec with multiple tests because the `key` wasn't unique.

https://www.loom.com/share/9ef0adb12d1a4c319f82c0168d50d020

## Resolution

Ensure the key is unique