### PR TITLE
Switch breakpoints-02 to Chromium example

### DIFF
--- a/packages/e2e-tests/tests/breakpoints-02.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-02.test.ts
@@ -4,7 +4,7 @@ import { rewindToLine } from "../helpers/pause-information-panel";
 import { addBreakpoint } from "../helpers/source-panel";
 import test from "../testFixtureCloneRecording";
 
-test.use({ exampleKey: "doc_rr_basic.html" });
+test.use({ exampleKey: "doc_rr_basic_chromium.html" });
 
 test(`breakpoints-02: Test unhandled divergence while evaluating at a breakpoint`, async ({
   pageWithMeta: { page, recordingId },
@@ -18,9 +18,9 @@ test(`breakpoints-02: Test unhandled divergence while evaluating at a breakpoint
   await rewindToLine(page, 21);
 
   await executeAndVerifyTerminalExpression(page, "number", "10");
-  await executeAndVerifyTerminalExpression(page, "dump(3)", `undefined`);
+  await executeAndVerifyTerminalExpression(page, "stop()", `undefined`);
   await executeAndVerifyTerminalExpression(page, "number", "10");
-  await executeAndVerifyTerminalExpression(page, "dump(3)", `undefined`);
+  await executeAndVerifyTerminalExpression(page, "stop()", `undefined`);
   await executeAndVerifyTerminalExpression(page, "number", "10");
   await executeAndVerifyTerminalExpression(page, "testStepping2()", "undefined");
 });


### PR DESCRIPTION
This test only failed because it tries to call `dump()`, which only exists in Firefox. I changed it to call `stop()` instead.