### PR TITLE
Reorganize root error boundary to not drop session/user info

### DIFF
--- a/packages/replay-next/components/errors/UnexpectedErrorForm.tsx
+++ b/packages/replay-next/components/errors/UnexpectedErrorForm.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from "react";
 
 import { SupportForm } from "replay-next/components/support/SupportForm";
+import { ReplayClientInterface } from "shared/client/types";
 
 import styles from "./UnexpectedErrorForm.module.css";
 
@@ -8,9 +9,26 @@ import styles from "./UnexpectedErrorForm.module.css";
 // It will show a contact form so the user can send additional repro steps.
 // If additional error details can be shown, they should be passed in as props.
 
-export function UnexpectedErrorForm({ details, title }: { details?: ReactNode; title: ReactNode }) {
+export function UnexpectedErrorForm({
+  currentUserEmail,
+  currentUserId,
+  currentUserName,
+  details,
+  replayClient,
+  title,
+}: {
+  currentUserEmail: string | null;
+  currentUserId: string | null;
+  currentUserName: string | null;
+  details?: ReactNode;
+  replayClient: ReplayClientInterface;
+  title: ReactNode;
+}) {
   return (
     <SupportForm
+      currentUserEmail={currentUserEmail}
+      currentUserId={currentUserId}
+      currentUserName={currentUserName}
       details={
         <>
           {details && <div className={styles.Details}>{details}</div>}
@@ -20,6 +38,7 @@ export function UnexpectedErrorForm({ details, title }: { details?: ReactNode; t
           </div>
         </>
       }
+      replayClient={replayClient}
       title={title}
     />
   );

--- a/packages/shared/client/ReplayClient.ts
+++ b/packages/shared/client/ReplayClient.ts
@@ -141,6 +141,7 @@ export class ReplayClient implements ReplayClientInterface {
   // Apps that only communicate with the Replay protocol through this client should use the initialize method instead.
   async configure(sessionId: string): Promise<void> {
     this._sessionId = sessionId;
+    this._dispatchEvent("sessionCreated");
     this.sessionWaiter.resolve(sessionId);
 
     await this.syncFocusWindow();
@@ -260,6 +261,7 @@ export class ReplayClient implements ReplayClientInterface {
     const { sessionId } = await client.Recording.createSession({ recordingId });
 
     this._sessionId = sessionId;
+    this._dispatchEvent("sessionCreated");
     this.sessionWaiter.resolve(sessionId);
 
     await this.syncFocusWindow();
@@ -770,9 +772,7 @@ export class ReplayClient implements ReplayClientInterface {
     return endpoint;
   }
 
-  getSessionId(): SessionId | null {
-    return this._sessionId;
-  }
+  getSessionId = (): SessionId | null => this._sessionId;
 
   async getSourceHitCounts(
     sourceId: SourceId,

--- a/packages/shared/client/types.ts
+++ b/packages/shared/client/types.ts
@@ -151,7 +151,8 @@ export type PointBehavior = {
 export type ReplayClientEvents =
   | "focusWindowChange"
   | "loadedRegionsChange"
-  | "processingProgressChange";
+  | "processingProgressChange"
+  | "sessionCreated";
 
 export type HitPointStatus =
   | "complete"

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,11 +9,12 @@ import { Provider } from "react-redux";
 import "../src/global-css";
 import "../src/test-prep";
 
-import { RootErrorBoundary } from "ui/components/Errors/RootErrorBoundary";
 import { SystemProvider } from "design";
 import { recordData as recordTelemetryData } from "replay-next/src/utils/telemetry";
+import { replayClient } from "shared/client/ReplayClientContext";
 import { ApolloWrapper } from "ui/components/ApolloWrapper";
 import _App from "ui/components/App";
+import { RootErrorBoundary } from "ui/components/Errors/RootErrorBoundary";
 import MaintenanceModeScreen from "ui/components/MaintenanceMode";
 import { ConfirmProvider } from "ui/components/shared/Confirm";
 import LoadingScreen from "ui/components/shared/LoadingScreen";
@@ -77,8 +78,6 @@ function Routing({ Component, pageProps }: AppProps) {
   }, []);
 
   if (!store) {
-    // We hide the tips here since we don't have the store ready yet, which
-    // the tips need to work properly.
     return null;
   }
 
@@ -89,7 +88,7 @@ function Routing({ Component, pageProps }: AppProps) {
   return (
     <Provider store={store}>
       <MemoizedHeader />
-      <RootErrorBoundary name="_app">
+      <RootErrorBoundary replayClient={replayClient}>
         <_App>
           <InstallRouteListener />
           <React.Suspense fallback={<LoadingScreen message="Fetching data..." />}>

--- a/pages/recording/[[...id]].tsx
+++ b/pages/recording/[[...id]].tsx
@@ -208,7 +208,7 @@ function RecordingPage({
     return (
       <>
         {head}
-        <DevTools apiKey={apiKey} uploadComplete={uploadComplete} />
+        <DevTools apiKey={apiKey} replayClient={replayClient} uploadComplete={uploadComplete} />
       </>
     );
   }

--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -5,7 +5,6 @@ import QuickOpenModal from "devtools/client/debugger/src/components/QuickOpenMod
 import { getQuickOpenEnabled } from "devtools/client/debugger/src/selectors";
 import { getSystemColorScheme } from "shared/theme/getSystemColorScheme";
 import { Theme } from "shared/theme/types";
-import { useTheme } from "shared/theme/useTheme";
 import { userData } from "shared/user-data/GraphQL/UserData";
 import { isTest } from "shared/utils/environment";
 import { actions } from "ui/actions";
@@ -114,7 +113,6 @@ function App({ children, hideModal, modal, quickOpenEnabled }: AppProps) {
   const auth = useAuth0();
   const dismissNag = hooks.useDismissNag();
   const userInfo = useGetUserInfo();
-  const theme = useTheme();
 
   useEffect(() => {
     if (userInfo.nags && shouldShowNag(userInfo.nags, Nag.FIRST_LOG_IN)) {

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -17,6 +17,7 @@ import { SelectedFrameContextRoot } from "replay-next/src/contexts/SelectedFrame
 import { useIsRecordingProcessed } from "replay-next/src/hooks/useIsRecordingProcessed";
 import usePreferredFontSize from "replay-next/src/hooks/usePreferredFontSize";
 import { setDefaultTags } from "replay-next/src/utils/telemetry";
+import { ReplayClientInterface } from "shared/client/types";
 import { getTestEnvironment } from "shared/test-suites/RecordingTestMetadata";
 import { useGraphQLUserData } from "shared/user-data/GraphQL/useGraphQLUserData";
 import { userData } from "shared/user-data/GraphQL/UserData";
@@ -62,7 +63,11 @@ import Video from "./Video";
 
 const Viewer = React.lazy(() => import("./Viewer"));
 
-type DevToolsProps = PropsFromRedux & { apiKey?: string; uploadComplete: boolean };
+type DevToolsProps = PropsFromRedux & {
+  apiKey?: string;
+  replayClient: ReplayClientInterface;
+  uploadComplete: boolean;
+};
 
 function ViewLoader() {
   const [showLoader, setShowLoader] = useState(false);
@@ -148,6 +153,7 @@ function _DevTools({
   apiKey,
   createSocket,
   loadingFinished,
+  replayClient,
   sessionId,
   showCommandPalette,
   showSupportForm,
@@ -159,7 +165,7 @@ function _DevTools({
   const { recording } = useGetRecording(recordingId);
   const { trackLoadingIdleTime } = useTrackLoadingIdleTime(uploadComplete, recording);
   const { userIsAuthor, loading } = useUserIsAuthor();
-  const { id: userId, email: userEmail, loading: userLoading } = useGetUserInfo();
+  const { id: userId, email: userEmail, loading: userLoading, name: userName } = useGetUserInfo();
 
   const isProcessed = useIsRecordingProcessed(recording);
 
@@ -285,7 +291,13 @@ function _DevTools({
                               <Body />
                               {showCommandPalette ? <CommandPaletteModal /> : null}
                               {showSupportForm ? (
-                                <SupportForm onDismiss={dismissSupportForm} />
+                                <SupportForm
+                                  currentUserEmail={userEmail}
+                                  currentUserId={userId}
+                                  currentUserName={userName}
+                                  onDismiss={dismissSupportForm}
+                                  replayClient={replayClient}
+                                />
                               ) : null}
                               <KeyboardShortcuts />
                             </KeyModifiers>

--- a/src/ui/components/Errors/RootErrorBoundary.tsx
+++ b/src/ui/components/Errors/RootErrorBoundary.tsx
@@ -2,7 +2,9 @@ import { ErrorInfo } from "react";
 import { ErrorBoundary, ErrorBoundaryProps } from "react-error-boundary";
 
 import { UnexpectedErrorForm } from "replay-next/components/errors/UnexpectedErrorForm";
+import { ReplayClientInterface } from "shared/client/types";
 import { setExpectedError, setUnexpectedError } from "ui/actions/errors";
+import { useGetUserInfo } from "ui/hooks/users";
 import { getExpectedError, getUnexpectedError } from "ui/reducers/app";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 
@@ -15,14 +17,16 @@ import { ExpectedErrorModal } from "./ExpectedErrorModal";
 
 export function RootErrorBoundary({
   children,
-  name,
+  replayClient,
   ...rest
 }: Omit<ErrorBoundaryProps, "fallback" | "fallbackRender" | "FallbackComponent" | "resetKeys"> & {
-  name: string;
+  replayClient: ReplayClientInterface;
 }) {
   const expectedError = useAppSelector(getExpectedError);
   const unexpectedError = useAppSelector(getUnexpectedError);
   const dispatch = useAppDispatch();
+
+  const currentUserInfo = useGetUserInfo();
 
   const onError = (error: Error, info: ErrorInfo) => {
     if (error instanceof Error && error.name === "ChunkLoadError") {
@@ -55,7 +59,11 @@ export function RootErrorBoundary({
   } else if (unexpectedError) {
     return (
       <UnexpectedErrorForm
+        currentUserEmail={currentUserInfo?.email ?? null}
+        currentUserId={currentUserInfo?.id ?? null}
+        currentUserName={currentUserInfo?.name ?? null}
         details={unexpectedError.content ?? ""}
+        replayClient={replayClient}
         title={unexpectedError.message ?? "Error"}
       />
     );


### PR DESCRIPTION
I can think of a few ways to do this. I wonder what your thoughts are on this one, @hbenl?

Worth noting that if we run into an error during the initial render– it will prevent the session from being created, but even in that scenario we'll get user info after this change.