### PR TITLE
Small alignment changes for testsuites

### DIFF
--- a/src/ui/components/Library/Team/View/TestRuns/TestRunSpecDetails.module.css
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunSpecDetails.module.css
@@ -65,7 +65,7 @@
   text-align: left;
   overflow: hidden;
   white-space: nowrap;
-  text-overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .errorToggleIcon {

--- a/src/ui/components/Library/Team/View/TestRuns/TestRunSpecDetails.module.css
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunSpecDetails.module.css
@@ -39,7 +39,7 @@
 
 .errorToggleButton {
   display: flex;
-  align-items: flex-start;
+  align-items: center; /* Changed from flex-start to center */
   justify-content: space-between;
   gap: 0.25rem;
 }

--- a/src/ui/components/Library/Team/View/TestRuns/TestRunSpecDetails.module.css
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunSpecDetails.module.css
@@ -39,7 +39,7 @@
 
 .errorToggleButton {
   display: flex;
-  align-items: center; /* Changed from flex-start to center */
+  align-items: center;
   justify-content: space-between;
   gap: 0.25rem;
 }


### PR DESCRIPTION
Addresses https://linear.app/replay/issue/DES-1081/jaril-arrow-polish-items

1. Arrows are aligned in the centre, vertically
2. Added truncation to error message blurbs

Jaril, you mentioned the arrows being aligned left rather than extending all the way to the right. I did this on purpose because I (subjectively) don't think it's a strong a design with a ton of arrows making a long column on the right.