### PR TITLE
Incremental graphics refactor– paints cache, array and image utils

### DIFF
--- a/packages/protocol/PaintsCache.test.ts
+++ b/packages/protocol/PaintsCache.test.ts
@@ -1,0 +1,154 @@
+import { ScreenShot } from "@replayio/protocol";
+
+import {
+  PaintsCache,
+  findFirstMeaningfulPaint,
+  findMostRecentPaint,
+  findNextPaintEvent,
+  findPreviousPaintEvent,
+} from "protocol/PaintsCache";
+import { screenshotCache } from "replay-next/src/suspense/ScreenshotCache";
+
+describe("PaintsCache", () => {
+  let OriginalImage: typeof Image;
+
+  beforeEach(() => {
+    OriginalImage = window.Image;
+
+    // jsdom does not load images; we mock it for our purposes to encode expected image dimensions in a JSON string
+    // @ts-expect-error
+    window.Image = function ImageFactory(width?: number | undefined, height?: number | undefined) {
+      const image = new OriginalImage(width, height);
+      setTimeout(() => {
+        try {
+          const source = image.src;
+          const { height, width } = JSON.parse(source.substring(source.indexOf(",") + 1)) as any;
+
+          image.height = height;
+          image.width = width;
+
+          image.dispatchEvent(new Event("load"));
+        } catch (error) {
+          console.error(error);
+
+          image.dispatchEvent(new Event("error"));
+        }
+      });
+      return image;
+    };
+  });
+
+  afterEach(() => {
+    window.Image = OriginalImage;
+  });
+
+  function preCacheScreenshot(base64: string, mimeType: ScreenShot["mimeType"], data: string) {
+    screenshotCache.cache(
+      {
+        data,
+        hash: base64,
+        mimeType,
+        scale: 1,
+      },
+      null as any,
+      null as any,
+      base64
+    );
+  }
+
+  describe("findFirstMeaningfulPaint", () => {
+    it("should return undefined if no paints have been loaded", async () => {
+      PaintsCache.cache([]);
+
+      const firstMeaningfulPaint = await findFirstMeaningfulPaint();
+      expect(firstMeaningfulPaint).toBeUndefined();
+    });
+
+    it('should return the first "meaningful" paint in the sequence of loaded paints', async () => {
+      PaintsCache.cache([
+        { time: 0, point: "0", paintHash: "" },
+        {
+          time: 10,
+          point: "10",
+          paintHash: JSON.stringify({ height: 50, width: 50 }),
+        },
+        {
+          time: 20,
+          point: "20",
+          paintHash: JSON.stringify({
+            height: 50,
+            width: 50,
+            junk: "This is a long string to make the image seem like it has a lot of unique pixels/colors",
+          }),
+        },
+      ]);
+
+      const points = PaintsCache.read();
+      points?.forEach(point => preCacheScreenshot(point.paintHash, "image/jpeg", point.paintHash));
+
+      const firstMeaningfulPaint = await findFirstMeaningfulPaint();
+      expect(firstMeaningfulPaint?.time).toBe(20);
+    });
+  });
+
+  describe("findMostRecentPaint", () => {
+    it("should return the expected paint", () => {
+      PaintsCache.cache([
+        { time: 0, point: "0", paintHash: "" },
+        { time: 10, point: "10", paintHash: "" },
+        { time: 20, point: "20", paintHash: "" },
+      ]);
+
+      expect(findMostRecentPaint(0)?.time).toBe(0);
+      expect(findMostRecentPaint(1)?.time).toBe(0);
+      expect(findMostRecentPaint(9)?.time).toBe(0);
+
+      expect(findMostRecentPaint(10)?.time).toBe(10);
+      expect(findMostRecentPaint(11)?.time).toBe(10);
+      expect(findMostRecentPaint(19)?.time).toBe(10);
+
+      expect(findMostRecentPaint(20)?.time).toBe(20);
+      expect(findMostRecentPaint(21)?.time).toBe(20);
+    });
+  });
+
+  describe("findNextPaintEvent", () => {
+    it("should return the expected paint", () => {
+      PaintsCache.cache([
+        { time: 0, point: "0", paintHash: "" },
+        { time: 10, point: "10", paintHash: "" },
+        { time: 20, point: "20", paintHash: "" },
+      ]);
+
+      expect(findNextPaintEvent(0)?.time).toBe(10);
+      expect(findNextPaintEvent(9)?.time).toBe(10);
+
+      expect(findNextPaintEvent(10)?.time).toBe(20);
+      expect(findNextPaintEvent(19)?.time).toBe(20);
+
+      expect(findNextPaintEvent(20)).toBeNull();
+    });
+  });
+
+  describe("findPreviousPaintEvent", () => {
+    it("should return the expected paint", () => {
+      PaintsCache.cache([
+        { time: 0, point: "0", paintHash: "" },
+        { time: 10, point: "10", paintHash: "" },
+        { time: 20, point: "20", paintHash: "" },
+      ]);
+
+      expect(findPreviousPaintEvent(0)).toBeNull();
+
+      expect(findPreviousPaintEvent(1)?.time).toBe(0);
+      expect(findPreviousPaintEvent(9)?.time).toBe(0);
+      expect(findPreviousPaintEvent(10)?.time).toBe(0);
+
+      expect(findPreviousPaintEvent(11)?.time).toBe(10);
+      expect(findPreviousPaintEvent(19)?.time).toBe(10);
+      expect(findPreviousPaintEvent(20)?.time).toBe(10);
+
+      expect(findPreviousPaintEvent(21)?.time).toBe(20);
+    });
+  });
+});

