### PR TITLE
Better wrapping in testsuites

### DIFF
--- a/src/ui/components/Library/Team/View/NewTestRuns/Chart.tsx
+++ b/src/ui/components/Library/Team/View/NewTestRuns/Chart.tsx
@@ -112,7 +112,7 @@ export const Chart = () => {
       </svg>
       <ResponsiveLine
         data={data}
-        markers={markers}
+        markers={markers as CartesianMarkerProps<DatumValue>[]}
         margin={{ top: 10, right: 10, bottom: 10, left: 4 }}
         axisBottom={null}
         axisLeft={null}

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.module.css
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.module.css
@@ -9,10 +9,15 @@
   margin-left: 2ch;
 }
 
+.Event {
+  flex: 1;
+}
+
 .Badge,
 .SelectedBadge {
   padding: 0 0.25rem;
   border-radius: 0.25rem;
+  margin-right: 0.25rem;
 }
 .Badge {
   background-color: var(--testsuites-capsule-alias-bgcolor);
@@ -26,6 +31,7 @@
 .Number {
   color: var(--color-dim);
   margin-right: 1ch;
+  flex: none;
 }
 
 .Name[data-name="assert"] {
@@ -57,7 +63,7 @@
 }
 
 .Name {
-  flex: 0 1 auto;
+  flex: 1 1 auto;
   overflow: hidden;
   text-overflow: ellipsis;
   word-break: break-word;

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.module.css
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.module.css
@@ -52,6 +52,7 @@
 }
 
 .Text {
+  display: flex;
   flex: 1;
 }
 

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
@@ -135,7 +135,7 @@ export default memo(function UserActionEventRow({
         }
 
         if (event === userActionEvent) {
-          return eventNumber;
+          return eventNumber < 10 ? `0${eventNumber}` : eventNumber;
         }
       }
     }
@@ -153,22 +153,30 @@ export default memo(function UserActionEventRow({
       onMouseLeave={() => setIsHovered(false)}
     >
       <div className={styles.Text}>
-        {eventNumber != null ? <span className={styles.Number}>{eventNumber}</span> : null}
-        <span
-          className={`${styles.Name} ${styles.Name}`}
-          data-name={command.name}
-          title={command.name}
-        >
-          {command.name}
-        </span>{" "}
-        <span className={`${styles.Args} ${styles.Args}`} title={argsString}>
-          {argsString}
-        </span>
+        {eventNumber != null ? (
+          <div className="flex-none">
+            <span className={styles.Number}>{eventNumber}</span>
+          </div>
+        ) : null}
+        <div className="flex-grow">
+          <span
+            className={`${styles.Name} ${styles.Name}`}
+            data-name={command.name}
+            title={command.name}
+          >
+            {command.name}
+          </span>{" "}
+          <span className={`${styles.Args} ${styles.Args}`} title={argsString}>
+            {argsString}
+          </span>
+        </div>
       </div>
       {showBadge && (
-        <Suspense fallback={<Loader />}>
-          <Badge isSelected={isSelected} timeStampedPoint={resultPoint} />
-        </Suspense>
+        <div className="flex-none">
+          <Suspense fallback={<Loader />}>
+            <Badge isSelected={isSelected} timeStampedPoint={resultPoint} />
+          </Suspense>
+        </div>
       )}
       {showJumpToCode && jumpToCodeAnnotation && (
         <div className={styles.JumpToCodeButton}>

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
@@ -153,12 +153,8 @@ export default memo(function UserActionEventRow({
       onMouseLeave={() => setIsHovered(false)}
     >
       <div className={styles.Text}>
-        {eventNumber != null ? (
-          <div className="flex-none">
-            <span className={styles.Number}>{eventNumber}</span>
-          </div>
-        ) : null}
-        <div className="flex-grow">
+        {eventNumber != null ? <div className={styles.Number}>{eventNumber}</div> : null}
+        <div className={styles.Event}>
           <span
             className={`${styles.Name} ${styles.Name}`}
             data-name={command.name}
@@ -172,11 +168,9 @@ export default memo(function UserActionEventRow({
         </div>
       </div>
       {showBadge && (
-        <div className="flex-none">
-          <Suspense fallback={<Loader />}>
-            <Badge isSelected={isSelected} timeStampedPoint={resultPoint} />
-          </Suspense>
-        </div>
+        <Suspense fallback={<Loader />}>
+          <Badge isSelected={isSelected} timeStampedPoint={resultPoint} />
+        </Suspense>
       )}
       {showJumpToCode && jumpToCodeAnnotation && (
         <div className={styles.JumpToCodeButton}>

--- a/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.module.css
+++ b/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.module.css
@@ -9,6 +9,7 @@
   border-left: 2px solid transparent;
   background-color: var(--row-background-color);
   color: var(--row-color);
+  column-gap: 0;
 }
 .Row:hover,
 .Row[data-context-menu-active] {


### PR DESCRIPTION
**Summary**

We're giving the numbers on the left their own column so it's easier to scan.

Old:
<img width="461" alt="image" src="https://github.com/replayio/devtools/assets/9154902/021030d9-3712-49b6-881a-b1d28a565f5f">

New:
<img width="461" alt="image" src="https://github.com/replayio/devtools/assets/9154902/a7d042b2-554e-4979-98b5-7d3c114e5a54">
