### PR TITLE
Update e2e tests to use newer Chromium

### DIFF
--- a/packages/e2e-tests/examples.json
+++ b/packages/e2e-tests/examples.json
@@ -4,8 +4,8 @@
     "buildId": "linux-chromium-20230813-7ceb833b4749-fbca4ec81b14"
   },
   "authenticated_comments.html": {
-    "recording": "3a585e03-bab9-4358-b7bd-f069a294fc3f",
-    "buildId": "macOS-chromium-20231208-59d13ff47173-ad0834963a29"
+    "recording": "b50dd5b7-ab70-4987-8987-cc3240dd2cf3",
+    "buildId": "macOS-chromium-20240110-e5625ebd3edc-50d01be708a2"
   },
   "authenticated_comments_1.html": {
     "recording": "10f1cf17-2a29-4cde-b54e-dcf77f738fbd",
@@ -20,8 +20,8 @@
     "buildId": "macOS-gecko-20230322-7777175a1013-228a8d6652a4"
   },
   "authenticated_logpoints.html": {
-    "recording": "56438362-24a2-407c-9a03-802104488523",
-    "buildId": "macOS-chromium-20231208-59d13ff47173-ad0834963a29"
+    "recording": "aefdfcfb-33e3-420b-915a-8d3be4b683b6",
+    "buildId": "macOS-chromium-20240110-e5625ebd3edc-50d01be708a2"
   },
   "authenticated_logpoints_1.html": {
     "recording": "f7e69589-ddb8-4a0e-b517-f393d225991e",
@@ -108,8 +108,8 @@
     "buildId": "macOS-gecko-20220722-76bf615bc154-b7eae18423ef"
   },
   "doc_recursion.html": {
-    "recording": "6bde4533-a2ff-404e-8795-9bf7f38e1590",
-    "buildId": "macOS-chromium-20231208-59d13ff47173-ad0834963a29"
+    "recording": "b49f38bb-79a3-404c-acbf-186aaa15968d",
+    "buildId": "macOS-chromium-20240110-e5625ebd3edc-50d01be708a2"
   },
   "doc_rr_basic.html": {
     "recording": "84bfc1b8-edf2-4d1e-b55e-c31aba7d139d",
@@ -120,8 +120,8 @@
     "buildId": "macOS-gecko-20220722-76bf615bc154-b7eae18423ef"
   },
   "doc_rr_console.html": {
-    "recording": "6c9ccfe5-f87c-4efa-b030-22b6b6be9330",
-    "buildId": "macOS-chromium-20231208-59d13ff47173-ad0834963a29"
+    "recording": "a00acf1e-3dd6-4e75-b909-bad040bc6a91",
+    "buildId": "macOS-chromium-20240110-e5625ebd3edc-50d01be708a2"
   },
   "doc_rr_error.html": {
     "recording": "15c145a7-8969-4385-aaed-f084f9c0141d",
@@ -136,24 +136,24 @@
     "buildId": "linux-gecko-20230919-72cad6f42a93-4d0a9f5b9de2"
   },
   "doc_rr_preview.html": {
-    "recording": "372ab5e6-dc92-4508-ada1-2f0557c5dfb8",
-    "buildId": "macOS-chromium-20231208-59d13ff47173-ad0834963a29"
+    "recording": "1cd7b33e-cf87-4ff1-9785-25821582bd96",
+    "buildId": "macOS-chromium-20240110-e5625ebd3edc-50d01be708a2"
   },
   "doc_rr_region_loading.html": {
-    "recording": "78b24dc9-155c-4612-a53e-9dcfa57e2abf",
-    "buildId": "macOS-chromium-20231208-59d13ff47173-ad0834963a29"
+    "recording": "0271dff8-1e72-489f-8937-5cd901293dc4",
+    "buildId": "macOS-chromium-20240110-e5625ebd3edc-50d01be708a2"
   },
   "doc_rr_worker.html": {
-    "recording": "5eca0b91-ccd6-4957-b861-f97f7307faaf",
-    "buildId": "macOS-chromium-20231208-59d13ff47173-ad0834963a29"
+    "recording": "bc72d6e5-ee21-48c7-a59e-98d99ef2c814",
+    "buildId": "macOS-chromium-20240110-e5625ebd3edc-50d01be708a2"
   },
   "doc_stacking.html": {
     "recording": "233a22c5-428e-46f8-a1ac-4b2488ac517e",
     "buildId": "macOS-gecko-20220722-76bf615bc154-b7eae18423ef"
   },
   "doc_stacking_chromium.html": {
-    "recording": "b48014b2-e04a-414c-9d2f-77aff91d4ecd",
-    "buildId": "macOS-chromium-20231208-59d13ff47173-ad0834963a29"
+    "recording": "284db28d-b148-4e00-b8e4-88dbdc46a7cb",
+    "buildId": "macOS-chromium-20240110-e5625ebd3edc-50d01be708a2"
   },
   "flake/adding-spec.ts": {
     "recording": "7b0db00a-d9a9-4d2d-b816-af14a1b682a6",
@@ -204,11 +204,11 @@
     "buildId": "macOS-chromium-20231208-59d13ff47173-ad0834963a29"
   },
   "redux-fundamentals/dist/index.html": {
-    "recording": "76c9a8db-5e05-40c1-89e6-70053248041e",
-    "buildId": "linux-chromium-20230922-a3b77ea9490c-4d0a9f5b9de2"
+    "recording": "446b1dd2-407a-4eb1-9798-232a1ba7c67e",
+    "buildId": "macOS-chromium-20240110-e5625ebd3edc-50d01be708a2"
   },
   "redux/dist/index.html": {
-    "recording": "72ffbc74-ea61-492f-af66-cb8302b89c8d",
-    "buildId": "linux-chromium-20230922-a3b77ea9490c-4d0a9f5b9de2"
+    "recording": "c70d9bf2-bee0-443c-b966-fd542fc43371",
+    "buildId": "macOS-chromium-20240110-e5625ebd3edc-50d01be708a2"
   }
 }


### PR DESCRIPTION
Update examples to by recorded with latest Chromium release (`macOS-chromium-20240110-e5625ebd3edc-50d01be708a2`)
- [x] Re-record recordings made with `macOS-chromium-20231208-59d13ff47173-ad0834963a29`
- [ ] ~Update other (older) Chromium recordings~~

The most recent [CI run](https://tests.replay.io/team/dzowNDAyOGMwYS05ZjM1LTQ2ZjktYTkwYi1jNzJkMTIzNzUxOTI=/runs/76b8c1f5-70e7-4469-adb0-16d7363506b4?param=dzowNDAyOGMwYS05ZjM1LTQ2ZjktYTkwYi1jNzJkMTIzNzUxOTI%3D&param=runs&param=582145e9-255c-4d4f-8c7c-88b0466e5beb) is happy:
![Screenshot 2024-01-11 at 9 14 51 AM](https://github.com/replayio/devtools/assets/29597/7deafa7f-7a4e-4519-9139-43221daea853)
