### PR TITLE
Add new (Advanced) user setting to show log-point above source line

### DIFF
--- a/packages/replay-next/components/Icon.tsx
+++ b/packages/replay-next/components/Icon.tsx
@@ -46,6 +46,8 @@ export type IconType =
   | "inspect"
   | "invisible"
   | "invoke-getter"
+  | "log-point-panel-arrow-above"
+  | "log-point-panel-arrow-below"
   | "menu-closed"
   | "menu-open"
   | "open"
@@ -308,6 +310,14 @@ export default function Icon({
           <polygon points="13,6 11.59,7.41 16.17,12 11.59,16.59 13,18 19,12" />
         </>
       );
+      break;
+    case "log-point-panel-arrow-above":
+      path =
+        "M17.17,11l-1.59,1.59L17,14l4-4l-4-4l-1.41,1.41L17.17,9L9,9c-1.1,0-2,0.9-2,2v9h2v-9L17.17,11z";
+      break;
+    case "log-point-panel-arrow-below":
+      path =
+        "M17.17 13L15.58 11.41L17 10L21 14L17 18L15.59 16.59L17.17 15H9C7.9 15 7 14.1 7 13V4H9V13H17.17Z";
       break;
     case "menu-closed":
       path = "M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z";

--- a/packages/replay-next/components/Icon.tsx
+++ b/packages/replay-next/components/Icon.tsx
@@ -313,11 +313,11 @@ export default function Icon({
       break;
     case "log-point-panel-arrow-above":
       path =
-        "M17.17,11l-1.59,1.59L17,14l4-4l-4-4l-1.41,1.41L17.17,9L9,9c-1.1,0-2,0.9-2,2v9h2v-9L17.17,11z";
+        "M11 17.17L12.59 15.58L14 17L10 21L6 17L7.41 15.59L9 17.17L9 9C9 7.9 9.9 7 11 7L20 7L20 9L11 9L11 17.17Z";
       break;
     case "log-point-panel-arrow-below":
       path =
-        "M17.17 13L15.58 11.41L17 10L21 14L17 18L15.59 16.59L17.17 15H9C7.9 15 7 14.1 7 13V4H9V13H17.17Z";
+        "M11 6.83L12.59 8.42L14 7L10 3L6 7L7.41 8.41L9 6.83L9 15C9 16.1 9.9 17 11 17L20 17L20 15L11 15L11 6.83Z";
       break;
     case "menu-closed":
       path = "M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z";

--- a/packages/replay-next/components/sources/SourceListRow.module.css
+++ b/packages/replay-next/components/sources/SourceListRow.module.css
@@ -74,17 +74,31 @@
   color: var(--color-dimmer);
 }
 
+.Row[data-log-point-placement="above"] {
+  align-items: flex-end;
+}
+
 .LogPointPanel {
   position: absolute;
   left: var(--source-line-number-offset);
-}
-
-.Row[data-log-point-placement="above"] {
-  align-items: flex-end;
 }
 .Row[data-log-point-placement="above"] .LogPointPanel {
   top: 0;
 }
 .Row[data-log-point-placement="below"] .LogPointPanel {
   top: var(--line-height);
+}
+
+.LogPointPanelIcon {
+  position: absolute;
+  left: 1rem;
+  width: 1rem;
+  height: 1rem;
+  color: var(--color-dimmer);
+}
+.Row[data-log-point-placement="above"] .LogPointPanelIcon {
+  top: calc(50% - 1rem);
+}
+.Row[data-log-point-placement="below"] .LogPointPanelIcon {
+  top: calc(50%);
 }

--- a/packages/replay-next/components/sources/SourceListRow.module.css
+++ b/packages/replay-next/components/sources/SourceListRow.module.css
@@ -90,8 +90,9 @@
 }
 
 .LogPointPanelIcon {
+  font-size: var(--font-size-tiny);
   position: absolute;
-  left: 1rem;
+  left: calc(var(--line-number-size) - 1ch);
   width: 1rem;
   height: 1rem;
   color: var(--color-dimmer);

--- a/packages/replay-next/components/sources/SourceListRow.module.css
+++ b/packages/replay-next/components/sources/SourceListRow.module.css
@@ -73,3 +73,18 @@
   line-height: 0.75rem;
   color: var(--color-dimmer);
 }
+
+.LogPointPanel {
+  position: absolute;
+  left: var(--source-line-number-offset);
+}
+
+.Row[data-log-point-placement="above"] {
+  align-items: flex-end;
+}
+.Row[data-log-point-placement="above"] .LogPointPanel {
+  top: 0;
+}
+.Row[data-log-point-placement="below"] .LogPointPanel {
+  top: var(--line-height);
+}

--- a/packages/replay-next/components/sources/SourceListRow.tsx
+++ b/packages/replay-next/components/sources/SourceListRow.tsx
@@ -2,6 +2,7 @@ import { SameLineSourceLocations } from "@replayio/protocol";
 import { CSSProperties, useContext, useMemo } from "react";
 import { STATUS_PENDING, useImperativeIntervalCacheValues } from "suspense";
 
+import Icon from "replay-next/components/Icon";
 import {
   ExecutionPointLineHighlight,
   LineHighlight,
@@ -217,6 +218,12 @@ export default function SourceListRow({
         <SourceListRowFormattedText
           parsedTokens={parsedTokens ? parsedTokens[lineIndex] ?? null : null}
           plainText={plainText[lineIndex] ?? null}
+        />
+      )}
+      {showPointPanel && (
+        <Icon
+          className={styles.LogPointPanelIcon}
+          type={logPointPanelAbove ? "log-point-panel-arrow-above" : "log-point-panel-arrow-below"}
         />
       )}
       {showPointPanel && (

--- a/packages/replay-next/components/sources/SourceListRow.tsx
+++ b/packages/replay-next/components/sources/SourceListRow.tsx
@@ -24,6 +24,7 @@ import { bucketVisibleLines } from "replay-next/src/utils/source";
 import { ParsedToken } from "replay-next/src/utils/syntax-parser";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { LineHitCounts, POINT_BEHAVIOR_DISABLED, Point } from "shared/client/types";
+import { useGraphQLUserData } from "shared/user-data/GraphQL/useGraphQLUserData";
 import { toPointRange } from "shared/utils/time";
 
 import LogPointPanel from "./log-point-panel/LogPointPanel";
@@ -80,6 +81,8 @@ export default function SourceListRow({
   const client = useContext(ReplayClientContext);
   const [{ enabled: searchEnabled, index: searchResultIndex, results: searchResults }] =
     useContext(SourceSearchContext);
+
+  const [logPointPanelAbove] = useGraphQLUserData("feature_showLogPointPanelAboveLine");
 
   const visibleSearchResults = useMemo<SourceSearchResult[]>(
     () => (searchEnabled ? searchResults.filter(result => result.lineIndex == lineIndex) : []),
@@ -154,6 +157,7 @@ export default function SourceListRow({
   return (
     <div
       className={styles.Row}
+      data-log-point-placement={logPointPanelAbove ? "above" : "below"}
       data-test-hitcounts-loaded={hitCounts != null ? true : undefined}
       data-test-line-has-hits={lineHitCounts != null ? hitCount > 0 : undefined}
       data-test-line-number={lineNumber}
@@ -217,7 +221,7 @@ export default function SourceListRow({
       )}
       {showPointPanel && (
         <LogPointPanel
-          className={styles.PointPanel}
+          className={styles.LogPointPanel}
           pointWithPendingEdits={pointWithPendingEdits}
           pointForSuspense={pointForSuspense!}
         />

--- a/packages/replay-next/components/sources/SourceListRowLineHighlight.module.css
+++ b/packages/replay-next/components/sources/SourceListRowLineHighlight.module.css
@@ -4,7 +4,6 @@
   position: absolute;
   left: var(--source-line-number-offset);
   width: calc(var(--longest-line-width) - var(--source-line-number-offset));
-  top: 0;
   height: var(--line-height);
   z-index: -1;
 }

--- a/packages/replay-next/components/sources/log-point-panel/LogPointPanel.module.css
+++ b/packages/replay-next/components/sources/log-point-panel/LogPointPanel.module.css
@@ -1,9 +1,6 @@
 .Panel,
 .Loader,
 .ErrorFallback {
-  position: absolute;
-  top: var(--line-height);
-  left: var(--source-line-number-offset);
   width: calc(var(--list-width) - var(--source-line-number-offset));
   border-left: var(--hit-count-bar-size) solid var(--color-hit-counts-bar-0);
   font-size: var(--font-size-small);

--- a/packages/shared/user-data/GraphQL/config.ts
+++ b/packages/shared/user-data/GraphQL/config.ts
@@ -171,6 +171,11 @@ export const config = {
     label: "Visualize protocol events in the timeline",
     legacyKey: "devtools.features.protocolTimeline",
   },
+  feature_showLogPointPanelAboveLine: {
+    defaultValue: Boolean(false),
+    label: "Show log point panel above source line",
+    legacyKey: null,
+  },
 
   global_disableLogRocket: {
     defaultValue: Boolean(false),

--- a/src/ui/components/shared/UserSettingsModal/panels/Advanced.tsx
+++ b/src/ui/components/shared/UserSettingsModal/panels/Advanced.tsx
@@ -3,6 +3,7 @@ import { PreferencesKey } from "shared/user-data/GraphQL/types";
 import { BooleanPreference } from "ui/components/shared/UserSettingsModal/components/BooleanPreference";
 
 export const PREFERENCES: PreferencesKey[] = [
+  "feature_showLogPointPanelAboveLine",
   "backend_sampleAllTraces",
   "global_logTelemetryEvent",
   "feature_protocolTimeline",


### PR DESCRIPTION
Log point expressions are evaluated _before_ the line of source code they're added to. Showing them _below_ the source code line implies that they're evaluated _after_ the line, which causes confusion. I've long thought that we should display them above, but that's somewhat controversial– so this PR adds an advanced setting to control their placement.

- [x] Add configurable setting
- [x] Add an arrow from the row/line to the log point panel (to help associate the two)
- [x] Verify current execution point highlight
- [x] Verify search result highlights

---

New advanced opt-in setting:

![Screenshot 2024-01-29 at 2 13 02 PM](https://github.com/replayio/devtools/assets/29597/ba4954f0-888f-4625-a8ce-5319ba2047e6)

---

#### Below (default)
![Screenshot 2024-01-29 at 2 00 25 PM](https://github.com/replayio/devtools/assets/29597/39a0622b-9395-405c-8062-ac69912934a3)

#### Above
![Screenshot 2024-01-29 at 1 58 54 PM](https://github.com/replayio/devtools/assets/29597/0f7c2062-3412-4af7-93c2-6014123d88f6)

---

I've also verified that search result highlighting and current execution point highlighting continue to work with this new setting:

|  | Above | Below |
| :--- | :--- |:--- |
| Search | ![Screenshot 2024-01-29 at 2 09 26 PM](https://github.com/replayio/devtools/assets/29597/024d1108-be50-4a4b-ac12-33a1e65fbcd4) | ![Screenshot 2024-01-29 at 2 11 26 PM](https://github.com/replayio/devtools/assets/29597/8dceffb2-44d1-4798-975a-65843f815971) |
| View-source | ![Screenshot 2024-01-29 at 2 09 07 PM](https://github.com/replayio/devtools/assets/29597/1089a8c2-712a-41cc-99ff-a3a0109757b5) | ![Screenshot 2024-01-29 at 2 11 05 PM](https://github.com/replayio/devtools/assets/29597/9cf3f3f8-29d4-454c-877d-f0efa7abc309) |
| Execution point | ![Screenshot 2024-01-29 at 2 09 49 PM](https://github.com/replayio/devtools/assets/29597/6e9b0b58-7e0a-4736-9c0a-cf9e437719a6) | ![Screenshot 2024-01-29 at 2 10 55 PM](https://github.com/replayio/devtools/assets/29597/72f9924d-abfa-4716-8bb6-fef50183381c) |

---

I also tested the arrow positioning with various hit count widths:

![Screenshot 2024-01-29 at 4 22 51 PM](https://github.com/replayio/devtools/assets/29597/a04588ce-c670-49b8-87af-2ce4b7a934be)

![Screenshot 2024-01-29 at 4 23 08 PM](https://github.com/replayio/devtools/assets/29597/3f8729d7-c0f3-4852-b833-e538982440d7)

![Screenshot 2024-01-29 at 4 22 55 PM](https://github.com/replayio/devtools/assets/29597/c0bed50f-80bc-41ac-8f1e-25be5855654d)

---

cc @jcmorrow @jonbell-lot23 @jasonLaster 