### PR TITLE
Convert more tailwind to css modules in testsuites

### DIFF
--- a/src/ui/components/Library/Team/View/NewTestRuns/TestRunSpecDetails.module.css
+++ b/src/ui/components/Library/Team/View/NewTestRuns/TestRunSpecDetails.module.css
@@ -1,0 +1,85 @@
+.mainContainer {
+  display: flex;
+  flex-grow: 1;
+  flex-direction: column;
+  gap: 2rem;
+  overflow-y: auto;
+  padding-top: 0.5rem;
+  padding-bottom: 3rem;
+}
+
+.subContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+}
+
+.title {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.errorGroupContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  overflow-x: auto;
+  border-radius: 0.375rem;
+  background-color: var(--testsuites-v2-error-bg);
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+}
+
+.errorToggleButton {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.25rem;
+}
+
+.errorCountLabel {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.375rem;
+  background-color: var(--testsuites-failed-color);
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0;
+  padding-bottom: 0;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.errorSummary {
+  margin-left: 0.5rem;
+  flex-grow: 1;
+  text-align: left;
+  overflow: hidden;
+}
+
+.errorToggleIcon {
+  transition-duration: 140ms;
+  min-width: 1rem;
+  min-height: 1rem;
+  width: 1rem;
+  height: 1rem;
+}
+
+.errorDetails {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: monospace;
+  font-size: 0.75rem;
+}

--- a/src/ui/components/Library/Team/View/NewTestRuns/TestRunSpecDetails.module.css
+++ b/src/ui/components/Library/Team/View/NewTestRuns/TestRunSpecDetails.module.css
@@ -63,6 +63,8 @@
   flex-grow: 1;
   text-align: left;
   overflow: hidden;
+  white-space: nowrap;
+  text-overflow: hidden;
 }
 
 .errorToggleIcon {

--- a/src/ui/components/Library/Team/View/NewTestRuns/TestRunSpecDetails.tsx
+++ b/src/ui/components/Library/Team/View/NewTestRuns/TestRunSpecDetails.tsx
@@ -1,5 +1,6 @@
 import { useContext, useMemo, useState } from "react";
 
+import Icon from "replay-next/components/Icon";
 import { TestRunTestWithRecordings } from "shared/test-suites/TestRun";
 
 import { useTestRunDetailsSuspends } from "../TestRuns/hooks/useTestRunDetailsSuspends";
@@ -116,12 +117,26 @@ function ErrorGroup({
       className="flex w-full flex-col gap-2 overflow-x-auto rounded-md bg-[color:var(--testsuites-v2-error-bg)] px-3 py-4"
       data-test-id="TestRunSpecDetails-Error"
     >
-      <button className="flex flex-row gap-1" onClick={() => setExpanded(!expanded)}>
-        <div>({count})</div>
-        <div className="truncate">{summary}</div>
+      <button
+        className="flex flex-row items-start justify-between gap-1"
+        onClick={() => setExpanded(!expanded)}
+      >
+        <div className="mt-0.5 flex items-center justify-center rounded-md bg-[color:var(--testsuites-failed-color)] px-2 py-0 text-xs font-bold text-white">
+          {count}
+        </div>
+        <div className="ml-2 flex-grow truncate text-left">{summary}</div>
+        <Icon
+          data-test-id="TestRunResults-StatusGroup-Icon"
+          data-test-state={expanded ? "expanded" : "collapsed"}
+          className={`duration-140 mt-0.5 transition-transform ${
+            expanded ? "rotate-0" : "rotate-90"
+          }`}
+          style={{ minWidth: "1rem", minHeight: "1rem" }}
+          type="chevron-down"
+        />
       </button>
       {expanded ? (
-        <div className="flex flex-col gap-4 whitespace-pre-wrap break-words border-l-2 border-[color:var(--testsuites-v2-failed-header)] px-3">
+        <div className="mt-2 flex flex-col gap-4 whitespace-pre-wrap break-words ">
           <div className="font-mono text-xs">{message.split("\n").slice(0, 4).join("\n")}</div>
         </div>
       ) : null}

--- a/src/ui/components/Library/Team/View/NewTestRuns/TestRunSpecDetails.tsx
+++ b/src/ui/components/Library/Team/View/NewTestRuns/TestRunSpecDetails.tsx
@@ -8,6 +8,7 @@ import { TestSuitePanelMessage } from "../TestSuitePanelMessage";
 import { TestRunPanelWrapper } from "./TestRunPanelWrapper";
 import { TestRunResultList } from "./TestRunResultList";
 import { TestRunsContext } from "./TestRunsContextRoot";
+import styles from "./TestRunSpecDetails.module.css";
 
 export function TestRunSpecDetails() {
   const { spec, filterTestsByText } = useContext(TestRunsContext);
@@ -40,11 +41,9 @@ export function TestRunSpecDetails() {
 
   return (
     <TestRunPanelWrapper>
-      <div className="flex flex-grow flex-col gap-3 overflow-y-auto py-3">
-        <div className="flex flex-col gap-2 px-3">
-          <div className="overflow-hidden overflow-ellipsis whitespace-nowrap text-lg font-semibold">
-            Replays
-          </div>
+      <div className={styles.mainContainer}>
+        <div className={styles.subContainer}>
+          <div className={styles.title}>Replays</div>
           <TestRunResultList selectedSpecTests={selectedSpecTests} />
         </div>
         {failedTests.length ? <Errors failedTests={failedTests} /> : null}
@@ -90,10 +89,8 @@ function Errors({ failedTests }: { failedTests: TestRunTestWithRecordings[] }) {
   }, [failedTests]);
 
   return (
-    <div className="flex flex-col gap-2 px-3">
-      <div className="overflow-hidden overflow-ellipsis whitespace-nowrap text-lg font-semibold">
-        Errors
-      </div>
+    <div className={styles.subContainer}>
+      <div className={styles.title}>Errors</div>
       {sortedErrors.map((e, i) => (
         <ErrorGroup key={`${spec}-${i}`} message={e.message} count={e.count} summary={e.summary} />
       ))}
@@ -113,30 +110,19 @@ function ErrorGroup({
   const [expanded, setExpanded] = useState(false);
 
   return (
-    <div
-      className="flex w-full flex-col gap-2 overflow-x-auto rounded-md bg-[color:var(--testsuites-v2-error-bg)] px-3 py-4"
-      data-test-id="TestRunSpecDetails-Error"
-    >
-      <button
-        className="flex flex-row items-start justify-between gap-1"
-        onClick={() => setExpanded(!expanded)}
-      >
-        <div className="mt-0.5 flex items-center justify-center rounded-md bg-[color:var(--testsuites-failed-color)] px-2 py-0 text-xs font-bold text-white">
-          {count}
-        </div>
-        <div className="ml-2 flex-grow truncate text-left">{summary}</div>
+    <div className={styles.errorGroupContainer} data-test-id="TestRunSpecDetails-Error">
+      <button className={styles.errorToggleButton} onClick={() => setExpanded(!expanded)}>
+        <div className={styles.errorCountLabel}>{count}</div>
+        <div className={styles.errorSummary}>{summary}</div>
         <Icon
           data-test-id="TestRunResults-StatusGroup-Icon"
           data-test-state={expanded ? "expanded" : "collapsed"}
-          className={`duration-140 mt-0.5 transition-transform ${
-            expanded ? "rotate-0" : "rotate-90"
-          }`}
-          style={{ minWidth: "1rem", minHeight: "1rem", width: "1rem", height: "1rem" }}
+          className={`${styles.errorToggleIcon} ${expanded ? "rotate-0" : "rotate-90"}`}
           type="chevron-down"
         />
       </button>
       {expanded ? (
-        <div className="mt-2 flex flex-col gap-4 whitespace-pre-wrap break-words ">
+        <div className={styles.errorDetails}>
           <div className="font-mono text-xs">{message.split("\n").slice(0, 4).join("\n")}</div>
         </div>
       ) : null}

--- a/src/ui/components/Library/Team/View/NewTestRuns/TestRunSpecDetails.tsx
+++ b/src/ui/components/Library/Team/View/NewTestRuns/TestRunSpecDetails.tsx
@@ -131,7 +131,7 @@ function ErrorGroup({
           className={`duration-140 mt-0.5 transition-transform ${
             expanded ? "rotate-0" : "rotate-90"
           }`}
-          style={{ minWidth: "1rem", minHeight: "1rem" }}
+          style={{ minWidth: "1rem", minHeight: "1rem", width: "1rem", height: "1rem" }}
           type="chevron-down"
         />
       </button>


### PR DESCRIPTION
There are some small visual changes, but the big change is in the code.

Old:
<img width="422" alt="image" src="https://github.com/replayio/devtools/assets/9154902/0ee7ec68-36f7-4705-aad0-a95a6403bc89">

New:
<img width="456" alt="image" src="https://github.com/replayio/devtools/assets/9154902/2b90d176-2ab1-4a5b-bff8-60299a4b8760">

* I tightened up the spacing to make it more consistent with other columns. 
* Ignore the badge difference, that's from a previous change