### PR TITLE
Reimplement the "Free Trial Expired" modal

### DIFF
--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -21,12 +21,7 @@ import { UIThunkAction } from "ui/actions";
 import * as actions from "ui/actions/app";
 import { getRecording } from "ui/hooks/recordings";
 import { getUserId, getUserInfo } from "ui/hooks/users";
-import {
-  clearExpectedError,
-  getExpectedError,
-  getUnexpectedError,
-  setTrialExpired,
-} from "ui/reducers/app";
+import { clearExpectedError, getExpectedError, getUnexpectedError } from "ui/reducers/app";
 import { getToolboxLayout } from "ui/reducers/layout";
 import {
   ProtocolEvent,
@@ -176,7 +171,15 @@ export function createSocket(recordingId: string): UIThunkAction {
         recording.workspace &&
         subscriptionExpired(recording.workspace, new Date(recording.date))
       ) {
-        return dispatch(setTrialExpired());
+        dispatch(
+          setExpectedError({
+            message: "Free Trial Expired",
+            content:
+              "This replay is unavailable because it was recorded after your team's free trial expired.",
+            action: recording.userRole !== "team-admin" ? "library" : "team-billing",
+          })
+        );
+        return;
       }
 
       const experimentalSettings: ExperimentalSettings = {
@@ -375,8 +378,4 @@ export function onUploadedData({ uploaded, length }: uploadedData): UIThunkActio
     const lengthMB = length ? (length / (1024 * 1024)).toFixed(2) : undefined;
     dispatch(actions.setUploading({ total: lengthMB, amount: uploadedMB }));
   };
-}
-
-export function clearTrialExpired() {
-  return setTrialExpired(false);
 }

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -22,7 +22,7 @@ import { useGraphQLUserData } from "shared/user-data/GraphQL/useGraphQLUserData"
 import { userData } from "shared/user-data/GraphQL/UserData";
 import { setAccessToken } from "ui/actions/app";
 import { setShowSupportForm } from "ui/actions/layout";
-import { clearTrialExpired, createSocket } from "ui/actions/session";
+import { createSocket } from "ui/actions/session";
 import { DevToolsDynamicLoadingMessage } from "ui/components/DevToolsDynamicLoadingMessage";
 import { DevToolsProcessingScreen } from "ui/components/DevToolsProcessingScreen";
 import { NodePickerContextRoot } from "ui/components/NodePickerContext";
@@ -146,7 +146,6 @@ function Body() {
 
 function _DevTools({
   apiKey,
-  clearTrialExpired,
   createSocket,
   loadingFinished,
   sessionId,
@@ -222,11 +221,7 @@ function _DevTools({
       .catch(() => {
         console.error("Failed to create session");
       });
-
-    return () => {
-      clearTrialExpired();
-    };
-  }, [dispatch, isAuthenticated, clearTrialExpired, createSocket, recordingId]);
+  }, [dispatch, isAuthenticated, createSocket, recordingId]);
 
   useEffect(() => {
     if (uploadComplete && loadingFinished) {
@@ -318,7 +313,6 @@ const connector = connect(
   }),
   {
     createSocket,
-    clearTrialExpired,
   }
 );
 type PropsFromRedux = ConnectedProps<typeof connector>;

--- a/src/ui/components/Errors/ExpectedErrorModal.tsx
+++ b/src/ui/components/Errors/ExpectedErrorModal.tsx
@@ -144,8 +144,9 @@ function TeamBillingButton() {
   const currentWorkspaceId = useGetTeamIdFromRoute();
 
   const router = useRouter();
-  const onClick = () => {
-    router.push(`/team/${currentWorkspaceId}/settings/billing`);
+  const onClick = async () => {
+    await router.push(`/team/${currentWorkspaceId}/settings/billing`);
+    dispatch(clearExpectedError());
     dispatch(setModal("workspace-settings"));
   };
 

--- a/src/ui/components/Library/Team/utils.ts
+++ b/src/ui/components/Library/Team/utils.ts
@@ -2,6 +2,8 @@ import { ParsedUrlQuery } from "querystring";
 import { NextRouter, useRouter } from "next/router";
 
 import { View } from "ui/components/Library/Team/View/ViewContextRoot";
+import { getRecordingWorkspace } from "ui/reducers/app";
+import { useAppSelector } from "ui/setup/hooks";
 
 export function parseQueryParams(query: ParsedUrlQuery) {
   const [teamId, view, testRunId] = Array.isArray(query.param) ? query.param : [query.param!];
@@ -16,8 +18,17 @@ export function useGetTeamRouteParams() {
 }
 
 export function useGetTeamIdFromRoute() {
-  const params = useGetTeamRouteParams();
-  return params.teamId;
+  const { query, route } = useRouter();
+  const workspace = useAppSelector(getRecordingWorkspace);
+
+  if (route.startsWith("/team/")) {
+    const params = parseQueryParams(query);
+    return params.teamId;
+  }
+  if (workspace) {
+    return workspace.id;
+  }
+  return "me";
 }
 
 export function useRedirectToTeam(replace: boolean = false) {

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -39,7 +39,6 @@ export const initialAppState: AppState = {
   recordingWorkspace: null,
   selectedCommentId: null,
   sessionId: null,
-  trialExpired: false,
   unexpectedError: null,
   uploading: null,
   videoUrl: null,
@@ -76,9 +75,6 @@ const appSlice = createSlice({
       state.expectedError = null;
       state.modal = null;
       state.modalOptions = null;
-    },
-    setTrialExpired(state, action: PayloadAction<boolean | undefined>) {
-      state.trialExpired = action.payload ?? true;
     },
     setSessionId(state, action: PayloadAction<string>) {
       state.sessionId = action.payload;
@@ -150,7 +146,6 @@ export const {
   setRecordingTarget,
   setRecordingWorkspace,
   setSessionId,
-  setTrialExpired,
   setUnexpectedError,
   setUploading,
   setVideoUrl,
@@ -175,7 +170,6 @@ export const getAwaitingSourcemaps = (state: UIState) => state.app.awaitingSourc
 export const getSessionId = (state: UIState) => state.app.sessionId;
 export const getExpectedError = (state: UIState) => state.app.expectedError;
 export const getUnexpectedError = (state: UIState) => state.app.unexpectedError;
-export const getTrialExpired = (state: UIState) => state.app.trialExpired;
 export const getModal = (state: UIState) => state.app.modal;
 export const getModalOptions = (state: UIState) => state.app.modalOptions;
 export const getHoveredCommentId = (state: UIState) => state.app.hoveredCommentId;

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -98,7 +98,6 @@ export interface AppState {
   recordingWorkspace: Workspace | null;
   selectedCommentId: string | null;
   sessionId: SessionId | null;
-  trialExpired: boolean;
   unexpectedError: UnexpectedError | null;
   uploading: UploadInfo | null;
   videoUrl: string | null;


### PR DESCRIPTION
This PR reimplements the modal that was shown for recordings that were recorded after their workspace's trial expired, which had been removed in #10068.
Instead of treating this as a separate kind of error (in addition to `ExpectedError` and `UnexpectedError`), we now use an `ExpectedError` modal.
Furthermore this fixes the `workspaceId` used by the `<TeamBillingButton>` shown in that modal.
