### PR TITLE
Hide the Share button if the user has no role

### DIFF
--- a/packages/e2e-tests/authenticated/passport-04.test.ts
+++ b/packages/e2e-tests/authenticated/passport-04.test.ts
@@ -18,7 +18,10 @@ test(`authenticated/passport-04: Multiplayer`, async ({
   await enablePassport(page);
 
   expect(await isPassportItemCompleted(page, "Add a comment")).toBeFalsy();
-  expect(await isPassportItemCompleted(page, "Share")).toBeFalsy();
+
+  // Test users have no role, so they don't see the "Share" button
+  //
+  // expect(await isPassportItemCompleted(page, "Share")).toBeFalsy();
 
   await openDevToolsTab(page);
 
@@ -33,9 +36,11 @@ test(`authenticated/passport-04: Multiplayer`, async ({
     expect(await isPassportItemCompleted(page, "Add a comment")).toBeTruthy()
   );
 
-  await page.locator('button:has-text("Share")').click();
-  await page.locator('button:has-text("Copy URL")').click();
-  await page.keyboard.press("Escape");
-
-  await waitFor(async () => expect(await isPassportItemCompleted(page, "Share")).toBeTruthy());
+  // Test users have no role, so they don't see the "Share" button
+  //
+  // await page.locator('button:has-text("Share")').click();
+  // await page.locator('button:has-text("Copy URL")').click();
+  // await page.keyboard.press("Escape");
+  //
+  // await waitFor(async () => expect(await isPassportItemCompleted(page, "Share")).toBeTruthy());
 });

--- a/src/ui/components/Header/ShareButton.tsx
+++ b/src/ui/components/Header/ShareButton.tsx
@@ -4,7 +4,7 @@ import { ConnectedProps, connect } from "react-redux";
 import { useNag } from "replay-next/src/hooks/useNag";
 import { Nag } from "shared/graphql/types";
 import * as actions from "ui/actions/app";
-import { useGetRecordingId } from "ui/hooks/recordings";
+import { useGetRecordingId, useHasNoRole } from "ui/hooks/recordings";
 import { trackEvent } from "ui/utils/telemetry";
 
 import MaterialIcon from "../shared/MaterialIcon";
@@ -12,6 +12,11 @@ import MaterialIcon from "../shared/MaterialIcon";
 function ShareButton({ setModal }: PropsFromRedux) {
   const recordingId = useGetRecordingId();
   const [, dismissShareNag] = useNag(Nag.SHARE); // Properly call useNag and destructure dismissShareNag
+
+  const { hasNoRole, loading } = useHasNoRole();
+  if (hasNoRole || loading) {
+    return null;
+  }
 
   const onClick = () => {
     trackEvent("header.open_share");

--- a/src/ui/components/shared/SharingModal/SharingModal.tsx
+++ b/src/ui/components/shared/SharingModal/SharingModal.tsx
@@ -89,12 +89,6 @@ function CollaboratorsSection({
   showPrivacy: boolean;
   setShowPrivacy: React.Dispatch<React.SetStateAction<boolean>>;
 }) {
-  const { hasNoRole, loading } = useHasNoRole();
-
-  if (hasNoRole || loading) {
-    return null;
-  }
-
   return (
     <section className="space-y-4 bg-modalBgcolor p-4">
       <div className="flex w-full flex-col justify-between space-y-3">
@@ -208,6 +202,11 @@ function SharingModal({ recording, hideModal }: SharingModalProps) {
   const [showPrivacy, setShowPrivacy] = useState(false);
   const [modalMode, setModalMode] = useState<ModalMode>("sharing");
   const showEnvironmentVariables = recordingTarget == "node";
+
+  const { hasNoRole, loading } = useHasNoRole();
+  if (hasNoRole || loading) {
+    return null;
+  }
 
   return (
     <Modal options={{ maskTransparency: "translucent" }} onMaskClick={hideModal}>


### PR DESCRIPTION
This is less confusing than showing an empty dialog.

The `authenticated/passport-04` failed after the change, because our test user has no role. So I made additional changes in this PR:
* Don't show the NUX for "Share" if the user has no role
* Remove the "Share" part of the passport-04 test.

I also cleaned up some unused stuff in `Passport.tsx`; cc @jonbell-lot23 