### PR TITLE
Fix the icons shown in the tests view

### DIFF
--- a/src/ui/components/Library/Team/View/Tests/Overview/TestDetails.tsx
+++ b/src/ui/components/Library/Team/View/Tests/Overview/TestDetails.tsx
@@ -54,8 +54,14 @@ export function getReplayResult(result: string, index: number, total: number) {
   } else if (result === "failed") {
     return "failed";
   } else if (result === "flaky") {
-    // return passing for the first (last) one, failing for the rest
-    return index === 0 ? "passed" : "failed";
+    if (total === 1) {
+      // If there's only one replay but the test is flaky,
+      // it's cypress and the flake was resolved internally
+      return "flaky";
+    } else {
+      // return passing for the first (last) one, flaky for the rest
+      return index === 0 ? "passed" : "flaky";
+    }
   } else {
     return result;
   }


### PR DESCRIPTION
### Cypress + Flaky:
#### 1 result: flaky icon for the 1 result
<img width="766" alt="image" src="https://github.com/replayio/devtools/assets/15959269/10f0f763-fd88-4bde-8aa8-3dbb833ac65a">

#### 1+ results: green icon for the latest result, flaky icons for the remaining results
<img width="757" alt="image" src="https://github.com/replayio/devtools/assets/15959269/7ad0b28a-c6ac-40ea-9216-e94c65a890bb">

### Playwright + Flaky:
#### 1 result: green icon for the 1 result

#### 1+ results: green icon for the latest result, flaky icons for the remaining results
<img width="752" alt="image" src="https://github.com/replayio/devtools/assets/15959269/7bae5581-8aa7-4e5a-9d70-3dbaaf5aa741">
