### PR TITLE
Fix focus mode icon in light theme

### DIFF
--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -528,7 +528,7 @@
 
   /* DevTools header (Dark) */
   --theme-toggle-bgcolor: var(--theme-base-85);
-  --theme-toggle-color: white;
+  --theme-toggle-color: var(--theme-icon-color);
   --theme-toggle-handle-bgcolor: var(--theme-base-100);
   --title-hover-bgcolor: var(--theme-toggle-bgcolor);
 
@@ -1074,7 +1074,7 @@
   /* DevTools header (Light) */
 
   --theme-toggle-bgcolor: var(--theme-base-85);
-  --theme-toggle-color: var(--grey-70);
+  --theme-toggle-color: var(--theme-icon-color);
   --theme-toggle-handle-bgcolor: var(--theme-base-100);
   --title-hover-bgcolor: #e6e6e6;
 

--- a/src/ui/components/Timeline/EditFocusButton.module.css
+++ b/src/ui/components/Timeline/EditFocusButton.module.css
@@ -27,5 +27,5 @@
   color: white;
 }
 .ToggleOffIcon {
-  background-color: var(--theme-icon-color);
+  background-color: var(--theme-toggle-color);
 }

--- a/src/ui/components/Timeline/EditFocusButton.module.css
+++ b/src/ui/components/Timeline/EditFocusButton.module.css
@@ -27,5 +27,5 @@
   color: white;
 }
 .ToggleOffIcon {
-  background-color: var(--theme-toggle-color);
+  background-color: var(--theme-icon-color);
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -71,7 +71,6 @@ module.exports = {
         themeTextFieldColor: "var(--theme-text-field-color)",
         themeToggleBgcolor: "var(--theme-toggle-bgcolor)",
         themeToggleHandleBgcolor: "var(--theme-toggle-handle-bgcolor)",
-        themeToggleColor: "var(--theme-toggle-color)",
         themeToolbarPanelIconColor: "var(--theme-toolbar-panel-icon-color)",
         toolbarBackground: "var(--theme-toolbar-background)",
         toolbarBackgroundHover: "var(--theme-toolbar-background-hover)",


### PR DESCRIPTION
Now:
<img width="210" alt="image" src="https://github.com/replayio/devtools/assets/9154902/fb099ee6-4a61-44f4-b1e6-6edc867e8a25">
<img width="210" alt="image" src="https://github.com/replayio/devtools/assets/9154902/d9e34a88-b4f8-4939-9768-d0a3822283bd">


After fix:
<img width="210" alt="image" src="https://github.com/replayio/devtools/assets/9154902/cfa4a5ce-0ad0-44d6-8ef2-3e74d7e20803">
<img width="210" alt="image" src="https://github.com/replayio/devtools/assets/9154902/e8fea265-f4fa-489a-a68a-0d2934d75409">


**Summary**
Obviously the icon should appear, so this fixes that. Specifically:

* This is an icon, so we're pointing to our standard icon color
* We don't use the tailwind version of this anywhere so I removed that line