### PR TITLE
Padding adjustment for testsuites

### DIFF
--- a/src/ui/components/TestSuite/views/GroupedTestCases/TestRecordingTreeRow.module.css
+++ b/src/ui/components/TestSuite/views/GroupedTestCases/TestRecordingTreeRow.module.css
@@ -13,7 +13,6 @@
 .SkippedRow {
   color: var(--color-dim);
 }
-
 .Row[data-is-pending] {
   opacity: 0.5;
 }
@@ -52,6 +51,7 @@
 }
 
 .Error {
+  margin-top: 8px;
   padding: 0.5rem 0.75rem;
   border-radius: 0.25rem;
   font-family: var(--font-family-monospace);


### PR DESCRIPTION
When the error starts, there should be a bit more space above it.

Old:
![image](https://github.com/replayio/devtools/assets/9154902/f7109fa1-6041-4fec-9b18-63aae0288543)

New:
![image](https://github.com/replayio/devtools/assets/9154902/09c0ef1f-4eb0-47be-80dd-debb00dc70f9)
