### PR TITLE
Fix badges so they don't truncate

### DIFF
--- a/src/ui/components/Library/Team/View/NewTestRuns/RunStats.tsx
+++ b/src/ui/components/Library/Team/View/NewTestRuns/RunStats.tsx
@@ -31,10 +31,7 @@ const pillStyles = {
 
 function Pill({ status, value }: { status: "failed" | "success" | "flaky"; value: number }) {
   return (
-    <div
-      data-test-id={`Pill-${status}`}
-      className={`flex h-[1.35rem] min-w-[1.35rem] items-center justify-center rounded-md text-xs font-bold ${pillStyles[status]}`}
-    >
+    <div data-test-id={`Pill-${status}`} className={`${styles.Pill} ${pillStyles[status]}`}>
       {value}
     </div>
   );

--- a/src/ui/components/Library/Team/View/NewTestRuns/TestRuns.module.css
+++ b/src/ui/components/Library/Team/View/NewTestRuns/TestRuns.module.css
@@ -36,20 +36,31 @@
   background-color: var(--primary-accent-dimmed-hover);
 }
 
+.Pill {
+  display: flex;
+  height: 1.35rem;
+  min-width: 1.35rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0 0.5rem;
+}
 .flakyPill {
   color: var(--theme-base-100);
   background-color: var(--testsuites-flaky-color);
 }
 
 .failedPill {
-  color: var(--theme-base-100);
+  color: #fff; /* we want white in both themes, or else the contrast is bad */
   background-color: var(--testsuites-failed-color);
 }
 
 .successPill {
   color: var(--theme-base-100);
   background-color: var(--testsuites-success-color);
-  border-radius: 50%;
+  border-radius: 12px;
 }
 
 .testsuitesSuccess {


### PR DESCRIPTION
Addresses https://linear.app/replay/issue/SCS-1773/add-padding-for-the-test-counts

Old on left, new on right:

<img width="1296" alt="image" src="https://github.com/replayio/devtools/assets/9154902/6397ca50-a46e-46b9-a233-82c00709a149">
