### PR TITLE
Improve e2e test scripts

### DIFF
--- a/packages/e2e-tests/examples.json
+++ b/packages/e2e-tests/examples.json
@@ -1,7 +1,8 @@
 {
   "React Hook Form/conditionalField.cy.ts": {
     "recording": "122c4fe7-8a58-4c5c-9639-16b35b5f2ef1",
-    "buildId": "linux-chromium-20230813-7ceb833b4749-fbca4ec81b14"
+    "buildId": "linux-chromium-20230813-7ceb833b4749-fbca4ec81b14",
+    "requiresManualUpdate": true
   },
   "authenticated_comments.html": {
     "recording": "b50dd5b7-ab70-4987-8987-cc3240dd2cf3",
@@ -13,7 +14,8 @@
   },
   "breakpoints-01": {
     "recording": "c8debea5-3270-4728-8f08-2252855897cc",
-    "buildId": "linux-chromium-20230922-bda476c612fc-4d0a9f5b9de2"
+    "buildId": "linux-chromium-20230922-bda476c612fc-4d0a9f5b9de2",
+    "requiresManualUpdate": true
   },
   "cra/dist/index.html": {
     "recording": "757aa270-fc4b-4cdd-867c-743d6524fb7e",
@@ -25,7 +27,8 @@
   },
   "cypress-realworld/bankaccounts.spec.js": {
     "recording": "7c605061-71fe-433d-8926-88e91354d21d",
-    "buildId": "linux-chromium-20231121-eb1e910276b2-0bfd56d9bb06"
+    "buildId": "linux-chromium-20231121-eb1e910276b2-0bfd56d9bb06",
+    "requiresManualUpdate": true
   },
   "doc_async.html": {
     "recording": "26fcd678-77fe-43de-b29c-e7c5ae43e609",
@@ -137,7 +140,8 @@
   },
   "flake/adding-spec.ts": {
     "recording": "7b0db00a-d9a9-4d2d-b816-af14a1b682a6",
-    "buildId": "linux-chromium-20230713-9fb0f2ba86de-cd7086fd0adc"
+    "buildId": "linux-chromium-20230713-9fb0f2ba86de-cd7086fd0adc",
+    "requiresManualUpdate": true
   },
   "log_points_and_block_scope.html": {
     "recording": "1eebc813-d877-4c0d-8eeb-f52e268a9c25",
@@ -185,7 +189,8 @@
   },
   "redux-fundamentals/dist/index.html": {
     "recording": "446b1dd2-407a-4eb1-9798-232a1ba7c67e",
-    "buildId": "macOS-chromium-20240110-e5625ebd3edc-50d01be708a2"
+    "buildId": "macOS-chromium-20240110-e5625ebd3edc-50d01be708a2",
+    "playwrightScript": "examples/redux-fundamentals/tests/example-script"
   },
   "redux/dist/index.html": {
     "recording": "c70d9bf2-bee0-443c-b966-fd542fc43371",

--- a/packages/e2e-tests/examples/redux-fundamentals/tests/example-script.ts
+++ b/packages/e2e-tests/examples/redux-fundamentals/tests/example-script.ts
@@ -60,7 +60,10 @@ function getFiltersPanel(page: Page) {
   return page.locator('div.filters')
 }
 
-export const testFunction = async (page: Page, expect: typeof expectType) => {
+export default async function testFunction(
+  page: Page,
+  expect: typeof expectType
+) {
   const listItems = getTodoListItems(page)
 
   async function waitForListItemsCount(count: number) {

--- a/packages/e2e-tests/helpers/index.ts
+++ b/packages/e2e-tests/helpers/index.ts
@@ -89,9 +89,18 @@ export async function commandPalette(page: Page, query: string) {
   await page.keyboard.press("Enter");
 }
 
+// Intersection (rather than Union) of JSON attributes
+type GetKeys<U> = U extends Record<infer K, any> ? K : never;
+type UnionToIntersection<U extends object> = {
+  [K in GetKeys<U>]: U extends Record<K, infer T> ? T : never;
+};
+
 export type TestRecordingKey = keyof typeof exampleRecordings;
-export type TestRecordingValue = (typeof exampleRecordings)[TestRecordingKey];
-export type ExamplesData = Record<TestRecordingKey, TestRecordingValue>;
+export type TestRecordingUnionValue = (typeof exampleRecordings)[TestRecordingKey];
+export type TestRecordingIntersectionValue = UnionToIntersection<
+  (typeof exampleRecordings)[TestRecordingKey]
+>;
+export type ExamplesData = Record<TestRecordingKey, TestRecordingUnionValue>;
 
 export async function startTest(
   page: Page,

--- a/packages/e2e-tests/print-test-stats.ts
+++ b/packages/e2e-tests/print-test-stats.ts
@@ -15,3 +15,13 @@ console.table(browserSummaryStats);
 console.table(osSummaryStats);
 console.table(releaseYearStats);
 console.table(testFileToInfoMap);
+
+/* Log data in a format easily imported by Google Sheets
+console.log(
+  Object.entries(testFileToInfoMap)
+    .map(([key, { recordingId, runtime, runtimeOS, runtimeReleaseDate }]) => {
+      return [runtimeReleaseDate, runtimeOS, runtime, key, recordingId].join(",");
+    })
+    .join("\n")
+);
+*/

--- a/packages/e2e-tests/scripts/get-stats.ts
+++ b/packages/e2e-tests/scripts/get-stats.ts
@@ -20,7 +20,7 @@ export function getStats() {
   const testFileToInfoMap: {
     [testFile: string]: {
       runtime: string;
-      runtimeReleaseDate: string;
+      runtimeReleaseDate: Date;
       runtimeOS: string;
       recordingId: string;
     };
@@ -73,10 +73,11 @@ export function getStats() {
 
         testFileToInfoMap[relativeFilePath] = {
           runtime,
-          runtimeReleaseDate: `${releaseDate.substring(0, 4)}-${releaseDate.substring(
-            4,
-            6
-          )}-${releaseDate.substring(6)}`,
+          runtimeReleaseDate: new Date(
+            `${releaseDate.substring(0, 4)}-${releaseDate.substring(4, 6)}-${releaseDate.substring(
+              6
+            )} 00:00:00`
+          ),
           runtimeOS: os,
           recordingId: recording,
         };
@@ -131,6 +132,30 @@ export function getStats() {
       releaseYearStats[year].numTests += numTests;
     });
 
+  const sortedTestFileToInfoMap: typeof testFileToInfoMap = {};
+  const entries = Object.entries(testFileToInfoMap).sort((a, b) => {
+    const aValue = a[1];
+    const bValue = b[1];
+
+    if (aValue.runtimeReleaseDate.getTime() !== bValue.runtimeReleaseDate.getTime()) {
+      return aValue.runtimeReleaseDate.getTime() - bValue.runtimeReleaseDate.getTime();
+    } else if (aValue.runtimeOS !== bValue.runtimeOS) {
+      return aValue.runtimeOS.localeCompare(bValue.runtimeOS);
+    } else if (aValue.runtime !== bValue.runtime) {
+      return aValue.runtime.localeCompare(bValue.runtime);
+    } else {
+      return a[0].localeCompare(b[0]);
+    }
+  });
+  entries.forEach(([key, { recordingId, runtime, runtimeOS, runtimeReleaseDate }]) => {
+    sortedTestFileToInfoMap[key] = {
+      runtimeReleaseDate: runtimeReleaseDate.toISOString().slice(0, 10) as any,
+      runtimeOS,
+      runtime,
+      recordingId,
+    };
+  });
+
   return {
     browserSummaryStats,
     exampleToTestMap,
@@ -138,6 +163,6 @@ export function getStats() {
     releaseYearStats,
     sortedStats,
     testFileList,
-    testFileToInfoMap,
+    testFileToInfoMap: sortedTestFileToInfoMap,
   };
 }

--- a/packages/e2e-tests/scripts/save-examples.ts
+++ b/packages/e2e-tests/scripts/save-examples.ts
@@ -4,12 +4,11 @@
 // Use the API key for the "Frontend E2E Test Team" that we have set up in admin,
 // as that should let us mark these recordings as public.
 
-import { existsSync, readFileSync, writeFileSync } from "fs";
+import { existsSync, writeFileSync } from "fs";
 import { join } from "path";
 import type { Page, expect as expectFunction } from "@playwright/test";
 import { removeRecording, uploadRecording } from "@replayio/replay";
 import axios from "axios";
-import { blue, underline, yellow } from "chalk";
 import chalk from "chalk";
 import { dots } from "cli-spinners";
 import logUpdate from "log-update";
@@ -19,8 +18,8 @@ import yargs from "yargs";
 import { SetRecordingIsPrivateVariables } from "../../shared/graphql/generated/SetRecordingIsPrivate";
 import { UpdateRecordingTitleVariables } from "../../shared/graphql/generated/UpdateRecordingTitle";
 import config, { BrowserName } from "../config";
-import { testFunction as reduxFundamentalsScript } from "../examples/redux-fundamentals/tests/example-script";
-import { ExamplesData } from "../helpers";
+import examplesJson from "../examples.json";
+import { ExamplesData, TestRecordingIntersectionValue } from "../helpers";
 import { getStats } from "./get-stats";
 import { recordNodeExample } from "./record-node";
 import { recordPlaywright, uploadLastRecording } from "./record-playwright";
@@ -59,268 +58,6 @@ type TestExampleFile = {
   runtime: "firefox" | "chromium" | "node";
   playwrightScript?: PlaywrightScript;
 };
-
-const knownExamples: TestExampleFile[] = [
-  {
-    filename: "authenticated_comments.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "chromium",
-  },
-  {
-    filename: "authenticated_logpoints.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "chromium",
-  },
-  {
-    filename: "cra/dist/index.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "firefox",
-  },
-  {
-    filename: "cra/dist/index_chromium.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "chromium",
-  },
-  {
-    filename: "redux/dist/index.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "chromium",
-  },
-  {
-    filename: "doc_async.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "chromium",
-  },
-  {
-    filename: "doc_control_flow.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "firefox",
-  },
-  {
-    filename: "doc_debugger_statements.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "chromium",
-  },
-  {
-    filename: "doc_events.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "firefox",
-  },
-  {
-    filename: "doc_events_chromium.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "chromium",
-  },
-  {
-    filename: "doc_exceptions.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "firefox",
-  },
-  {
-    filename: "doc_exceptions_bundle.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "firefox",
-  },
-  {
-    filename: "doc_inspector_basic.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "chromium",
-  },
-  {
-    filename: "doc_inspector_shorthand.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "firefox",
-  },
-  {
-    filename: "doc_inspector_sourcemapped.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "chromium",
-  },
-  {
-    filename: "doc_inspector_styles.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "firefox",
-  },
-  {
-    filename: "doc_minified.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "chromium",
-  },
-  {
-    filename: "doc_navigate.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "chromium",
-  },
-  {
-    filename: "doc_prod_bundle.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "chromium",
-  },
-  {
-    filename: "doc_recursion.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "chromium",
-  },
-  {
-    filename: "doc_rr_basic.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "firefox",
-  },
-  {
-    filename: "doc_rr_blackbox.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "chromium",
-  },
-  {
-    filename: "doc_rr_console.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "chromium",
-  },
-  {
-    filename: "doc_rr_error.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "chromium",
-  },
-  {
-    filename: "doc_rr_logs.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "chromium",
-  },
-  {
-    filename: "doc_rr_objects.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "firefox",
-  },
-  {
-    filename: "doc_rr_preview.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "chromium",
-  },
-  {
-    filename: "doc_rr_region_loading.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "chromium",
-  },
-  {
-    filename: "doc_rr_worker.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "chromium",
-  },
-  {
-    filename: "doc_stacking.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "firefox",
-  },
-  {
-    filename: "doc_stacking_chromium.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "chromium",
-  },
-  {
-    filename: "log_points_and_block_scope.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "chromium",
-  },
-  {
-    filename: "redux-fundamentals/dist/index.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "chromium",
-    playwrightScript: reduxFundamentalsScript,
-  },
-  {
-    filename: "rdt-react-versions/dist/index.html",
-    folder: config.browserExamplesPath,
-    category: "browser",
-    runtime: "chromium",
-  },
-  {
-    filename: "node/control_flow.js",
-    folder: config.nodeExamplesPath,
-    category: "node",
-    runtime: "node",
-  },
-  {
-    filename: "node/async.js",
-    folder: config.nodeExamplesPath,
-    category: "node",
-    runtime: "node",
-  },
-  {
-    filename: "node/basic.js",
-    folder: config.nodeExamplesPath,
-    category: "node",
-    runtime: "node",
-  },
-  {
-    filename: "node/error.js",
-    folder: config.nodeExamplesPath,
-    category: "node",
-    runtime: "node",
-  },
-  {
-    filename: "node/exceptions.js",
-    folder: config.nodeExamplesPath,
-    category: "node",
-    runtime: "node",
-  },
-  {
-    filename: "node/objects.js",
-    folder: config.nodeExamplesPath,
-    category: "node",
-    runtime: "node",
-  },
-  {
-    filename: "node/run_worker.js",
-    folder: config.nodeExamplesPath,
-    category: "node",
-    runtime: "node",
-  },
-  {
-    filename: "node/spawn.js",
-    folder: config.nodeExamplesPath,
-    category: "node",
-    runtime: "node",
-  },
-  // The two separate Cypress examples from "cypress-realworld"
-  // and "flake" are not listed here. We don't re-record those
-  // ourselves. Instead we use specific recordings from CI runs
-  // in those benchmark repos.
-  // Similarly, the "breakpoints-01" recording is not listed here.
-  // See README.md for instructions on updating those recording IDs.
-];
 
 const examplesJsonPath = join(__dirname, "..", "examples.json");
 
@@ -368,6 +105,7 @@ async function saveRecording(
       },
     },
   });
+
   const buildId = response.data.data.recording.buildId;
 
   const done = logAnimated(`Saving ${chalk.bold(example)} with recording id ${recordingId}`);
@@ -383,11 +121,10 @@ async function saveRecording(
   await makeReplayPublic(apiKey, recordingId);
   await updateRecordingTitle(apiKey, recordingId, `E2E Example: ${example}`);
 
-  const text = "" + readFileSync(examplesJsonPath);
-
   const json: ExamplesData = {
-    ...JSON.parse(text),
+    ...examplesJson,
     [example]: {
+      ...examplesJson[example],
       recording: recordingId,
       buildId,
     },
@@ -420,7 +157,52 @@ async function saveExamples(
   examplesTarget: Target,
   callback: (args: TestRunCallbackArgs) => Promise<void>
 ) {
-  let examplesToRun = knownExamples.filter(example => example.category === examplesTarget);
+  let examplesToRun: TestExampleFile[] = [];
+
+  for (const key in examplesJson) {
+    const {
+      buildId,
+      playwrightScript,
+      requiresManualUpdate = false,
+    } = examplesJson[key] as TestRecordingIntersectionValue;
+
+    if (requiresManualUpdate) {
+      // A few of our examples require manual updates;
+      // See README.md for instructions on updating them
+      continue;
+    }
+
+    const [_, runtime] = buildId.split("-");
+
+    let category: TestExampleFile["category"];
+    let folder: TestExampleFile["folder"];
+
+    switch (runtime) {
+      case "chromium":
+      case "gecko": {
+        category = "browser";
+        folder = config.browserExamplesPath;
+        break;
+      }
+      case "node": {
+        category = "node";
+        folder = config.nodeExamplesPath;
+        break;
+      }
+    }
+
+    if (category === examplesTarget) {
+      examplesToRun.push({
+        category,
+        filename: key,
+        folder,
+        runtime: runtime as TestExampleFile["runtime"],
+        playwrightScript: playwrightScript
+          ? require(join("..", playwrightScript)).default
+          : undefined,
+      });
+    }
+  }
 
   const specificExamples = argv.example.split(",").filter(s => s.length > 0);
 
@@ -636,7 +418,7 @@ async function waitUntilMessage(
     );
     console.log(
       newRecordingIds
-        .map(recordingId => ` • ${blue(underline(`https://go/r/${recordingId}`))}`)
+        .map(recordingId => ` • ${chalk.blue(chalk.underline(`https://go/r/${recordingId}`))}`)
         .join("\n")
     );
 
@@ -649,7 +431,7 @@ async function waitUntilMessage(
         .map(example => {
           const tests = exampleToTestMap[example];
 
-          return ` • ${yellow(example)}${tests.map(test => `\n   • ${test}`).join("")}`;
+          return ` • ${chalk.yellow(example)}${tests.map(test => `\n   • ${test}`).join("")}`;
         })
         .join("\n")
     );


### PR DESCRIPTION
We had a lot of redundant, overlapping data between `examples.json` and the hardcoded `knownExamples` array in `save-examples`. I got tired of trying to update an example that was missing from `knownExamples`. There's no reason to have both.