### PR TITLE
Migrate doc_rr_blackbox.html fixes FE-2192

### DIFF
--- a/packages/e2e-tests/examples.json
+++ b/packages/e2e-tests/examples.json
@@ -96,8 +96,8 @@
     "buildId": "linux-gecko-20230919-72cad6f42a93-4d0a9f5b9de2"
   },
   "doc_rr_blackbox.html": {
-    "recording": "3faddf0d-facb-40f7-91f1-f6c800803b64",
-    "buildId": "macOS-gecko-20220722-76bf615bc154-b7eae18423ef"
+    "recording": "865905de-ffbc-4c52-9c0a-9289df930916",
+    "buildId": "macOS-chromium-20240110-3078216bece0-50d01be708a2"
   },
   "doc_rr_console.html": {
     "recording": "a00acf1e-3dd6-4e75-b909-bad040bc6a91",


### PR DESCRIPTION
migrates `source-line-highlights.test.ts` to chromium