### PR TITLE
Break the infinite sync loop between SourcesContext and NewSourceAdapter

### DIFF
--- a/packages/e2e-tests/helpers/source-panel.ts
+++ b/packages/e2e-tests/helpers/source-panel.ts
@@ -70,6 +70,13 @@ export async function addBreakpoint(
   });
 
   await waitForBreakpoint(page, options);
+
+  // We want to add a slight delay after adding a breakpoint so that the
+  // breakpoint logic will have time to send protocol commands to the server,
+  // since that is not guaranteed to happen synchronously on click. This is
+  // important for cases where we add a breakpoint and then immediately
+  // attempt to step to the breakpoint location.
+  await delay(500);
 }
 
 export async function editBadge(

--- a/packages/replay-next/src/contexts/SourcesContext.tsx
+++ b/packages/replay-next/src/contexts/SourcesContext.tsx
@@ -38,7 +38,8 @@ type SourcesContextType = {
     sourceId: SourceId,
     startLineIndex?: number,
     endLineIndex?: number,
-    columnNumber?: number
+    columnNumber?: number,
+    callSelectLocation?: boolean
   ) => void;
   activeSourceIds: SourceId[];
   pendingFocusUpdate: boolean;
@@ -374,7 +375,8 @@ export function SourcesContextRoot({
       sourceId: SourceId,
       startLineIndex: number | null = null,
       endLineIndex: number | null = null,
-      columnNumber: number | null = null
+      columnNumber: number | null = null,
+      callSelectLocation = true
     ) => {
       startTransition(() => {
         dispatch({
@@ -389,7 +391,7 @@ export function SourcesContextRoot({
         });
 
         const selectLocation = selectLocationRef.current;
-        if (selectLocation) {
+        if (selectLocation && callSelectLocation) {
           selectLocation({
             line: startLineIndex !== null ? startLineIndex + 1 : undefined,
             sourceId,

--- a/src/devtools/client/debugger/src/components/Editor/NewSourceAdapter.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/NewSourceAdapter.tsx
@@ -71,7 +71,7 @@ function NewSourceAdapter() {
       focusedSource?.startLineIndex !== lineIndex ||
       !locationHasScrolled
     ) {
-      openSource("view-source", location.sourceId, lineIndex, lineIndex, columnNumber);
+      openSource("view-source", location.sourceId, lineIndex, lineIndex, columnNumber, false);
     }
   }, [focusedSource, location, locationHasScrolled, openSource]);
 


### PR DESCRIPTION
It would be nice to refactor the code so that we don't duplicate the selected location state. But refactoring this code is a major effort and this PR will fix the issue until we get to it.