### PR TITLE
Change email from help@replay.io to support@replay.io

### DIFF
--- a/packages/replay-next/components/support/SupportForm.tsx
+++ b/packages/replay-next/components/support/SupportForm.tsx
@@ -212,7 +212,7 @@ export function SupportForm({
           </ExternalLink>
           <ExternalLink
             className={styles.Footer}
-            href="mailto:help@replay.io"
+            href="mailto:support@replay.io"
             onClick={closeIfEmpty}
           >
             <svg


### PR DESCRIPTION
support@replay.io is referred to throughout our codebase, docs, and on the internet. help@replay.io is a new email address that is redundant. With this change, all the known ways to contact us will route correctly.