### PR TITLE
Fix runtime value for save examples script

### DIFF
--- a/packages/e2e-tests/scripts/record-playwright.ts
+++ b/packages/e2e-tests/scripts/record-playwright.ts
@@ -1,5 +1,5 @@
 import type { Page, expect as expectFunction } from "@playwright/test";
-import { chromium, expect } from "@playwright/test";
+import { chromium, expect, firefox } from "@playwright/test";
 import { getExecutablePath } from "@replayio/playwright";
 import * as cli from "@replayio/replay";
 import findLast from "lodash/findLast";
@@ -15,7 +15,9 @@ export async function recordPlaywright(
     executablePath = config.browserPath || getExecutablePath(browserName)!;
   }
 
-  const browserServer = await chromium.launchServer({
+  const browserType = browserName === "chromium" ? chromium : firefox;
+
+  const browserServer = await browserType.launchServer({
     env: {
       ...process.env,
       // @ts-ignore

--- a/packages/e2e-tests/scripts/save-examples.ts
+++ b/packages/e2e-tests/scripts/save-examples.ts
@@ -153,21 +153,24 @@ async function saveExamples(
       continue;
     }
 
-    const [_, runtime] = buildId.split("-");
+    const [_, buildRuntime] = buildId.split("-");
 
     let category: TestExampleFile["category"];
     let folder: TestExampleFile["folder"];
+    let runtime: TestExampleFile["runtime"];
 
-    switch (runtime) {
+    switch (buildRuntime) {
       case "chromium":
       case "gecko": {
         category = "browser";
         folder = config.browserExamplesPath;
+        runtime = buildRuntime === "gecko" ? "firefox" : "chromium";
         break;
       }
       case "node": {
         category = "node";
         folder = config.nodeExamplesPath;
+        runtime = "node";
         break;
       }
     }
@@ -178,7 +181,7 @@ async function saveExamples(
         category,
         filename: key,
         folder,
-        runtime: runtime as TestExampleFile["runtime"],
+        runtime,
         playwrightScript: playwrightScript
           ? require(join("..", playwrightScript)).default
           : undefined,


### PR DESCRIPTION
This fixes sending correct `runtime` value to `getExecutablePath` but the Firefox browser can't launch because our fork only supports 1.19 and the script uses features from a newer version.