### PR TITLE
Revert "Fix object properties ordering (#10241)"

### DIFF
--- a/packages/replay-next/components/inspector/KeyValueRenderer.module.css
+++ b/packages/replay-next/components/inspector/KeyValueRenderer.module.css
@@ -13,10 +13,6 @@
 .VerticalNameWithFlag {
   color: var(--object-inspector-expanded-key-with-flag);
 }
-.VerticalName.GetterValue,
-.VerticalNameWithFlag.GetterValue {
-  color: var(--object-inspector-gettervalue-key);
-}
 
 .ToggleAlignmentPadding {
   margin-left: 1.25rem;

--- a/packages/replay-next/components/inspector/KeyValueRenderer.tsx
+++ b/packages/replay-next/components/inspector/KeyValueRenderer.tsx
@@ -26,7 +26,7 @@ export type Props = {
   onContextMenu?: (event: MouseEvent) => void;
   path?: string;
   pauseId: PauseId;
-  protocolValue: (ProtocolValue | ProtocolNamedValue) & { isGetterValue?: boolean };
+  protocolValue: ProtocolValue | ProtocolNamedValue;
 };
 
 // Renders a protocol Object/ObjectPreview as a key+value pair.
@@ -131,9 +131,6 @@ export default function KeyValueRenderer({
     } else {
       nameClass = styles.VerticalName;
     }
-  }
-  if (protocolValue.isGetterValue) {
-    nameClass += " " + styles.GetterValue;
   }
 
   // What we show when expanded or collapsed depends on the context we are displayed in.

--- a/packages/replay-next/components/inspector/PropertiesRenderer.tsx
+++ b/packages/replay-next/components/inspector/PropertiesRenderer.tsx
@@ -12,7 +12,7 @@ import { FC, Fragment, ReactNode, Suspense, useContext, useMemo } from "react";
 import Expandable from "replay-next/components/Expandable";
 import Loader from "replay-next/components/Loader";
 import { objectCache } from "replay-next/src/suspense/ObjectPreviews";
-import { isArrayElement } from "replay-next/src/utils/protocol";
+import { mergePropertiesAndGetterValues } from "replay-next/src/utils/protocol";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
 import GetterRenderer from "./GetterRenderer";
@@ -56,29 +56,31 @@ export default function PropertiesRenderer({
       return [];
     }
 
-    const ownProperties = sortBy(preview.properties || [], property =>
-      isArrayElement(property) ? Number(property.name) : property.name
+    let [properties] = mergePropertiesAndGetterValues(
+      preview.properties || [],
+      preview.getterValues || []
     );
 
-    const getterValues = sortBy(preview.getterValues || [], getterValue => getterValue.name);
+    properties = sortBy(properties, ({ name }) => {
+      const maybeNumber = Number(name);
+      return isNaN(maybeNumber) ? name : maybeNumber;
+    });
 
     if (preview.promiseState) {
       if (preview.promiseState.value) {
-        getterValues.unshift({ name: "<value>", ...preview.promiseState.value });
+        properties.unshift({ name: "<value>", ...preview.promiseState.value });
       }
-      getterValues.unshift({ name: "<state>", value: preview.promiseState.state });
+      properties.unshift({ name: "<state>", value: preview.promiseState.state });
     }
 
     if (preview.proxyState) {
-      getterValues.unshift(
+      properties.unshift(
         { name: "<target>", ...preview.proxyState.target },
         { name: "<handler>", ...preview.proxyState.handler }
       );
     }
 
-    return ownProperties
-      .map(property => ({ ...property, isGetterValue: false }))
-      .concat(getterValues.map(getterValue => ({ ...getterValue, isGetterValue: true })));
+    return properties;
   }, [preview]);
 
   let EntriesRenderer: FC<EntriesRendererProps> = ContainerEntriesRenderer;

--- a/packages/replay-next/components/inspector/values/ObjectRenderer.tsx
+++ b/packages/replay-next/components/inspector/values/ObjectRenderer.tsx
@@ -1,4 +1,6 @@
-import { ReactNode } from "react";
+import { ReactNode, useMemo } from "react";
+
+import { mergePropertiesAndGetterValues } from "replay-next/src/utils/protocol";
 
 import KeyValueRenderer from "../KeyValueRenderer";
 import { ObjectPreviewRendererProps } from "./types";
@@ -13,11 +15,22 @@ const MAX_PROPERTIES_TO_PREVIEW = 5;
 export default function ObjectRenderer({ context, object, pauseId }: ObjectPreviewRendererProps) {
   const { className, preview } = object;
 
-  const properties = preview?.properties?.slice(0, MAX_PROPERTIES_TO_PREVIEW);
-  let propertiesList: ReactNode[] | null = null;
-  if (context !== "nested" && properties) {
-    const showOverflowMarker = preview?.overflow || properties.length > MAX_PROPERTIES_TO_PREVIEW;
+  const [properties, propertiesWereTruncated] = useMemo(() => {
+    if (preview == null) {
+      return [[], false];
+    }
 
+    return mergePropertiesAndGetterValues(
+      preview.properties || [],
+      preview.getterValues || [],
+      MAX_PROPERTIES_TO_PREVIEW
+    );
+  }, [preview]);
+
+  const showOverflowMarker = object.preview?.overflow || propertiesWereTruncated;
+
+  let propertiesList: ReactNode[] | null = null;
+  if (context !== "nested") {
     propertiesList = properties.map((property, index) => (
       <span key={index} className={styles.Value}>
         <KeyValueRenderer

--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -275,7 +275,6 @@
   --object-inspector-go-to-definition-icon-color-hover: #ffffff;
   --object-inspector-go-to-definition-icon-color: #dddddd;
   --object-inspector-inline-key: #36d1c4;
-  --object-inspector-gettervalue-key: #939395;
   --object-inspector-invoke-getter-icon-color-hover: #ffffff;
   --object-inspector-invoke-getter-icon-color: #dddddd;
   --object-inspector-prototype-color: #939395;
@@ -825,7 +824,6 @@
   --object-inspector-go-to-definition-icon-color-hover: #000000;
   --object-inspector-go-to-definition-icon-color: #222222;
   --object-inspector-inline-key: #0074e8;
-  --object-inspector-gettervalue-key: #737373;
   --object-inspector-invoke-getter-icon-color-hover: #000000;
   --object-inspector-invoke-getter-icon-color: #222222;
   --object-inspector-prototype-color: #737373;

--- a/packages/replay-next/src/utils/protocol.ts
+++ b/packages/replay-next/src/utils/protocol.ts
@@ -45,6 +45,40 @@ export function filterNonEnumerableProperties(properties: ProtocolProperty[]): P
   return properties.filter(property => property.flags == null || property.flags & 4);
 }
 
+export function mergePropertiesAndGetterValues(
+  properties: ProtocolProperty[],
+  getterValues: NamedValue[],
+  maxEntries: number = Infinity
+): [Array<NamedValue | ProtocolProperty>, boolean] {
+  const trackedNames: Set<string> = new Set();
+  const mergedProperties: Array<NamedValue | ProtocolProperty> = [];
+
+  for (let index = 0; index < properties.length; index++) {
+    const property = properties[index];
+
+    if (mergedProperties.length >= maxEntries) {
+      return [mergedProperties, true];
+    }
+
+    trackedNames.add(property.name);
+    mergedProperties.push(property);
+  }
+
+  for (let index = 0; index < getterValues.length; index++) {
+    if (mergedProperties.length >= maxEntries) {
+      return [mergedProperties, true];
+    }
+
+    const getterValue = getterValues[index];
+
+    if (!trackedNames.has(getterValue.name)) {
+      mergedProperties.push(getterValue);
+    }
+  }
+
+  return [mergedProperties, false];
+}
+
 function isProtocolProperty(
   valueOrProperty: ProtocolValue | ProtocolNamedValue | ProtocolProperty
 ): valueOrProperty is ProtocolProperty {


### PR DESCRIPTION
This reverts commit 6ea805126860f4612ff8932c2d1cd4332e4082da

That caused a regression for 4 tests (which started [on that branch](https://app.replay.io/team/dzowNDAyOGMwYS05ZjM1LTQ2ZjktYTkwYi1jNzJkMTIzNzUxOTI=/runs/c1040dbc-4a02-455f-bde7-27d65938fcad?param=dzowNDAyOGMwYS05ZjM1LTQ2ZjktYTkwYi1jNzJkMTIzNzUxOTI%3D&param=runs&param=60318204-9364-4829-b9ab-9b619d0e866b&param=tests&param=dHJ0OmNkNmZmYTMzODIzNTc5YTQxOWM0NjYyMDI3OWM2NDdmOTM5YTExMjk%3D).  Here is one, with a comment: [go/r/e433ab82-f093-4321-bf48-0014d3270e02](http://go/r/e433ab82-f093-4321-bf48-0014d3270e02)