### PR TITLE
Fix potential source of duplicate recorded mouse events

### DIFF
--- a/packages/protocol/RecordedEventsCache.ts
+++ b/packages/protocol/RecordedEventsCache.ts
@@ -46,7 +46,7 @@ export const RecordedClickEventsCache = createSingleEntryCache<[], MouseEvent[]>
   config: { immutable: true },
   debugLabel: "RecordedClickEventsCache",
   load: async () => {
-    const events = await replayClient.findMouseEvents();
+    const events = await RecordedMouseEventsCache.readAsync();
 
     // This is kind of funky but it's what Replay has always called a "click" event
     // github.com/replayio/devtools/commit/770952935755b67c8ea02f3aa1b4f0334ec22ee0


### PR DESCRIPTION
I noticed an oversight in the `RecordedEventsCache` that could result in calling `Session.findMouseEvents` twice in parallel, which (because of the way the `@replayio/protocol` API is designed) could result in duplicate events being added to the returned array.

This commit fixes that case by removing the 2nd caller. In general, this is a flaw of the `@replayio/protocol` package though and one we can't totally patch on the frontend.

See [go/r/c1cb4a29-e311-47da-975b-5ce14b10d654](http://go/r/c1cb4a29-e311-47da-975b-5ce14b10d654) for an example of the bug this commit fixes.