### PR TITLE
Lexical CodePlugin properly prevents TAB key from changing focus

### DIFF
--- a/packages/replay-next/components/console/ConsoleInput.tsx
+++ b/packages/replay-next/components/console/ConsoleInput.tsx
@@ -199,6 +199,7 @@ function ConsoleInputSuspends({ inputRef }: { inputRef?: RefObject<ImperativeHan
             key={incrementedKey}
             onChange={onChange}
             onSave={onSubmit}
+            preventTabFocusChange
             ref={inputRef}
             time={time}
           />

--- a/packages/replay-next/components/lexical/CodeEditor.tsx
+++ b/packages/replay-next/components/lexical/CodeEditor.tsx
@@ -66,6 +66,7 @@ type Props = {
   onChange?: (markdown: string, editorState: SerializedEditorState) => void;
   onSave: (markdown: string, editorState: SerializedEditorState) => void;
   placeholder?: string;
+  preventTabFocusChange?: boolean;
   time: number;
 };
 
@@ -84,6 +85,7 @@ function CodeEditor({
   onChange,
   onSave,
   placeholder = "",
+  preventTabFocusChange = false,
   time,
 }: Props): JSX.Element {
   const historyState = useMemo(() => createEmptyHistoryState(), []);
@@ -237,7 +239,7 @@ function CodeEditor({
           ErrorBoundary={LexicalErrorBoundary}
         />
         <FormPlugin onCancel={onFormCancel} onChange={onFormChange} onSubmit={onFormSubmit} />
-        <CodePlugin />
+        <CodePlugin preventTabFocusChange={preventTabFocusChange} />
         <CodeCompletionPlugin
           context={context}
           dataTestId={dataTestId ? `${dataTestId}-CodeTypeAhead` : undefined}

--- a/packages/replay-next/components/lexical/plugins/code/CodePlugin.tsx
+++ b/packages/replay-next/components/lexical/plugins/code/CodePlugin.tsx
@@ -7,7 +7,6 @@ import {
   $isParagraphNode,
   $isRangeSelection,
   $isTextNode,
-  COMMAND_PRIORITY_EDITOR,
   COMMAND_PRIORITY_LOW,
   COMMAND_PRIORITY_NORMAL,
   KEY_ARROW_DOWN_COMMAND,
@@ -29,7 +28,11 @@ import $isCodeNode from "./utils/$isCodeNode";
 import parsedTokensToCodeTextNode from "./utils/parsedTokensToCodeTextNode";
 import parseTokens from "./utils/parseTokens";
 
-export default function CodePlugin(): null {
+export default function CodePlugin({
+  preventTabFocusChange,
+}: {
+  preventTabFocusChange: boolean;
+}): null {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
@@ -46,9 +49,12 @@ export default function CodePlugin(): null {
       }
     }
 
-    const onTabCommand = (_: KeyboardEvent) => {
-      // Tab characters should not indent code blocks.
-      // Tabbing should change focus.
+    const onTabCommand = (event: KeyboardEvent) => {
+      if (preventTabFocusChange) {
+        event.preventDefault();
+      }
+
+      // Tab key should not indent code blocks.
       return true;
     };
 
@@ -76,7 +82,7 @@ export default function CodePlugin(): null {
         COMMAND_PRIORITY_LOW
       )
     );
-  }, [editor]);
+  }, [editor, preventTabFocusChange]);
 
   return null;
 }


### PR DESCRIPTION
If the typeahead auto-complete popup is visible, TAB will continue to select the current option. If it is not open, then the behavior will depend on the newly added `preventTabFocusChange` prop.

1. The Console uses this prop to prevent TAB from changing focus.
2. The log point editor does not use this prop, because I think TAB to accept a log point is useful. (This may be controversial, as Chrome's own log point editor treats TAB as an indentation, not a focus change. Happy to discuss this and change my stance if others disagree.)

cc @Andarist 