### PR TITLE
Fix file search result summary

### DIFF
--- a/packages/e2e-tests/tests/file-search-01.test.ts
+++ b/packages/e2e-tests/tests/file-search-01.test.ts
@@ -29,8 +29,8 @@ test("file-search-01: should search files", async ({ pageWithMeta: { page, recor
   // Verify search results for the string "test"
   await searchSources(page, "test");
   await verifySourceSearchOverflowMessageShown(page, false);
-  await verifySourceSearchSummary(page, "12 results in 1 file");
-  await verifyVisibleResultsCount(page, 16); // 12 results in 4 different files
+  await verifySourceSearchSummary(page, "12 results in 4 files");
+  await verifyVisibleResultsCount(page, 16);
 
   // Verify files can be collapsed
   await toggleSearchResultsForFileName(page, false, { fileName: "jsonp%20chunk%20loading" });
@@ -44,8 +44,8 @@ test("file-search-01: should search files", async ({ pageWithMeta: { page, recor
   // Now include node_modules in the search
   await toggleExcludeNodeModulesCheckbox(page, false);
   await verifySourceSearchOverflowMessageShown(page, false);
-  await verifySourceSearchSummary(page, "16 results in 1 file");
-  await verifyVisibleResultsCount(page, 22); // 16 results in 6 different files
+  await verifySourceSearchSummary(page, "16 results in 6 files");
+  await verifyVisibleResultsCount(page, 22);
 
   // Collapse the first few results
   await toggleSearchResultsForFileName(page, false, { fileName: "unsupportedIterableToArray.js" });

--- a/packages/replay-next/src/suspense/SearchCache.ts
+++ b/packages/replay-next/src/suspense/SearchCache.ts
@@ -43,9 +43,6 @@ export type StreamingSearchValue = StreamingValue<SourceSearchResult[], Streamin
 
 const MAX_SEARCH_RESULTS_TO_DISPLAY = 1_000;
 
-let sourceIdsWithNodeModules: SourceId[] | null = null;
-let sourceIdsWithoutNodeModules: SourceId[] | null = null;
-
 export function isSourceSearchResultLocation(
   result: SourceSearchResult
 ): result is SourceSearchResultLocation {
@@ -174,7 +171,8 @@ export const searchCache = createStreamingCache<
             orderedResults.push({ match, type: "match" });
           }
 
-          update(orderedResults, undefined, metadata);
+          // Clone results array to avoid breaking/bypassing external memoization
+          update([...orderedResults], undefined, metadata);
         }
       );
 


### PR DESCRIPTION
`SearchCache` pushes results to the same array (`orderedResults`). I think the intention was to avoid recreating a bunch of arrays "unnecessarily" but this caused the `useMemo` memoization to fail, since it would only run on the initial set of results (which might not have all of the files).

I could have fixed this in `SearchResults` by adding `status` as a dependency but then this bug might bite us again some other place so I updated the cache.