### PR TITLE
Better wrapping in testsuites (3)

### DIFF
--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.module.css
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.module.css
@@ -9,10 +9,15 @@
   margin-left: 2ch;
 }
 
+.Event {
+  flex: 1;
+}
+
 .Badge,
 .SelectedBadge {
   padding: 0 0.25rem;
   border-radius: 0.25rem;
+  margin-right: 0.25rem;
 }
 .Badge {
   background-color: var(--testsuites-capsule-alias-bgcolor);
@@ -26,6 +31,7 @@
 .Number {
   color: var(--color-dim);
   margin-right: 1ch;
+  flex: none;
 }
 
 .Name[data-name="assert"] {
@@ -52,11 +58,12 @@
 }
 
 .Text {
+  display: flex;
   flex: 1;
 }
 
 .Name {
-  flex: 0 1 auto;
+  flex: 1 1 auto;
   overflow: hidden;
   text-overflow: ellipsis;
   word-break: break-word;

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
@@ -135,7 +135,7 @@ export default memo(function UserActionEventRow({
         }
 
         if (event === userActionEvent) {
-          return eventNumber;
+          return eventNumber < 10 ? `0${eventNumber}` : eventNumber;
         }
       }
     }
@@ -153,17 +153,19 @@ export default memo(function UserActionEventRow({
       onMouseLeave={() => setIsHovered(false)}
     >
       <div className={styles.Text}>
-        {eventNumber != null ? <span className={styles.Number}>{eventNumber}</span> : null}
-        <span
-          className={`${styles.Name} ${styles.Name}`}
-          data-name={command.name}
-          title={command.name}
-        >
-          {command.name}
-        </span>{" "}
-        <span className={`${styles.Args} ${styles.Args}`} title={argsString}>
-          {argsString}
-        </span>
+        {eventNumber != null ? <div className={styles.Number}>{eventNumber}</div> : null}
+        <div className={styles.Event}>
+          <span
+            className={`${styles.Name} ${styles.Name}`}
+            data-name={command.name}
+            title={command.name}
+          >
+            {command.name}
+          </span>{" "}
+          <span className={`${styles.Args} ${styles.Args}`} title={argsString}>
+            {argsString}
+          </span>
+        </div>
       </div>
       {showBadge && (
         <Suspense fallback={<Loader />}>

--- a/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.module.css
+++ b/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.module.css
@@ -9,6 +9,7 @@
   border-left: 2px solid transparent;
   background-color: var(--row-background-color);
   color: var(--row-color);
+  column-gap: 0;
 }
 .Row:hover,
 .Row[data-context-menu-active] {


### PR DESCRIPTION
**Summary**

We're giving the numbers on the left their own column so it's easier to scan.

Old:
<img width="461" alt="image" src="https://github.com/replayio/devtools/assets/9154902/021030d9-3712-49b6-881a-b1d28a565f5f">

New:
![image](https://github.com/replayio/devtools/assets/9154902/748f791e-f2d9-446a-907a-dbf0c4b9d87e)

