### PR TITLE
Don't run node-based e2e tests in runtime CI

### DIFF
--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -11,7 +11,7 @@
     "test:chromium": "playwright test --project chromium --reporter=@replayio/playwright/reporter,line",
     "test:replay-chromium": "playwright test --project replay-chromium --reporter=@replayio/playwright/reporter,line",
     "test:debug": "playwright test --project chromium --workers 1 --headed",
-    "test:runtime": "playwright test --project chromium --workers 4",
+    "test:runtime": "playwright test --grep-invert node_ --project chromium --workers 4",
     "test:debug_local": "playwright test --project=replay-chromium-local --workers 1 --headed",
     "test:ui": "playwright test --ui",
     "test:install": "playwright install",

--- a/packages/e2e-tests/tests/node_console_dock.test.ts
+++ b/packages/e2e-tests/tests/node_console_dock.test.ts
@@ -8,7 +8,7 @@ import test from "../testFixtureCloneRecording";
 
 test.use({ exampleKey: "node/basic.js" });
 
-test("console_dock_node: Should show the correct docking behavior for recordings without video", async ({
+test("node_console_dock: Should show the correct docking behavior for recordings without video", async ({
   pageWithMeta: { page, recordingId },
   exampleKey,
 }) => {

--- a/packages/e2e-tests/tests/node_quick_open_modal-01.test.ts
+++ b/packages/e2e-tests/tests/node_quick_open_modal-01.test.ts
@@ -5,7 +5,7 @@ import test from "../testFixtureCloneRecording";
 
 test.use({ exampleKey: "node/basic.js" });
 
-test("quick_open_modal-01: Test basic searching functionality", async ({
+test("node_quick_open_modal-01: Test basic searching functionality", async ({
   pageWithMeta: { page, recordingId },
   exampleKey,
 }) => {


### PR DESCRIPTION
Renames two e2e tests so that the names of all tests that use node recordings start with `node_` and adds a playwright option to the `test:runtime` script to filter out these tests.