### PR TITLE
Add disable cloning flag and process recording automatically

### DIFF
--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -27,6 +27,7 @@
     "cypress": "^12.5.1",
     "log-update": "^4",
     "ts-node": "^10.7.0",
+    "ws": "^7.4.6",
     "yargs": "^17.6.0"
   },
   "dependencies": {

--- a/packages/e2e-tests/scripts/buildkite_run_fe_tests.js
+++ b/packages/e2e-tests/scripts/buildkite_run_fe_tests.js
@@ -55,6 +55,7 @@ function run_fe_tests(CHROME_BINARY_PATH) {
     // process.env.RECORD_REPLAY_DIRECTORY =
     process.env.AUTHENTICATED_TESTS_WORKSPACE_API_KEY = process.env.RECORD_REPLAY_API_KEY;
     process.env.PLAYWRIGHT_TEST_BASE_URL = "https://app.replay.io";
+    process.env.REPLAY_DISABLE_CLONE = "true";
 
     execSync(
       `xvfb-run ./packages/e2e-tests/scripts/save-examples.ts --runtime=chromium --target=browser --project=replay-chromium-local`,

--- a/packages/e2e-tests/scripts/loadRecording.ts
+++ b/packages/e2e-tests/scripts/loadRecording.ts
@@ -11,7 +11,23 @@ const callbacks: any = {
   onError: console.log,
 };
 
+const onProgress = ({
+  progressPercent,
+  recordingId,
+}: {
+  progressPercent: number;
+  recordingId: string;
+}) => {
+  console.log(`    ⏳ Processing recording ${recordingId} ${progressPercent}%`);
+};
+
 const client = new SimpleProtocolClient(new WebSocket(DISPATCH_URL), callbacks, console.log);
+
+client.addEventListener(
+  // @ts-expect-error - when we update protocol client to 0.68, it will throw an error - just remove this comment
+  "Recording.processRecordingProgress",
+  onProgress
+);
 
 export const loadRecording = async (recordingId: string) => {
   const { sessionId } = await client.sendCommand("Recording.createSession", {
@@ -19,19 +35,8 @@ export const loadRecording = async (recordingId: string) => {
   });
   console.log(`    ⏳ Processing recording ${recordingId} with session ${sessionId}`);
 
-  try {
-    client.addEventListener(
-      // @ts-expect-error - when we update protocol client to 0.68, it will throw an error - just remove this comment
-      "Recording.processRecordingProgress",
-      ({ progressPercent }: { progressPercent: number }) => {
-        console.log(`    ⏳ Processing recording ${recordingId} ${progressPercent}%`);
-      }
-    );
-
-    await client.sendCommand("Recording.processRecording", {
-      recordingId,
-    });
-  } finally {
-    console.log(`    ✅ Loaded recording ${recordingId}`);
-  }
+  await client.sendCommand("Recording.processRecording", {
+    recordingId,
+  });
+  console.log(`    ✅ Loaded recording ${recordingId}`);
 };

--- a/packages/e2e-tests/scripts/loadRecording.ts
+++ b/packages/e2e-tests/scripts/loadRecording.ts
@@ -1,0 +1,42 @@
+import { loadedRegions as LoadedRegions } from "@replayio/protocol";
+
+import { defer } from "protocol/utils";
+
+import { newProtocolClient } from "./protocolClient/protocolClient";
+
+const DISPATCH_URL =
+  process.env.DISPATCH_ADDRESS ||
+  process.env.NEXT_PUBLIC_DISPATCH_URL ||
+  "wss://dispatch.replay.io";
+
+export const clientPromise = newProtocolClient(DISPATCH_URL);
+
+export const loadRecording = async (recordingId: string) => {
+  const client = await clientPromise;
+  const { sessionId } = await client.sendCommand("Recording.createSession", {
+    recordingId,
+  });
+
+  console.log(`    ⏳ Loading recording ${recordingId} with session ${sessionId}`);
+
+  const { promise: allLoadedPromise, resolve: allLoadedResolve } = defer<void>();
+  let loadedRegion: LoadedRegions["loaded"][0] | undefined;
+  client.addEventListener("Session.loadedRegions", event => {
+    if (
+      event.loaded.length !== 1 ||
+      event.loading.length !== 1 ||
+      event.indexed.length !== 1 ||
+      event.loading[0]?.end?.point !== event.loaded[0]?.end?.point
+    ) {
+      return;
+    }
+
+    loadedRegion = event.loaded[0];
+    allLoadedResolve();
+  });
+
+  await Promise.race([
+    allLoadedPromise,
+    client.sendCommand("Session.listenForLoadChanges", {}, sessionId),
+  ]);
+};

--- a/packages/e2e-tests/scripts/log.ts
+++ b/packages/e2e-tests/scripts/log.ts
@@ -1,0 +1,42 @@
+import chalk from "chalk";
+import { dots } from "cli-spinners";
+import logUpdate from "log-update";
+
+let currentAnimatedLog: (() => void) | null = null;
+
+export function logAnimated(initialText: string) {
+  if (currentAnimatedLog != null) {
+    currentAnimatedLog();
+    console.error("Cannot log two animated texts at once");
+  }
+
+  let index = 0;
+  let text = initialText;
+
+  const update = () => {
+    const frame = dots.frames[++index % dots.frames.length];
+
+    logUpdate(`${chalk.yellowBright(frame)} ${text}`);
+  };
+
+  const intervalId = setInterval(update, dots.interval);
+
+  currentAnimatedLog = () => {
+    currentAnimatedLog = null;
+    clearInterval(intervalId);
+    logUpdate(`${chalk.greenBright("✓")} ${text}`);
+    logUpdate.done();
+  };
+
+  return {
+    completeLog: () => {
+      if (currentAnimatedLog != null) {
+        currentAnimatedLog();
+        currentAnimatedLog = null;
+      }
+    },
+    updateLog: (updatedText: string) => {
+      text = updatedText;
+    },
+  };
+}

--- a/packages/e2e-tests/scripts/record-playwright.ts
+++ b/packages/e2e-tests/scripts/record-playwright.ts
@@ -27,7 +27,6 @@ export async function recordPlaywright(
   let executablePath: string | undefined = undefined;
   if (config.shouldRecordTest) {
     executablePath = config.browserPath || getExecutablePath(browserName)!;
-    console.log(`Recording with executable at ${executablePath}`);
   }
 
   const browserServer = await browserEntry.launchServer({
@@ -60,7 +59,7 @@ export async function recordPlaywright(
   try {
     return await script(page as any, playwrightTest.expect);
   } catch (err) {
-    console.log("PLAYWRIGHT ERROR", err);
+    console.error("PLAYWRIGHT ERROR", err);
   } finally {
     await page.close();
     await context.close();

--- a/packages/e2e-tests/scripts/save-examples.ts
+++ b/packages/e2e-tests/scripts/save-examples.ts
@@ -421,7 +421,6 @@ async function waitUntilMessage(
 
     for (const recordingId of newRecordingIds) {
       await loadRecording(recordingId);
-      console.log(`    ✅ Loaded recording ${recordingId}`);
     }
 
     console.log("\n");

--- a/packages/e2e-tests/scripts/save-examples.ts
+++ b/packages/e2e-tests/scripts/save-examples.ts
@@ -21,6 +21,7 @@ import config, { BrowserName } from "../config";
 import examplesJson from "../examples.json";
 import { ExamplesData, TestRecordingIntersectionValue } from "../helpers";
 import { getStats } from "./get-stats";
+import { loadRecording } from "./loadRecording";
 import { recordNodeExample } from "./record-node";
 import { recordPlaywright, uploadLastRecording } from "./record-playwright";
 
@@ -413,15 +414,15 @@ async function waitUntilMessage(
 
     console.log("\n");
     console.log(
-      `${newRecordingIds.length} new recordings have been saved. Open each recording to ensure it has been pre-processed:`
-    );
-    console.log(
-      newRecordingIds
-        .map(recordingId => ` • ${chalk.blue(chalk.underline(`https://go/r/${recordingId}`))}`)
-        .join("\n")
+      `${newRecordingIds.length} new recordings have been saved. Loading each recording to ensure it has been pre-processed.`
     );
 
     const { exampleToTestMap } = getStats();
+
+    for (const recordingId of newRecordingIds) {
+      await loadRecording(recordingId);
+      console.log(`    ✅ Loaded recording ${recordingId}`);
+    }
 
     console.log("\n");
     console.log("The following tests have been impacted by this change:");

--- a/packages/e2e-tests/scripts/save-examples.ts
+++ b/packages/e2e-tests/scripts/save-examples.ts
@@ -60,6 +60,8 @@ type TestExampleFile = {
 };
 const examplesJsonPath = join(__dirname, "..", "examples.json");
 
+let mutableExamplesJSON = { ...examplesJson };
+
 const exampleToNewRecordingId: { [example: string]: string } = {};
 
 async function saveRecording(
@@ -105,29 +107,18 @@ async function saveRecording(
   await makeReplayPublic(apiKey, recordingId);
   await updateRecordingTitle(apiKey, recordingId, `E2E Example: ${example}`);
 
-  const json: ExamplesData = {
-    ...examplesJson,
+  mutableExamplesJSON = {
+    ...mutableExamplesJSON,
     [example]: {
-      ...examplesJson[example],
+      ...mutableExamplesJSON[example],
       recording: recordingId,
       buildId,
     },
   };
 
-  const keys = Object.keys(json).sort();
+  const keys = Object.keys(mutableExamplesJSON).sort();
 
-  writeFileSync(
-    examplesJsonPath,
-    JSON.stringify(
-      keys.reduce((accumulated, key) => {
-        accumulated[key] = json[key];
-
-        return accumulated;
-      }, {}),
-      null,
-      2
-    )
-  );
+  writeFileSync(examplesJsonPath, JSON.stringify(mutableExamplesJSON, null, 2));
 
   completeLog();
 }

--- a/packages/e2e-tests/testFixtureCloneRecording.ts
+++ b/packages/e2e-tests/testFixtureCloneRecording.ts
@@ -23,6 +23,14 @@ const testWithCloneRecording = base.extend<TestIsolatedRecordingFixture>({
       throw new Error("Invalid recording");
     }
 
+    if (process.env.REPLAY_DISABLE_CLONE) {
+      await use({
+        page,
+        recordingId: exampleRecordings[exampleKey].recording,
+      });
+      return;
+    }
+
     let newRecordingId: string | undefined = undefined;
     try {
       const { recording } = exampleRecordings[exampleKey];

--- a/yarn.lock
+++ b/yarn.lock
@@ -9754,6 +9754,7 @@ __metadata:
     log-update: ^4
     strip-ansi: ^6.0.0
     ts-node: ^10.7.0
+    ws: ^7.4.6
     yargs: ^17.6.0
   languageName: unknown
   linkType: soft
@@ -18752,6 +18753,21 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 49479ccf3ddab6500c5906fbcc316e9c8cd44b0ffb3903a6c1caf9b38cb9e06691685722a4c642cfa7d4c6eb390424fc3142cd4f8b940cfc7a9ce9761b1cd65b
+  languageName: node
+  linkType: hard
+
+"ws@npm:^7.4.6":
+  version: 7.5.9
+  resolution: "ws@npm:7.5.9"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ^5.0.2
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: c3c100a181b731f40b7f2fddf004aa023f79d64f489706a28bc23ff88e87f6a64b3c6651fbec3a84a53960b75159574d7a7385709847a62ddb7ad6af76f49138
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes SCS-1824.

Discussion around this change: https://discord.com/channels/779097926135054346/1196841641118543994

- Adds env flag to disable cloning for FE Runtime tests.
- Automatically loads recording after saving a new example. Missing two files right now (websocket.ts and protocolClient.ts)

<img width="944" alt="Screenshot 2024-01-17 at 11 48 43 PM" src="https://github.com/replayio/devtools/assets/2629902/523d99e6-ec30-4be9-9b65-cca45f6daec3">

