### PR TITLE
Ignore empty token from browser

### DIFF
--- a/src/ui/utils/browser.ts
+++ b/src/ui/utils/browser.ts
@@ -24,7 +24,7 @@ export function setAccessTokenInBrowserPrefs(token: string | null) {
 export function listenForAccessToken(callback: (accessToken: string) => void) {
   window.addEventListener("WebChannelMessageToContent", (ev: any) => {
     const { error, token } = ev.detail?.message || {};
-    if (!error) {
+    if (token && !error) {
       callback(token);
     }
   });


### PR DESCRIPTION
The behavior of our Chromium browser is slightly different from our Firefox browser: when the browser doesn't have a token stored, it will send an event without a token (but also without an error) to the app whereas the Firefox browser doesn't send an event at all.
Note that I couldn't test this PR because our Chromium browser will only send events to `https://app.replay.io`.