### PR TITLE
Fix missing browser server close; fix broken example recording.

### DIFF
--- a/packages/e2e-tests/scripts/record-playwright.ts
+++ b/packages/e2e-tests/scripts/record-playwright.ts
@@ -66,6 +66,7 @@ export async function recordPlaywright(
     await page.close();
     await context.close();
     await browser.close();
+    await browserServer.close();
   }
 }
 

--- a/packages/e2e-tests/scripts/save-examples.ts
+++ b/packages/e2e-tests/scripts/save-examples.ts
@@ -30,6 +30,7 @@ const argv = yargs
     alias: "e",
     description: "Only re-generate tests for a single file, or a comma-separated list of files",
     type: "string",
+    default: "",
   })
   .option("runtime", {
     alias: "r",
@@ -425,7 +426,7 @@ async function saveExamples(
 
   const specificExamples = argv.example.split(",").filter(s => s.length > 0);
 
-  if (specificExamples) {
+  if (specificExamples.length > 0) {
     examplesToRun = examplesToRun.filter(example => specificExamples.includes(example.filename));
   }
 


### PR DESCRIPTION
I broke examples running when _not_ specifying examples; this fixes that issue.  I also noticed chromium instances hanging around when running many tests, and realized I missed adding a browser server `close` call.