### PR TITLE
Make sure we're displaying all the days within the chart from the date filter

### DIFF
--- a/src/ui/components/Library/Team/View/NewTestRuns/Chart.tsx
+++ b/src/ui/components/Library/Team/View/NewTestRuns/Chart.tsx
@@ -59,7 +59,7 @@ function generateChartData(testRuns: TestRun[], days: number) {
 export const Chart = () => {
   const { testRuns } = useContext(TestRunsContext);
   const { startTime, endTime } = useContext(TimeFilterContext);
-  const days = (endTime.getTime() - startTime.getTime()) / 1000 / 60 / 60 / 24;
+  const days = Math.floor((endTime.getTime() - startTime.getTime()) / 1000 / 60 / 60 / 24);
   const data = useMemo(() => generateChartData(testRuns, days), [testRuns, days]);
   const [hoveredPoint, setHoveredPoint] = useState<Point | null>(null);
 


### PR DESCRIPTION
This makes it so that we're displaying all the days in the chart. 

For example, if there's only 2 days worth of data but the user has selected the 7 day filter, the chart should be showing 7 days worth of columns.

<img width="750" alt="Screenshot 2024-01-11 at 13 04 33" src="https://github.com/replayio/devtools/assets/15959269/30234f8c-08fe-4f25-85f5-95f2b4097c9a">
<img width="746" alt="Screenshot 2024-01-11 at 13 04 26" src="https://github.com/replayio/devtools/assets/15959269/f15acf70-fbcb-4af7-bee3-be24f013eb68">

