### PR TITLE
Suspense caches for paint (points) and recorded mouse events

### DIFF
--- a/packages/protocol/PaintsCache.ts
+++ b/packages/protocol/PaintsCache.ts
@@ -1,0 +1,56 @@
+import { createCache } from "suspense";
+
+import { recordingCapabilitiesCache } from "replay-next/src/suspense/BuildIdCache";
+import { findIndex } from "replay-next/src/utils/array";
+import { replayClient } from "shared/client/ReplayClientContext";
+import { TimeStampedPointWithPaintHash } from "shared/client/types";
+
+// This could be a streaming cache, but streaming APIs are more awkward to interop with
+// Since we wait for processing to complete before loading a recording, paints should always load very quickly
+export const PaintsCache = createCache<[], TimeStampedPointWithPaintHash[]>({
+  config: { immutable: true },
+  debugLabel: "PaintsCache",
+  getKey: () => ``, // Single entry cache
+  load: async ([]) => {
+    const recordingCapabilities = await recordingCapabilitiesCache.readAsync(replayClient);
+    if (recordingCapabilities.supportsRepaintingGraphics) {
+      return await replayClient.findPaints();
+    } else {
+      return [];
+    }
+  },
+});
+
+export function mostRecentPaint(time: number) {
+  const paints = PaintsCache.getValueIfCached() ?? [];
+
+  const index = findIndex(
+    paints,
+    { paintHash: "", point: "", time },
+    (a, b) => a.time - b.time,
+    false
+  );
+
+  // This is the nearest paint, but it may be before or after the time
+  const paint = paints[index];
+
+  if (paint.time <= time) {
+    return paint;
+  } else if (index > 0) {
+    return paints[index - 1];
+  } else {
+    return null;
+  }
+}
+
+// TODO [FE-2401] Do we need to keep this method? Maybe not.
+export function timeIsBeyondKnownPaints(time: number) {
+  const paints = PaintsCache.getValueIfCached();
+  if (!paints) {
+    return false;
+  }
+
+  const lastPoint = paints[paints.length - 1];
+
+  return lastPoint.time < time;
+}

--- a/packages/protocol/PaintsCache.ts
+++ b/packages/protocol/PaintsCache.ts
@@ -1,6 +1,6 @@
 import { createSingleEntryCache } from "suspense";
 
-import { recordingCapabilitiesCache } from "replay-next/src/suspense/BuildIdCache";
+import { recordingTargetCache } from "replay-next/src/suspense/BuildIdCache";
 import { findIndex } from "replay-next/src/utils/array";
 import { replayClient } from "shared/client/ReplayClientContext";
 import { TimeStampedPointWithPaintHash } from "shared/client/types";
@@ -11,12 +11,14 @@ export const PaintsCache = createSingleEntryCache<[], TimeStampedPointWithPaintH
   config: { immutable: true },
   debugLabel: "PaintsCache",
   load: async ([]) => {
-    const recordingCapabilities = await recordingCapabilitiesCache.readAsync(replayClient);
-    if (recordingCapabilities.supportsRepaintingGraphics) {
-      return await replayClient.findPaints();
-    } else {
-      return [];
+    const target = await recordingTargetCache.readAsync(replayClient);
+    switch (target) {
+      case "node": {
+        return [];
+      }
     }
+
+    return await replayClient.findPaints();
   },
 });
 

--- a/packages/protocol/PaintsCache.ts
+++ b/packages/protocol/PaintsCache.ts
@@ -1,4 +1,4 @@
-import { createCache } from "suspense";
+import { createSingleEntryCache } from "suspense";
 
 import { recordingCapabilitiesCache } from "replay-next/src/suspense/BuildIdCache";
 import { findIndex } from "replay-next/src/utils/array";
@@ -7,10 +7,9 @@ import { TimeStampedPointWithPaintHash } from "shared/client/types";
 
 // This could be a streaming cache, but streaming APIs are more awkward to interop with
 // Since we wait for processing to complete before loading a recording, paints should always load very quickly
