### PR TITLE
Update example recordings from the 2024-01-23 to the 2024-01-26 build

### DIFF
--- a/packages/e2e-tests/examples.json
+++ b/packages/e2e-tests/examples.json
@@ -9,8 +9,8 @@
     "buildId": "linux-chromium-20240123-609ec6caa105-50d01be708a2"
   },
   "authenticated_logpoints.html": {
-    "recording": "8f4049fa-4bb8-4717-b146-811a1bede5ed",
-    "buildId": "linux-chromium-20240123-609ec6caa105-50d01be708a2"
+    "recording": "40a54b56-1d11-4009-87f8-61423bfc2e05",
+    "buildId": "linux-chromium-20240126-c9de98d17d37-50d01be708a2"
   },
   "breakpoints-01": {
     "recording": "d8614dc0-129b-421e-bc67-8c63048fb6c9",
@@ -27,24 +27,24 @@
     "requiresManualUpdate": true
   },
   "doc_async.html": {
-    "recording": "c0b469af-654d-40a8-9c55-458dee9870fb",
-    "buildId": "linux-chromium-20240123-609ec6caa105-50d01be708a2"
+    "recording": "22857e2a-e6f9-4d79-b9b4-b3eaf293d326",
+    "buildId": "linux-chromium-20240126-c9de98d17d37-50d01be708a2"
   },
   "doc_control_flow.html": {
-    "recording": "0cd81b35-85fe-41e0-bffc-84975df0761f",
-    "buildId": "linux-chromium-20240123-609ec6caa105-50d01be708a2"
+    "recording": "73be1d20-519f-49a0-ae8b-439c9f6fe187",
+    "buildId": "linux-chromium-20240126-c9de98d17d37-50d01be708a2"
   },
   "doc_control_flow_firefox.html": {
     "recording": "8b024e1a-1e84-4424-97bd-3c2c528642fd",
     "buildId": "macOS-gecko-20220722-76bf615bc154-b7eae18423ef"
   },
   "doc_debugger_statements.html": {
-    "recording": "44d3e310-8840-4228-b644-d80d92f3bc14",
-    "buildId": "linux-chromium-20240123-609ec6caa105-50d01be708a2"
+    "recording": "0ada5d1e-9f3d-4cab-a67e-879b9162d71d",
+    "buildId": "linux-chromium-20240126-c9de98d17d37-50d01be708a2"
   },
   "doc_events.html": {
-    "recording": "6fe23adc-09e6-44e2-8297-01ebcb4fae73",
-    "buildId": "linux-chromium-20240123-609ec6caa105-50d01be708a2"
+    "recording": "5d741c42-23c0-471f-89d7-97285fb48bc7",
+    "buildId": "linux-chromium-20240126-c9de98d17d37-50d01be708a2"
   },
   "doc_exceptions.html": {
     "recording": "11d683a6-30bb-46c2-ab55-f8d990bffa9e",
@@ -55,8 +55,8 @@
     "buildId": "macOS-gecko-20220722-76bf615bc154-b7eae18423ef"
   },
   "doc_inspector_basic.html": {
-    "recording": "14b8f627-106c-4d48-b3de-5685bf827c23",
-    "buildId": "linux-chromium-20240123-609ec6caa105-50d01be708a2"
+    "recording": "97d74cb5-9c91-436e-ac47-ba18a579b3cd",
+    "buildId": "linux-chromium-20240126-c9de98d17d37-50d01be708a2"
   },
   "doc_inspector_shorthand.html": {
     "recording": "28f3f493-c7cb-43bb-a8fc-c0f661e9096d",
@@ -75,40 +75,40 @@
     "buildId": "macOS-gecko-20220722-76bf615bc154-b7eae18423ef"
   },
   "doc_minified_chromium.html": {
-    "recording": "f3f7d7a8-04fc-4d5c-bd24-c38bd371e282",
-    "buildId": "linux-chromium-20240123-609ec6caa105-50d01be708a2"
+    "recording": "0296c6a8-77af-4a66-9fbd-1f36da70f10e",
+    "buildId": "linux-chromium-20240126-c9de98d17d37-50d01be708a2"
   },
   "doc_navigate.html": {
-    "recording": "4f8e4f4f-987f-4938-830b-428039c82e6b",
-    "buildId": "linux-chromium-20240123-609ec6caa105-50d01be708a2"
+    "recording": "846c99b2-ec38-46af-a166-e7cac2186827",
+    "buildId": "linux-chromium-20240126-c9de98d17d37-50d01be708a2"
   },
   "doc_prod_bundle.html": {
-    "recording": "6f0a99ee-4e0a-4237-a32f-58d109ce79d4",
-    "buildId": "linux-chromium-20240123-609ec6caa105-50d01be708a2"
+    "recording": "44c76a3f-e8fe-4680-b2b3-aaff5c0b7605",
+    "buildId": "linux-chromium-20240126-c9de98d17d37-50d01be708a2"
   },
   "doc_recursion.html": {
-    "recording": "ff6a3773-383a-4c74-bfb3-bfd13b26494a",
-    "buildId": "linux-chromium-20240123-609ec6caa105-50d01be708a2"
+    "recording": "7b3cc0d6-39a1-42d6-babd-861fd78cf6e3",
+    "buildId": "linux-chromium-20240126-c9de98d17d37-50d01be708a2"
   },
   "doc_rr_basic.html": {
     "recording": "84bfc1b8-edf2-4d1e-b55e-c31aba7d139d",
     "buildId": "linux-gecko-20230919-72cad6f42a93-4d0a9f5b9de2"
   },
   "doc_rr_basic_chromium.html": {
-    "recording": "02da5eac-be78-4418-ae3e-bef8fb1540c7",
-    "buildId": "linux-chromium-20240123-609ec6caa105-50d01be708a2"
+    "recording": "d5205590-f3bb-41e5-adf8-499f8755d36a",
+    "buildId": "linux-chromium-20240126-c9de98d17d37-50d01be708a2"
   },
   "doc_rr_blackbox.html": {
-    "recording": "852d9ece-bec7-4616-bfe1-3ddf495d73a2",
-    "buildId": "linux-chromium-20240123-609ec6caa105-50d01be708a2"
+    "recording": "d4a2f902-dc01-4b2e-b253-52c4fdb36860",
+    "buildId": "linux-chromium-20240126-c9de98d17d37-50d01be708a2"
   },
   "doc_rr_console.html": {
-    "recording": "0c3f19f9-78bb-4171-a157-fba3d709ae56",
-    "buildId": "linux-chromium-20240123-609ec6caa105-50d01be708a2"
+    "recording": "160a03d1-af8b-47b7-9811-9f3ae497a031",
+    "buildId": "linux-chromium-20240126-c9de98d17d37-50d01be708a2"
   },
   "doc_rr_error.html": {
-    "recording": "29fb738f-9a78-46fb-8d7d-84cf4474e437",
-    "buildId": "linux-chromium-20240123-609ec6caa105-50d01be708a2"
+    "recording": "448bca6d-d081-4255-8774-b5b4fe2faecf",
+    "buildId": "linux-chromium-20240126-c9de98d17d37-50d01be708a2"
   },
   "doc_rr_logs.html": {
     "recording": "1a735f4e-dc3f-4fcf-a41c-9bee22c7ba77",
@@ -119,24 +119,24 @@
     "buildId": "linux-gecko-20230919-72cad6f42a93-4d0a9f5b9de2"
   },
   "doc_rr_preview.html": {
-    "recording": "942cd72a-bbda-41de-a941-bae20cf9cc81",
-    "buildId": "linux-chromium-20240123-609ec6caa105-50d01be708a2"
+    "recording": "e39e2dcb-be59-4387-bfc4-8bb11167f09c",
+    "buildId": "linux-chromium-20240126-c9de98d17d37-50d01be708a2"
   },
   "doc_rr_region_loading.html": {
-    "recording": "39147fc3-96da-430a-b4dc-da79f2e433c1",
-    "buildId": "linux-chromium-20240123-609ec6caa105-50d01be708a2"
+    "recording": "82d7b26b-09cf-4d3d-840f-56cfc7125ac2",
+    "buildId": "linux-chromium-20240126-c9de98d17d37-50d01be708a2"
   },
   "doc_rr_worker.html": {
-    "recording": "d5a71d57-734b-49ea-8a38-0f585adbb0d8",
-    "buildId": "linux-chromium-20240123-609ec6caa105-50d01be708a2"
+    "recording": "ee7f1f27-6b12-4c7e-bdec-4eb09fc17ef4",
+    "buildId": "linux-chromium-20240126-c9de98d17d37-50d01be708a2"
   },
   "doc_stacking.html": {
     "recording": "233a22c5-428e-46f8-a1ac-4b2488ac517e",
     "buildId": "macOS-gecko-20220722-76bf615bc154-b7eae18423ef"
   },
   "doc_stacking_chromium.html": {
-    "recording": "4981f045-88b5-45c6-9355-355c843abfef",
-    "buildId": "linux-chromium-20240123-609ec6caa105-50d01be708a2"
+    "recording": "fa5a2a8b-a095-44ef-83ca-324da9f7bde8",
+    "buildId": "linux-chromium-20240126-c9de98d17d37-50d01be708a2"
   },
   "flake/adding-spec.ts": {
     "recording": "7b0db00a-d9a9-4d2d-b816-af14a1b682a6",
@@ -144,8 +144,8 @@
     "requiresManualUpdate": true
   },
   "log_points_and_block_scope.html": {
-    "recording": "95efeb5e-c8fc-49f6-9438-51e700dce3db",
-    "buildId": "linux-chromium-20240123-609ec6caa105-50d01be708a2"
+    "recording": "10a829d0-6562-4dfc-9955-662613e5a23a",
+    "buildId": "linux-chromium-20240126-c9de98d17d37-50d01be708a2"
   },
   "node/async.js": {
     "recording": "c81bddb8-3edd-45c3-b7b1-486a7e07f741",
@@ -185,16 +185,16 @@
     "requiresManualUpdate": true
   },
   "rdt-react-versions/dist/index.html": {
-    "recording": "f5bc3a10-4e83-4f8b-8286-5e13e2ef6bf7",
-    "buildId": "linux-chromium-20240123-609ec6caa105-50d01be708a2"
+    "recording": "38908ebb-83dd-48e6-9eb5-ce453423069d",
+    "buildId": "linux-chromium-20240126-c9de98d17d37-50d01be708a2"
   },
   "redux-fundamentals/dist/index.html": {
-    "recording": "845410d4-8355-4815-baed-53ef57d3e1f0",
-    "buildId": "linux-chromium-20240123-609ec6caa105-50d01be708a2",
+    "recording": "6cb44cbd-8dd9-4c36-b1b1-0e65675229b9",
+    "buildId": "linux-chromium-20240126-c9de98d17d37-50d01be708a2",
     "playwrightScript": "examples/redux-fundamentals/tests/example-script"
   },
   "redux/dist/index.html": {
-    "recording": "8e3e7dbe-1876-4e8a-b29a-d22a26136261",
-    "buildId": "linux-chromium-20240123-609ec6caa105-50d01be708a2"
+    "recording": "1f9257ab-de04-4b46-82fd-552be879bd74",
+    "buildId": "linux-chromium-20240126-c9de98d17d37-50d01be708a2"
   }
 }

