### PR TITLE
Source Search UI/UX improvements

### DIFF
--- a/packages/e2e-tests/tests/file-search-01.test.ts
+++ b/packages/e2e-tests/tests/file-search-01.test.ts
@@ -18,6 +18,14 @@ test("file-search-01: should search files", async ({ pageWithMeta: { page, recor
   await openDevToolsTab(page);
   await openFileSearchPanel(page);
 
+  // Verify message shown at first
+  await verifySourceSearchSummary(page, "");
+
+  // Verify overflow message
+  await searchSources(page, "a");
+  await verifySourceSearchOverflowMessageShown(page, true);
+  await verifySourceSearchSummary(page, "First 1000 results.");
+
   // Verify search results for the string "test"
   await searchSources(page, "test");
   await verifySourceSearchOverflowMessageShown(page, false);

--- a/packages/e2e-tests/tests/file-search-01.test.ts
+++ b/packages/e2e-tests/tests/file-search-01.test.ts
@@ -24,12 +24,12 @@ test("file-search-01: should search files", async ({ pageWithMeta: { page, recor
   // Verify overflow message
   await searchSources(page, "a");
   await verifySourceSearchOverflowMessageShown(page, true);
-  await verifySourceSearchSummary(page, "First 1000 results.");
+  await verifySourceSearchSummary(page, "First 1000 results");
 
   // Verify search results for the string "test"
   await searchSources(page, "test");
   await verifySourceSearchOverflowMessageShown(page, false);
-  await verifySourceSearchSummary(page, "21 results in 1 file.");
+  await verifySourceSearchSummary(page, "21 results in 1 file");
   await verifyVisibleResultsCount(page, 25); // 21 results in 4 different files
 
   // Verify files can be collapsed
@@ -44,7 +44,7 @@ test("file-search-01: should search files", async ({ pageWithMeta: { page, recor
   // Now include node_modules in the search
   await toggleExcludeNodeModulesCheckbox(page, false);
   await verifySourceSearchOverflowMessageShown(page, false);
-  await verifySourceSearchSummary(page, "25 results in 1 file.");
+  await verifySourceSearchSummary(page, "25 results in 1 file");
   await verifyVisibleResultsCount(page, 31); // 25 results in 6 different files
 
   // Collapse the first few results

--- a/packages/e2e-tests/tests/file-search-01.test.ts
+++ b/packages/e2e-tests/tests/file-search-01.test.ts
@@ -21,7 +21,7 @@ test("file-search-01: should search files", async ({ pageWithMeta: { page, recor
   // Verify search results for the string "test"
   await searchSources(page, "test");
   await verifySourceSearchOverflowMessageShown(page, false);
-  await verifySourceSearchSummary(page, "21 results");
+  await verifySourceSearchSummary(page, "21 results in 1 file.");
   await verifyVisibleResultsCount(page, 25); // 21 results in 4 different files
 
   // Verify files can be collapsed
@@ -36,7 +36,7 @@ test("file-search-01: should search files", async ({ pageWithMeta: { page, recor
   // Now include node_modules in the search
   await toggleExcludeNodeModulesCheckbox(page, false);
   await verifySourceSearchOverflowMessageShown(page, false);
-  await verifySourceSearchSummary(page, "25 results");
+  await verifySourceSearchSummary(page, "25 results in 1 file.");
   await verifyVisibleResultsCount(page, 31); // 25 results in 6 different files
 
   // Collapse the first few results

--- a/packages/replay-next/components/elements-new/ElementsPanel.module.css
+++ b/packages/replay-next/components/elements-new/ElementsPanel.module.css
@@ -85,6 +85,9 @@
 
 .SearchResults {
   font-size: var(--font-size-small);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .ListRow {

--- a/packages/replay-next/components/elements-new/ElementsPanel.tsx
+++ b/packages/replay-next/components/elements-new/ElementsPanel.tsx
@@ -199,6 +199,11 @@ export function ElementsPanel({
     // So just set focus on the search input and let the user trigger the search when they're ready.
   };
 
+  let searchResultsText = "";
+  if (!searchInProgress && searchState !== null) {
+    searchResultsText = `${searchState.index + 1} of ${searchState.indices.length}`;
+  }
+
   return (
     <div className={styles.Panel}>
       <div className={styles.SearchRow}>
@@ -228,8 +233,12 @@ export function ElementsPanel({
         </button>
         {searchInProgress && <Icon className={styles.SpinnerIcon} type="spinner" />}
         {!searchInProgress && searchState !== null && (
-          <div className={styles.SearchResults} data-test-id="ElementsPanel-SearchResult">
-            {searchState.index + 1} of {searchState.indices.length}
+          <div
+            className={styles.SearchResults}
+            data-test-id="ElementsPanel-SearchResult"
+            title={searchResultsText}
+          >
+            {searchResultsText}
           </div>
         )}
       </div>

--- a/packages/replay-next/components/elements/ElementsPanel.module.css
+++ b/packages/replay-next/components/elements/ElementsPanel.module.css
@@ -65,6 +65,9 @@
 
 .SearchResults {
   font-size: var(--font-size-small);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .ListRow {

--- a/packages/replay-next/components/elements/ElementsPanel.tsx
+++ b/packages/replay-next/components/elements/ElementsPanel.tsx
@@ -155,6 +155,11 @@ export function ElementsPanel({
     }
   };
 
+  let searchResultsText = "";
+  if (!searchInProgress && searchState !== null) {
+    searchResultsText = `${searchState.index + 1} of ${searchState.results.length}`;
+  }
+
   return (
     <div className={styles.Panel}>
       <div className={styles.SearchRow}>
@@ -175,8 +180,12 @@ export function ElementsPanel({
         </label>
         {searchInProgress && <Icon className={styles.SpinnerIcon} type="spinner" />}
         {!searchInProgress && searchState !== null && (
-          <div className={styles.SearchResults} data-test-id="ElementsPanel-SearchResult">
-            {searchState.index + 1} of {searchState.results.length}
+          <div
+            className={styles.SearchResults}
+            data-test-id="ElementsPanel-SearchResult"
+            title={searchResultsText}
+          >
+            {searchResultsText}
           </div>
         )}
       </div>

--- a/packages/replay-next/components/search-files/ResultsList.module.css
+++ b/packages/replay-next/components/search-files/ResultsList.module.css
@@ -15,23 +15,3 @@
   overflow: hidden;
   flex: 1 1 auto;
 }
-
-.OverflowHeader {
-  display: flex;
-  padding: 0 0.5rem;
-  color: var(--color-dim);
-  font-size: var(--font-size-small);
-  background-color: var(--background-color-source-search);
-  border-top: 1px solid var(--border-color-source-search);
-  border-bottom: 1px solid var(--border-color-source-search);
-  padding: 0.5rem;
-  margin-bottom: 0.5rem;
-}
-
-.OverflowIcon {
-  flex: 0 0 0.75rem;
-  width: 0.75rem;
-  height: 0.75rem;
-  color: var(--color-warning);
-  margin-right: 1ch;
-}

--- a/packages/replay-next/components/search-files/ResultsList.module.css
+++ b/packages/replay-next/components/search-files/ResultsList.module.css
@@ -11,11 +11,6 @@
   opacity: 0.5;
 }
 
-.NoResults {
-  padding: 0 0.5rem;
-  color: var(--color-dim);
-}
-
 .List {
   overflow: hidden;
   flex: 1 1 auto;

--- a/packages/replay-next/components/search-files/ResultsList.tsx
+++ b/packages/replay-next/components/search-files/ResultsList.tsx
@@ -30,8 +30,6 @@ export default function ResultsList({
 
   const sources = sourcesCache.read(replayClient);
 
-  const didOverflow = data?.didOverflow ?? false;
-
   const listData = useMemo(() => new FileSearchListData(orderedResults), [orderedResults]);
 
   // Data streams in to the same array, so we need to let the list know when to recompute the item count.
@@ -57,13 +55,6 @@ export default function ResultsList({
       className={isPending ? styles.ResultsPending : styles.Results}
       data-test-id="SourceSearch-Results"
     >
-      {didOverflow && (
-        <div className={styles.OverflowHeader} data-test-id="SourceSearch-OverflowMessage">
-          <Icon className={styles.OverflowIcon} type="warning" />
-          The result set only contains a subset of all matches. Be more specific in your search to
-          narrow down the results.
-        </div>
-      )}
       <div className={styles.List}>
         <AutoSizer
           children={({ height, width }) => (

--- a/packages/replay-next/components/search-files/ResultsList.tsx
+++ b/packages/replay-next/components/search-files/ResultsList.tsx
@@ -49,11 +49,7 @@ export default function ResultsList({
   );
 
   if (status === STATUS_RESOLVED && orderedResults.length === 0) {
-    return (
-      <div className={styles.Results}>
-        <div className={styles.NoResults}>No results found</div>
-      </div>
-    );
+    return null;
   }
 
   return (

--- a/packages/replay-next/components/search-files/SearchFiles.tsx
+++ b/packages/replay-next/components/search-files/SearchFiles.tsx
@@ -10,8 +10,8 @@ import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { Nag } from "shared/graphql/types";
 
 import Icon, { IconType } from "../Icon";
-import InlineResultsCount from "./InlineResultsCount";
 import ResultsList from "./ResultsList";
+import SearchResults from "./SearchResults";
 import styles from "./SearchFiles.module.css";
 
 export const SHOW_GLOBAL_SEARCH_EVENT_TYPE = "show-global-search";
@@ -139,9 +139,6 @@ export default function SearchFiles({ limit }: { limit?: number }) {
             type="text"
             value={queryForDisplay}
           />
-          <Suspense>
-            <InlineResultsCount streaming={streaming} />
-          </Suspense>
           <FilterButton
             active={caseSensitive}
             toggle={() => setCaseSensitive(!caseSensitive)}
@@ -208,6 +205,9 @@ export default function SearchFiles({ limit }: { limit?: number }) {
             tooltip="Exclude Node Modules"
           />
         </div>
+        <Suspense>
+          <SearchResults query={queryForSearch} streaming={streaming} />
+        </Suspense>
         <Suspense>
           <ResultsList query={queryForSearch} streaming={streaming} />
         </Suspense>

--- a/packages/replay-next/components/search-files/SearchFiles.tsx
+++ b/packages/replay-next/components/search-files/SearchFiles.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, Suspense, useContext, useEffect, useRef, useState } from "react";
+import { ChangeEvent, MouseEvent, Suspense, useContext, useEffect, useRef, useState } from "react";
 import { STATUS_REJECTED, useStreamingValue } from "suspense";
 
 import { SourcesContext } from "replay-next/src/contexts/SourcesContext";
@@ -102,6 +102,22 @@ export default function SearchFiles({ limit }: { limit?: number }) {
     };
   }, [dismissSearchSourceTextNag]);
 
+  const onInputContainerClick = (event: MouseEvent) => {
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    const input = event.currentTarget.querySelector("input");
+    if (input) {
+      input.focus();
+      input.select();
+    }
+  };
+
+  const onInputClick = (event: MouseEvent) => {
+    event.preventDefault();
+  };
+
   return (
     <div className={styles.SearchFiles} data-test-id="FileSearch-Pane">
       <div className={styles.Content}>
@@ -109,6 +125,7 @@ export default function SearchFiles({ limit }: { limit?: number }) {
           className={styles.InputWrapper}
           data-error={didError || undefined}
           data-test-id="SearchFiles-SearchInput"
+          onClick={onInputContainerClick}
         >
           <Icon className={styles.Icon} type="search" />
           <input
@@ -116,6 +133,7 @@ export default function SearchFiles({ limit }: { limit?: number }) {
             className={styles.Input}
             data-test-id="FileSearch-Input"
             onChange={onChange(setQueryForDisplay)}
+            onClick={onInputClick}
             placeholder="Find in files..."
             ref={inputRef}
             type="text"
@@ -147,12 +165,14 @@ export default function SearchFiles({ limit }: { limit?: number }) {
           className={styles.InputWrapper}
           data-error={didError || undefined}
           data-test-id="IncludeFiles-SearchInput"
+          onClick={onInputContainerClick}
         >
           <Icon className={styles.Icon} type="folder-open" />
           <input
             className={styles.Input}
             data-test-id="FileInclude-Input"
             onChange={onChange(setIncludedFiles)}
+            onClick={onInputClick}
             placeholder="Files to include..."
             type="text"
             value={includedFiles}
@@ -168,12 +188,14 @@ export default function SearchFiles({ limit }: { limit?: number }) {
           className={styles.InputWrapper}
           data-error={didError || undefined}
           data-test-id="ExcludeFiles-SearchInput"
+          onClick={onInputContainerClick}
         >
           <Icon className={styles.Icon} type="folder-closed" />
           <input
             className={styles.Input}
             data-test-id="FileExclude-Input"
             onChange={onChange(setExcludedFiles)}
+            onClick={onInputClick}
             placeholder="Files to exclude..."
             type="text"
             value={excludedFiles}

--- a/packages/replay-next/components/search-files/SearchResults.module.css
+++ b/packages/replay-next/components/search-files/SearchResults.module.css
@@ -4,7 +4,7 @@
   color: var(--color-dim);
   font-size: var(--font-size-small);
   user-select: none;
-  margin-right: 0.5rem;
+  padding: 0 0.5rem;
 }
 .ResultsCountPending {
   opacity: 0.5;

--- a/packages/replay-next/components/search-files/SearchResults.module.css
+++ b/packages/replay-next/components/search-files/SearchResults.module.css
@@ -23,6 +23,25 @@
   animation: 1s spin linear infinite;
 }
 
+.OverflowHeader {
+  display: block;
+  padding: 0 0.5rem;
+  color: var(--color-dim);
+  font-size: var(--font-size-small);
+  background-color: var(--background-color-source-search);
+  border-top: 1px solid var(--border-color-source-search);
+  border-bottom: 1px solid var(--border-color-source-search);
+  padding: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.OverflowIcon {
+  display: inline;
+  width: 0.75rem;
+  height: 0.75rem;
+  color: var(--color-warning);
+}
+
 @keyframes spin {
   0% {
     transform: rotate(0);

--- a/packages/replay-next/components/search-files/SearchResults.tsx
+++ b/packages/replay-next/components/search-files/SearchResults.tsx
@@ -63,7 +63,9 @@ export default function SearchResults({
           if (didOverflow) {
             rendered = `First ${fetchedCount} results.`;
           } else {
-            rendered = `${fetchedCount} results in ${fileCount} files.`;
+            rendered = `${fetchedCount} results in ${fileCount} ${
+              fileCount === 1 ? "file" : "files"
+            }.`;
           }
           break;
       }

--- a/packages/replay-next/components/search-files/SearchResults.tsx
+++ b/packages/replay-next/components/search-files/SearchResults.tsx
@@ -53,19 +53,19 @@ export default function SearchResults({
       switch (fetchedCount) {
         case 0:
           if (query) {
-            rendered = "No results found. Review your settings for configured exclusions.";
+            rendered = "No results found. Review your settings for configured exclusions";
           }
           break;
         case 1:
-          rendered = "1 result.";
+          rendered = "1 result";
           break;
         default:
           if (didOverflow) {
-            rendered = `First ${fetchedCount} results.`;
+            rendered = `First ${fetchedCount} results`;
           } else {
             rendered = `${fetchedCount} results in ${fileCount} ${
               fileCount === 1 ? "file" : "files"
-            }.`;
+            }`;
           }
           break;
       }

--- a/packages/replay-next/components/search-files/SearchResults.tsx
+++ b/packages/replay-next/components/search-files/SearchResults.tsx
@@ -4,9 +4,15 @@ import { STATUS_PENDING, STATUS_REJECTED, useStreamingValue } from "suspense";
 import Icon from "replay-next/components/Icon";
 import { StreamingSearchValue } from "replay-next/src/suspense/SearchCache";
 
-import styles from "./InlineResultsCount.module.css";
+import styles from "./SearchResults.module.css";
 
-export default function InlineResultsCount({ streaming }: { streaming: StreamingSearchValue }) {
+export default function SearchResults({
+  query,
+  streaming,
+}: {
+  query: string;
+  streaming: StreamingSearchValue;
+}) {
   const { data, error, status } = useStreamingValue(streaming);
 
   const didOverflow = data?.didOverflow ?? false;
@@ -31,14 +37,16 @@ export default function InlineResultsCount({ streaming }: { streaming: Streaming
     default: {
       switch (fetchedCount) {
         case 0:
-          rendered = "No matches";
+          if (query) {
+            rendered = "No results found. Review your settings for configured exclusions.";
+          }
           break;
         case 1:
           rendered = "1 result";
           break;
         default:
           if (didOverflow) {
-            rendered = `first ${fetchedCount} results`;
+            rendered = `First ${fetchedCount} results`;
           } else {
             rendered = `${fetchedCount} results`;
           }

--- a/packages/replay-next/components/search-files/SearchResults.tsx
+++ b/packages/replay-next/components/search-files/SearchResults.tsx
@@ -73,12 +73,20 @@ export default function SearchResults({
   const isPending = status === STATUS_PENDING;
 
   return (
-    <div
-      className={isPending ? styles.ResultsCountPending : styles.ResultsCount}
-      data-test-id="SearchFiles-SummaryLabel"
-      data-test-state={isPending ? "pending" : "complete"}
-    >
-      {rendered}
-    </div>
+    <>
+      <div
+        className={isPending ? styles.ResultsCountPending : styles.ResultsCount}
+        data-test-id="SearchFiles-SummaryLabel"
+        data-test-state={isPending ? "pending" : "complete"}
+      >
+        {rendered}
+      </div>
+      {didOverflow && (
+        <div className={styles.OverflowHeader} data-test-id="SourceSearch-OverflowMessage">
+          <Icon className={styles.OverflowIcon} type="warning" /> The result set only contains a
+          subset of all matches. Be more specific in your search to narrow down the results.
+        </div>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
- [x] Clicking anywhere "within" a search field will focus the input.

https://github.com/replayio/devtools/assets/29597/7ed93f57-1e12-495e-8f4c-18f6ac4f6355

- [x] Improve the results count information to better match VS Code

| State | Screenshot |
| :-- | :-- |
| Empty: Show nothing in this case | ![Screenshot 2024-01-10 at 1 03 02 PM](https://github.com/replayio/devtools/assets/29597/0def4071-689c-4fc8-ab86-8c0546f69d7d) |
| No results: Add message to check exclusion filters | ![Screenshot 2024-01-10 at 1 03 41 PM](https://github.com/replayio/devtools/assets/29597/3ab1794f-5a9e-43fb-9860-30ba271221fc) |
| Results: Show unique file count | ![Screenshot 2024-01-10 at 1 12 31 PM](https://github.com/replayio/devtools/assets/29597/0925b6b2-2ee5-46b6-8f82-4643e7daa7a0) |
| Too many results | ![Screenshot 2024-01-10 at 1 21 14 PM](https://github.com/replayio/devtools/assets/29597/76c94be3-3d84-4b33-b7e8-b0837796d0a9) |

- [x] Change alignment/flow of too many results message to better match VS Code

| Before | After |
| :--- | :--- |
| ![Screenshot 2024-01-10 at 1 15 40 PM](https://github.com/replayio/devtools/assets/29597/60e04b2f-05f7-472f-b326-031e48aba7f6) | ![Screenshot 2024-01-10 at 1 21 27 PM](https://github.com/replayio/devtools/assets/29597/224af4fb-1b24-4e83-8a88-2679959ca05a) |

---

This was technically in an unrelated part of code, but I also fixed a small formatting bug I noticed in the Elements search panel:

| Before | After |
| :--- | :--- |
| ![Screenshot 2024-01-10 at 2 41 31 PM](https://github.com/replayio/devtools/assets/29597/2edf837f-4287-458d-b926-3394e9668d88) | ![Screenshot 2024-01-10 at 2 41 22 PM](https://github.com/replayio/devtools/assets/29597/909cee04-bd5c-4077-869a-de9f032a7de6) |

---

There is one failing e2e test [for this PR](https://tests.replay.io/team/dzowNDAyOGMwYS05ZjM1LTQ2ZjktYTkwYi1jNzJkMTIzNzUxOTI=/runs/3b4eae24-ee3d-463f-b7c3-b0d191c7ab09?param=dzowNDAyOGMwYS05ZjM1LTQ2ZjktYTkwYi1jNzJkMTIzNzUxOTI%3D&param=runs&param=2db4a936-dc84-4c96-904c-0029255695d7) but it seems unrelated. I've filed a RUN bug about it.

---

cc @jonbell-lot23 