-export const PaintsCache = createCache<[], TimeStampedPointWithPaintHash[]>({
+export const PaintsCache = createSingleEntryCache<[], TimeStampedPointWithPaintHash[]>({
   config: { immutable: true },
   debugLabel: "PaintsCache",
-  getKey: () => ``, // Single entry cache
   load: async ([]) => {
     const recordingCapabilities = await recordingCapabilitiesCache.readAsync(replayClient);
     if (recordingCapabilities.supportsRepaintingGraphics) {

--- a/packages/protocol/RecordedEventsCache.ts
+++ b/packages/protocol/RecordedEventsCache.ts
@@ -1,0 +1,31 @@
+import { KeyboardEvent, MouseEvent, NavigationEvent } from "@replayio/protocol";
+import { createCache } from "suspense";
+
+import { replayClient } from "shared/client/ReplayClientContext";
+
+export const RecordedKeyboardEventsCache = createCache<[], KeyboardEvent[]>({
+  config: { immutable: true },
+  debugLabel: "RecordedKeyboardEventsCache",
+  getKey: () => ``, // Single entry cache
+  load: async () => {
+    return replayClient.findKeyboardEvents();
+  },
+});
+
+export const RecordedMouseEventsCache = createCache<[], MouseEvent[]>({
+  config: { immutable: true },
+  debugLabel: "RecordedMouseEventsCache",
+  getKey: () => ``, // Single entry cache
+  load: async () => {
+    return replayClient.findMouseEvents();
+  },
+});
+
+export const RecordedNavigationEventsCache = createCache<[], NavigationEvent[]>({
+  config: { immutable: true },
+  debugLabel: "RecordedNavigationEventsCache",
+  getKey: () => ``, // Single entry cache
+  load: async () => {
+    return replayClient.findNavigationEvents();
+  },
+});

--- a/packages/protocol/RecordedEventsCache.ts
+++ b/packages/protocol/RecordedEventsCache.ts
@@ -1,30 +1,27 @@
 import { KeyboardEvent, MouseEvent, NavigationEvent } from "@replayio/protocol";
-import { createCache } from "suspense";
+import { createSingleEntryCache } from "suspense";
 
 import { replayClient } from "shared/client/ReplayClientContext";
 
-export const RecordedKeyboardEventsCache = createCache<[], KeyboardEvent[]>({
+export const RecordedKeyboardEventsCache = createSingleEntryCache<[], KeyboardEvent[]>({
   config: { immutable: true },
   debugLabel: "RecordedKeyboardEventsCache",
-  getKey: () => ``, // Single entry cache
   load: async () => {
     return replayClient.findKeyboardEvents();
   },
 });
 
-export const RecordedMouseEventsCache = createCache<[], MouseEvent[]>({
+export const RecordedMouseEventsCache = createSingleEntryCache<[], MouseEvent[]>({
   config: { immutable: true },
   debugLabel: "RecordedMouseEventsCache",
-  getKey: () => ``, // Single entry cache
   load: async () => {
     return replayClient.findMouseEvents();
   },
 });
 
-export const RecordedNavigationEventsCache = createCache<[], NavigationEvent[]>({
+export const RecordedNavigationEventsCache = createSingleEntryCache<[], NavigationEvent[]>({
   config: { immutable: true },
   debugLabel: "RecordedNavigationEventsCache",
-  getKey: () => ``, // Single entry cache
   load: async () => {
     return replayClient.findNavigationEvents();
   },

--- a/packages/protocol/graphics.ts
+++ b/packages/protocol/graphics.ts
@@ -1,19 +1,18 @@
 // Routines for managing and rendering graphics data fetched over the WRP.
-import { MouseEvent, PaintPoint, ScreenShot, TimeStampedPoint } from "@replayio/protocol";
-import maxBy from "lodash/maxBy";
+import { MouseEvent, ScreenShot } from "@replayio/protocol";
 
 import {
   getExecutionPoint,
   getPauseId,
   getTime,
+  paused,
 } from "devtools/client/debugger/src/reducers/pause";
-import { paused } from "devtools/client/debugger/src/reducers/pause";
-import {
-  recordingCapabilitiesCache,
-  recordingTargetCache,
-} from "replay-next/src/suspense/BuildIdCache";
+import { PaintsCache, timeIsBeyondKnownPaints } from "protocol/PaintsCache";
+import { RecordedMouseEventsCache } from "protocol/RecordedEventsCache";
+import { recordingCapabilitiesCache } from "replay-next/src/suspense/BuildIdCache";
 import { screenshotCache } from "replay-next/src/suspense/ScreenshotCache";
 import { replayClient } from "shared/client/ReplayClientContext";
+import { TimeStampedPointWithPaintHash } from "shared/client/types";
 import { startAppListening } from "ui/setup/listenerMiddleware";
 import { AppStore } from "ui/setup/store";
 import { getCurrentPauseId } from "ui/utils/app";
@@ -94,94 +93,40 @@ function closerEntry<T1 extends Timed, T2 extends Timed>(
 // Paint / Mouse Event Points
 //////////////////////////////
 
-export interface TimeStampedPointWithPaintHash extends TimeStampedPoint {
-  paintHash: string;
-}
-
-// All paints that have occurred in the recording, in order. Include the
-// beginning point of the recording as well, which is not painted and has
-// a known point and time.
+// TODO [FE-2104] Delete these arrays
 export const gPaintPoints: TimeStampedPointWithPaintHash[] = [
   { point: "0", time: 0, paintHash: "" },
 ];
-
-// All mouse events that have occurred in the recording, in order.
 const gMouseEvents: MouseEvent[] = [];
-
-// All mouse click events that have occurred in the recording, in order.
 const gMouseClickEvents: MouseEvent[] = [];
 
 // Device pixel ratio used by the current screenshot.
 let gDevicePixelRatio = 1;
 
-function onPaints(paints: PaintPoint[]) {
-  paints.forEach(async ({ point, time, screenShots }) => {
-    const paintHash = screenShots.find(desc => desc.mimeType == "image/jpeg")!.hash;
-    insertEntrySorted(gPaintPoints, { point, time, paintHash });
-  });
-}
+export async function setupGraphics(store: AppStore) {
+  await Promise.all([PaintsCache.readAsync(), RecordedMouseEventsCache.readAsync()]);
 
-function onMouseEvents(events: MouseEvent[]) {
-  events.forEach(entry => {
-    insertEntrySorted(gMouseEvents, entry);
+  // TODO [FE-2104] Remove gPaintPoints entirely
+  gPaintPoints.push(...PaintsCache.getValue());
+
+  // TODO [FE-2104] Remove gMouseEvents and gMouseClickEvents entirely
+  RecordedMouseEventsCache.getValue().forEach(entry => {
+    gMouseEvents.push(entry);
     if (entry.kind == "mousedown") {
-      insertEntrySorted(gMouseClickEvents, entry);
+      gMouseClickEvents.push(entry);
     }
   });
 
+  // TODO [FE-2104] Remove this callback
   if (typeof onMouseDownEvents === "function") {
     onMouseDownEvents(gMouseClickEvents);
   }
-}
 
-export let hasAllPaintPoints = false;
-
-export const setHasAllPaintPoints = (newValue: boolean) => {
-  hasAllPaintPoints = newValue;
-};
-export const timeIsBeyondKnownPaints = (time: number) =>
-  !hasAllPaintPoints && gPaintPoints[gPaintPoints.length - 1].time < time;
-
-export function setupGraphics(store: AppStore) {
-  replayClient.waitForSession().then(async (sessionId: string) => {
-    let paintedGraphics = false;
-    const maybePaintGraphics = async () => {
-      if (!paintedGraphics) {
-        const { screen, mouse } = await getGraphicsAtTime(getTime(store.getState()), false, true);
-        if (screen) {
-          paintedGraphics = true;
-          paintGraphics(screen, mouse);
-        }
-      }
-    };
-
-    const { client } = await import("./socket");
-    client.Graphics.addPaintPointsListener(async ({ paints }) => {
-      onPaints(paints);
-      if (gPaintPoints.length >= INITIAL_PAINT_COUNT) {
-        initialPaintsReceivedWaiter.resolve(null);
-      }
-      const latestPaint = BigInt(maxBy(paints, p => BigInt(p.point))?.point || 0);
-      const currentPoint = getExecutionPoint(store.getState());
-      if (currentPoint && latestPaint >= BigInt(currentPoint)) {
-        maybePaintGraphics();
-      }
-    });
-    client.Graphics.findPaints({}, sessionId).then(async () => {
-      initialPaintsReceivedWaiter.resolve(null);
-      hasAllPaintPoints = true;
-      maybePaintGraphics();
-    });
-
-    client.Session.addMouseEventsListener(({ events }) => onMouseEvents(events));
-    client.Session.findMouseEvents({}, sessionId);
-
-    const recordingTarget = await recordingTargetCache.readAsync(replayClient);
-    if (recordingTarget === "node") {
-      // Make sure we never wait for any paints when trying to do things like playback
-      setHasAllPaintPoints(true);
-    }
-  });
+  const currentTime = getTime(store.getState());
+  const { screen, mouse } = await getGraphicsAtTime(currentTime, false);
+  if (screen) {
+    paintGraphics(screen, mouse);
+  }
 
   async function repaint() {
     const state = store.getState();
@@ -566,10 +511,10 @@ async function getScreenshotDimensions(screen: ScreenShot) {
 
 // the maximum number of paints to be considered when looking for the first meaningful paint
 const INITIAL_PAINT_COUNT = 10;
-const initialPaintsReceivedWaiter = defer();
 
 export async function getFirstMeaningfulPaint() {
-  await initialPaintsReceivedWaiter.promise;
+  await PaintsCache.readAsync();
+
   for (const paintPoint of gPaintPoints.slice(0, INITIAL_PAINT_COUNT)) {
     const { screen } = await getGraphicsAtTime(paintPoint.time);
     if (!screen) {

--- a/packages/replay-next/src/utils/testing.tsx
+++ b/packages/replay-next/src/utils/testing.tsx
@@ -206,13 +206,14 @@ export function createMockReplayClient() {
     point: timeToFakeExecutionPoint(1_000),
     time: 1_000,
   }));
-  mockClient.findKeyboardEvents.mockImplementation(async () => {});
+  mockClient.findKeyboardEvents.mockImplementation(async () => []);
   mockClient.findMessages.mockImplementation(async () => ({ messages: [], overflow: false }));
   mockClient.findMessagesInRange.mockImplementation(async () => ({
     messages: [],
     overflow: false,
   }));
-  mockClient.findNavigationEvents.mockImplementation(async () => {});
+  mockClient.findMouseEvents.mockImplementation(async () => []);
+  mockClient.findNavigationEvents.mockImplementation(async () => []);
   mockClient.findSources.mockImplementation(async () => []);
   mockClient.removeEventListener.mockImplementation(() => {});
   mockClient.getCurrentFocusWindow.mockImplementation(() => null);

--- a/packages/shared/client/ReplayClient.ts
+++ b/packages/shared/client/ReplayClient.ts
@@ -4,10 +4,13 @@ import {
   ExecutionPoint,
   FrameId,
   FunctionMatch,
+  KeyboardEvent,
   loadedRegions as LoadedRegions,
   Location,
   MappedLocation,
   Message,
+  MouseEvent,
+  NavigationEvent,
   ObjectId,
   ObjectPreviewLevel,
   PauseData,
@@ -59,8 +62,10 @@ import {
   getScopeResult,
   getTopFrameResult,
   keyboardEvents,
+  mouseEvents,
   navigationEvents,
   newSources,
+  paintPoints,
   performSearchResult,
   querySelectorResult,
   repaintGraphicsResult,
@@ -76,6 +81,7 @@ import uniqueId from "lodash/uniqueId";
 import { addEventListener, client, initSocket, removeEventListener } from "protocol/socket";
 import { assert, compareNumericStrings, defer, waitForTime } from "protocol/utils";
 import { initProtocolMessagesStore } from "replay-next/components/protocol/ProtocolMessagesStore";
+import { insert } from "replay-next/src/utils/array";
 import { TOO_MANY_POINTS_TO_FIND } from "shared/constants";
 import { ProtocolError, commandError } from "shared/utils/error";
 import { isPointInRegion, isRangeInRegions } from "shared/utils/time";
@@ -85,6 +91,7 @@ import {
   ReplayClientEvents,
   ReplayClientInterface,
   SourceLocationRange,
+  TimeStampedPointWithPaintHash,
 } from "./types";
 
 export const MAX_POINTS_TO_FIND = 10_000;
@@ -122,15 +129,6 @@ export class ReplayClient implements ReplayClientInterface {
       client.Session.addAnnotationsListener(this.onAnnotations);
     });
   }
-
-  private getSessionIdThrows(): SessionId {
-    const sessionId = this._sessionId;
-    if (sessionId === null) {
-      throw Error("Invalid session");
-    }
-    return sessionId;
-  }
-
   // Configures the client to use an already initialized session iD.
   // This method should be used for apps that use the protocol package directly.
   // Apps that only communicate with the Replay protocol through this client should use the initialize method instead.
@@ -160,7 +158,7 @@ export class ReplayClient implements ReplayClientInterface {
   }
 
   async breakpointAdded(location: Location, condition: string | null): Promise<BreakpointId> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
 
     const { breakpointId } = await client.Debugger.setBreakpoint(
       {
@@ -174,7 +172,7 @@ export class ReplayClient implements ReplayClientInterface {
   }
 
   async breakpointRemoved(breakpointId: BreakpointId): Promise<void> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     await client.Debugger.removeBreakpoint({ breakpointId }, sessionId);
   }
 
@@ -185,7 +183,7 @@ export class ReplayClient implements ReplayClientInterface {
   }
 
   async createPause(executionPoint: ExecutionPoint): Promise<createPauseResult> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
 
     await this.waitForPointToBeInFocusRange(executionPoint);
 
@@ -200,7 +198,7 @@ export class ReplayClient implements ReplayClientInterface {
     frameId: FrameId | null,
     pure?: boolean
   ): Promise<EvaluationResult> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
 
     // Edge case handling:
     // User is logging a plan object (e.g. "{...}")
@@ -261,24 +259,35 @@ export class ReplayClient implements ReplayClientInterface {
   }
 
   async findAnnotations(kind: string, listener: AnnotationListener) {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     assert(!this.annotationListeners.has(kind), `Annotations of kind ${kind} requested twice`);
     this.annotationListeners.set(kind, listener);
     await client.Session.findAnnotations({ kind }, sessionId);
   }
 
-  async findKeyboardEvents(onKeyboardEvents: (events: keyboardEvents) => void) {
-    const sessionId = this.getSessionIdThrows();
+  async findKeyboardEvents() {
+    const sessionId = await this.waitForSession();
+
+    const sortedEvents: KeyboardEvent[] = [];
+
+    const onKeyboardEvents = ({ events }: keyboardEvents) => {
+      events.forEach(event => {
+        insert(sortedEvents, event, (a, b) => a.time - b.time);
+      });
+    };
+
     client.Session.addKeyboardEventsListener(onKeyboardEvents);
-    await client.Session.findKeyboardEvents({}, sessionId!);
+    await client.Session.findKeyboardEvents({}, sessionId);
     client.Session.removeKeyboardEventsListener(onKeyboardEvents);
+
+    return sortedEvents;
   }
 
   async findMessages(onMessage?: (message: Message) => void): Promise<{
     messages: Message[];
     overflow: boolean;
   }> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
 
     const sortedMessages: Message[] = [];
 
@@ -324,7 +333,7 @@ export class ReplayClient implements ReplayClientInterface {
     messages: Message[];
     overflow: boolean;
   }> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
 
     // It is important to wait until the range is fully loaded before requesting messages.
     // It would be better if findMessagesInRange errored when the requested range could not be returned,
@@ -350,11 +359,40 @@ export class ReplayClient implements ReplayClientInterface {
     };
   }
 
-  async findNavigationEvents(onNavigationEvents: (events: navigationEvents) => void) {
-    const sessionId = this.getSessionIdThrows();
+  async findMouseEvents() {
+    const sessionId = await this.waitForSession();
+
+    const sortedEvents: MouseEvent[] = [];
+
+    const onMouseEvents = ({ events }: mouseEvents) => {
+      events.forEach(event => {
+        insert(sortedEvents, event, (a, b) => a.time - b.time);
+      });
+    };
+
+    client.Session.addMouseEventsListener(onMouseEvents);
+    await client.Session.findMouseEvents({}, sessionId);
+    client.Session.removeMouseEventsListener(onMouseEvents);
+
+    return sortedEvents;
+  }
+
+  async findNavigationEvents() {
+    const sessionId = await this.waitForSession();
+
+    const sortedEvents: NavigationEvent[] = [];
+
+    const onNavigationEvents = ({ events }: navigationEvents) => {
+      events.forEach(event => {
+        insert(sortedEvents, event, (a, b) => a.time - b.time);
+      });
+    };
+
     client.Session.addNavigationEventsListener(onNavigationEvents);
-    await client.Session.findNavigationEvents({}, sessionId!);
+    await client.Session.findNavigationEvents({}, sessionId);
     client.Session.removeNavigationEventsListener(onNavigationEvents);
+
+    return sortedEvents;
   }
 
   _findNetworkRequestsCalled: boolean = false;
@@ -395,12 +433,36 @@ export class ReplayClient implements ReplayClientInterface {
     return { events, requests };
   }
 
+  async findPaints(): Promise<TimeStampedPointWithPaintHash[]> {
+    const sessionId = await this.waitForSession();
+
+    const sortedPaints: TimeStampedPointWithPaintHash[] = [{ point: "0", time: 0, paintHash: "" }];
+
+    const onPaints = async ({ paints }: paintPoints) => {
+      paints.forEach(async ({ point, time, screenShots }) => {
+        const paint: TimeStampedPointWithPaintHash = {
+          paintHash: screenShots.find(({ mimeType }) => mimeType == "image/jpeg")?.hash ?? "",
+          point,
+          time,
+        };
+
+        insert(sortedPaints, paint, (a, b) => a.time - b.time);
+      });
+    };
+
+    client.Graphics.addPaintPointsListener(onPaints);
+    await client.Graphics.findPaints({}, sessionId);
+    client.Graphics.removePaintPointsListener(onPaints);
+
+    return sortedPaints;
+  }
+
   async findPoints(
     pointSelector: PointSelector,
     pointLimits?: PointPageLimits
   ): Promise<PointDescription[]> {
     const points: PointDescription[] = [];
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     const findPointsId = String(this.nextFindPointsId++);
     pointLimits = pointLimits ? { ...pointLimits } : {};
     if (!pointLimits.maxCount) {
@@ -440,37 +502,37 @@ export class ReplayClient implements ReplayClientInterface {
   }
 
   async findRewindTarget(point: ExecutionPoint): Promise<PauseDescription> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     const { target } = await client.Debugger.findRewindTarget({ point }, sessionId);
     return target;
   }
 
   async findResumeTarget(point: ExecutionPoint): Promise<PauseDescription> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     const { target } = await client.Debugger.findResumeTarget({ point }, sessionId);
     return target;
   }
 
   async findStepInTarget(point: ExecutionPoint): Promise<PauseDescription> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     const { target } = await client.Debugger.findStepInTarget({ point }, sessionId);
     return target;
   }
 
   async findStepOutTarget(point: ExecutionPoint): Promise<PauseDescription> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     const { target } = await client.Debugger.findStepOutTarget({ point }, sessionId);
     return target;
   }
 
   async findStepOverTarget(point: ExecutionPoint): Promise<PauseDescription> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     const { target } = await client.Debugger.findStepOverTarget({ point }, sessionId);
     return target;
   }
 
   async findReverseStepOverTarget(point: ExecutionPoint): Promise<PauseDescription> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     const { target } = await client.Debugger.findReverseStepOverTarget({ point }, sessionId);
     return target;
   }
@@ -480,7 +542,7 @@ export class ReplayClient implements ReplayClientInterface {
 
     await this.waitForSession();
 
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
 
     const newSourceListener = (source: Source) => {
       sources.push(source);
@@ -501,13 +563,13 @@ export class ReplayClient implements ReplayClientInterface {
   }
 
   async getAllFrames(pauseId: PauseId): Promise<getAllFramesResult> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     const result = await client.Pause.getAllFrames({}, sessionId, pauseId);
     return result;
   }
 
   async getPointStack(point: ExecutionPoint, maxCount: number): Promise<PointStackFrame[]> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     const result = await client.Session.getPointStack({ point, maxCount }, sessionId);
     return result.frames;
   }
@@ -563,30 +625,30 @@ export class ReplayClient implements ReplayClientInterface {
   }
 
   async getTopFrame(pauseId: PauseId): Promise<getTopFrameResult> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     const result = await client.Pause.getTopFrame({}, sessionId, pauseId);
     return result;
   }
 
   async hasAnnotationKind(kind: string): Promise<boolean> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     const { hasKind } = await client.Session.hasAnnotationKind({ kind }, sessionId);
     return hasKind;
   }
 
   async getAnnotationKinds(): Promise<string[]> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     const { kinds } = await client.Session.getAnnotationKinds({}, sessionId);
     return kinds;
   }
 
   async getAllBoundingClientRects(pauseId: string): Promise<getAllBoundingClientRectsResult> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     return client.DOM.getAllBoundingClientRects({}, sessionId, pauseId);
   }
 
   async getAppliedRules(pauseId: string, nodeId: string): Promise<getAppliedRulesResult> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     return client.CSS.getAppliedRules({ node: nodeId }, sessionId, pauseId);
   }
 
@@ -594,37 +656,37 @@ export class ReplayClient implements ReplayClientInterface {
     pauseId: string,
     nodeId: string
   ): Promise<getBoundingClientRectResult> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     return client.DOM.getBoundingClientRect({ node: nodeId }, sessionId, pauseId);
   }
 
   async getBoxModel(pauseId: string, nodeId: string): Promise<getBoxModelResult> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     return client.DOM.getBoxModel({ node: nodeId }, sessionId, pauseId);
   }
 
   async getComputedStyle(pauseId: PauseId, nodeId: string): Promise<getComputedStyleResult> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     return client.CSS.getComputedStyle({ node: nodeId }, sessionId, pauseId);
   }
 
   async getDocument(pauseId: string): Promise<getDocumentResult> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     return client.DOM.getDocument({}, sessionId, pauseId);
   }
 
   async getEventListeners(pauseId: string, nodeId: string): Promise<getEventListenersResult> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     return client.DOM.getEventListeners({ node: nodeId }, sessionId, pauseId);
   }
 
   async getParentNodes(pauseId: string, nodeId: string): Promise<getParentNodesResult> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     return client.DOM.getParentNodes({ node: nodeId }, sessionId, pauseId);
   }
 
   async performSearch(pauseId: string, query: string): Promise<performSearchResult> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     return client.DOM.performSearch({ query }, sessionId, pauseId);
   }
 
@@ -633,7 +695,7 @@ export class ReplayClient implements ReplayClientInterface {
     nodeId: string,
     selector: string
   ): Promise<querySelectorResult> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     return client.DOM.querySelector({ node: nodeId, selector }, sessionId, pauseId);
   }
 
@@ -641,7 +703,7 @@ export class ReplayClient implements ReplayClientInterface {
     eventTypes: string[],
     range: PointRange | null
   ): Promise<Record<string, number>> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     const { counts } = await client.Debugger.getEventHandlerCounts(
       { eventTypes, range: range ?? undefined },
       sessionId
@@ -650,7 +712,7 @@ export class ReplayClient implements ReplayClientInterface {
   }
 
   async getAllEventHandlerCounts(range: PointRange | null): Promise<Record<string, number>> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     const { counts } = await client.Debugger.getAllEventHandlerCounts(
       { range: range ?? undefined },
       sessionId
@@ -659,13 +721,13 @@ export class ReplayClient implements ReplayClientInterface {
     return countsObject;
   }
 
-  getExceptionValue(pauseId: PauseId): Promise<getExceptionValueResult> {
-    const sessionId = this.getSessionIdThrows();
+  async getExceptionValue(pauseId: PauseId): Promise<getExceptionValueResult> {
+    const sessionId = await this.waitForSession();
     return client.Pause.getExceptionValue({}, sessionId, pauseId);
   }
 
   private async syncFocusWindow(): Promise<TimeStampedPointRange> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     const { window } = await client.Session.getFocusWindow({}, sessionId);
     this.focusWindow = window;
     this._dispatchEvent("focusWindowChange", window);
@@ -673,7 +735,7 @@ export class ReplayClient implements ReplayClientInterface {
   }
 
   async getFrameSteps(pauseId: PauseId, frameId: FrameId): Promise<PointDescription[]> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     const { steps } = await client.Pause.getFrameSteps({ frameId }, sessionId, pauseId);
     return steps;
   }
@@ -683,7 +745,7 @@ export class ReplayClient implements ReplayClientInterface {
     pauseId: PauseId,
     propertyName: string
   ): Promise<Result> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     const { result } = await client.Pause.getObjectProperty(
       {
         object: objectId,
@@ -700,7 +762,7 @@ export class ReplayClient implements ReplayClientInterface {
     pauseId: PauseId,
     level?: ObjectPreviewLevel
   ): Promise<PauseData> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     const result = await client.Pause.getObjectPreview(
       { level, object: objectId },
       sessionId,
@@ -710,14 +772,14 @@ export class ReplayClient implements ReplayClientInterface {
   }
 
   async getPointNearTime(time: number): Promise<TimeStampedPoint> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
 
     const { point } = await client.Session.getPointNearTime({ time }, sessionId);
     return point;
   }
 
   async getPointsBoundingTime(time: number): Promise<PointsBoundingTime> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
 
     const result = await client.Session.getPointsBoundingTime({ time }, sessionId);
     return result;
@@ -728,19 +790,19 @@ export class ReplayClient implements ReplayClientInterface {
   }
 
   async getScope(pauseId: PauseId, scopeId: ScopeId): Promise<getScopeResult> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     const result = await client.Pause.getScope({ scope: scopeId }, sessionId, pauseId);
     return result;
   }
 
   async getScopeMap(location: Location): Promise<VariableMapping[] | undefined> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     const { map } = await client.Debugger.getScopeMap({ location }, sessionId);
     return map;
   }
 
   async getScreenshot(point: ExecutionPoint): Promise<ScreenShot> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     const { screen } = await client.Graphics.getPaintContents(
       { point, mimeType: "image/jpeg" },
       sessionId
@@ -749,7 +811,7 @@ export class ReplayClient implements ReplayClientInterface {
   }
 
   async mapExpressionToGeneratedScope(expression: string, location: Location): Promise<string> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     const result = await client.Debugger.mapExpressionToGeneratedScope(
       { expression, location },
       sessionId
@@ -758,7 +820,7 @@ export class ReplayClient implements ReplayClientInterface {
   }
 
   async getSessionEndpoint(): Promise<TimeStampedPoint> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     const { endpoint } = await client.Session.getEndpoint({}, sessionId);
     return endpoint;
   }
@@ -770,7 +832,7 @@ export class ReplayClient implements ReplayClientInterface {
     locations: SameLineSourceLocations[],
     focusRange: PointRange | null
   ) {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     await this.waitForRangeToBeInFocusRange(focusRange);
     const { hits } = await client.Debugger.getHitCounts(
       { sourceId, locations, maxHits: TOO_MANY_POINTS_TO_FIND, range: focusRange || undefined },
@@ -779,15 +841,16 @@ export class ReplayClient implements ReplayClientInterface {
     return hits;
   }
 
-  getSourceOutline(sourceId: SourceId) {
-    return client.Debugger.getSourceOutline({ sourceId }, this.getSessionIdThrows());
+  async getSourceOutline(sourceId: SourceId) {
+    const sessionId = await this.waitForSession();
+    return client.Debugger.getSourceOutline({ sourceId }, sessionId);
   }
 
   async getBreakpointPositions(
     sourceId: SourceId,
     locationRange: SourceLocationRange | null
   ): Promise<SameLineSourceLocations[]> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     const begin = locationRange ? locationRange.start : undefined;
     const end = locationRange ? locationRange.end : undefined;
 
@@ -803,13 +866,13 @@ export class ReplayClient implements ReplayClientInterface {
   }
 
   async getMappedLocation(location: Location): Promise<MappedLocation> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     const { mappedLocation } = await client.Debugger.getMappedLocation({ location }, sessionId);
     return mappedLocation;
   }
 
   async requestFocusWindow(params: PointRangeFocusRequest): Promise<TimeStampedPointRange> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
 
     const { window } = await client.Session.requestFocusWindow(
       {
@@ -834,8 +897,8 @@ export class ReplayClient implements ReplayClientInterface {
     }
   }
 
-  repaintGraphics(pauseId: PauseId): Promise<repaintGraphicsResult> {
-    const sessionId = this.getSessionIdThrows();
+  async repaintGraphics(pauseId: PauseId): Promise<repaintGraphicsResult> {
+    const sessionId = await this.waitForSession();
     return client.DOM.repaintGraphics({}, sessionId, pauseId);
   }
 
@@ -852,7 +915,7 @@ export class ReplayClient implements ReplayClientInterface {
     },
     onMatches: (matches: FunctionMatch[]) => void
   ): Promise<void> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     const thisSearchUniqueId = uniqueId("search-fns-");
 
     let pendingMatches: FunctionMatch[] = [];
@@ -913,7 +976,7 @@ export class ReplayClient implements ReplayClientInterface {
     },
     onMatches: (matches: SearchSourceContentsMatch[], didOverflow: boolean) => void
   ): Promise<void> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     const thisSearchUniqueId = uniqueId("search-sources-");
 
     let didOverflow = false;
@@ -986,7 +1049,7 @@ export class ReplayClient implements ReplayClientInterface {
     },
     onResults: (results: RunEvaluationResult[]) => void
   ): Promise<void> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
     const runEvaluationId = String(this.nextRunEvaluationId++);
     const pointLimits: PointPageLimits = opts.limits ? { ...opts.limits } : {};
     if (!pointLimits.maxCount) {
@@ -1036,7 +1099,7 @@ export class ReplayClient implements ReplayClientInterface {
     onSourceContentsInfo: (params: sourceContentsInfo) => void,
     onSourceContentsChunk: (params: sourceContentsChunk) => void
   ): Promise<void> {
-    const sessionId = this.getSessionIdThrows();
+    const sessionId = await this.waitForSession();
 
     let pendingChunk = "";
     let pendingThrottlePromise: Promise<void> | null = null;

--- a/packages/shared/client/types.ts
+++ b/packages/shared/client/types.ts
@@ -1,8 +1,6 @@
 import {
   Annotation,
-  AppliedRule,
   BreakpointId,
-  ComputedStyleProperty,
   ContentType,
   Result as EvaluationResult,
   EventHandlerType,
@@ -66,8 +64,6 @@ import {
   getScopeResult,
   getSourceOutlineResult,
   getTopFrameResult,
-  keyboardEvents,
-  navigationEvents,
   performSearchResult,
   querySelectorResult,
   repaintGraphicsResult,
@@ -162,6 +158,10 @@ export interface SourceLocationRange {
   end: SourceLocation;
 }
 
+export interface TimeStampedPointWithPaintHash extends TimeStampedPoint {
+  paintHash: string;
+}
+
 export type AnnotationListener = (annotation: Annotation) => void;
 
 export interface ReplayClientInterface {
@@ -178,7 +178,7 @@ export interface ReplayClientInterface {
     pure?: boolean
   ): Promise<EvaluationResult>;
   findAnnotations(kind: string, listener: AnnotationListener): Promise<void>;
-  findKeyboardEvents(onKeyboardEvents: (events: keyboardEvents) => void): Promise<void>;
+  findKeyboardEvents(): Promise<KeyboardEvent[]>;
   findMessages(onMessage?: (message: Message) => void): Promise<{
     messages: Message[];
     overflow: boolean;
@@ -187,13 +187,15 @@ export interface ReplayClientInterface {
     messages: Message[];
     overflow: boolean;
   }>;
-  findNavigationEvents(onKeyboardEvents: (events: navigationEvents) => void): Promise<void>;
+  findMouseEvents(): Promise<MouseEvent[]>;
+  findNavigationEvents(): Promise<NavigationEvent[]>;
   findNetworkRequests(
     onRequestsReceived?: (data: { requests: RequestInfo[]; events: RequestEventInfo[] }) => void
   ): Promise<{
     events: RequestEventInfo[];
     requests: RequestInfo[];
   }>;
+  findPaints(): Promise<TimeStampedPointWithPaintHash[]>;
   findPoints(selector: PointSelector, limits?: PointLimits): Promise<PointDescription[]>;
   findRewindTarget(point: ExecutionPoint): Promise<PauseDescription>;
   findResumeTarget(point: ExecutionPoint): Promise<PauseDescription>;

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -46,8 +46,8 @@ import {
   nextPaintOrMouseEvent,
   paintGraphics,
   previousPaintEvent,
-  timeIsBeyondKnownPaints,
 } from "protocol/graphics";
+import { mostRecentPaint, timeIsBeyondKnownPaints } from "protocol/PaintsCache";
 import { waitForTime } from "protocol/utils";
 import { recordingCapabilitiesCache } from "replay-next/src/suspense/BuildIdCache";
 import {
@@ -850,12 +850,11 @@ export function precacheScreenshots(beginTime: number): UIThunkAction {
 
     const endTime = Math.min(beginTime + PRECACHE_DURATION, recordingDuration);
     for (let time = beginTime; time < endTime; time += SNAP_TIME_INTERVAL) {
-      const index = mostRecentIndex(gPaintPoints, time);
-      if (index === undefined) {
+      const paintPoint = mostRecentPaint(time);
+      if (paintPoint === null) {
         return;
       }
 
-      const paintPoint = gPaintPoints[index];
       // the client isn't used in the cache key, so it's OK to pass a dummy value here
       if (!screenshotCache.getValueIfCached(null as any, paintPoint.point, paintPoint.paintHash)) {
         const graphicsPromise = getGraphicsAtTime(time, true);

--- a/src/ui/components/ProtocolTimeline.tsx
+++ b/src/ui/components/ProtocolTimeline.tsx
@@ -5,7 +5,7 @@ import {
 } from "@replayio/protocol";
 import clamp from "lodash/clamp";
 
-import { gPaintPoints, hasAllPaintPoints } from "protocol/graphics";
+import { PaintsCache } from "protocol/PaintsCache";
 import useLoadedRegions from "replay-next/src/hooks/useLoadedRegions";
 import { getZoomRegion } from "ui/reducers/timeline";
 import { useAppSelector } from "ui/setup/hooks";
@@ -80,8 +80,9 @@ const EMPTY_LOADED_REGIONS: LoadedRegions = {
 export default function ProtocolTimeline() {
   const loadedRegions = useLoadedRegions() ?? EMPTY_LOADED_REGIONS;
 
-  const firstPaint = gPaintPoints[0];
-  const lastPaint = gPaintPoints[gPaintPoints.length - 1];
+  const paints = PaintsCache.read();
+  const firstPaint = paints[0];
+  const lastPaint = paints[paints.length - 1];
 
   return (
     <div className="flex w-full flex-col space-y-1">
@@ -97,11 +98,13 @@ export default function ProtocolTimeline() {
         regions={[
           {
             begin: { point: firstPaint.point, time: firstPaint.time },
-            end: { point: lastPaint.point, time: hasAllPaintPoints ? Infinity : lastPaint.time },
+            // This timeline should always extend to the end,
+            // even though the final paint will be before the end
+            end: { point: lastPaint.point, time: Infinity },
           },
         ]}
         color="sky-500"
-        points={gPaintPoints}
+        points={paints}
         title="Paints"
       />
     </div>

--- a/src/ui/components/Timeline/Timeline.tsx
+++ b/src/ui/components/Timeline/Timeline.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, useContext, useLayoutEffect, useRef, useState } from "react";
+import { MouseEvent, Suspense, useContext, useLayoutEffect, useRef, useState } from "react";
 
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
 import { useGraphQLUserData } from "shared/user-data/GraphQL/useGraphQLUserData";
@@ -150,7 +150,11 @@ export default function Timeline() {
           onMouseUp={onMouseUp}
         >
           <div className="progress-bar-stack" onContextMenu={onContextMenu}>
-            {showProtocolTimeline && <ProtocolTimeline />}
+            {showProtocolTimeline && (
+              <Suspense>
+                <ProtocolTimeline />
+              </Suspense>
+            )}
             <div className="progress-bar" data-test-id="Timeline-ProgressBar" ref={progressBarRef}>
               <ProgressBars />
               <PreviewMarkers />

--- a/src/ui/reducers/timeline.test.ts
+++ b/src/ui/reducers/timeline.test.ts
@@ -1,4 +1,4 @@
-import { setHasAllPaintPoints } from "protocol/graphics";
+import { PaintsCache } from "protocol/PaintsCache";
 import { createTestStore } from "test/testUtils";
 import { UIStore } from "ui/actions";
 
@@ -29,7 +29,10 @@ describe("Redux timeline state", () => {
     );
 
     // Fake having loaded paint points.
-    setHasAllPaintPoints(true);
+    PaintsCache.cache([
+      { point: "0", time: 0, paintHash: "" },
+      { point: "1", time: 100, paintHash: "" },
+    ]);
   });
 
   describe("focus region", () => {

--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -206,7 +206,7 @@ export default async function setupDevtools(store: AppStore, replayClient: Repla
     );
   });
 
-  await setupApp(store, replayClient);
+  setupApp(store, replayClient);
   setupTimeline(store);
   setupGraphics(store);
 

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -111,7 +111,7 @@ interface Events {
   [key: string]: ReplayEvent[];
 }
 
-// Todo: We should move this deifnition to the protocol instead of typing it here.
+// Todo: We should move this definition to the protocol instead of typing it here.
 export type ReplayNavigationEvent = Omit<NavigationEvent, "kind"> & {
   kind: "navigation";
 };


### PR DESCRIPTION
Begin moving state out of the `protocol/graphics` package and into our typical suspense-caches. Eventually we've move the imperative logic out of that package as well.

This commit also removes the internal `ReplayClient.getSessionIdThrows()` method. It seems dangerous in that it can lead to an error being thrown if an API is called too early. These APIs are async anyway so it doesn't seem to be worth the risk to avoid the overhead of an extra promise tick.

This is an incremental step toward some larger [planned refactoring work](https://www.notion.so/replayio/Untangling-legacy-graphics-code-d1d999faf7414f47ab9996ae92f717ff).