### PR TITLE
Increase Playwright command timeout

### DIFF
--- a/packages/e2e-tests/helpers/utils.ts
+++ b/packages/e2e-tests/helpers/utils.ts
@@ -98,6 +98,7 @@ export async function waitForRecordingToFinishIndexing(page: Page): Promise<void
     },
     {
       retryInterval: 1_000,
+      timeout: 150_000,
     }
   );
 }

--- a/packages/e2e-tests/helpers/utils.ts
+++ b/packages/e2e-tests/helpers/utils.ts
@@ -98,7 +98,6 @@ export async function waitForRecordingToFinishIndexing(page: Page): Promise<void
     },
     {
       retryInterval: 1_000,
-      timeout: 150_000,
     }
   );
 }

--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -84,11 +84,11 @@ const config: PlaywrightTestConfig = {
       height: 1024,
     },
     // Don't allow any one action to take more than 15s
-    actionTimeout: 15_000,
+    actionTimeout: 65_000,
   },
 
   expect: {
-    timeout: 10_000,
+    timeout: 15_000,
   },
 
   // Retry failed tests on CI to account for some basic flakiness.

--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -83,8 +83,8 @@ const config: PlaywrightTestConfig = {
       width: 1280,
       height: 1024,
     },
-    // Don't allow any one action to take more than 15s
-    actionTimeout: 65_000,
+    // Don't allow any one action to take more than 60s
+    actionTimeout: 60_000,
   },
 
   expect: {


### PR DESCRIPTION
Related: RUN-3133, RUN-3140, [Discord](https://discord.com/channels/779097926135054346/1197146238282383441/1197557363180318730).

Let's see what happens. (I don't expect this change to make an observable difference in FE e2e tests.)