### PR TITLE
Add queue for step commands to support stepping quickly

### DIFF
--- a/packages/e2e-tests/tests/stepping-07.test.ts
+++ b/packages/e2e-tests/tests/stepping-07.test.ts
@@ -1,0 +1,38 @@
+import { openDevToolsTab, startTest } from "../helpers";
+import {
+  openPauseInformationPanel,
+  rewindToLine,
+  waitForPaused,
+} from "../helpers/pause-information-panel";
+import { clickSourceTreeNode } from "../helpers/source-explorer-panel";
+import { addBreakpoint } from "../helpers/source-panel";
+import test from "../testFixtureCloneRecording";
+
+test.use({ exampleKey: "doc_rr_objects.html" });
+
+test("stepping-07: Test quick stepping using the keyboard", async ({
+  pageWithMeta: { page, recordingId },
+  exampleKey,
+}) => {
+  await startTest(page, recordingId);
+  await openDevToolsTab(page);
+
+  // Open doc_rr_objects.html
+  await clickSourceTreeNode(page, "test");
+  await clickSourceTreeNode(page, "examples");
+  await clickSourceTreeNode(page, exampleKey);
+
+  await openPauseInformationPanel(page);
+
+  // Pause on line 50
+  await addBreakpoint(page, { lineNumber: 50, url: exampleKey });
+  await rewindToLine(page, 50);
+
+  // "Step over" ten times *without* waiting for each step to complete
+  for (let i = 0; i < 10; i++) {
+    await page.keyboard.press("F10");
+  }
+
+  // after all steps have been executed we should be paused on line 60
+  await waitForPaused(page, 60);
+});

--- a/src/devtools/client/debugger/src/reducers/pause.ts
+++ b/src/devtools/client/debugger/src/reducers/pause.ts
@@ -189,6 +189,9 @@ const pauseSlice = createSlice({
       } satisfies Partial<PauseState>);
       state.threadcx.isPaused = false;
     },
+    clearQueuedCommands(state) {
+      state.queuedCommands = [];
+    },
     enqueueCommand(state, action: PayloadAction<FindTargetCommand>) {
       state.queuedCommands.push(action.payload);
     },
@@ -210,6 +213,7 @@ export const {
   pauseHistoryDecremented,
   pauseHistoryIncremented,
   stepping,
+  clearQueuedCommands,
   enqueueCommand,
   dequeueCommand,
 } = pauseSlice.actions;


### PR DESCRIPTION
- add a queue for step commands
- move the action for stepping (formerly known as `executeCommandOperation`) to `src/ui/actions/timeline.ts` (next to the `seek()` action)
- reduce the amount of time that the stepping buttons are disabled (we don't need to wait for frames to be loaded)
- add an e2e test
