### PR TITLE
Fixing padding in replay list

### DIFF
--- a/src/ui/components/Library/Team/View/NewTestRuns/TestRunSpecDetails.module.css
+++ b/src/ui/components/Library/Team/View/NewTestRuns/TestRunSpecDetails.module.css
@@ -12,13 +12,13 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  padding-left: 0.25rem;
   padding-right: 0.25rem;
 }
 
 .title {
   text-overflow: ellipsis;
   white-space: nowrap;
+  padding-left: 0.3rem;
   font-size: 1.125rem;
   font-weight: 600;
 }
@@ -34,6 +34,7 @@
   padding-right: 0.75rem;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
+  margin-left: 0.3rem;
 }
 
 .errorToggleButton {

--- a/src/ui/components/Library/Testsuites.module.css
+++ b/src/ui/components/Library/Testsuites.module.css
@@ -29,6 +29,7 @@
   gap: 0.5rem;
   overflow: hidden;
   border-radius: 0.375rem;
+  padding: 4px;
 }
 
 .linkContent {


### PR DESCRIPTION
Fixes [SCS-1792](https://linear.app/replay/issue/SCS-1792/test-run-details-view-needs-some-padding)

**Summary**

This adds some padding to the hover effect, but that also means pushing other things over to make the lines line up when not hovered.

Examples:
<img width="282" alt="image" src="https://github.com/replayio/devtools/assets/9154902/0e8c72a5-b03a-4aca-9229-1931256ac1bd">

<img width="411" alt="image" src="https://github.com/replayio/devtools/assets/9154902/f2a7dc60-42b4-4737-9c01-c0e1d27b5b75">
