### PR TITLE
More explicit type guard for recordings without Paints

### DIFF
--- a/packages/protocol/PaintsCache.ts
+++ b/packages/protocol/PaintsCache.ts
@@ -7,14 +7,14 @@ import { TimeStampedPointWithPaintHash } from "shared/client/types";
 
 // This could be a streaming cache, but streaming APIs are more awkward to interop with
 // Since we wait for processing to complete before loading a recording, paints should always load very quickly
-export const PaintsCache = createSingleEntryCache<[], TimeStampedPointWithPaintHash[]>({
+export const PaintsCache = createSingleEntryCache<[], TimeStampedPointWithPaintHash[] | null>({
   config: { immutable: true },
   debugLabel: "PaintsCache",
   load: async ([]) => {
     const target = await recordingTargetCache.readAsync(replayClient);
     switch (target) {
       case "node": {
-        return [];
+        return null;
       }
     }
 
@@ -47,7 +47,7 @@ export function mostRecentPaint(time: number) {
 // TODO [FE-2401] Do we need to keep this method? Maybe not.
 export function timeIsBeyondKnownPaints(time: number) {
   const paints = PaintsCache.getValueIfCached();
-  if (!paints) {
+  if (!paints || paints.length === 0) {
     return false;
   }
 

--- a/packages/protocol/graphics.ts
+++ b/packages/protocol/graphics.ts
@@ -107,7 +107,10 @@ export async function setupGraphics(store: AppStore) {
   await Promise.all([PaintsCache.readAsync(), RecordedMouseEventsCache.readAsync()]);
 
   // TODO [FE-2104] Remove gPaintPoints entirely
-  gPaintPoints.push(...PaintsCache.getValue());
+  const paints = PaintsCache.getValue();
+  if (paints) {
+    gPaintPoints.push(...paints);
+  }
 
   // TODO [FE-2104] Remove gMouseEvents and gMouseClickEvents entirely
   RecordedMouseEventsCache.getValue().forEach(entry => {

--- a/src/ui/components/ProtocolTimeline.tsx
+++ b/src/ui/components/ProtocolTimeline.tsx
@@ -7,6 +7,7 @@ import clamp from "lodash/clamp";
 
 import { PaintsCache } from "protocol/PaintsCache";
 import useLoadedRegions from "replay-next/src/hooks/useLoadedRegions";
+import { TimeStampedPointWithPaintHash } from "shared/client/types";
 import { getZoomRegion } from "ui/reducers/timeline";
 import { useAppSelector } from "ui/setup/hooks";
 
@@ -80,9 +81,14 @@ const EMPTY_LOADED_REGIONS: LoadedRegions = {
 export default function ProtocolTimeline() {
   const loadedRegions = useLoadedRegions() ?? EMPTY_LOADED_REGIONS;
 
+  let firstPaint: TimeStampedPointWithPaintHash | null = null;
+  let lastPaint: TimeStampedPointWithPaintHash | null = null;
+
   const paints = PaintsCache.read();
-  const firstPaint = paints[0];
-  const lastPaint = paints[paints.length - 1];
+  if (paints && paints.length > 0) {
+    firstPaint = paints[0];
+    lastPaint = paints[paints.length - 1];
+  }
 
   return (
     <div className="flex w-full flex-col space-y-1">
@@ -94,19 +100,21 @@ export default function ProtocolTimeline() {
       <Spans regions={loadedRegions.loading} color="gray-500" title="Loading" />
       <Spans regions={loadedRegions.loaded} color="orange-500" title="Loaded" />
       <Spans regions={loadedRegions.indexed} color="green-500" title="Indexed" />
-      <Spans
-        regions={[
-          {
-            begin: { point: firstPaint.point, time: firstPaint.time },
-            // This timeline should always extend to the end,
-            // even though the final paint will be before the end
-            end: { point: lastPaint.point, time: Infinity },
-          },
-        ]}
-        color="sky-500"
-        points={paints}
-        title="Paints"
-      />
+      {paints && (
+        <Spans
+          regions={[
+            {
+              begin: { point: firstPaint?.point ?? "0", time: firstPaint?.time ?? 0 },
+              // This timeline should always extend to the end,
+              // even though the final paint will be before the end
+              end: { point: lastPaint?.point ?? "0", time: Infinity },
+            },
+          ]}
+          color="sky-500"
+          points={paints}
+          title="Paints"
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
#10230 broke playback for Node recordings because it didn't properly handle the case of array out-of-bounds. Unfortunately I wish TypeScript was stricter about that in our project, but for now I've updated the `PaintsCache` to return an explicit `null` value/type for Node recordings, to force us to be more explicit with our handling of the no-paints case.