### PR TITLE
Update file search expectations in screenshot tests

### DIFF
--- a/packages/replay-next/playwright/tests/source-search/should-expand-and-collapse-sources.ts
+++ b/packages/replay-next/playwright/tests/source-search/should-expand-and-collapse-sources.ts
@@ -16,7 +16,7 @@ beforeEach();
 test("should expand and collapse sources", async ({ page }, testInfo) => {
   await toggleExcludeNodeModulesCheckbox(page, false);
   await searchSources(page, "function t");
-  await verifySourceSearchSummary(page, "3 results in 1 file");
+  await verifySourceSearchSummary(page, "3 results in 3 files");
   await verifyVisibleResultsCount(page, 6);
   await takeScreenshot(
     page,
@@ -55,7 +55,7 @@ test("should expand and collapse sources", async ({ page }, testInfo) => {
 
   await toggleSearchResultsForFileName(page, true, { sourceId: "h1" });
   await toggleSearchResultsForFileName(page, true, { sourceId: "1" });
-  await verifySourceSearchSummary(page, "3 results in 1 file");
+  await verifySourceSearchSummary(page, "3 results in 3 files");
   await verifyVisibleResultsCount(page, 6);
   await takeScreenshot(
     page,

--- a/packages/replay-next/playwright/tests/source-search/should-find-matches-in-multiple-sources.ts
+++ b/packages/replay-next/playwright/tests/source-search/should-find-matches-in-multiple-sources.ts
@@ -16,7 +16,7 @@ beforeEach();
 test("should find matches in multiple sources", async ({ page }, testInfo) => {
   await toggleExcludeNodeModulesCheckbox(page, false);
   await searchSources(page, "function t");
-  await verifySourceSearchSummary(page, "3 results in 1 file");
+  await verifySourceSearchSummary(page, "3 results in 3 files");
   // wait for hit counts to be loaded
   await waitFor(async () =>
     expect(

--- a/packages/replay-next/playwright/tests/source-search/should-include-or-exclude-external-modules-as-requested.ts
+++ b/packages/replay-next/playwright/tests/source-search/should-include-or-exclude-external-modules-as-requested.ts
@@ -13,7 +13,7 @@ beforeEach();
 test("should include or exclude external modules as requested", async ({ page }, testInfo) => {
   await toggleExcludeNodeModulesCheckbox(page, true);
   await searchSources(page, "react");
-  await verifySourceSearchSummary(page, "4 results in 1 file");
+  await verifySourceSearchSummary(page, "4 results in 2 files");
   await verifySourceSearchMatchingLocations(page, ["2", "h1"]);
 
   await toggleExcludeNodeModulesCheckbox(page, false);

--- a/packages/replay-next/playwright/tests/source-search/should-open-a-source-and-scroll-to-the-correct-line.ts
+++ b/packages/replay-next/playwright/tests/source-search/should-open-a-source-and-scroll-to-the-correct-line.ts
@@ -15,7 +15,7 @@ beforeEach();
 test("should open a source and scroll to the correct line", async ({ page }, testInfo) => {
   await toggleExcludeNodeModulesCheckbox(page, false);
   await searchSources(page, "function t");
-  await verifySourceSearchSummary(page, "3 results in 1 file");
+  await verifySourceSearchSummary(page, "3 results in 3 files");
   await verifyVisibleResultsCount(page, 6);
 
   await clickSearchResultRow(page, 6);


### PR DESCRIPTION
The file search result summary was fixed in #10195, these tests were still expecting the old (broken) behavior.