--- a/packages/protocol/PaintsCache.ts
+++ b/packages/protocol/PaintsCache.ts
@@ -1,7 +1,9 @@
 import { createSingleEntryCache } from "suspense";
 
 import { recordingTargetCache } from "replay-next/src/suspense/BuildIdCache";
-import { findIndex } from "replay-next/src/utils/array";
+import { screenshotCache } from "replay-next/src/suspense/ScreenshotCache";
+import { find, findIndexGTE, findIndexLTE } from "replay-next/src/utils/array";
+import { getDimensions } from "replay-next/src/utils/image";
 import { replayClient } from "shared/client/ReplayClientContext";
 import { TimeStampedPointWithPaintHash } from "shared/client/types";
 
@@ -22,24 +24,73 @@ export const PaintsCache = createSingleEntryCache<[], TimeStampedPointWithPaintH
   },
 });
 
-export function mostRecentPaint(time: number) {
+export function findClosestPaint(time: number) {
   const paints = PaintsCache.getValueIfCached() ?? [];
 
-  const index = findIndex(
+  return find(paints, { paintHash: "", point: "", time }, (a, b) => a.time - b.time, false);
+}
+
+// The maximum number of paints to be considered when looking for the first meaningful paint
+// TODO We should reconsider this metric; loading spinners make it useless
+const INITIAL_PAINT_COUNT = 10;
+
+export async function findFirstMeaningfulPaint() {
+  const paints = await PaintsCache.readAsync();
+  if (paints) {
+    for (let index = 0; index < Math.min(paints.length, INITIAL_PAINT_COUNT); index++) {
+      const paint = paints[index];
+
+      try {
+        const { data, hash, mimeType } = await screenshotCache.readAsync(
+          replayClient,
+          paint.point,
+          paint.paintHash
+        );
+
+        const { width, height } = await getDimensions(hash, mimeType);
+
+        // Estimate how interesting the image is by the unique pixel density (given an arbitrary image size)
+        if (data.length > (width * height) / 40) {
+          return paint;
+        }
+      } catch (error) {
+        console.warn(error);
+      }
+    }
+  }
+}
+
+export function findMostRecentPaint(time: number) {
+  const paints = PaintsCache.getValueIfCached() ?? [];
+  const index = findMostRecentPaintIndex(time);
+  return index >= 0 ? paints[index] : null;
+}
+
+export function findMostRecentPaintIndex(time: number) {
+  const paints = PaintsCache.getValueIfCached() ?? [];
+  return findIndexLTE(paints, { time } as TimeStampedPointWithPaintHash, (a, b) => a.time - b.time);
+}
+
+export function findNextPaintEvent(time: number) {
+  const paints = PaintsCache.getValueIfCached() ?? [];
+  const index = findIndexGTE(
     paints,
-    { paintHash: "", point: "", time },
-    (a, b) => a.time - b.time,
-    false
+    { time } as TimeStampedPointWithPaintHash,
+    (a, b) => a.time - b.time
   );
 
-  // This is the nearest paint, but it may be before or after the time
   const paint = paints[index];
-
-  if (paint.time <= time) {
-    return paint;
-  } else if (index > 0) {
-    return paints[index - 1];
-  } else {
-    return null;
+  if (paint && paint.time == time) {
+    return index + 1 < paints.length ? paints[index + 1] : null;
   }
+
+  return paint;
+}
+
+export function findPreviousPaintEvent(time: number) {
+  const paint = findMostRecentPaint(time);
+  if (paint && paint.time == time) {
+    return findMostRecentPaint(time - 1);
+  }
+  return paint;
 }

--- a/packages/protocol/utils.ts
+++ b/packages/protocol/utils.ts
@@ -42,7 +42,15 @@ export function defer<T>() {
   return { promise, resolve, reject };
 }
 
-export const waitForTime = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+export function waitForTime(ms: number) {
+  const start = Date.now();
+  return new Promise<number>(resolve => {
+    setTimeout(() => {
+      const end = Date.now();
+      resolve(end - start);
+    }, ms);
+  });
+}
 
 export function throttle(callback: () => void, time: number) {
   let scheduled = false;

--- a/packages/replay-next/src/utils/array.test.ts
+++ b/packages/replay-next/src/utils/array.test.ts
@@ -1,4 +1,12 @@
-import { findIndex, findIndexBigInt, findIndexString, insert, insertString } from "./array";
+import {
+  findIndex,
+  findIndexBigInt,
+  findIndexGTE,
+  findIndexLTE,
+  findIndexString,
+  insert,
+  insertString,
+} from "./array";
 
 describe("array utils", () => {
   describe("findIndex", () => {
@@ -59,6 +67,62 @@ describe("array utils", () => {
         // Ambiguous case!
         expect(findIndex([1, 3], 2, compare, false)).toEqual(1);
       });
+    });
+  });
+
+  describe("findIndexGTE", () => {
+    const compare = (a: number, b: number) => {
+      if (a === b) {
+        return 0;
+      } else {
+        return a > b ? 1 : -1;
+      }
+    };
+
+    it("should return -1 if no match can be found", () => {
+      expect(findIndexGTE([], 1, compare)).toBe(-1);
+      expect(findIndexGTE([2], 3, compare)).toBe(-1);
+    });
+
+    it("should return the smallest match that is gte the specified item", () => {
+      expect(findIndexGTE([1, 5, 25], 25, compare)).toBe(2);
+      expect(findIndexGTE([1, 5, 25], 24, compare)).toBe(2);
+      expect(findIndexGTE([1, 5, 25], 6, compare)).toBe(2);
+
+      expect(findIndexGTE([1, 5, 25], 5, compare)).toBe(1);
+      expect(findIndexGTE([1, 5, 25], 4, compare)).toBe(1);
+      expect(findIndexGTE([1, 5, 25], 2, compare)).toBe(1);
+
+      expect(findIndexGTE([1, 5, 25], 1, compare)).toBe(0);
+      expect(findIndexGTE([1, 5, 25], 0, compare)).toBe(0);
+    });
+  });
+
+  describe("findIndexLTE", () => {
+    const compare = (a: number, b: number) => {
+      if (a === b) {
+        return 0;
+      } else {
+        return a > b ? 1 : -1;
+      }
+    };
+
+    it("should return -1 if no match can be found", () => {
+      expect(findIndexLTE([], 1, compare)).toBe(-1);
+      expect(findIndexLTE([2], 1, compare)).toBe(-1);
+    });
+
+    it("should return the largest match that is lte the specified item", () => {
+      expect(findIndexLTE([1, 5, 25], 1, compare)).toBe(0);
+      expect(findIndexLTE([1, 5, 25], 2, compare)).toBe(0);
+      expect(findIndexLTE([1, 5, 25], 4, compare)).toBe(0);
+
+      expect(findIndexLTE([1, 5, 25], 5, compare)).toBe(1);
+      expect(findIndexLTE([1, 5, 25], 6, compare)).toBe(1);
+      expect(findIndexLTE([1, 5, 25], 24, compare)).toBe(1);
+
+      expect(findIndexLTE([1, 5, 25], 25, compare)).toBe(2);
+      expect(findIndexLTE([1, 5, 25], 26, compare)).toBe(2);
     });
   });
 

--- a/packages/replay-next/src/utils/array.ts
+++ b/packages/replay-next/src/utils/array.ts
@@ -19,6 +19,46 @@ export function find<T>(
   return index >= 0 ? sortedItems[index] : null;
 }
 
+export function findIndexLTE<T>(
+  sortedItems: T[],
+  targetItem: T,
+  comparisonFunction: ComparisonFunction<T>
+): number {
+  const index = findIndex(sortedItems, targetItem, comparisonFunction, false);
+
+  // This is the nearest item, but it may be greater
+  const item = sortedItems[index];
+  if (item) {
+    if (comparisonFunction(targetItem, item) >= 0) {
+      return index;
+    } else {
+      return index - 1;
+    }
+  }
+
+  return -1;
+}
+
+export function findIndexGTE<T>(
+  sortedItems: T[],
+  targetItem: T,
+  comparisonFunction: ComparisonFunction<T>
+): number {
+  const index = findIndex(sortedItems, targetItem, comparisonFunction, false);
+
+  // This is the nearest item, but it may be lesser
+  const item = sortedItems[index];
+  if (item) {
+    if (comparisonFunction(targetItem, item) <= 0) {
+      return index;
+    } else if (index < sortedItems.length - 1) {
+      return index + 1;
+    }
+  }
+
+  return -1;
+}
+
 // Note that for non-exact matches to work
 // the comparison function should return more fine-grained delta values than the typical -1, 0, or 1.
 export function findIndex<T>(

--- a/packages/replay-next/src/utils/image.ts
+++ b/packages/replay-next/src/utils/image.ts
@@ -1,0 +1,38 @@
+type Dimensions = { aspectRatio: number; height: number; width: number };
+
+export async function getDimensions(base64: string, mimeType: string): Promise<Dimensions> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.addEventListener("load", () => {
+      const { height, width } = image;
+      resolve({
+        aspectRatio: width / height,
+        height,
+        width,
+      });
+    });
+    image.addEventListener("error", () => {
+      reject();
+    });
+    image.src = `data:${mimeType};base64,${base64}`;
+  });
+}
+
+export function fitImageToContainer({
+  containerHeight,
+  containerWidth,
+  imageHeight,
+  imageWidth,
+}: {
+  containerHeight: number;
+  containerWidth: number;
+  imageHeight: number;
+  imageWidth: number;
+}): {
+  height: number;
+  width: number;
+} {
+  const ratio = Math.min(containerWidth / imageWidth, containerHeight / imageHeight);
+
+  return { width: imageWidth * ratio, height: imageHeight * ratio };
+}

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -47,7 +47,7 @@ import {
   paintGraphics,
   previousPaintEvent,
 } from "protocol/graphics";
-import { mostRecentPaint } from "protocol/PaintsCache";
+import { findMostRecentPaint } from "protocol/PaintsCache";
 import { waitForTime } from "protocol/utils";
 import { recordingCapabilitiesCache } from "replay-next/src/suspense/BuildIdCache";
 import {
@@ -526,7 +526,7 @@ export function playbackPoints(
       if (currentTime >= nextGraphicsTime) {
         try {
           let maybeNextGraphics = await Promise.race([nextGraphicsPromise, waitForTime(500)]);
-          if (!maybeNextGraphics) {
+          if (typeof maybeNextGraphics === "number") {
             dispatch(setPlaybackStalled(true));
             maybeNextGraphics = await nextGraphicsPromise;
             dispatch(setPlaybackStalled(false));
@@ -846,7 +846,7 @@ export function precacheScreenshots(beginTime: number): UIThunkAction {
 
     const endTime = Math.min(beginTime + PRECACHE_DURATION, recordingDuration);
     for (let time = beginTime; time < endTime; time += SNAP_TIME_INTERVAL) {
-      const paintPoint = mostRecentPaint(time);
+      const paintPoint = findMostRecentPaint(time);
       if (paintPoint === null) {
         return;
       }


### PR DESCRIPTION
Some standalone changes from #10255 (to de-risk the larger PR and make it easier to review)
- [x] Add new helper methods to `PaintsCache` (with unit tests); these will eventually replace the `protocol/graphics` methods
- [x] Update `waitForTime` helper method to resolve with the actual amount of time it waited for; (this will unblock a later change in #10255)
- [x] Added new `findIndexGTE` and `findIndexLTE` helper array utils method (and tests)
- [x] Added image utility methods `getDimensions` and `fitImageToContainer`