### PR TITLE
Remove recording-based flaky test grouping

### DIFF
--- a/src/ui/utils/testRuns.ts
+++ b/src/ui/utils/testRuns.ts
@@ -51,9 +51,6 @@ export function groupRecordings(tests: TestRunTestWithRecordings[]): TestGroups 
     const recordingTests = recordingsMap[filePath];
     recordingTests.sort((testA, testB) => testA.attempt - testB.attempt);
 
-    const didAnyTestFail = recordingTests.some(testFailed);
-    const didAnyTestPass = recordingTests.some(testPassed);
-
     function addToTestGroup(group: TestGroup, test: TestRunTestWithRecordings) {
       if (group.fileNameToTests[filePath]) {
         group.fileNameToTests[filePath].push(test);
@@ -65,32 +62,12 @@ export function groupRecordings(tests: TestRunTestWithRecordings[]): TestGroups 
 
     for (const test of recordingTests) {
       if (test.result === "passed") {
-        if (didAnyTestFail) {
-          addToTestGroup(flakyRecordings, test);
-        } else {
-          addToTestGroup(passedRecordings, test);
-        }
+        addToTestGroup(passedRecordings, test);
       } else if (test.result === "failed") {
-        if (didAnyTestPass) {
-          addToTestGroup(flakyRecordings, test);
-        } else {
-          addToTestGroup(failedRecordings, test);
-        }
+        addToTestGroup(failedRecordings, test);
       } else if (test.result === "flaky") {
         addToTestGroup(flakyRecordings, test);
       }
-    }
-
-    if (didAnyTestFail && didAnyTestPass) {
-      flakyRecordings.fileNameToTests[filePath].sort((recordingA, recordingB) => {
-        if (testPassed(recordingA) && testFailed(recordingB)) {
-          return 1;
-        } else if (testFailed(recordingA) && testPassed(recordingB)) {
-          return -1;
-        } else {
-          return 0;
-        }
-      });
     }
   }
 


### PR DESCRIPTION
This code hasn't been required for a while now that the backend responds with a `flaky` status but is now actively blocking us from rolling out the changes to roll up by test instead of spec file because the frontend thinks that it should group cypress instead of relying on the data from the backend.