### PR TITLE
Change email from "help@replay.io" to "support@replay.io"

### DIFF
--- a/packages/replay-next/components/support/SupportForm.tsx
+++ b/packages/replay-next/components/support/SupportForm.tsx
@@ -212,7 +212,7 @@ export function SupportForm({
           </ExternalLink>
           <ExternalLink
             className={styles.Footer}
-            href="mailto:help@replay.io"
+            href="mailto:support@replay.io"
             onClick={closeIfEmpty}
           >
             <svg


### PR DESCRIPTION
We're not sure, but we think help@replay.io might not go anywhere.