### PR TITLE
Re-record doc_navigate with Chromium

### DIFF
--- a/packages/e2e-tests/examples.json
+++ b/packages/e2e-tests/examples.json
@@ -100,8 +100,8 @@
     "buildId": "macOS-chromium-20231208-59d13ff47173-ad0834963a29"
   },
   "doc_navigate.html": {
-    "recording": "768b3f13-0635-4dbc-8b8e-e3f53a70e405",
-    "buildId": "macOS-gecko-20220722-76bf615bc154-b7eae18423ef"
+    "recording": "1e08543b-64de-45fa-bb0d-c9453565f09a",
+    "buildId": "linux-chromium-20240110-3078216bece0-50d01be708a2"
   },
   "doc_prod_bundle.html": {
     "recording": "07d4015d-bcf5-497d-b9bd-989692e38238",

--- a/packages/e2e-tests/scripts/save-examples.ts
+++ b/packages/e2e-tests/scripts/save-examples.ts
@@ -171,7 +171,7 @@ const knownExamples: TestExampleFile[] = [
     filename: "doc_navigate.html",
     folder: config.browserExamplesPath,
     category: "browser",
-    runtime: "firefox",
+    runtime: "chromium",
   },
   {
     filename: "doc_prod_bundle.html",

--- a/packages/e2e-tests/tests/breakpoints-08.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-08.test.ts
@@ -18,23 +18,23 @@ test(`breakpoints-08: should be temporarily disabled`, async ({
   await openDevToolsTab(page);
 
   // Add breakpoint and verify text in console
-  await addBreakpoint(page, { lineNumber: 5, url: exampleKey });
+  await addBreakpoint(page, { lineNumber: 4, url: exampleKey });
 
   // Find the newly added point in the side panel
   await openPauseInformationPanel(page);
   await openPrintStatementsAccordionPane(page);
-  const breakpoints = findPoints(page, "breakpoint", { lineNumber: 5 });
-  await expect(await breakpoints.count()).toBe(1);
+  const breakpoints = findPoints(page, "breakpoint", { lineNumber: 4 });
+  expect(await breakpoints.count()).toBe(1);
   const breakpoint = breakpoints.first();
 
   // Temporarily disable breakpoint and verify that it's still in the panel
   await togglePoint(page, breakpoint, false);
-  await expect(await breakpoints.count()).toBe(1);
+  expect(await breakpoints.count()).toBe(1);
 
   // Re-enable breakpoint
   await togglePoint(page, breakpoint, true);
 
   // Delete the breakpoint and verify that it's no longer in the side panel
-  await removeBreakpoint(page, { lineNumber: 5, url: exampleKey });
-  await expect(await breakpoints.count()).toBe(0);
+  await removeBreakpoint(page, { lineNumber: 4, url: exampleKey });
+  expect(await breakpoints.count()).toBe(0);
 });


### PR DESCRIPTION
I found one more e2e example recording that can be switched to Chromium. One of the tests needed to be updated because it used a breakpoint location that is not available in the Chromium recording (I didn't see this as a parity issue because I don't think we expect the breakable locations to be exactly the same for different runtimes).