### PR TITLE
Removed mouse events from protocol/graphics

### DIFF
--- a/packages/protocol/RecordedEventsCache.ts
+++ b/packages/protocol/RecordedEventsCache.ts
@@ -1,7 +1,58 @@
-import { KeyboardEvent, MouseEvent, NavigationEvent } from "@replayio/protocol";
+import {
+  KeyboardEvent,
+  MouseEvent,
+  NavigationEvent as ProtocolNavigationEvent,
+} from "@replayio/protocol";
 import { createSingleEntryCache } from "suspense";
 
+import { compareNumericStrings } from "protocol/utils";
 import { replayClient } from "shared/client/ReplayClientContext";
+
+// TODO [BAC-4618] Update the type definition in the protocol package
+// This hack dates back to 2021 (github.com/replayio/devtools/pull/4713)
+export type NavigationEvent = Omit<ProtocolNavigationEvent, "kind"> & {
+  kind: "navigation";
+};
+
+export type RecordedEvent = MouseEvent | KeyboardEvent | NavigationEvent;
+
+export async function preloadAllRecordedEventsCache(): Promise<void> {
+  await Promise.all([
+    RecordedEventsCache.readAsync(),
+    RecordedClickEventsCache.readAsync(),
+    RecordedKeyboardEventsCache.readAsync(),
+    RecordedNavigationEventsCache.readAsync(),
+    RecordedMouseEventsCache.readAsync(),
+  ]);
+}
+
+export const RecordedEventsCache = createSingleEntryCache<[], RecordedEvent[]>({
+  config: { immutable: true },
+  debugLabel: "RecordedEventsCache",
+  load: async () => {
+    const [keyboardEvents, mouseEvents, navigationEvents] = await Promise.all([
+      RecordedKeyboardEventsCache.readAsync(),
+      RecordedMouseEventsCache.readAsync(),
+      RecordedNavigationEventsCache.readAsync(),
+    ]);
+
+    const events = [...keyboardEvents, ...mouseEvents, ...navigationEvents];
+
+    return events.sort((a, b) => compareNumericStrings(a.point, b.point));
+  },
+});
+
+export const RecordedClickEventsCache = createSingleEntryCache<[], MouseEvent[]>({
+  config: { immutable: true },
+  debugLabel: "RecordedClickEventsCache",
+  load: async () => {
+    const events = await replayClient.findMouseEvents();
+
+    // This is kind of funky but it's what Replay has always called a "click" event
+    // github.com/replayio/devtools/commit/770952935755b67c8ea02f3aa1b4f0334ec22ee0
+    return events.filter(event => event.kind === "mousedown");
+  },
+});
 
 export const RecordedKeyboardEventsCache = createSingleEntryCache<[], KeyboardEvent[]>({
   config: { immutable: true },
@@ -23,6 +74,10 @@ export const RecordedNavigationEventsCache = createSingleEntryCache<[], Navigati
   config: { immutable: true },
   debugLabel: "RecordedNavigationEventsCache",
   load: async () => {
-    return replayClient.findNavigationEvents();
+    const events = await replayClient.findNavigationEvents();
+    return events.map(event => ({
+      ...event,
+      kind: "navigation",
+    }));
   },
 });

--- a/src/devtools/client/inspector/markup/components/PreviewNodeHighlighter.tsx
+++ b/src/devtools/client/inspector/markup/components/PreviewNodeHighlighter.tsx
@@ -2,6 +2,7 @@ import type { Quads } from "@replayio/protocol";
 import React from "react";
 
 import { assert } from "protocol/utils";
+import { getCanvas } from "ui/reducers/app";
 import { useAppSelector } from "ui/setup/hooks";
 
 import { getNodeBoxModelById } from "../reducers/markup";
