### PR TITLE
add a dependabot config to notify us about updates to all the replay-cli packages

### DIFF
--- a/.dependabot.yml
+++ b/.dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "@replayio/replay"
+      - dependency-name: "@replayio/cypress"
+      - dependency-name: "@replayio/playwright"
+      - dependency-name: "@replayio/puppeteer"
+      - dependency-name: "@replayio/node"
+      - dependency-name: "@replayio/sourcemap-upload"
+      - dependency-name: "@replayio/sourcemap-upload-webpack-plugin"
+
+  - package-ecosystem: "npm"
+    directory: "/packages/e2e-tests"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "@replayio/replay"
+      - dependency-name: "@replayio/cypress"
+      - dependency-name: "@replayio/playwright"
+      - dependency-name: "@replayio/puppeteer"
+      - dependency-name: "@replayio/node"
+      - dependency-name: "@replayio/sourcemap-upload"
+      - dependency-name: "@replayio/sourcemap-upload-webpack-plugin"


### PR DESCRIPTION
part of work for RUN-3159

Nag.. someone (volunteering myself for the time being unless there's someone better) about keeping replay-cli packages up-to-date.

I'm not entirely sure of a couple of things here:
1. if this is something you want in this repo at all :)
2. who to add to `reviewers`.  I'm more than willing to `@dependabot squash and merge` (or merge manually) if everything is green, but I'm not sure if you are.  If that sounds good I'll add `reviewers: "toshok"` to the config.
3. I listed the packages in https://github.com/replayio/replay-cli manually (can't use `@replayio/*` because that'll catch some other deps).  I'm not sure if dependabot will be okay with deps in the yaml that aren't in package.json files.
4. If dependabot is enabled for this repo at all.  I don't have access to settings so can't tell.
