### PR TITLE
Don't fail save-examples if a recording fails to process; RUN: add debug CLI logging for buildkite.

### DIFF
--- a/packages/e2e-tests/scripts/buildkite_run_fe_tests.js
+++ b/packages/e2e-tests/scripts/buildkite_run_fe_tests.js
@@ -52,13 +52,12 @@ function run_fe_tests(CHROME_BINARY_PATH) {
     process.env.REPLAY_BROWSER_BINARY_PATH = CHROME_BINARY_PATH;
     process.env.REPLAY_CHROMIUM_EXECUTABLE_PATH = CHROME_BINARY_PATH;
     process.env.RECORD_REPLAY_PATH = CHROME_BINARY_PATH;
-    // process.env.RECORD_REPLAY_DIRECTORY =
     process.env.AUTHENTICATED_TESTS_WORKSPACE_API_KEY = process.env.RECORD_REPLAY_API_KEY;
     process.env.PLAYWRIGHT_TEST_BASE_URL = "https://app.replay.io";
     process.env.REPLAY_DISABLE_CLONE = "true";
 
     execSync(
-      `xvfb-run ./packages/e2e-tests/scripts/save-examples.ts --runtime=chromium --target=browser --project=replay-chromium-local`,
+      `xvfb-run DEBUG=replay:cli ./packages/e2e-tests/scripts/save-examples.ts --runtime=chromium --target=browser --project=replay-chromium-local`,
       { stdio: "inherit", env: process.env }
     );
 

--- a/packages/e2e-tests/scripts/loadRecording.ts
+++ b/packages/e2e-tests/scripts/loadRecording.ts
@@ -29,9 +29,11 @@ export async function loadRecording(recordingId: string) {
   const client = new SimpleProtocolClient(new WebSocket(DISPATCH_URL), callbacks, console.log);
   client.addEventListener("Recording.processRecordingProgress", onProgress);
 
-  await client.sendCommand("Recording.processRecording", {
-    recordingId,
-  });
-
-  completeLog();
+  try {
+    await client.sendCommand("Recording.processRecording", {
+      recordingId,
+    });
+  } finally {
+    completeLog();
+  }
 }

--- a/packages/e2e-tests/scripts/save-examples.ts
+++ b/packages/e2e-tests/scripts/save-examples.ts
@@ -386,7 +386,11 @@ async function waitUntilMessage(
     const { exampleToTestMap } = getStats();
 
     for (const recordingId of newRecordingIds) {
-      await loadRecording(recordingId);
+      try {
+        await loadRecording(recordingId);
+      } catch (e) {
+        console.log(`Error during processing: ${e}`);
+      }
     }
 
     console.log("The following tests have been impacted by this change:");
@@ -394,8 +398,9 @@ async function waitUntilMessage(
       updatedExamples
         .map(example => {
           const tests = exampleToTestMap[example];
-
-          return ` • ${chalk.yellow(example)}${tests.map(test => `\n   • ${test}`).join("")}`;
+          return tests
+            ? ` • ${chalk.yellow(example)}${tests.map(test => `\n   • ${test}`).join("")}`
+            : "";
         })
         .join("\n")
     );

--- a/packages/e2e-tests/scripts/save-examples.ts
+++ b/packages/e2e-tests/scripts/save-examples.ts
@@ -400,7 +400,7 @@ async function waitUntilMessage(
           const tests = exampleToTestMap[example];
           return tests
             ? ` • ${chalk.yellow(example)}${tests.map(test => `\n   • ${test}`).join("")}`
-            : "";
+            : ` • ${chalk.red(example)} is updated, but has no associated tests`;
         })
         .join("\n")
     );


### PR DESCRIPTION
Also add a fix if a given example key has no associated tests.