### PR TITLE
Don't show Playwright toolbar button for non-test recordings

### DIFF
--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -403,14 +403,15 @@ export default function Toolbar() {
             onClick={handleButtonClick}
           />
         ) : null}
-        {testRunner === "cypress" ? (
+        {testRunner === "cypress" && (
           <ToolbarButton
             icon="cypress"
             label="Cypress Panel"
             name="cypress"
             onClick={handleButtonClick}
           />
-        ) : (
+        )}
+        {testRunner === "playwright" && (
           <ToolbarButton
             icon="playwright"
             label="Test Info"


### PR DESCRIPTION
This regressed in #10206 (my fault)

| Recording Type | Screenshot |
| :--- | :--- |
| Manual | ![Screenshot 2024-02-01 at 1 17 05 PM](https://github.com/replayio/devtools/assets/29597/dc9fda2b-6f91-4c57-93a6-5a0e62e8241a) |
| Cypress | ![Screenshot 2024-02-01 at 1 17 40 PM](https://github.com/replayio/devtools/assets/29597/e3e2984a-02ad-4ec0-907f-78f7ed0a3b1b) |
| Playwright | ![Screenshot 2024-02-01 at 1 17 43 PM](https://github.com/replayio/devtools/assets/29597/b52f7494-96ea-4ef3-80eb-23ef28dd956e) |