### PR TITLE
Remove "basic processing progress" feature

### DIFF
--- a/packages/protocol/graphics.ts
+++ b/packages/protocol/graphics.ts
@@ -115,10 +115,6 @@ const gMouseClickEvents: MouseEvent[] = [];
 let gDevicePixelRatio = 1;
 
 function onPaints(paints: PaintPoint[]) {
-  if (typeof onPointsReceived === "function") {
-    onPointsReceived(paints);
-  }
-
   paints.forEach(async ({ point, time, screenShots }) => {
     const paintHash = screenShots.find(desc => desc.mimeType == "image/jpeg")!.hash;
     insertEntrySorted(gPaintPoints, { point, time, paintHash });
@@ -126,10 +122,6 @@ function onPaints(paints: PaintPoint[]) {
 }
 
 function onMouseEvents(events: MouseEvent[]) {
-  if (typeof onPointsReceived === "function") {
-    onPointsReceived(events);
-  }
-
   events.forEach(entry => {
     insertEntrySorted(gMouseEvents, entry);
     if (entry.kind == "mousedown") {
@@ -178,7 +170,6 @@ export function setupGraphics(store: AppStore) {
     client.Graphics.findPaints({}, sessionId).then(async () => {
       initialPaintsReceivedWaiter.resolve(null);
       hasAllPaintPoints = true;
-      onAllPaintsReceived(true);
       maybePaintGraphics();
     });
 
@@ -624,16 +615,6 @@ export function setPausedonPausedAtTimeCallback(callback: typeof onPausedAtTime)
 let onPlaybackStatus: (stalled: boolean) => void;
 export function setPlaybackStatusCallback(callback: typeof onPlaybackStatus): void {
   onPlaybackStatus = callback;
-}
-
-let onPointsReceived: (points: TimeStampedPoint[]) => void;
-export function setPointsReceivedCallback(callback: typeof onPointsReceived): void {
-  onPointsReceived = callback;
-}
-
-let onAllPaintsReceived: (received: boolean) => void;
-export function setAllPaintsReceivedCallback(callback: typeof onAllPaintsReceived): void {
-  onAllPaintsReceived = callback;
 }
 
 let onRefreshGraphics: (canvas: Canvas) => void;

--- a/packages/replay-next/src/suspense/AnalysisCache.ts
+++ b/packages/replay-next/src/suspense/AnalysisCache.ts
@@ -77,7 +77,6 @@ export function createAnalysisCache<
     load: async (begin, end, client, ...paramsWithCacheLoadOptions) => {
       const params = paramsWithCacheLoadOptions.slice(0, -1) as TParams;
       const points = await findPoints(client, begin, end, ...params);
-      onPointsReceived?.(points);
 
       if (points.length === 0) {
         return [];
@@ -170,9 +169,4 @@ export function createAnalysisCache<
     pointsIntervalCache,
     resultsCache,
   };
-}
-
-let onPointsReceived: ((points: TimeStampedPoint[]) => void) | undefined;
-export function setPointsReceivedCallback(callback: typeof onPointsReceived): void {
-  onPointsReceived = callback;
 }

--- a/packages/shared/user-data/GraphQL/UserData.test.ts
+++ b/packages/shared/user-data/GraphQL/UserData.test.ts
@@ -58,7 +58,7 @@ describe("UserData", () => {
   it("should return default values for preferences not in localStorage or GraphQL", () => {
     const userData = require("./UserData").userData;
 
-    expect(userData.get("feature_basicProcessingLoadingBar")).toBe(false);
+    expect(userData.get("feature_commentAttachments")).toBe(false);
     expect(userData.get("layout_breakpointsPanelExpanded")).toBe(true);
   });
 
@@ -74,8 +74,7 @@ describe("UserData", () => {
       }
     });
 
-    window.location.search =
-      "?features=feature_basicProcessingLoadingBar,layout_sidePanelCollapsed";
+    window.location.search = "?features=feature_commentAttachments,layout_sidePanelCollapsed";
 
     const userData = require("./UserData").userData;
 
@@ -83,7 +82,7 @@ describe("UserData", () => {
     expect(userData.get("layout_sidePanelCollapsed")).toBe(true);
 
     // null in localStorage, defaults to false, but true in URL
-    expect(userData.get("feature_basicProcessingLoadingBar")).toBe(true);
+    expect(userData.get("feature_commentAttachments")).toBe(true);
   });
 
   it("should read/write values to localStorage", async () => {

--- a/packages/shared/user-data/GraphQL/config.ts
+++ b/packages/shared/user-data/GraphQL/config.ts
@@ -148,14 +148,6 @@ export const config = {
     legacyKey: "devtools.debugger.ui.framework-grouping-on",
   },
 
-  feature_basicProcessingLoadingBar: {
-    defaultValue: Boolean(false),
-    description:
-      "Split the loading bar's progress between gathering static resources from the recording and indexing runtime information",
-    label: "Detailed loading bar",
-    legacyKey: "devtools.features.basicProcessingLoadingBar",
-  },
-
   feature_chromiumNetMonitor: {
     defaultValue: Boolean(true),
     legacyKey: "devtools.features.chromiumNetMonitor",

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -78,7 +78,7 @@ import {
   getRecordingDuration,
   getShowFocusModeControls,
   getZoomRegion,
-  pointsReceived,
+  setEndpoint,
   setPlaybackPrecachedTime,
 } from "ui/reducers/timeline";
 import { getMutableParamsFromURL } from "ui/setup/dynamic/url";
@@ -126,8 +126,10 @@ export function jumpToInitialPausePoint(): UIThunkAction<Promise<void>> {
   return async (dispatch, getState, { replayClient }) => {
     const recordingId = getRecordingId(getState());
     assert(recordingId);
+
     const endpoint = await sessionEndPointCache.readAsync(replayClient);
-    dispatch(pointsReceived([endpoint]));
+    dispatch(setEndpoint(endpoint));
+
     let { point, time } = endpoint;
 
     const state = getState();

--- a/src/ui/components/SessionContextAdapter.tsx
+++ b/src/ui/components/SessionContextAdapter.tsx
@@ -5,7 +5,7 @@ import { SessionContext, SessionContextType } from "replay-next/src/contexts/Ses
 import { useGetRecordingId } from "ui/hooks/recordings";
 import { useGetUserInfo } from "ui/hooks/users";
 import { getAccessToken, getSessionId } from "ui/reducers/app";
-import { getPoints, getRecordingDuration } from "ui/reducers/timeline";
+import { getEndpoint, getRecordingDuration } from "ui/reducers/timeline";
 import { useAppSelector } from "ui/setup/hooks";
 import { trackEventOnce } from "ui/utils/mixpanel";
 import { trackEvent } from "ui/utils/telemetry";
@@ -30,8 +30,7 @@ export default function SessionContextAdapter({
   const accessToken = useAppSelector(getAccessToken);
   const sessionId = useAppSelector(getSessionId);
   const duration = useAppSelector(getRecordingDuration)!;
-  const receivedPoints = useAppSelector(getPoints);
-  const endpoint = receivedPoints[receivedPoints.length - 1];
+  const endpoint = useAppSelector(getEndpoint);
 
   const sessionContext = useMemo<SessionContextType>(
     () => ({

--- a/src/ui/components/Timeline/Capsule.tsx
+++ b/src/ui/components/Timeline/Capsule.tsx
@@ -4,10 +4,9 @@ import { CircularProgressbar, buildStyles } from "react-circular-progressbar";
 
 import ExternalLink from "replay-next/components/ExternalLink";
 import { useIndexingProgress } from "replay-next/src/hooks/useIndexingProgress";
-import { useGraphQLUserData } from "shared/user-data/GraphQL/useGraphQLUserData";
 import { useLoadingIsSlow } from "ui/components/Timeline/useLoadingIsSlow";
 import useModalDismissSignal from "ui/hooks/useModalDismissSignal";
-import { getBasicProcessingProgress, getShowFocusModeControls } from "ui/reducers/timeline";
+import { getShowFocusModeControls } from "ui/reducers/timeline";
 import { useAppSelector } from "ui/setup/hooks";
 
 import Icon from "../shared/Icon";
@@ -22,14 +21,7 @@ export default function Capsule({
 }: {
   setShowLoadingProgress: React.Dispatch<React.SetStateAction<boolean>>;
 }) {
-  const indexingProgress = useIndexingProgress();
-  const basicProcessingProgress = Math.round(useAppSelector(getBasicProcessingProgress) * 100);
-  const [basicProcessingLoadingBar] = useGraphQLUserData("feature_basicProcessingLoadingBar");
-
-  let progress = indexingProgress;
-  if (basicProcessingLoadingBar) {
-    progress = Math.round((basicProcessingProgress + indexingProgress) / 2);
-  }
+  const progress = useIndexingProgress();
 
   const showFocusModeControls = useAppSelector(getShowFocusModeControls);
 

--- a/src/ui/components/shared/UserSettingsModal/panels/Advanced.tsx
+++ b/src/ui/components/shared/UserSettingsModal/panels/Advanced.tsx
@@ -10,7 +10,6 @@ export const PREFERENCES: PreferencesKey[] = [
   "backend_newControllerOnRefresh",
   "protocol_chromiumRepaints",
   "backend_profileWorkerThreads",
-  "feature_basicProcessingLoadingBar",
   "backend_disableCache",
   "backend_disableScanDataCache",
   "backend_enableRoutines",

--- a/src/ui/state/timeline.ts
+++ b/src/ui/state/timeline.ts
@@ -12,7 +12,6 @@ export interface ZoomRegion {
 }
 
 export interface TimelineState {
-  allPaintsReceived: boolean;
   currentTime: number;
   dragging: boolean;
   focusWindow: TimeRange | null;
@@ -20,7 +19,6 @@ export interface TimelineState {
   hoverTime: number | null;
   markTimeStampedPoint: TimeStampedPoint | null;
   maxRecordingDurationForRoutines: number;
-  paints: TimeStampedPoint[];
   playback: {
     beginTime: number;
     beginDate: number;
@@ -28,7 +26,7 @@ export interface TimelineState {
   } | null;
   playbackFocusWindow: boolean;
   playbackPrecachedTime: number;
-  points: TimeStampedPoint[];
+  endpoint: TimeStampedPoint;
   recordingDuration: number | null;
   shouldAnimate: boolean;
   showFocusModeControls: boolean;
@@ -38,8 +36,8 @@ export interface TimelineState {
 }
 
 export interface HoveredItem {
-  target: "timeline" | "console" | "widget" | "transcript";
   point?: string;
+  target: "timeline" | "console" | "widget" | "transcript";
   time?: number;
   location?: HoveredLocation;
 }


### PR DESCRIPTION
This feature was a hacky workaround for the problem of loading being "stuck" ([DES-82](https://linear.app/replay/issue/DES-82/sometimes-loading-appears-stuck-at-0percent)). We now have a much better solution in place for this– explicitly wait on the backend to complete processing before loading DevTools UI (FE-2170).

This feature was disabled by default as an _advanced_ setting, so deleting it should have minimal user impact.

Removing this code allows us to also remove the redundant `timeline.paints` and `timeline.points` values from Redux, which has the added benefit of unblocking some [planned refactoring work](https://www.notion.so/replayio/Untangling-legacy-graphics-code-d1d999faf7414f47ab9996ae92f717ff).