### PR TITLE
Partially revert "Migrate doc_control_flow (#10188)"

### DIFF
--- a/packages/e2e-tests/examples.json
+++ b/packages/e2e-tests/examples.json
@@ -38,6 +38,10 @@
     "recording": "822cacfc-40a8-4230-9c80-9ef5b87c4520",
     "buildId": "macOS-chromium-20240110-3078216bece0-50d01be708a2"
   },
+  "doc_control_flow_firefox.html": {
+    "recording": "8b024e1a-1e84-4424-97bd-3c2c528642fd",
+    "buildId": "macOS-gecko-20220722-76bf615bc154-b7eae18423ef"
+  },
   "doc_debugger_statements.html": {
     "recording": "ed568038-f53c-4788-870c-44ca36967b1c",
     "buildId": "macOS-chromium-20240110-3078216bece0-50d01be708a2"

--- a/packages/e2e-tests/tests/repaint.test.ts
+++ b/packages/e2e-tests/tests/repaint.test.ts
@@ -1,15 +1,10 @@
 import { openDevToolsTab, startTest } from "../helpers";
-import {
-  resumeToLine,
-  rewindToLine,
-  stepOver,
-  waitForPaused,
-} from "../helpers/pause-information-panel";
+import { rewindToLine, stepOver, waitForPaused } from "../helpers/pause-information-panel";
 import { addBreakpoint } from "../helpers/source-panel";
 import { waitFor } from "../helpers/utils";
 import { Page, test } from "../testFixtureCloneRecording";
 
-test.use({ exampleKey: "doc_control_flow.html" });
+test.use({ exampleKey: "doc_control_flow_firefox.html" });
 
 test("repaint: repaints the screen screen when stepping over code that modifies the DOM", async ({
   pageWithMeta: { page, recordingId },
@@ -18,13 +13,16 @@ test("repaint: repaints the screen screen when stepping over code that modifies 
   await startTest(page, recordingId);
   await openDevToolsTab(page);
 
-  await addBreakpoint(page, { lineNumber: 50, url: exampleKey });
+  await addBreakpoint(page, { lineNumber: 50, url: "doc_control_flow.html" });
   await rewindToLine(page, 50);
 
   const prevDataUrl = await getCanvasDataUrl(page);
 
-  await addBreakpoint(page, { lineNumber: 55, url: exampleKey });
-  await resumeToLine(page, 55);
+  // this steps over a (synchronous) DOM update. The recorded screenshot for the point after the step
+  // will not have changed (because the browser doesn't repaint in the middle of javascript execution),
+  // but the repainted screenshot must have changed.
+  await stepOver(page);
+  await waitForPaused(page);
 
   await waitFor(async () => {
     const nextDataUrl = await getCanvasDataUrl(page);


### PR DESCRIPTION
Bring back the Firefox recording of `doc_control_flow` and revert the changes to `repaint.test.ts`. Since the other tests using `doc_control_flow` work with the Chromium version, I've decided to bring the Firefox version back as `doc_control_flow_firefox`.