### PR TITLE
Update replay cli to fix missing sourcemap upload issue.

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@jest/console": "^28.0.2",
     "@jridgewell/trace-mapping": "^0.3.14",
     "@next/bundle-analyzer": "^12.2.0",
-    "@replayio/replay": "^0.12.4",
+    "@replayio/replay": "^0.20.1",
     "@tailwindcss/forms": "^0.5.0",
     "@testing-library/jest-dom": "^5.16.3",
     "@testing-library/react": "^13.3.0",

--- a/packages/e2e-tests/scripts/buildkite_run_fe_tests.js
+++ b/packages/e2e-tests/scripts/buildkite_run_fe_tests.js
@@ -46,41 +46,51 @@ function run_fe_tests(CHROME_BINARY_PATH) {
   process.env.AUTHENTICATED_TESTS_WORKSPACE_API_KEY = process.env.RECORD_REPLAY_API_KEY;
   process.env.PLAYWRIGHT_TEST_BASE_URL = "https://app.replay.io";
 
-  // Generate new recordings for known-passing tests with the new chromium build.
-  const htmlFiles = [
-    "authenticated_comments.html",
-    "authenticated_logpoints.html",
-    "doc_minified_chromium.html",
-    "doc_recursion.html",
-    "doc_rr_console.html",
-    "doc_rr_preview.html",
-    "doc_rr_region_loading.html",
-    "doc_stacking_chromium.html",
-    "rdt-react-versions/dist/index.html",
-  ];
-
-  // Run the known-passind tests.
+  // Run the known-passing tests.
   const testNames = [
+    "breakpoints-01",
+    "breakpoints-03",
+    "breakpoints-04",
+    "breakpoints-05",
+    "breakpoints-06",
     "comments-01",
-    //"comments-02",
+    "comments-02",
     "comments-03",
+    "console_async_eval", 
+    "console_dock", 
+    "console_eval", 
+    "console-expressions-01",
+    "cypress-01", 
+    "cypress-02", 
+    "cypress-03",
+    "elements-search",
+    "focus_mode-01",
     "logpoints-01",
-    //"stepping-05_chromium",
-    "scopes_renderer",
+    "logpoints-02",
+    "logpoints-03_chromium",
+    "logpoints-05",
+    "logpoints-06",
+    "logpoints-07",
+    "logpoints-08",
+    "logpoints-09",
+    "network-0",
+    "object_preview-03",
+    "object_preview-04", 
+    "object_preview-05",
     "passport-01",
     "passport-03",
     "passport-04",
-    "object_preview-03",
-    "focus_mode-01",
-    "elements-search",
-    "stacking_chromium",
+    "react_devtools-01-basic.test",
     "react_devtools-03-multiple-versions",
+    "react_devtools-04-seeking",
+    "scopes_renderer",
+    "stacking_chromium",
+    "stepping-01",
+    "stepping-05_chromium",
   ];
 
   execSync(
-    `xvfb-run ./packages/e2e-tests/scripts/save-examples.ts --runtime=chromium --project=replay-chromium-local --example=${htmlFiles.join(
-      ","
-    )}`,
+    `xvfb-run ./packages/e2e-tests/scripts/save-examples.ts --runtime=chromium --project=replay-chromium-local`,
     { stdio: "inherit", env: process.env }
   );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3725,6 +3725,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@replayio/replay@npm:^0.20.1":
+  version: 0.20.1
+  resolution: "@replayio/replay@npm:0.20.1"
+  dependencies:
+    "@replayio/sourcemap-upload": ^1.1.1
+    "@types/semver": ^7.5.6
+    commander: ^7.2.0
+    debug: ^4.3.4
+    is-uuid: ^1.0.2
+    jsonata: ^1.8.6
+    node-fetch: ^2.6.8
+    p-map: ^4.0.0
+    query-registry: ^2.6.0
+    semver: ^7.5.4
+    superstruct: ^0.15.4
+    text-table: ^0.2.0
+    ws: ^7.5.0
+  bin:
+    replay: bin/replay.js
+  checksum: a0968e2bbff6d80e8eb71471c024f099658ad1a521dcc662208ecf0d37abe7bd3820c61425d95c42fe812b6bc41914550c6d02802cbf956171ec2151854fb099
+  languageName: node
+  linkType: hard
+
 "@replayio/sourcemap-upload@npm:^1.0.6, @replayio/sourcemap-upload@npm:^1.1.1":
   version: 1.1.1
   resolution: "@replayio/sourcemap-upload@npm:1.1.1"
@@ -15461,7 +15484,7 @@ __metadata:
     "@replayio/overboard": ^0.4.1
     "@replayio/protocol": ^0.63.0
     "@replayio/react-devtools-inline": 4.28.6
-    "@replayio/replay": ^0.12.4
+    "@replayio/replay": ^0.20.1
     "@sentry/react": ^7.9.0
     "@sentry/tracing": ^7.9.0
     "@stripe/react-stripe-js": ^1.7.0


### PR DESCRIPTION
No idea why this is broken on the older cli, but have confirmed(?) this fix by running with the 0.20 CLI and rolling back to the old 0.12 cli multiple times.  This unlocks a number of tests, so I'm going to put "understanding" aside for know.