@@ -136,7 +137,7 @@ function getOuterBounds(boxModelQuads: BoxModelQuads) {
 
 export function PreviewNodeHighlighter({ nodeId }: { nodeId: string }) {
   const highlightedNodeBoxModel = useAppSelector(state => getNodeBoxModelById(state, nodeId));
-  const canvas = useAppSelector(state => state.app.canvas);
+  const canvas = useAppSelector(getCanvas);
 
   if (!highlightedNodeBoxModel || !canvas) {
     return null;

--- a/src/ui/components/Events/Event.tsx
+++ b/src/ui/components/Events/Event.tsx
@@ -1,18 +1,14 @@
 import classnames from "classnames";
-import React, { ReactNode, useState } from "react";
+import React, { ReactNode, memo } from "react";
 
+import { RecordedEvent } from "protocol/RecordedEventsCache";
 import { useNag } from "replay-next/src/hooks/useNag";
 import { Nag } from "shared/graphql/types";
-import {
-  PointWithEventType,
-  jumpToClickEventFunctionLocation,
-  jumpToKnownEventListenerHit,
-} from "ui/actions/eventListeners/jumpToCode";
+import { jumpToKnownEventListenerHit } from "ui/actions/eventListeners/jumpToCode";
 import useEventContextMenu from "ui/components/Events/useEventContextMenu";
 import { JumpToCodeButton, JumpToCodeStatus } from "ui/components/shared/JumpToCodeButton";
 import { setMarkTimeStampPoint } from "ui/reducers/timeline";
 import { useAppDispatch } from "ui/setup/hooks";
-import { ReplayEvent } from "ui/state/app";
 import { ParsedJumpToCodeAnnotation } from "ui/suspense/annotationsCaches";
 
 import MaterialIcon from "../shared/MaterialIcon";
@@ -21,14 +17,14 @@ import styles from "./Event.module.css";
 
 type EventProps = {
   currentTime: number;
-  event: ReplayEvent;
+  event: RecordedEvent;
   executionPoint: string;
   jumpToCodeAnnotation?: ParsedJumpToCodeAnnotation;
   jumpToCodeLoadingStatus: "loading" | "complete";
   onSeek: (point: string, time: number) => void;
 };
 
-export const getEventLabel = (event: ReplayEvent) => {
+export const getEventLabel = (event: RecordedEvent) => {
   const { kind } = event;
   const { label } = getReplayEvent(kind);
 
@@ -44,7 +40,7 @@ export const getEventLabel = (event: ReplayEvent) => {
   return label;
 };
 
-export default React.memo(function Event({
+export default memo(function Event({
   currentTime,
   executionPoint,
   event,

--- a/src/ui/components/Events/Events.tsx
+++ b/src/ui/components/Events/Events.tsx
@@ -4,11 +4,11 @@ import React, { memo, useContext, useMemo } from "react";
 import { STATUS_PENDING, STATUS_RESOLVED, useImperativeCacheValue } from "suspense";
 
 import { getExecutionPoint } from "devtools/client/debugger/src/reducers/pause";
+import { RecordedEvent } from "protocol/RecordedEventsCache";
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
 import { isExecutionPointsWithinRange } from "replay-next/src/utils/time";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { useGraphQLUserData } from "shared/user-data/GraphQL/useGraphQLUserData";
-import { getSortedEventsForDisplay } from "ui/actions/app";
 import { seek } from "ui/actions/timeline";
 import { getCurrentTime } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
@@ -31,12 +31,11 @@ export function CurrentTimeLine({ isActive }: { isActive: boolean }) {
 
 const NO_ANNOTATIONS: ParsedJumpToCodeAnnotation[] = [];
 
-function Events() {
+function Events({ events }: { events: RecordedEvent[] }) {
   const client = useContext(ReplayClientContext);
   const dispatch = useAppDispatch();
   const currentTime = useAppSelector(getCurrentTime);
   const executionPoint = useAppSelector(getExecutionPoint);
-  const events = useAppSelector(getSortedEventsForDisplay);
   const { range: focusWindow } = useContext(FocusContext);
 
   const { status: annotationsStatus, value: parsedAnnotations } = useImperativeCacheValue(
@@ -57,8 +56,6 @@ function Events() {
         }
 
         switch (event.kind) {
-          case "keydown":
-          case "keyup":
           case "keypress":
             return filters.keyboard !== false;
           case "mousedown":
@@ -67,7 +64,7 @@ function Events() {
             return filters.navigation !== false;
         }
 
-        return true;
+        return false;
       }),
     [events, filters, focusWindow]
   );

--- a/src/ui/components/Events/useEventContextMenu.tsx
+++ b/src/ui/components/Events/useEventContextMenu.tsx
@@ -1,12 +1,12 @@
 import { ContextMenuDivider, ContextMenuItem, useContextMenu } from "use-context-menu";
 
+import { RecordedEvent } from "protocol/RecordedEventsCache";
 import Icon from "replay-next/components/Icon";
 import { copyToClipboard as copyTextToClipboard } from "replay-next/components/sources/utils/clipboard";
 import { requestFocusWindow } from "ui/actions/timeline";
 import { useAppDispatch } from "ui/setup/hooks";
-import { ReplayEvent } from "ui/state/app";
 
-export default function useEventContextMenu(event: ReplayEvent) {
+export default function useEventContextMenu(event: RecordedEvent) {
   const dispatch = useAppDispatch();
 
   const setFocusEnd = () => {

--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -1,8 +1,10 @@
-import { useContext, useEffect, useMemo, useRef, useState } from "react";
+import { Suspense, useContext, useEffect, useMemo, useRef, useState } from "react";
 
 import PrimaryPanes from "devtools/client/debugger/src/components/PrimaryPanes";
 import SecondaryPanes from "devtools/client/debugger/src/components/SecondaryPanes";
 import Accordion from "devtools/client/debugger/src/components/shared/Accordion";
+import { RecordedEventsCache } from "protocol/RecordedEventsCache";
+import { PanelLoader } from "replay-next/components/PanelLoader";
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
 import { isExecutionPointsWithinRange } from "replay-next/src/utils/time";
 import { setSelectedPrimaryPanel } from "ui/actions/layout";
@@ -13,7 +15,6 @@ import TestSuitePanel from "ui/components/TestSuite";
 import { isTestSuiteReplay } from "ui/components/TestSuite/utils/isTestSuiteReplay";
 import hooks from "ui/hooks";
 import { useGetRecording, useGetRecordingId } from "ui/hooks/recordings";
-import { getSortedEventsForDisplay } from "ui/reducers/app";
 import { getSelectedPrimaryPanel } from "ui/reducers/layout";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { PrimaryPanelName } from "ui/state/layout";
@@ -61,12 +62,21 @@ function useInitialPrimaryPanel() {
 }
 
 export default function SidePanel() {
+  return (
+    <Suspense fallback={<PanelLoader />}>
+      <SidePanelSuspends />
+    </Suspense>
+  );
+}
+
+function SidePanelSuspends() {
   const { range: focusWindow } = useContext(FocusContext);
   const selectedPrimaryPanel = useInitialPrimaryPanel();
   const [replayInfoCollapsed, setReplayInfoCollapsed] = useState(false);
   const [eventsCollapsed, setEventsCollapsed] = useState(false);
-  const events = useAppSelector(getSortedEventsForDisplay);
   const { isAuthenticated } = useAuth0();
+
+  const events = RecordedEventsCache.read();
 
   const hasEventsInFocusWindow = useMemo(
     () =>
@@ -97,12 +107,12 @@ export default function SidePanel() {
       header: (
         <div className={styles.EventsHeader}>
           Events
-          <EventsDropDownMenu />
+          <EventsDropDownMenu events={events} />
         </div>
       ),
       buttons: null,
       className: "events-info flex-1 border-t overflow-hidden border-themeBorder",
-      component: <Events />,
+      component: <Events events={events} />,
       opened: !eventsCollapsed,
       onToggle: () => setEventsCollapsed(!eventsCollapsed),
     });

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -1,8 +1,7 @@
-import { PayloadAction, createSelector, createSlice } from "@reduxjs/toolkit";
+import { PayloadAction, createSlice } from "@reduxjs/toolkit";
 import { RecordingId } from "@replayio/protocol";
 
 import { RecordingTarget } from "replay-next/src/suspense/BuildIdCache";
-import { compareExecutionPoints } from "replay-next/src/utils/time";
 import { Workspace } from "shared/graphql/types";
 import { getMutableParamsFromURL } from "ui/setup/dynamic/url";
 import { UIState } from "ui/state";
@@ -10,11 +9,9 @@ import {
   AppMode,
   AppState,
   Canvas,
-  EventKind,
   ExpectedError,
   ModalOptionsType,
   ModalType,
-  ReplayEvent,
   SettingsTabTitle,
   UnexpectedError,
   UploadInfo,
@@ -29,7 +26,6 @@ export const initialAppState: AppState = {
   defaultSelectedReactElementId: null,
   defaultSettingsTab: "Preferences",
   displayedLoadingProgress: null,
-  events: {},
   expectedError: null,
   hoveredCommentId: null,
   loading: 4,
@@ -100,10 +96,6 @@ const appSlice = createSlice({
         };
       },
     },
-    loadReceivedEvents(state, action: PayloadAction<Record<EventKind, ReplayEvent[]>>) {
-      // Load multiple event types into state at once
-      Object.assign(state.events, action.payload);
-    },
     setCanvas(state, action: PayloadAction<Canvas>) {
       state.canvas = action.payload;
     },
@@ -146,7 +138,6 @@ export const {
   setCanvas,
   setDefaultSelectedReactElementId,
   setDefaultSettingsTab,
-  loadReceivedEvents,
   setExpectedError,
   setLoadingFinished,
   setModal,
@@ -184,27 +175,6 @@ export const getHoveredCommentId = (state: UIState) => state.app.hoveredCommentI
 export const getDefaultSelectedReactElementId = (state: UIState) =>
   state.app.defaultSelectedReactElementId;
 export const getSelectedCommentId = (state: UIState) => state.app.selectedCommentId;
-
-const NO_EVENTS: MouseEvent[] = [];
-export const getEventsForType = (state: UIState, type: string) =>
-  state.app.events[type] || NO_EVENTS;
-
-export const getSortedEventsForDisplay = createSelector(
-  (state: UIState) => state.app.events,
-  events => {
-    let sortedEvents: ReplayEvent[] = [];
-
-    for (let [eventType, eventsOfType] of Object.entries(events)) {
-      if (["keydown", "keyup"].includes(eventType)) {
-        continue;
-      }
-      sortedEvents = sortedEvents.concat(eventsOfType);
-    }
-
-    sortedEvents.sort((a, b) => compareExecutionPoints(a.point, b.point));
-    return sortedEvents;
-  }
-);
 
 export const getCanvas = (state: UIState) => state.app.canvas;
 export const getDefaultSettingsTab = (state: UIState) => state.app.defaultSettingsTab;

--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -1,9 +1,8 @@
 // Side-effectful import, has to be imported before event-listeners
 // Ordering matters here
 import { ActionCreatorWithoutPayload, bindActionCreators } from "@reduxjs/toolkit";
-import { MouseEvent, sessionError, uploadedData } from "@replayio/protocol";
+import { sessionError, uploadedData } from "@replayio/protocol";
 import { IDBPDatabase, openDB } from "idb";
-import debounce from "lodash/debounce";
 
 import { setupSourcesListeners } from "devtools/client/debugger/src/actions/sources";
 import * as dbgClient from "devtools/client/debugger/src/client";
@@ -11,7 +10,6 @@ import debuggerReducers from "devtools/client/debugger/src/reducers";
 import * as inspectorReducers from "devtools/client/inspector/reducers";
 import {
   Canvas,
-  setMouseDownEventsCallback,
   setPausedonPausedAtTimeCallback,
   setPlaybackStatusCallback,
   setRefreshGraphicsCallback,
@@ -30,7 +28,7 @@ import { UIStore, actions } from "ui/actions";
 import { setCanvas } from "ui/actions/app";
 import { precacheScreenshots } from "ui/actions/timeline";
 import { selectors } from "ui/reducers";
-import app, { loadReceivedEvents } from "ui/reducers/app";
+import app from "ui/reducers/app";
 import network from "ui/reducers/network";
 import protocolMessages from "ui/reducers/protocolMessages";
 import timeline, { setPlaybackStalled } from "ui/reducers/timeline";
@@ -223,19 +221,6 @@ export default async function setupDevtools(store: AppStore, replayClient: Repla
   // Add protocol event listeners for things that the Redux store needs to stay in sync with.
   // TODO We should revisit this as part of a larger architectural redesign (#6932).
 
-  setMouseDownEventsCallback(
-    // We seem to get duplicate mousedown events each time, like ["a"], ["a"], ["a", "b"], ["a", "b"], etc.
-    // Debounce the callback so we only dispatch the last set.
-    debounce((events: MouseEvent[]) => {
-      if (!events.length) {
-        // No reason to dispatch when there's 0 events
-        return;
-      }
-
-      //
-      store.dispatch(loadReceivedEvents({ mousedown: [...events] }));
-    }, 1_000)
-  );
   setPausedonPausedAtTimeCallback((time: number) => {
     store.dispatch(precacheScreenshots(time));
   });

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -1,12 +1,4 @@
-import {
-  ExecutionPoint,
-  KeyboardEvent,
-  KeyboardEventKind,
-  MouseEvent,
-  MouseEventKind,
-  NavigationEvent,
-  SessionId,
-} from "@replayio/protocol";
+import { NavigationEvent, SessionId } from "@replayio/protocol";
 
 import type { RecordingTarget } from "replay-next/src/suspense/BuildIdCache";
 import { Workspace } from "shared/graphql/types";
@@ -85,7 +77,6 @@ export interface AppState {
   defaultSelectedReactElementId: number | null;
   defaultSettingsTab: SettingsTabTitle;
   displayedLoadingProgress: number | null;
-  events: Events;
   expectedError: ExpectedError | null;
   hoveredCommentId: string | null;
   loading: number;
@@ -106,20 +97,6 @@ export interface AppState {
 }
 
 export type AppMode = "devtools" | "sourcemap-visualizer";
-
-interface Events {
-  [key: string]: ReplayEvent[];
-}
-
-// Todo: We should move this definition to the protocol instead of typing it here.
-export type ReplayNavigationEvent = Omit<NavigationEvent, "kind"> & {
-  kind: "navigation";
-};
-
-export type ReplayEvent = MouseEvent | KeyboardEvent | ReplayNavigationEvent;
-
-export type EventCategory = "mouse" | "keyboard" | "navigation";
-export type EventKind = MouseEventKind | KeyboardEventKind | string;
 
 export interface Canvas {
   gDevicePixelRatio: number;


### PR DESCRIPTION
Some standalone changes from https://github.com/replayio/devtools/pull/10255 (to de-risk the larger PR and make it easier to review)

- [x] Remove redundant mouse/click events from `protocol/graphics`; single source of truth is now the Suspense "recorded events" caches
- [x] For now, `protocol/graphics` reads from those caches; it will be removed entirely in #10255
- [x] Removed redundant `onKeyboardEvents` and `onNavigationEvents` callbacks in Redux (and the `loadReceivedEvents` Redux state)
- [x] Updated events sidebar components to read data from the new events caches