### PR TITLE
Fix rerunning basic search in the new ElementsPanel

### DIFF
--- a/packages/e2e-tests/tests/elements-search.test.ts
+++ b/packages/e2e-tests/tests/elements-search.test.ts
@@ -79,7 +79,7 @@ test("elements-search: Element panel should support basic and advanced search mo
   await verifySelectedElement(page, "</body>");
 
   // Change timeline and verify results are updated
-  await seekToTimePercent(page, 2);
+  await seekToTimePercent(page, 1);
   await verifySearchResults(page, {
     currentNumber: 0,
     totalNumber: 0,

--- a/packages/replay-next/components/elements-new/ElementsPanel.tsx
+++ b/packages/replay-next/components/elements-new/ElementsPanel.tsx
@@ -87,12 +87,14 @@ export function ElementsPanel({
 
     let indices: number[];
 
+    setSearchInProgress(true);
+
     if (!advancedSearch) {
+      await listData.waitUntilLoaded();
+
       // Basic search is an in-memory, what-you-see search
       indices = listData.search(query);
     } else {
-      setSearchInProgress(true);
-
       // Advanced search uses the protocol API and mirrors Chrome's element search
       let ids = await domSearchCache.readAsync(replayClient, pauseId, query);
 


### PR DESCRIPTION
The new `<ElementsPanel>` reruns the search after seeking to a new pause but it didn't wait for the elements to be loaded before searching.