### PR TITLE
Handle more response types from RDT backend

### DIFF
--- a/src/ui/components/SecondaryToolbox/react-devtools/components/SelectedElement.module.css
+++ b/src/ui/components/SecondaryToolbox/react-devtools/components/SelectedElement.module.css
@@ -118,3 +118,8 @@
   align-items: center;
   justify-content: center;
 }
+
+.Error {
+  padding: 0.5rem;
+  font-style: italic;
+}

--- a/src/ui/components/SecondaryToolbox/react-devtools/components/SelectedElement.tsx
+++ b/src/ui/components/SecondaryToolbox/react-devtools/components/SelectedElement.tsx
@@ -73,6 +73,17 @@ export function SelectedElement({
     () => nodesToFiberIdsCache.read(replayClient, pauseId!, store)
   );
 
+  if (inspectedElement == null) {
+    return (
+      <div className={styles.Panel} data-is-pending={isPending || undefined}>
+        <div className={styles.TopRow}>
+          <div className={styles.ComponentName}>{displayName}</div>
+        </div>
+        <div className={styles.Error}>The selected component could not be inspected.</div>
+      </div>
+    );
+  }
+
   const {
     context,
     contextObjectId,


### PR DESCRIPTION
This was an oversight in my previous implementation. The React DevTools has a few possible message types:
```ts
export type InspectedElementResponseType =
  | 'error'
  | 'full-data'
  | 'hydrated-path'
  | 'no-change'
  | 'not-found';
```

Some of these are not relevant in Relay's usage (like "hydrated-path" for example, since we fetch values with Replay's protocol instead) but I should have been handling the "not-found" case, and I guess to be complete– the "error" case as well. This commit adds handling for those two, along with a user-facing error message.

![Screenshot 2024-01-26 at 10 34 34 AM](https://github.com/replayio/devtools/assets/29597/2fd63136-13eb-43d0-a603-ae3a1245458f)