### PR TITLE
Fix object properties ordering

### DIFF
--- a/packages/replay-next/components/inspector/KeyValueRenderer.module.css
+++ b/packages/replay-next/components/inspector/KeyValueRenderer.module.css
@@ -13,6 +13,10 @@
 .VerticalNameWithFlag {
   color: var(--object-inspector-expanded-key-with-flag);
 }
+.VerticalName.GetterValue,
+.VerticalNameWithFlag.GetterValue {
+  color: var(--object-inspector-gettervalue-key);
+}
 
 .ToggleAlignmentPadding {
   margin-left: 1.25rem;

--- a/packages/replay-next/components/inspector/KeyValueRenderer.tsx
+++ b/packages/replay-next/components/inspector/KeyValueRenderer.tsx
@@ -26,7 +26,7 @@ export type Props = {
   onContextMenu?: (event: MouseEvent) => void;
   path?: string;
   pauseId: PauseId;
-  protocolValue: ProtocolValue | ProtocolNamedValue;
+  protocolValue: (ProtocolValue | ProtocolNamedValue) & { isGetterValue?: boolean };
 };
 
 // Renders a protocol Object/ObjectPreview as a key+value pair.
@@ -131,6 +131,9 @@ export default function KeyValueRenderer({
     } else {
       nameClass = styles.VerticalName;
     }
+  }
+  if (protocolValue.isGetterValue) {
+    nameClass += " " + styles.GetterValue;
   }
 
   // What we show when expanded or collapsed depends on the context we are displayed in.

--- a/packages/replay-next/components/inspector/values/ObjectRenderer.tsx
+++ b/packages/replay-next/components/inspector/values/ObjectRenderer.tsx
@@ -1,6 +1,4 @@
-import { ReactNode, useMemo } from "react";
-
-import { mergePropertiesAndGetterValues } from "replay-next/src/utils/protocol";
+import { ReactNode } from "react";
 
 import KeyValueRenderer from "../KeyValueRenderer";
 import { ObjectPreviewRendererProps } from "./types";
@@ -15,22 +13,11 @@ const MAX_PROPERTIES_TO_PREVIEW = 5;
 export default function ObjectRenderer({ context, object, pauseId }: ObjectPreviewRendererProps) {
   const { className, preview } = object;
 
-  const [properties, propertiesWereTruncated] = useMemo(() => {
-    if (preview == null) {
-      return [[], false];
-    }
-
-    return mergePropertiesAndGetterValues(
-      preview.properties || [],
-      preview.getterValues || [],
-      MAX_PROPERTIES_TO_PREVIEW
-    );
-  }, [preview]);
-
-  const showOverflowMarker = object.preview?.overflow || propertiesWereTruncated;
-
+  const properties = preview?.properties?.slice(0, MAX_PROPERTIES_TO_PREVIEW);
   let propertiesList: ReactNode[] | null = null;
-  if (context !== "nested") {
+  if (context !== "nested" && properties) {
+    const showOverflowMarker = preview?.overflow || properties.length > MAX_PROPERTIES_TO_PREVIEW;
+
     propertiesList = properties.map((property, index) => (
       <span key={index} className={styles.Value}>
         <KeyValueRenderer

--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -275,6 +275,7 @@
   --object-inspector-go-to-definition-icon-color-hover: #ffffff;
   --object-inspector-go-to-definition-icon-color: #dddddd;
   --object-inspector-inline-key: #36d1c4;
+  --object-inspector-gettervalue-key: #939395;
   --object-inspector-invoke-getter-icon-color-hover: #ffffff;
   --object-inspector-invoke-getter-icon-color: #dddddd;
   --object-inspector-prototype-color: #939395;
@@ -824,6 +825,7 @@
   --object-inspector-go-to-definition-icon-color-hover: #000000;
   --object-inspector-go-to-definition-icon-color: #222222;
   --object-inspector-inline-key: #0074e8;
+  --object-inspector-gettervalue-key: #737373;
   --object-inspector-invoke-getter-icon-color-hover: #000000;
   --object-inspector-invoke-getter-icon-color: #222222;
   --object-inspector-prototype-color: #737373;

--- a/packages/replay-next/src/utils/protocol.ts
+++ b/packages/replay-next/src/utils/protocol.ts
@@ -45,40 +45,6 @@ export function filterNonEnumerableProperties(properties: ProtocolProperty[]): P
   return properties.filter(property => property.flags == null || property.flags & 4);
 }
 
-export function mergePropertiesAndGetterValues(
-  properties: ProtocolProperty[],
-  getterValues: NamedValue[],
-  maxEntries: number = Infinity
-): [Array<NamedValue | ProtocolProperty>, boolean] {
-  const trackedNames: Set<string> = new Set();
-  const mergedProperties: Array<NamedValue | ProtocolProperty> = [];
-
-  for (let index = 0; index < properties.length; index++) {
-    const property = properties[index];
-
-    if (mergedProperties.length >= maxEntries) {
-      return [mergedProperties, true];
-    }
-
-    trackedNames.add(property.name);
-    mergedProperties.push(property);
-  }
-
-  for (let index = 0; index < getterValues.length; index++) {
-    if (mergedProperties.length >= maxEntries) {
-      return [mergedProperties, true];
-    }
-
-    const getterValue = getterValues[index];
-
-    if (!trackedNames.has(getterValue.name)) {
-      mergedProperties.push(getterValue);
-    }
-  }
-
-  return [mergedProperties, false];
-}
-
 function isProtocolProperty(
   valueOrProperty: ProtocolValue | ProtocolNamedValue | ProtocolProperty
 ): valueOrProperty is ProtocolProperty {


### PR DESCRIPTION
- don't add `getterValues` to the inline preview
- show `getterValues` below `properties` in the expanded preview (together with the special properties for `Promise` and `Proxy`)
- show the names of `getterValues` in grey