### PR TITLE
Update Test Suites dashboard e2e tests to be less flaky/timing sensitive

### DIFF
--- a/packages/e2e-tests/helpers/test-suite-dashboard.ts
+++ b/packages/e2e-tests/helpers/test-suite-dashboard.ts
@@ -29,7 +29,9 @@ export const filterTestRunsByText = async (page: Page, text: string) => {
   // Wait for the update to be rendered to the DOM before completing
   // This simplifies the corresponding expect() code in the caller
   const list = page.locator('[data-test-id="TestRunList"]');
-  await expect(await list.getAttribute("data-filtered-by-text")).toBe(text);
+  await waitFor(async () => {
+    await expect(await list.getAttribute("data-filtered-by-text")).toBe(text);
+  });
 };
 
 export const filterTestRunsByBranch = async (page: Page, branch: "all" | "primary") => {
@@ -48,7 +50,9 @@ export const filterTestRunsByBranch = async (page: Page, branch: "all" | "primar
   // Wait for the update to be rendered to the DOM before completing
   // This simplifies the corresponding expect() code in the caller
   const list = page.locator('[data-test-id="TestRunList"]');
-  await expect(await list.getAttribute("data-filtered-by-branch")).toBe(branch);
+  await waitFor(async () => {
+    await expect(await list.getAttribute("data-filtered-by-branch")).toBe(branch);
+  });
 };
 
 export const filterTestRunsByStatus = async (page: Page, status: "all" | "failed") => {
@@ -67,7 +71,9 @@ export const filterTestRunsByStatus = async (page: Page, status: "all" | "failed
   // Wait for the update to be rendered to the DOM before completing
   // This simplifies the corresponding expect() code in the caller
   const list = page.locator('[data-test-id="TestRunList"]');
-  await expect(await list.getAttribute("data-filtered-by-status")).toBe(status);
+  await waitFor(async () => {
+    await expect(await list.getAttribute("data-filtered-by-status")).toBe(status);
+  });
 };
 
 export const filterSummaryTestsByText = async (page: Page, text: string) => {
@@ -77,7 +83,9 @@ export const filterSummaryTestsByText = async (page: Page, text: string) => {
   // Wait for the update to be rendered to the DOM before completing
   // This simplifies the corresponding expect() code in the caller
   const list = page.locator('[data-test-id="TestRunResults"]');
-  await expect(await list.getAttribute("data-filtered-by-text")).toBe(text);
+  await waitFor(async () => {
+    await expect(await list.getAttribute("data-filtered-by-text")).toBe(text);
+  });
 };
 
 export const filterSummaryByStatus = async (page: Page, status: "all" | "failed-and-flaky") => {
@@ -96,7 +104,9 @@ export const filterSummaryByStatus = async (page: Page, status: "all" | "failed-
   // Wait for the update to be rendered to the DOM before completing
   // This simplifies the corresponding expect() code in the caller
   const list = page.locator('[data-test-id="TestRunResults"]');
-  await expect(await list.getAttribute("data-filtered-by-status")).toBe(status);
+  await waitFor(async () => {
+    await expect(await list.getAttribute("data-filtered-by-status")).toBe(status);
+  });
 };
 
 export const findTestRunByText = async (page: Page, locator: Locator, text: string) => {

--- a/packages/e2e-tests/helpers/test-suite-dashboard.ts
+++ b/packages/e2e-tests/helpers/test-suite-dashboard.ts
@@ -1,9 +1,10 @@
 import { Locator, Page } from "@playwright/test";
 import chalk from "chalk";
 
+import { expect } from "../testFixtureTestSuiteDashboard";
 import { openContextMenu } from "./console-panel";
 import { selectContextMenuItem } from "./context-menu";
-import { debugPrint } from "./utils";
+import { debugPrint, waitFor } from "./utils";
 
 export const noTestRunsMessage = (page: Page) => page.locator('[data-test-id="NoTestRuns"]');
 export const noTestRunSelectedMessage = (page: Page) =>
@@ -20,25 +21,82 @@ export const testRecordings = (page: Page) =>
   page.locator('[data-test-id="TestRunResultsListItem"]');
 export const testErrors = (page: Page) => page.locator('[data-test-id="TestRunSpecDetails-Error"]');
 
-export const filterRunsByText = async (page: Page, text: string) => {
-  await debugPrint(page, `Filtering test runs list by text`, "filterTestRunsList");
+export const filterTestRunsByText = async (page: Page, text: string) => {
+  await debugPrint(page, `Filtering test runs list by text: "${text}"`, "filterTestRunsList");
+
   await page.fill("data-test-id=TestRunsPage-FilterByText-Input", text);
+
+  // Wait for the update to be rendered to the DOM before completing
+  // This simplifies the corresponding expect() code in the caller
+  const list = page.locator('[data-test-id="TestRunList"]');
+  await expect(await list.getAttribute("data-filtered-by-text")).toBe(text);
 };
 
-export const filterTestRunsByBranch = async (
-  page: Page,
-  searchText: string,
-  contextMenuItemTestId: string
-) => {
-  const branchDropdown = page.locator('[data-test-id="TestRunsPage-BranchFilter-DropdownTrigger"]');
-  await openContextMenu(branchDropdown, { useLeftClick: true });
-  await selectContextMenuItem(page, { contextMenuItemTestId });
-  await filterRunsByText(page, searchText);
+export const filterTestRunsByBranch = async (page: Page, branch: "all" | "primary") => {
+  await debugPrint(
+    page,
+    `Filtering test runs list by branch: "${branch}"`,
+    "filterTestRunsByBranch"
+  );
+
+  const dropdown = page.locator('[data-test-id="TestRunsPage-BranchFilter-DropdownTrigger"]');
+  await openContextMenu(dropdown, { useLeftClick: true });
+  await selectContextMenuItem(page, {
+    contextMenuItemTestId: branch === "primary" ? "show-only-primary-branch" : "show-all-branches",
+  });
+
+  // Wait for the update to be rendered to the DOM before completing
+  // This simplifies the corresponding expect() code in the caller
+  const list = page.locator('[data-test-id="TestRunList"]');
+  await expect(await list.getAttribute("data-filtered-by-branch")).toBe(branch);
+};
+
+export const filterTestRunsByStatus = async (page: Page, status: "all" | "failed") => {
+  await debugPrint(
+    page,
+    `Filtering test runs list by status: "${status}"`,
+    "filterTestRunsByStatus"
+  );
+
+  const dropdown = page.locator('[data-test-id="TestRunsPage-ResultFilter-DropdownTrigger"]');
+  await openContextMenu(dropdown, { useLeftClick: true });
+  await selectContextMenuItem(page, {
+    contextMenuItemTestId: status === "failed" ? "show-only-failures" : "show-all-runs",
+  });
+
+  // Wait for the update to be rendered to the DOM before completing
+  // This simplifies the corresponding expect() code in the caller
+  const list = page.locator('[data-test-id="TestRunList"]');
+  await expect(await list.getAttribute("data-filtered-by-status")).toBe(status);
 };
 
 export const filterSummaryTestsByText = async (page: Page, text: string) => {
-  await debugPrint(page, `Filtering test list by text`, "filterTestList");
+  await debugPrint(page, `Filtering test list by text: "${text}"`, "filterSummaryTestsByText");
   await page.fill("data-test-id=TestRunSummary-Filter", text);
+
+  // Wait for the update to be rendered to the DOM before completing
+  // This simplifies the corresponding expect() code in the caller
+  const list = page.locator('[data-test-id="TestRunResults"]');
+  await expect(await list.getAttribute("data-filtered-by-text")).toBe(text);
+};
+
+export const filterSummaryByStatus = async (page: Page, status: "all" | "failed-and-flaky") => {
+  await debugPrint(
+    page,
+    `Filtering test summary list by status: "${status}"`,
+    "filterSummaryByStatus"
+  );
+
+  const dropdown = page.locator('[data-test-id="TestRunSummary-StatusFilter-DropdownTrigger"]');
+  await openContextMenu(dropdown, { useLeftClick: true });
+  await selectContextMenuItem(page, {
+    contextMenuItemTestId: status === "failed-and-flaky" ? "failed-and-flaky" : "all",
+  });
+
+  // Wait for the update to be rendered to the DOM before completing
+  // This simplifies the corresponding expect() code in the caller
+  const list = page.locator('[data-test-id="TestRunResults"]');
+  await expect(await list.getAttribute("data-filtered-by-status")).toBe(status);
 };
 
 export const findTestRunByText = async (page: Page, locator: Locator, text: string) => {

--- a/packages/e2e-tests/helpers/testsuites.ts
+++ b/packages/e2e-tests/helpers/testsuites.ts
@@ -1,16 +1,7 @@
 import { Locator, Page, expect } from "@playwright/test";
 
 import { getKeyValueEntryHeader, getKeyValueEntryValue } from "./object-inspector";
-import {
-  clearTextArea,
-  debugPrint,
-  delay,
-  getByTestName,
-  getCommandKey,
-  locatorTextToNumber,
-  mapLocators,
-  waitFor,
-} from "./utils";
+import { getByTestName, locatorTextToNumber, waitFor } from "./utils";
 
 export function getTestSuitePanel(page: Page) {
   return getByTestName(page, "TestSuitePanel");
@@ -68,10 +59,6 @@ export function getSelectedTestCase(row: Page | Locator) {
 
 export function getTestSuiteResult(page: Page) {
   return getByTestName(page, "TestSuiteResult");
-}
-
-export function getResultDropdown(page: Page) {
-  return page.getByTestId("TestRunsPage-ResultFilter-DropdownTrigger");
 }
 
 export async function getTestSuiteResultsPassedCount(page: Page): Promise<number | null> {

--- a/packages/e2e-tests/test-suite-dashboard/test-runs-01.test.ts
+++ b/packages/e2e-tests/test-suite-dashboard/test-runs-01.test.ts
@@ -1,10 +1,10 @@
 import { startLibraryTest } from "../helpers";
 import { TEST_RUN_WORKSPACE_API_KEY, TEST_RUN_WORKSPACE_TEAM_ID } from "../helpers/authentication";
-import { openContextMenu } from "../helpers/console-panel";
-import { selectContextMenuItem } from "../helpers/context-menu";
 import {
-  filterRunsByText,
+  filterSummaryByStatus,
   filterSummaryTestsByText,
+  filterTestRunsByStatus,
+  filterTestRunsByText,
   findTestRunByText,
   noTestRunSelectedMessage,
   noTestRunsMessage,
@@ -14,7 +14,6 @@ import {
   testRunSummary,
   testRunsItems,
 } from "../helpers/test-suite-dashboard";
-import { getResultDropdown } from "../helpers/testsuites";
 import test, { expect } from "../testFixtureTestSuiteDashboard";
 
 test.use({ testRunState: "SUCCESS_IN_MAIN_WITH_SOURCE" });
@@ -38,30 +37,23 @@ test(`test-suite-dashboard/test-runs-01: passed run in main branch with source`,
   const testRunItemDate = testRun.locator('[data-test-id="TestRun-Date"]');
   expect(await testRunItemDate.count()).toBe(1);
 
-  // >>> Filted by text, only test runs in which the pull request title match the provided text should be displayed
-  await filterRunsByText(page, clientKey);
+  // >>> Filter by text, only test runs in which the pull request title match the provided text should be displayed
+  await filterTestRunsByText(page, clientKey);
 
   expect(await testRunsItems(page).count()).toBe(1);
   const testItem = testRunsItems(page).first();
   expect(await testItem.innerText()).toContain(clientKey);
   expect(await noTestRunsMessage(page).count()).toBe(0);
-  await filterRunsByText(page, "");
+  await filterTestRunsByText(page, "");
 
   // >>> filtered by failures, only test runs containing one or more failures should be displayed
-  const resultDropdown = getResultDropdown(page);
-  await openContextMenu(resultDropdown, { useLeftClick: true });
-  await selectContextMenuItem(page, {
-    contextMenuItemTestId: "show-only-failures",
-  });
+  await filterTestRunsByStatus(page, "failed");
   const failedItemsCount = await testRunsItems(page).count();
   for (let i = 0; i < failedItemsCount; i++) {
     const testRunItem = testRunsItems(page).nth(i);
     expect(await testRunItem.locator('[data-test-status="fail"]').count()).toBe(1);
   }
-  await openContextMenu(resultDropdown, { useLeftClick: true });
-  await selectContextMenuItem(page, {
-    contextMenuItemTestId: "show-all-runs",
-  });
+  await filterTestRunsByStatus(page, "all");
 
   // >>> Workspace with limited retention limit should not show large time range filter
   expect(await page.getByTestId("month").count()).toBe(0);
@@ -69,7 +61,7 @@ test(`test-suite-dashboard/test-runs-01: passed run in main branch with source`,
   // > Selected test run
 
   // >>> Opens test run overview
-  await filterRunsByText(page, clientKey);
+  await filterTestRunsByText(page, clientKey);
 
   expect(await testRunsItems(page).count()).toBe(1);
   await testRunsItems(page).first().click();
@@ -99,21 +91,12 @@ test(`test-suite-dashboard/test-runs-01: passed run in main branch with source`,
   await filterSummaryTestsByText(page, "");
 
   // >>> Filter by status
-  const statusDropdown = page.locator(
-    '[data-test-id="TestRunSummary-StatusFilter-DropdownTrigger"]'
-  );
-  await openContextMenu(statusDropdown, { useLeftClick: true });
-  await selectContextMenuItem(page, {
-    contextMenuItemTestId: "failed-and-flaky",
-  });
+  await filterSummaryByStatus(page, "failed-and-flaky");
   expect(await testItems(page).count()).toBe(0);
-  await openContextMenu(statusDropdown, { useLeftClick: true });
-  await selectContextMenuItem(page, {
-    contextMenuItemTestId: "all",
-  });
+  await filterSummaryByStatus(page, "all");
 
   // >>> When a test run was selected but omitted due to a change in filter, the run details view should show a message
-  await filterRunsByText(page, "something that would never exist");
+  await filterTestRunsByText(page, "something that would never exist");
 
   expect(await testRunsItems(page).count()).toBe(0);
   expect(await noTestRunsMessage(page).count()).toBe(1);

--- a/packages/e2e-tests/test-suite-dashboard/test-runs-01.test.ts
+++ b/packages/e2e-tests/test-suite-dashboard/test-runs-01.test.ts
@@ -46,14 +46,18 @@ test(`test-suite-dashboard/test-runs-01: passed run in main branch with source`,
   expect(await noTestRunsMessage(page).count()).toBe(0);
   await filterTestRunsByText(page, "");
 
+  const chartLabel = page.locator('[data-test-id="TestRunStats-ChartSummaryLabel"]');
+
   // >>> filtered by failures, only test runs containing one or more failures should be displayed
   await filterTestRunsByStatus(page, "failed");
+  expect(await chartLabel.textContent()).toBe("Failure rate: 100%");
   const failedItemsCount = await testRunsItems(page).count();
   for (let i = 0; i < failedItemsCount; i++) {
     const testRunItem = testRunsItems(page).nth(i);
     expect(await testRunItem.locator('[data-test-status="fail"]').count()).toBe(1);
   }
   await filterTestRunsByStatus(page, "all");
+  expect(await chartLabel.textContent()).not.toBe("Failure rate: 100%");
 
   // >>> Workspace with limited retention limit should not show large time range filter
   expect(await page.getByTestId("month").count()).toBe(0);

--- a/packages/e2e-tests/test-suite-dashboard/test-runs-02.test.ts
+++ b/packages/e2e-tests/test-suite-dashboard/test-runs-02.test.ts
@@ -1,9 +1,9 @@
 import { startLibraryTest } from "../helpers";
 import { TEST_RUN_WORKSPACE_API_KEY, TEST_RUN_WORKSPACE_TEAM_ID } from "../helpers/authentication";
 import {
-  filterRunsByText,
   filterSummaryTestsByText,
   filterTestRunsByBranch,
+  filterTestRunsByText,
   findTestRunByText,
   noTestSelected,
   testErrors,
@@ -26,12 +26,13 @@ test(`test-suite-dashboard/test-runs-02: failed run in temp branch without sourc
   // > List view
 
   // >>> Filter by primary branch
-  await filterTestRunsByBranch(page, clientKey, "show-only-primary-branch");
+  await filterTestRunsByBranch(page, "primary");
+  await filterTestRunsByText(page, clientKey);
   expect(await testRunsItems(page).count()).toBe(0);
-  await filterTestRunsByBranch(page, "", "show-all-branches");
+  await filterTestRunsByBranch(page, "all");
+  await filterTestRunsByText(page, "");
 
   // >>> A test run with any failing tests should display a count of the failures to the left of the test run title
-  const testRunItemCount = await testRunsItems(page).count();
   let failedRun = await findTestRunByText(page, testRunsItems(page), clientKey);
 
   const testRunStatusPill = failedRun.locator('[data-test-status="fail"]');
@@ -41,7 +42,7 @@ test(`test-suite-dashboard/test-runs-02: failed run in temp branch without sourc
   // >>> Run Overview
 
   // >>> Opens test run overview and match the title
-  await filterRunsByText(page, clientKey);
+  await filterTestRunsByText(page, clientKey);
 
   expect(await testRunsItems(page).count()).toBe(1);
   await testRunsItems(page).first().click();

--- a/packages/e2e-tests/test-suite-dashboard/test-runs-03.test.ts
+++ b/packages/e2e-tests/test-suite-dashboard/test-runs-03.test.ts
@@ -1,7 +1,7 @@
 import { startLibraryTest } from "../helpers";
 import { TEST_RUN_WORKSPACE_API_KEY, TEST_RUN_WORKSPACE_TEAM_ID } from "../helpers/authentication";
 import {
-  filterRunsByText,
+  filterTestRunsByText,
   findTestRunByText,
   noTestSelected,
   testItems,
@@ -30,7 +30,7 @@ test(`test-suite-dashboard/test-runs-03: flaky run in main branch with source`, 
   // > Selected test run
 
   // >>> Opens test run overview and match the title
-  await filterRunsByText(page, clientKey);
+  await filterTestRunsByText(page, clientKey);
 
   expect(await testRunsItems(page).count()).toBe(1);
   const testItem = testRunsItems(page).first();

--- a/src/ui/components/Library/Team/View/TestRuns/TestRunDetailsPanel/RunResults.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunDetailsPanel/RunResults.tsx
@@ -49,6 +49,7 @@ export function RunResults({
   return (
     <div
       className="flex flex-col overflow-y-auto"
+      data-filtered-by-status={filterCurrentRunByStatus}
       data-filtered-by-text={filterByTextDeferred}
       data-test-id="TestRunResults"
     >

--- a/src/ui/components/Library/Team/View/TestRuns/TestRunListPanel/TestRunListPanel.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunListPanel/TestRunListPanel.tsx
@@ -87,7 +87,7 @@ export default function TestRunListPanel() {
         <div className="grid w-full grid-cols-3 gap-2 bg-bodyBgcolor">
           <div
             className={dropdownStyles.dropdownTrigger}
-            data-testid="TestRunsPage-ResultFilter-DropdownTrigger"
+            data-test-id="TestRunsPage-ResultFilter-DropdownTrigger"
             onClick={onClickStatusFilter}
             onKeyDown={onKeyDownStatusFilter}
             tabIndex={0}
@@ -135,6 +135,7 @@ export default function TestRunListPanel() {
       <TestRunsStats />
       <div
         className="grow"
+        data-filtered-by-branch={filterByBranch}
         data-filtered-by-status={filterByStatus}
         data-filtered-by-text={filterByText}
         data-test-id="TestRunList"

--- a/src/ui/components/Library/Team/View/TestRuns/TestRunListPanel/TestRunsStats.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunListPanel/TestRunsStats.tsx
@@ -32,7 +32,7 @@ export function TestRunsStats() {
       <div className={styles.ChartWrapper}>
         <AutoSizer>
           {({ height, width }: { height: number; width: number }) => (
-            <ChartWithDimensions height={height} width={width} />
+            <ChartWithDimensions height={height} testRuns={testRuns} width={width} />
           )}
         </AutoSizer>
       </div>
@@ -43,8 +43,15 @@ export function TestRunsStats() {
   );
 }
 
-function ChartWithDimensions({ height, width }: { height: number; width: number }) {
-  const { filteredSortedTestRuns: testRuns } = useTestRunsSuspends();
+function ChartWithDimensions({
+  height,
+  testRuns,
+  width,
+}: {
+  height: number;
+  testRuns: TestRun[];
+  width: number;
+}) {
   const { startTime, endTime } = useContext(TimeFilterContext);
 
   const ref = useRef<HTMLCanvasElement>(null);

--- a/src/ui/components/Library/Team/View/TestRuns/TestRunListPanel/TestRunsStats.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunListPanel/TestRunsStats.tsx
@@ -36,8 +36,12 @@ export function TestRunsStats() {
           )}
         </AutoSizer>
       </div>
-      <div className={styles.FailureRateDescription} title={`${buildFailuresCount}/${buildsCount}`}>
-        <strong>Failure rate:</strong> {(buildFailureRate * 100).toFixed(2)}%
+      <div
+        className={styles.FailureRateDescription}
+        data-test-id="TestRunStats-ChartSummaryLabel"
+        title={`${buildFailuresCount}/${buildsCount} failed`}
+      >
+        <strong>Failure rate:</strong> {Math.round(buildFailureRate * 100)}%
       </div>
     </div>
   );

--- a/src/ui/components/Library/Team/View/TestRuns/hooks/useTestRunsSuspends.ts
+++ b/src/ui/components/Library/Team/View/TestRuns/hooks/useTestRunsSuspends.ts
@@ -9,7 +9,7 @@ import useToken from "ui/utils/useToken";
 import { TimeFilterContext } from "../../TimeFilterContextRoot";
 import { testRunsIntervalCache } from "../suspense/TestRunsCache";
 
-const EMPTY_ARRAY: any[] = [];
+const EMPTY_ARRAY: TestRun[] = [];
 
 export function useTestRunsSuspends() {
   const graphQLClient = useContext(GraphQLClientContext);


### PR DESCRIPTION
- [x] Refactor tests to use helper methods that wait for DOM updates before asserting
- [x] Updated `ChartWithDimensions` to accept `testRuns` via a prop (so it could avoid recomputing the filtered list)
- [x] Add e2e test coverage for summary chart/graphic updates with filters