### PR TITLE
Reset stackFrameIndex when selecting a different test step

### DIFF
--- a/src/ui/components/TestSuite/views/TestRecording/TestEventDetails.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestEventDetails.tsx
@@ -25,7 +25,11 @@ export default function TestEventDetails({ collapsed }: { collapsed: boolean }) 
 
   return (
     <InlineErrorBoundary name="TestEventDetails">
-      <UserEventDetailsComponent testEvent={testEvent} testEventPending={testEventPending} />
+      <UserEventDetailsComponent
+        key={testEvent.data.id}
+        testEvent={testEvent}
+        testEventPending={testEventPending}
+      />
     </InlineErrorBoundary>
   );
 }


### PR DESCRIPTION
This adds a `key` to force `<PlaywrightUserActionEventDetails>` to be remounted and have its state (i.e. `stackFrameIndex`) reset.
I could have used an effect to reset `stackFrameIndex` but I wanted to avoid the double rendering this would have caused.