### PR TITLE
Updating Gecko recordings will re-record with Chromium

### DIFF
--- a/packages/e2e-tests/config.ts
+++ b/packages/e2e-tests/config.ts
@@ -12,7 +12,7 @@ export default {
   browserPath: process.env.RECORD_REPLAY_PATH,
   devtoolsUrl: process.env.PLAYWRIGHT_TEST_BASE_URL || "http://localhost:8080",
   driverPath: process.env.RECORD_REPLAY_DRIVER,
-  headless: !!process.env.RECORD_REPLAY_PLAYWRIGHT_HEADLESS,
+  headless: process.env.RECORD_REPLAY_PLAYWRIGHT_HEADLESS != "false",
   nodeExamplesPath: join(__dirname, "../../test/examples"),
   nodePath: process.env.RECORD_REPLAY_NODE,
   // Browser recordings go into our "FE E2E Node 'Golden' Recordings'" workspace.

--- a/packages/e2e-tests/scripts/record-playwright.ts
+++ b/packages/e2e-tests/scripts/record-playwright.ts
@@ -4,15 +4,14 @@ import { getExecutablePath } from "@replayio/playwright";
 import * as cli from "@replayio/replay";
 import findLast from "lodash/findLast";
 
-import config, { BrowserName } from "../config";
+import config from "../config";
 
 export async function recordPlaywright(
-  browserName: BrowserName,
   script: (page: Page, expect?: typeof expectFunction) => Promise<void>
 ) {
   let executablePath: string | undefined = undefined;
   if (config.shouldRecordTest) {
-    executablePath = config.browserPath || getExecutablePath(browserName)!;
+    executablePath = config.browserPath || getExecutablePath("chromium");
   }
 
   const browserServer = await chromium.launchServer({

--- a/packages/e2e-tests/scripts/save-examples.ts
+++ b/packages/e2e-tests/scripts/save-examples.ts
@@ -17,7 +17,7 @@ import { SetRecordingIsPrivateVariables } from "../../shared/graphql/generated/S
 import { UpdateRecordingTitleVariables } from "../../shared/graphql/generated/UpdateRecordingTitle";
 import config, { BrowserName } from "../config";
 import examplesJson from "../examples.json";
-import { ExamplesData, TestRecordingIntersectionValue } from "../helpers";
+import { TestRecordingIntersectionValue } from "../helpers";
 import { getStats } from "./get-stats";
 import { loadRecording } from "./loadRecording";
 import { logAnimated } from "./log";
@@ -153,7 +153,7 @@ async function saveExamples(
       continue;
     }
 
-    const [_, runtime] = buildId.split("-");
+    let [_, runtime] = buildId.split("-");
 
     let category: TestExampleFile["category"];
     let folder: TestExampleFile["folder"];
@@ -220,7 +220,7 @@ async function saveBrowserExample({ example }: TestRunCallbackArgs) {
   const playwrightScript: PlaywrightScript = example.playwrightScript ?? defaultPlaywrightScript;
 
   // Shouldn't be "node" by this point
-  await recordPlaywright((argv.runtime || example.runtime) as BrowserName, async (page, expect) => {
+  await recordPlaywright(async (page, expect) => {
     const waitForLogPromise = playwrightScript(page, expect);
     const goToPagePromise = page.goto(exampleUrl);
 

--- a/packages/e2e-tests/scripts/save-examples.ts
+++ b/packages/e2e-tests/scripts/save-examples.ts
@@ -153,7 +153,7 @@ async function saveExamples(
       continue;
     }
 
-    let [_, runtime] = buildId.split("-");
+    const [_, runtime] = buildId.split("-");
 
     let category: TestExampleFile["category"];
     let folder: TestExampleFile["folder"];


### PR DESCRIPTION
Resolves FE-2216 and FE-2218

- [x] Saving new examples previously made with "gecko" will now automatically convert them to "chromium"
- [x] Saving new examples will default to _headless_ mode (though this can still be overridden with a `RECORD_REPLAY_PLAYWRIGHT_HEADLESS=false` flag)