--- a/packages/e2e-tests/tests/elements-search.test.ts
+++ b/packages/e2e-tests/tests/elements-search.test.ts
@@ -79,7 +79,7 @@ test("elements-search: Element panel should support basic and advanced search mo
   await verifySelectedElement(page, "</body>");
 
   // Change timeline and verify results are updated
-  await seekToTimePercent(page, 1);
+  await seekToTimePercent(page, 0);
   await verifySearchResults(page, {
     currentNumber: 0,
     totalNumber: 0,

--- a/packages/e2e-tests/tests/jump-to-code-01_basic.test.ts
+++ b/packages/e2e-tests/tests/jump-to-code-01_basic.test.ts
@@ -55,9 +55,14 @@ async function checkForJumpButton(eventLocator: Locator, shouldBeEnabled: boolea
   expect(await jumpButton.isVisible()).toBe(true);
   await jumpButton.hover({});
 
-  const buttonText = await getByTestName(jumpButton, "JumpToCodeButtonLabel").innerText();
-  const expectedText = shouldBeEnabled ? "Jump to code" : "No results";
-  expect(buttonText).toBe(expectedText);
+  await waitFor(
+    async () => {
+      const buttonText = await getByTestName(jumpButton, "JumpToCodeButtonLabel").innerText();
+      const expectedText = shouldBeEnabled ? "Jump to code" : "No results";
+      expect(buttonText).toBe(expectedText);
+    },
+    { timeout: 10_000 }
+  );
 
   return jumpButton;
 }


### PR DESCRIPTION
[This](https://github.com/replayio/devtools/pull/10248#discussion_r1472708579) convinced me that it's a good idea to keep the examples that work with the latest Chromium release up-to-date.
I haven't updated `authenticated_comments.html` due to [this](https://linear.app/replay/issue/RUN-3162/wrong-network-status-reported#comment-52a86b59)