### PR TITLE
Fix GraphQLClient headers without a test scope

### DIFF
--- a/packages/shared/graphql/GraphQLClient.ts
+++ b/packages/shared/graphql/GraphQLClient.ts
@@ -40,15 +40,19 @@ export class GraphQLClient implements GraphQLClientInterface {
       data.query = data.query.loc?.source.body ?? "";
     }
 
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (accessToken) {
+      headers["Authorization"] = `Bearer ${accessToken}`;
+    }
+    if (testScope) {
+      headers["replay-test-scope"] = testScope;
+    }
+
     const response = await fetch(this.url, {
       method: "POST",
-      headers: {
-        ...(accessToken && {
-          Authorization: `Bearer ${accessToken}`,
-          "replay-test-scope": this.testScope,
-        }),
-        "Content-Type": "application/json",
-      },
+      headers,
       body: JSON.stringify(data),
     });
 


### PR DESCRIPTION
`GraphQLClient` without a test scope currently sets the header `"replay-test-scope": "undefined"`.