### PR TITLE
Try to fix restart-session e2e test flakiness

### DIFF
--- a/packages/e2e-tests/tests/restart-session.test.ts
+++ b/packages/e2e-tests/tests/restart-session.test.ts
@@ -8,6 +8,6 @@ test(`restart debugging session`, async ({ pageWithMeta: { page, recordingId }, 
   await startTest(page, recordingId);
   await openDevToolsTab(page);
   await commandPalette(page, "restart session");
-  await page.waitForNavigation();
+  await page.waitForURL(/restart=true/);
   await waitForRecordingToFinishIndexing(page);
 });


### PR DESCRIPTION
`page.waitForNavigation()` is deprecated with the warning "This method is inherently racy", so let's see if this fixes the test flakiness.