### PR TITLE
Fix Console Event types filters

### DIFF
--- a/packages/e2e-tests/examples.json
+++ b/packages/e2e-tests/examples.json
@@ -60,8 +60,8 @@
     "buildId": "macOS-gecko-20220722-76bf615bc154-b7eae18423ef"
   },
   "doc_events_chromium.html": {
-    "recording": "90d2b06c-b6ef-46e2-bd10-e79ae4f38775",
-    "buildId": "linux-chromium-20230922-a3b77ea9490c-4d0a9f5b9de2"
+    "recording": "5385af28-ce9b-4712-aabe-783b4762ad2b",
+    "buildId": "macOS-chromium-20240110-e5625ebd3edc-50d01be708a2"
   },
   "doc_exceptions.html": {
     "recording": "11d683a6-30bb-46c2-ab55-f8d990bffa9e",

--- a/packages/e2e-tests/tests/logpoints-03.test.ts
+++ b/packages/e2e-tests/tests/logpoints-03.test.ts
@@ -13,7 +13,7 @@ test(`logpoints-03: should display event properties in the console`, async ({
 
   await addEventListenerLogpoints(page, [{ eventType: "event.mouse.click", categoryKey: "mouse" }]);
 
-  const message = await findConsoleMessage(page, "MouseEvent", "event");
+  const message = await findConsoleMessage(page, "(click)", "event");
 
   await expect(message).toContainText('type: "click"');
   await expect(message).toContainText("target: <div");

--- a/packages/e2e-tests/tests/logpoints-03_chromium.test.ts
+++ b/packages/e2e-tests/tests/logpoints-03_chromium.test.ts
@@ -10,8 +10,7 @@ import test, { expect } from "../testFixtureCloneRecording";
 // and the event type string. We've copy-pasted it to simplify getting _any_ E2E test working.
 test.use({ exampleKey: "doc_events_chromium.html" });
 
-// TODO [FE-2118] Re-enable this test once RUN-2669 eventually ships
-test.skip(`logpoints-03_chromium: should display event properties in the console`, async ({
+test(`logpoints-03_chromium: should display event properties in the console`, async ({
   pageWithMeta: { page, recordingId },
   exampleKey,
 }) => {

--- a/packages/e2e-tests/tests/stepping-05.test.ts
+++ b/packages/e2e-tests/tests/stepping-05.test.ts
@@ -36,7 +36,7 @@ test(`stepping-05: Test stepping in pretty-printed code`, async ({
 
   await openConsolePanel(page);
   await addEventListenerLogpoints(page, [{ eventType: "event.mouse.click", categoryKey: "mouse" }]);
-  await warpToMessage(page, "click", 15);
+  await warpToMessage(page, "(click)", 15);
 
   await stepInToLine(page, 2);
   await stepOutToLine(page, 15);

--- a/packages/e2e-tests/tests/stepping-05_chromium.test.ts
+++ b/packages/e2e-tests/tests/stepping-05_chromium.test.ts
@@ -38,7 +38,7 @@ test(`stepping-05_chromium: Test stepping in pretty-printed code`, async ({
 
   await openConsolePanel(page);
   await addEventListenerLogpoints(page, [{ eventType: "click", categoryKey: "mouse" }]);
-  await warpToMessage(page, "PointerEvent", 15);
+  await warpToMessage(page, "(click)", 15);
 
   await stepInToLine(page, 15);
   await stepOutToLine(page, 12);

--- a/packages/replay-next/components/console/filters/EventType.tsx
+++ b/packages/replay-next/components/console/filters/EventType.tsx
@@ -6,7 +6,7 @@ import Icon from "replay-next/components/Icon";
 import { ConsoleFiltersContext } from "replay-next/src/contexts/ConsoleFiltersContext";
 import { useCurrentFocusPointRange } from "replay-next/src/hooks/useCurrentFocusPointRange";
 import useTooltip from "replay-next/src/hooks/useTooltip";
-import { Event, eventsCache } from "replay-next/src/suspense/EventsCache";
+import { Event, eventPointsCache } from "replay-next/src/suspense/EventsCache";
 import { MAX_POINTS_TO_RUN_EVALUATION } from "shared/client/ReplayClient";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
@@ -27,11 +27,11 @@ export default function EventType({
   const focusPointRange = useCurrentFocusPointRange();
 
   const status = useIntervalCacheStatus(
-    eventsCache.pointsIntervalCache,
+    eventPointsCache,
     BigInt(focusPointRange.begin),
     BigInt(focusPointRange.end),
     client,
-    event.type
+    [event.type]
   );
 
   const { onMouseEnter, onMouseLeave, tooltip } = useTooltip({
@@ -39,14 +39,21 @@ export default function EventType({
     tooltip: "There are too many events. Please focus to a smaller time range and try again.",
   });
 
-  const checked = eventTypes[event.rawEventTypes[0]] === true;
+  const checked = eventTypes[event.rawEventTypes[0]]?.enabled ?? false;
   const newChecked = !checked;
-  const toggle = () =>
+  const toggle = () => {
     update({
       eventTypes: Object.fromEntries(
-        event.rawEventTypes.map(rawEventType => [rawEventType, newChecked])
+        event.rawEventTypes.map(rawEventType => [
+          rawEventType,
+          {
+            enabled: newChecked,
+            label: event.label,
+          },
+        ])
       ),
     });
+  };
 
   const stopPropagation = (event: MouseEvent) => {
     event.stopPropagation();

--- a/packages/replay-next/components/console/renderers/EventLogRenderer.tsx
+++ b/packages/replay-next/components/console/renderers/EventLogRenderer.tsx
@@ -94,7 +94,11 @@ function EventLogRenderer({
 function AnalyzedContent({ eventLog }: { eventLog: EventLog }) {
   const { showTimestamps } = useContext(ConsoleFiltersContext);
 
-  const { pauseId, values } = eventsCache.resultsCache.read(eventLog.point, eventLog.eventType);
+  const { pauseId, values } = eventsCache.resultsCache.read(
+    eventLog.point,
+    eventLog.eventType,
+    eventLog.label
+  );
 
   const content =
     values.length > 0
@@ -113,7 +117,7 @@ function AnalyzedContent({ eventLog }: { eventLog: EventLog }) {
       )}
       {content ? (
         <span className={styles.LogContents} data-test-name="LogContents">
-          {content}
+          <span className={styles.LogContentsEmpty}>({eventLog.label})</span> {content}
         </span>
       ) : (
         <span className={styles.LogContentsEmpty} data-test-name="LogContents">

--- a/packages/replay-next/src/contexts/ConsoleFiltersContext.tsx
+++ b/packages/replay-next/src/contexts/ConsoleFiltersContext.tsx
@@ -24,7 +24,10 @@ export type Toggles = {
 };
 
 export type EventTypes = {
-  [eventType: EventHandlerType]: boolean;
+  [eventType: EventHandlerType]: {
+    enabled: boolean;
+    label: string;
+  };
 };
 
 export type ConsoleFiltersContextType = Toggles & {


### PR DESCRIPTION
Supersedes #9971

- [x] Re-record underlying e2e test recording with latest Chromium release (20240110)
- [x] Re-enable temporarily disabled `logpoints-03_chromium.test` test
- [x] Update events cache to use new Replay API (`__RECORD_REPLAY__.getFrameArgumentsArray()`) for Chromium recordings
- [x] Update renderer to include explicit event type label

The latest [CI test results](https://tests.replay.io/team/dzowNDAyOGMwYS05ZjM1LTQ2ZjktYTkwYi1jNzJkMTIzNzUxOTI=/runs/c50194e4-c4fd-4c75-b640-75a14722a520?param=dzowNDAyOGMwYS05ZjM1LTQ2ZjktYTkwYi1jNzJkMTIzNzUxOTI%3D&param=runs&param=2db4a936-dc84-4c96-904c-0029255695d7) look good:
![Screenshot 2024-01-10 at 12 32 31 PM](https://github.com/replayio/devtools/assets/29597/10ec0991-b198-445d-ad16-cc9726a6b3ab)

### Firefox
![Screenshot 2024-01-10 at 11 23 55 AM](https://github.com/replayio/devtools/assets/29597/31666dc7-3d17-41aa-a608-a2b5b84c69ed)

### Chromium
![Screenshot 2024-01-10 at 11 24 05 AM](https://github.com/replayio/devtools/assets/29597/cc1dbfe8-25a3-4e5b-8d35-6eef6af52a96)

