### PR TITLE
doc_rr_objects: create Date object using the local timezone

### DIFF
--- a/public/test/examples/doc_rr_objects.html
+++ b/public/test/examples/doc_rr_objects.html
@@ -33,7 +33,7 @@ for (let i = 0; i < 20; i++) {
   g[`a${i}`] = i;
 }
 var h = /abc/gi;
-var i = new Date(1666130037374);
+var i = new Date(2022, 9, 18);
 var j = RangeError("foo");
 var k = document.getElementById("foo");
 var l = bar;


### PR DESCRIPTION
The `Date` object was created using a timestamp, which is interpreted in the UTC timezone. But when it is logged, it is stringified for the local timezone and so the console message depended on the timezone where it was recorded.
With this change, the stringified date will still contain the local timezone (e.g. `Tue Oct 18 2022 00:00:00 GMT+0200 (Central European Summer Time)`) but everything before that (i.e. `Tue Oct 18 2022 00:00:00`) will be independent of the local timezone.
See FE-2195.