### PR TITLE
Fix filtered test regression

### DIFF
--- a/packages/e2e-tests/test-suite-dashboard/test-runs-01.test.ts
+++ b/packages/e2e-tests/test-suite-dashboard/test-runs-01.test.ts
@@ -19,7 +19,7 @@ import test, { expect } from "../testFixtureTestSuiteDashboard";
 
 test.use({ testRunState: "SUCCESS_IN_MAIN_WITH_SOURCE" });
 
-test(`authenticated/new-test-suites/test-runs-01: passed run in main branch with source`, async ({
+test(`test-suite-dashboard/test-runs-01: passed run in main branch with source`, async ({
   pageWithMeta: { page, clientKey },
 }) => {
   await startLibraryTest(page, TEST_RUN_WORKSPACE_API_KEY, TEST_RUN_WORKSPACE_TEAM_ID);

--- a/packages/e2e-tests/test-suite-dashboard/test-runs-02.test.ts
+++ b/packages/e2e-tests/test-suite-dashboard/test-runs-02.test.ts
@@ -17,7 +17,7 @@ import test, { expect } from "../testFixtureTestSuiteDashboard";
 
 test.use({ testRunState: "FAILED_IN_TEMP_BRANCH_WITHOUT_SOURCE" });
 
-test(`authenticated/new-test-suites/test-runs-02: failed run in temp branch without source`, async ({
+test(`test-suite-dashboard/test-runs-02: failed run in temp branch without source`, async ({
   pageWithMeta: { page, clientKey },
 }) => {
   await startLibraryTest(page, TEST_RUN_WORKSPACE_API_KEY, TEST_RUN_WORKSPACE_TEAM_ID);

--- a/packages/e2e-tests/test-suite-dashboard/test-runs-03.test.ts
+++ b/packages/e2e-tests/test-suite-dashboard/test-runs-03.test.ts
@@ -13,7 +13,7 @@ import test, { expect } from "../testFixtureTestSuiteDashboard";
 
 test.use({ testRunState: "FLAKY_IN_MAIN_WITH_SOURCE" });
 
-test(`authenticated/new-test-suites/test-runs-03: flaky run in main branch with source`, async ({
+test(`test-suite-dashboard/test-runs-03: flaky run in main branch with source`, async ({
   pageWithMeta: { page, clientKey },
 }) => {
   await startLibraryTest(page, TEST_RUN_WORKSPACE_API_KEY, TEST_RUN_WORKSPACE_TEAM_ID);

--- a/packages/e2e-tests/test-suite-dashboard/test-runs-04.test.ts
+++ b/packages/e2e-tests/test-suite-dashboard/test-runs-04.test.ts
@@ -5,7 +5,7 @@ import test, { expect } from "../testFixtureTestSuiteDashboard";
 
 test.use({ testRunState: "FLAKY_IN_MAIN_WITH_SOURCE" });
 
-test(`authenticated/new-test-suites/test-runs-04: test ID in the URL`, async ({
+test(`test-suite-dashboard/test-runs-04: test ID in the URL`, async ({
   pageWithMeta: { page, clientKey, testRunId },
 }) => {
   await startLibraryTest(

--- a/src/ui/components/Library/Team/View/TestRuns/TestRunListPanel/TestRunList.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunListPanel/TestRunList.tsx
@@ -17,16 +17,16 @@ type ItemData = {
 
 export function TestRunList() {
   const { filterByText } = useContext(TestRunsContext);
-  const { testRuns } = useTestRunsSuspends();
+  const { filteredSortedTestRuns, rawTestRuns } = useTestRunsSuspends();
   const itemData = useMemo<ItemData>(
     () => ({
       filterByText,
-      testRuns,
+      testRuns: filteredSortedTestRuns,
     }),
-    [filterByText, testRuns]
+    [filterByText, filteredSortedTestRuns]
   );
 
-  if (testRuns.length > 0 && itemData.testRuns.length === 0) {
+  if (rawTestRuns.length > 0 && filteredSortedTestRuns.length === 0) {
     return (
       <TestSuitePanelMessage data-test-id="NoTestRuns" className={styles.message}>
         No test runs match the current filters

--- a/src/ui/components/Library/Team/View/TestRuns/TestRunListPanel/TestRunsStats.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunListPanel/TestRunsStats.tsx
@@ -17,7 +17,7 @@ const PADDING = 4;
 const POINT_RADIUS = 4;
 
 export function TestRunsStats() {
-  const { testRuns } = useTestRunsSuspends();
+  const { filteredSortedTestRuns: testRuns } = useTestRunsSuspends();
 
   if (!testRuns.length) {
     return null;
@@ -44,7 +44,7 @@ export function TestRunsStats() {
 }
 
 function ChartWithDimensions({ height, width }: { height: number; width: number }) {
-  const { testRuns } = useTestRunsSuspends();
+  const { filteredSortedTestRuns: testRuns } = useTestRunsSuspends();
   const { startTime, endTime } = useContext(TimeFilterContext);
 
   const ref = useRef<HTMLCanvasElement>(null);

--- a/src/ui/components/Library/Team/View/TestRuns/hooks/useTestRunsSuspends.ts
+++ b/src/ui/components/Library/Team/View/TestRuns/hooks/useTestRunsSuspends.ts
@@ -11,7 +11,7 @@ import { testRunsIntervalCache } from "../suspense/TestRunsCache";
 
 const EMPTY_ARRAY: any[] = [];
 
-export function useTestRunsSuspends(): { testRuns: TestRun[] } {
+export function useTestRunsSuspends() {
   const graphQLClient = useContext(GraphQLClientContext);
   const { teamId } = useContext(TeamContext);
   const { filterByText, filterByBranch, filterByStatus } = useContext(TestRunsContext);
@@ -45,5 +45,5 @@ export function useTestRunsSuspends(): { testRuns: TestRun[] } {
     return [...filteredTestRuns].reverse();
   }, [filterByBranch, filterByStatus, filterByText, testRuns]);
 
-  return { testRuns: filteredSortedTestRuns };
+  return { filteredSortedTestRuns, rawTestRuns: testRuns };
 }


### PR DESCRIPTION
cef19cd6537997b1c4b68ee07f10c8c7faeaaea3 introduced a regression that broke the test suites UI (and one of our e2e tests); this PR fixes that regression. I've confirmed that all 4 of the test-suites e2e tests pass locally after this change.

https://github.com/replayio/devtools/assets/29597/f58eb42d-81cf-4c6e-9098-4689ea459f47