### PR TITLE
Fix bug in joinChunksToString() parsing

### DIFF
--- a/packages/replay-next/src/utils/protocol.ts
+++ b/packages/replay-next/src/utils/protocol.ts
@@ -409,7 +409,12 @@ export function splitStringToChunks(string: string) {
 export function joinChunksToString(chunks: ProtocolProperty[]): string {
   let string = "";
   for (const prop of chunks) {
-    string += prop.value;
+    // Only iterate over array indices here;
+    // other properties (e.g. "length") should be ignored
+    const maybeNumber = parseInt(prop.name);
+    if (!Number.isNaN(maybeNumber)) {
+      string += prop.value;
+    }
   }
 
   return string;


### PR DESCRIPTION
If I'm understanding this correctly. I tested this by running...
```sh
# Download pending Replay build
RECORD_REPLAY_CHROMIUM_DOWNLOAD_FILE=macOS-chromium-20240125-cace42634490-50d01be708a2-dev-arm.tar.xz \
  replay update-browsers

# Re-record example with new build
./scripts/save-examples.ts --example=doc_stacking_chromium.html

# Run e2e test that was previously broken (now passes)
yarn test:debug tests/elements-search.test.ts
```