### PR TITLE
Re-add "events" info to Playwright tests

### DIFF
--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -403,23 +403,22 @@ export default function Toolbar() {
             onClick={handleButtonClick}
           />
         ) : null}
-        {testRunner !== null ? (
-          testRunner === "cypress" ? (
-            <ToolbarButton
-              icon="cypress"
-              label="Cypress Panel"
-              name="cypress"
-              onClick={handleButtonClick}
-            />
-          ) : (
-            <ToolbarButton
-              icon="playwright"
-              label="Test Info"
-              name="cypress"
-              onClick={handleButtonClick}
-            />
-          )
+        {testRunner === "cypress" ? (
+          <ToolbarButton
+            icon="cypress"
+            label="Cypress Panel"
+            name="cypress"
+            onClick={handleButtonClick}
+          />
         ) : (
+          <ToolbarButton
+            icon="playwright"
+            label="Test Info"
+            name="cypress"
+            onClick={handleButtonClick}
+          />
+        )}
+        {testRunner !== "cypress" && (
           <ToolbarButton
             icon="info"
             label="Replay Info"


### PR DESCRIPTION
Playwright recording data isn't rich enough. Doesn't even seem to have execution points anymore so I can't use test steps to seek to the a point in the recording. We need the events back to debug failing e2e tests.