### PR TITLE
Improve hover state for runs

### DIFF
--- a/src/ui/components/Library/Team/View/NewTestRuns/TestRunResultList.tsx
+++ b/src/ui/components/Library/Team/View/NewTestRuns/TestRunResultList.tsx
@@ -28,7 +28,7 @@ export function TestRunResultList({
   }
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col">
       {selectedSpecTests.map(s =>
         s.executions
           .filter(e => e.recordings.length > 0)

--- a/src/ui/components/Library/Team/View/NewTestRuns/TestRuns.module.css
+++ b/src/ui/components/Library/Team/View/NewTestRuns/TestRuns.module.css
@@ -6,7 +6,7 @@
 }
 
 :root:global(.theme-dark) .libraryRow:hover {
-  background-color: #1c2534;
+  background-color: var(--primary-accent-dimmed-hover);
 }
 
 :root:global(.theme-dark) .libraryRowSelected {

--- a/src/ui/components/Library/Team/View/NewTestRuns/TestRunsStats.tsx
+++ b/src/ui/components/Library/Team/View/NewTestRuns/TestRunsStats.tsx
@@ -22,7 +22,7 @@ export function TestRunsStats() {
     <div className="flex flex-col gap-2 text-sm">
       <Chart />
       <div className="flex flex-row gap-2">
-        <div className="flex flex-col gap-1 rounded-lg bg-chrome  p-4">
+        <div className="flex flex-col gap-1 rounded-lg bg-chrome p-4">
           <div className="font-bold">Build failure rate</div>
           <div className="flex flex-row gap-1">
             <div className={styles.failureRate}>{(buildFailureRate * 100).toFixed(0)}%</div>
@@ -32,7 +32,7 @@ export function TestRunsStats() {
           </div>
         </div>
         <div className="flex flex-row gap-2">
-          <div className="flex flex-col gap-1 rounded-lg bg-chrome  p-4">
+          <div className="flex flex-col gap-1 rounded-lg bg-chrome p-4">
             <div className="font-bold">Test failure rate</div>
             <div className="flex flex-row gap-1">
               <div className={styles.failureRate}>{(testFailureRate * 100).toFixed(0)}%</div>

--- a/src/ui/components/Library/Team/View/Tests/TestListItem.module.css
+++ b/src/ui/components/Library/Team/View/Tests/TestListItem.module.css
@@ -5,7 +5,7 @@
 
 :root:global(.theme-dark) .libraryRow:hover,
 :root:global(.theme-dark) .replayRow:hover {
-  background-color: #1c2534;
+  background-color: var(--primary-accent-dimmed-hover);
 }
 
 :root:global(.theme-dark) .libraryRowSelected {
@@ -40,7 +40,7 @@
 }
 
 .failedPill {
-  color: var(--theme-base-100);
+  color: #fff;
   background-color: var(--testsuites-failed-color);
 }
 

--- a/src/ui/components/Library/Testsuites.module.css
+++ b/src/ui/components/Library/Testsuites.module.css
@@ -36,6 +36,7 @@
   flex-direction: row;
   align-items: center;
   gap: 1rem;
+  padding: 12px 6px;
 }
 
 .icon {
@@ -164,7 +165,7 @@
 
 :root:global(.theme-dark) .libraryRow:hover,
 :root:global(.theme-dark) .replayRow:hover {
-  background-color: #1c2534;
+  background-color: var(--primary-accent-dimmed-hover);
 }
 
 :root:global(.theme-dark) .libraryRowSelected {


### PR DESCRIPTION
**Summary**

Addresses [DES-1073](https://linear.app/replay/issue/DES-1073/hover-state-should-be-more-clear). Our hover state is current extremely subtle, to the point where you can't see it. This makes it more clear and more consistent with other parts of the system.

I also added some better padding to the hover. Last week we added a hover but it was cut too close.

Old:
![image](https://github.com/replayio/devtools/assets/9154902/6f07ad94-438d-4312-ab6e-2d750e7c0759)

New:
![image](https://github.com/replayio/devtools/assets/9154902/ef0a4619-be3e-43d6-a6cc-9d736d9a3c8b)


Old, light theme:
![image](https://github.com/replayio/devtools/assets/9154902/41e90bcf-2603-4472-a552-d4f6f7da318b)

New, light theme:
![image](https://github.com/replayio/devtools/assets/9154902/210b2933-a187-4d92-8697-61d2bb685727)
