### PR TITLE
Try to fix seekToConsoleMessage() flakiness

### DIFF
--- a/packages/e2e-tests/helpers/console-panel.ts
+++ b/packages/e2e-tests/helpers/console-panel.ts
@@ -263,10 +263,17 @@ export async function seekToConsoleMessage(
 
   await debugPrint(page, `Seeking to message "${chalk.bold(textContent)}"`, "seekToConsoleMessage");
 
-  await consoleMessage.scrollIntoViewIfNeeded();
-  await consoleMessage.waitFor();
-  await consoleMessage.hover();
-  await consoleMessage.locator('[data-test-id="ConsoleMessageHoverButton"]').click();
+  await waitFor(async () => {
+    if ((await consoleMessage.getAttribute("data-test-paused-here")) === "true") {
+      return;
+    }
+    await consoleMessage.scrollIntoViewIfNeeded();
+    await consoleMessage.waitFor();
+    await consoleMessage.hover();
+    await consoleMessage
+      .locator('[data-test-id="ConsoleMessageHoverButton"]')
+      .click({ timeout: 1000 });
+  });
 
   await waitFor(
     async () =>


### PR DESCRIPTION
Our e2e tests sometimes fail in `seekToConsoleMessage()` with an error message like
```
TimeoutError: locator.click: Timeout 60000ms exceeded.
=========================== logs ===========================
waiting for locator('[data-test-name="Message"]:has-text(\'Done\')').first().locator('[data-test-id="ConsoleMessageHoverButton"]')
  locator resolved to <button data-test-id="ConsoleMessageHoverButton" class="…>…</button>
attempting click action
  waiting for element to be visible, enabled and stable
element was detached from the DOM, retrying
============================================================
```
This sounds like playwright retries clicking the `MessageHoverButton` for 60 seconds but fails. Perhaps it is retrying with the same (detached) DOM element instead of getting a new DOM element for the given locator in every try. If that theory is correct then retrying the click ourselves may fix this flake.