### PR TITLE
Removed time-is-beyond-known-paints check

### DIFF
--- a/packages/protocol/PaintsCache.ts
+++ b/packages/protocol/PaintsCache.ts
@@ -43,15 +43,3 @@ export function mostRecentPaint(time: number) {
     return null;
   }
 }
-
-// TODO [FE-2401] Do we need to keep this method? Maybe not.
-export function timeIsBeyondKnownPaints(time: number) {
-  const paints = PaintsCache.getValueIfCached();
-  if (!paints || paints.length === 0) {
-    return false;
-  }
-
-  const lastPoint = paints[paints.length - 1];
-
-  return lastPoint.time < time;
-}

--- a/packages/protocol/graphics.ts
+++ b/packages/protocol/graphics.ts
@@ -7,7 +7,7 @@ import {
   getTime,
   paused,
 } from "devtools/client/debugger/src/reducers/pause";
-import { PaintsCache, timeIsBeyondKnownPaints } from "protocol/PaintsCache";
+import { PaintsCache } from "protocol/PaintsCache";
 import { RecordedMouseEventsCache } from "protocol/RecordedEventsCache";
 import { recordingCapabilitiesCache } from "replay-next/src/suspense/BuildIdCache";
 import { screenshotCache } from "replay-next/src/suspense/ScreenshotCache";
@@ -18,7 +18,7 @@ import { AppStore } from "ui/setup/store";
 import { getCurrentPauseId } from "ui/utils/app";
 
 import { repaintGraphics } from "./repainted-graphics-cache";
-import { assert, binarySearch, defer } from "./utils";
+import { assert, binarySearch } from "./utils";
 
 const repaintedScreenshots: Map<string, ScreenShot> = new Map();
 
@@ -126,7 +126,7 @@ export async function setupGraphics(store: AppStore) {
   }
 
   const currentTime = getTime(store.getState());
-  const { screen, mouse } = await getGraphicsAtTime(currentTime, false);
+  const { screen, mouse } = await getGraphicsAtTime(currentTime);
   if (screen) {
     paintGraphics(screen, mouse);
   }
@@ -302,13 +302,10 @@ export interface MouseAndClickPosition {
 }
 
 export async function getGraphicsAtTime(
-  time: number,
-  forPlayback = false,
-  allowLastPaint = false
+  time: number
 ): Promise<{ screen?: ScreenShot; mouse?: MouseAndClickPosition }> {
   const paintIndex = mostRecentIndex(gPaintPoints, time);
-  if (paintIndex === undefined || (timeIsBeyondKnownPaints(time) && !allowLastPaint)) {
-    // There are no graphics to paint here.
+  if (paintIndex === undefined) {
     return {};
   }
 

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -47,7 +47,7 @@ import {
   paintGraphics,
   previousPaintEvent,
 } from "protocol/graphics";
-import { mostRecentPaint, timeIsBeyondKnownPaints } from "protocol/PaintsCache";
+import { mostRecentPaint } from "protocol/PaintsCache";
 import { waitForTime } from "protocol/utils";
 import { recordingCapabilitiesCache } from "replay-next/src/suspense/BuildIdCache";
 import {
@@ -395,7 +395,7 @@ export function togglePlayback(): UIThunkAction {
     const playback = getPlayback(state);
     const currentTime = getCurrentTime(state);
 
-    if (playback || timeIsBeyondKnownPaints(currentTime)) {
+    if (playback) {
       dispatch(stopPlayback());
     } else {
       dispatch(startPlayback());
@@ -412,10 +412,6 @@ export function startPlayback(
   return (dispatch, getState, { replayClient }) => {
     const state = getState();
     const currentTime = getCurrentTime(state);
-
-    if (timeIsBeyondKnownPaints(currentTime)) {
-      return;
-    }
 
     const endTime =
       optEndTime ||
@@ -494,7 +490,7 @@ export function playbackPoints(
 
     const prepareNextGraphics = () => {
       nextGraphicsTime = snapTimeForPlayback(nextPaintOrMouseEvent(currentTime)?.time || end.time);
-      nextGraphicsPromise = getGraphicsAtTime(nextGraphicsTime, true);
+      nextGraphicsPromise = getGraphicsAtTime(nextGraphicsTime);
       dispatch(precacheScreenshots(nextGraphicsTime));
     };
     const shouldContinuePlayback = () => getPlayback(getState());
@@ -857,7 +853,7 @@ export function precacheScreenshots(beginTime: number): UIThunkAction {
 
       // the client isn't used in the cache key, so it's OK to pass a dummy value here
       if (!screenshotCache.getValueIfCached(null as any, paintPoint.point, paintPoint.paintHash)) {
-        const graphicsPromise = getGraphicsAtTime(time, true);
+        const graphicsPromise = getGraphicsAtTime(time);
 
         const precachedTime = Math.max(time - SNAP_TIME_INTERVAL, beginTime);
         if (precachedTime > getPlaybackPrecachedTime(getState())) {


### PR DESCRIPTION
Paints are expected to load in very quickly. In fact, because of this, we recently removed the streaming behavior for them. Given that, the old check didn't make sense anymore.

I verified that after removing this check, trying to "play" after the last paint works like it used to (which is to say, the timeline marker moves forward and graphics stay the same).