### PR TITLE
Fix the missing background colors on non-test teams

### DIFF
--- a/src/ui/components/Library/Team/View/Recordings/RecordingListItem/RecordingListItem.tsx
+++ b/src/ui/components/Library/Team/View/Recordings/RecordingListItem/RecordingListItem.tsx
@@ -17,7 +17,7 @@ import { formatDuration } from "ui/utils/time";
 
 import { Redacted } from "../../../../../Redacted";
 import RecordingOptionsDropdown from "./RecordingOptionsDropdown";
-import styles from "../../../../Testsuites.module.css";
+import styles from "../../../../Library.module.css";
 
 export function getDurationString(durationMs: number | null | undefined) {
   if (typeof durationMs !== "number") {


### PR DESCRIPTION
After:

<img width="1790" alt="image" src="https://github.com/replayio/devtools/assets/15959269/15517f85-aebf-4a13-8608-7dc98ba178fb">

@jonbell-lot23 just double-checking, since this was a test team specific stylesheet that was applied to a non-test team. I think this was a casualty from maybe a find-and-replace? Let me know in case this runs into any hitches, otherwise it should be good to go.