### PR TITLE
Migrate doc_control_flow

### DIFF
--- a/packages/e2e-tests/examples.json
+++ b/packages/e2e-tests/examples.json
@@ -32,8 +32,8 @@
     "buildId": "linux-chromium-20240110-3078216bece0-50d01be708a2"
   },
   "doc_control_flow.html": {
-    "recording": "8b024e1a-1e84-4424-97bd-3c2c528642fd",
-    "buildId": "macOS-gecko-20220722-76bf615bc154-b7eae18423ef"
+    "recording": "822cacfc-40a8-4230-9c80-9ef5b87c4520",
+    "buildId": "macOS-chromium-20240110-3078216bece0-50d01be708a2"
   },
   "doc_debugger_statements.html": {
     "recording": "31dc0307-dfd6-4497-b4c9-11f12d6fa995",

--- a/packages/e2e-tests/examples.json
+++ b/packages/e2e-tests/examples.json
@@ -36,8 +36,8 @@
     "buildId": "macOS-chromium-20240110-3078216bece0-50d01be708a2"
   },
   "doc_debugger_statements.html": {
-    "recording": "31dc0307-dfd6-4497-b4c9-11f12d6fa995",
-    "buildId": "macOS-gecko-20220722-76bf615bc154-b7eae18423ef"
+    "recording": "ed568038-f53c-4788-870c-44ca36967b1c",
+    "buildId": "macOS-chromium-20240110-3078216bece0-50d01be708a2"
   },
   "doc_events.html": {
     "recording": "318c599b-7e5f-4dd5-a34b-0ffb37101e44",

--- a/packages/e2e-tests/tests/repaint.test.ts
+++ b/packages/e2e-tests/tests/repaint.test.ts
@@ -1,5 +1,10 @@
 import { openDevToolsTab, startTest } from "../helpers";
-import { resumeToLine, rewindToLine, stepOver, waitForPaused } from "../helpers/pause-information-panel";
+import {
+  resumeToLine,
+  rewindToLine,
+  stepOver,
+  waitForPaused,
+} from "../helpers/pause-information-panel";
 import { addBreakpoint } from "../helpers/source-panel";
 import { waitFor } from "../helpers/utils";
 import { Page, test } from "../testFixtureCloneRecording";

--- a/packages/e2e-tests/tests/repaint.test.ts
+++ b/packages/e2e-tests/tests/repaint.test.ts
@@ -1,5 +1,5 @@
 import { openDevToolsTab, startTest } from "../helpers";
-import { rewindToLine, stepOver, waitForPaused } from "../helpers/pause-information-panel";
+import { resumeToLine, rewindToLine, stepOver, waitForPaused } from "../helpers/pause-information-panel";
 import { addBreakpoint } from "../helpers/source-panel";
 import { waitFor } from "../helpers/utils";
 import { Page, test } from "../testFixtureCloneRecording";
@@ -18,8 +18,8 @@ test("repaint: repaints the screen screen when stepping over code that modifies 
 
   const prevDataUrl = await getCanvasDataUrl(page);
 
-  await stepOver(page);
-  await waitForPaused(page);
+  await addBreakpoint(page, { lineNumber: 55, url: exampleKey });
+  await resumeToLine(page, 55);
 
   await waitFor(async () => {
     const nextDataUrl = await getCanvasDataUrl(page);


### PR DESCRIPTION
Fixes FE-2187 and FE-2188

Migrates these four gecko tests to chromium
* tests/breakpoints-04.test.ts
* tests/repaint.test.ts
* tests/restart-session.test.ts
* tests/breakpoints-05.test.ts