### PR TITLE
Remove legacy comments attributes

### DIFF
--- a/packages/replay-next/components/comments/Comment.tsx
+++ b/packages/replay-next/components/comments/Comment.tsx
@@ -45,14 +45,7 @@ export default function CommentRenderer({ comment }: { comment: Comment }) {
   };
 
   const editCommentCallback = async (content: string, isPublished: boolean) => {
-    await updateCommentGraphQL(
-      graphQLClient,
-      accessToken!,
-      comment.id,
-      content,
-      isPublished,
-      comment.position
-    );
+    await updateCommentGraphQL(graphQLClient, accessToken!, comment.id, content, isPublished);
   };
 
   return (
@@ -64,11 +57,7 @@ export default function CommentRenderer({ comment }: { comment: Comment }) {
       deleteCallback={deleteCommentCallback}
       editCallback={editCommentCallback}
       isPublished={comment.isPublished}
-      networkRequestId={comment.networkRequestId}
       owner={comment.user}
-      primaryLabel={comment.primaryLabel || null}
-      secondaryLabel={comment.secondaryLabel || null}
-      sourceLocation={comment.sourceLocation}
       type={comment.type}
       typeData={comment.typeData}
     >
@@ -96,11 +85,7 @@ export default function CommentRenderer({ comment }: { comment: Comment }) {
             deleteCallback={deleteCommentReplyCallback}
             editCallback={editCommentReplyCallback}
             isPublished={reply.isPublished}
-            networkRequestId={null}
             owner={reply.user}
-            primaryLabel={null}
-            secondaryLabel={null}
-            sourceLocation={null}
             type={null}
             typeData={null}
           />
@@ -124,11 +109,7 @@ function EditableRemark({
   deleteCallback,
   editCallback,
   isPublished,
-  networkRequestId,
   owner,
-  primaryLabel,
-  secondaryLabel,
-  sourceLocation,
   type,
   typeData,
 }: {
@@ -139,11 +120,7 @@ function EditableRemark({
   deleteCallback: () => Promise<void>;
   editCallback: (newContent: string, newIsPublished: boolean) => Promise<void>;
   isPublished: boolean;
-  networkRequestId: string | null;
   owner: User;
-  primaryLabel: string | null;
-  secondaryLabel: string | null;
-  sourceLocation: CommentSourceLocation | null;
   type: string | null;
   typeData: any | null;
 }) {

--- a/packages/shared/graphql/Comments.ts
+++ b/packages/shared/graphql/Comments.ts
@@ -3,7 +3,7 @@ import { RecordingId } from "@replayio/protocol";
 import { GetComments } from "./generated/GetComments";
 import { AddCommentInput } from "./generated/globalTypes";
 import { GraphQLClientInterface } from "./GraphQLClient";
-import { Comment, CommentPosition } from "./types";
+import { Comment } from "./types";
 
 const AddCommentMutation = `
   mutation AddComment($input: AddCommentInput!) {
@@ -51,16 +51,11 @@ const GetCommentsQuery = `
         id
         isPublished
         content
-        primaryLabel
-        secondaryLabel
         createdAt
         updatedAt
         hasFrames
-        sourceLocation
         time
         point
-        position
-        networkRequestId
         type
         typeData
         user {
@@ -92,8 +87,8 @@ const GetCommentsQuery = `
 `;
 
 const UpdateCommentMutation = `
-  mutation UpdateCommentContent($newContent: String!, $newIsPublished: Boolean!, $commentId: ID!, $newPosition: JSONObject) {
-    updateComment(input: { id: $commentId, content: $newContent, isPublished: $newIsPublished, position: $newPosition }) {
+  mutation UpdateCommentContent($newContent: String!, $newIsPublished: Boolean!, $commentId: ID!) {
+    updateComment(input: { id: $commentId, content: $newContent, isPublished: $newIsPublished }) {
       success
     }
   }
@@ -212,11 +207,9 @@ export async function getComments(
           ...reply,
           content: reply.content,
           hasFrames: comment.hasFrames,
-          sourceLocation: comment.sourceLocation,
           time: comment.time,
           parentId: comment.id,
           point: comment.point,
-          position: comment.position,
         };
       }),
     };
@@ -228,14 +221,13 @@ export async function updateComment(
   accessToken: string,
   commentId: string,
   newContent: string,
-  newIsPublished: boolean,
-  newPosition: CommentPosition | null
+  newIsPublished: boolean
 ) {
   await graphQLClient.send<GetComments>(
     {
       operationName: "UpdateCommentContent",
       query: UpdateCommentMutation,
-      variables: { newContent, newIsPublished, newPosition, commentId },
+      variables: { newContent, newIsPublished, commentId },
     },
     accessToken
   );

--- a/packages/shared/graphql/types.ts
+++ b/packages/shared/graphql/types.ts
@@ -91,12 +91,6 @@ export interface Comment extends Remark {
   replies: Reply[];
   type: string | null;
   typeData: any | null;
-
-  // TODO [FE-2251]Remove these legacy attributes
-  position: CommentPosition | null;
-  networkRequestId: string | null;
-  primaryLabel?: string;
-  secondaryLabel?: string;
 }
 
 export interface Reply extends Remark {

--- a/src/ui/actions/comments.ts
+++ b/src/ui/actions/comments.ts
@@ -28,18 +28,7 @@ export function createComment(
   options: CommentOptions
 ): UIThunkAction {
   return async dispatch => {
-    let {
-      hasFrames,
-      type,
-      typeData,
-
-      // TODO [FE-1058] Delete legacy fields in favor of type/typeData
-      networkRequestId,
-      position,
-      primaryLabel = null,
-      secondaryLabel = null,
-      sourceLocation,
-    } = options;
+    let { hasFrames, type, typeData } = options;
 
     trackEvent("comments.create");
 
@@ -55,13 +44,6 @@ export function createComment(
           time,
           type,
           typeData,
-
-          // TODO [FE-1058] Delete legacy fields in favor of type/typeData
-          networkRequestId: networkRequestId || null,
-          position,
-          primaryLabel,
-          secondaryLabel,
-          sourceLocation,
         },
       },
     });
@@ -89,9 +71,7 @@ export function createFrameComment(
 
     dispatch(
       createComment(currentTime, executionPoint, recordingId, {
-        position,
         hasFrames: true,
-        sourceLocation: null,
         type: COMMENT_TYPE_VISUAL,
         typeData,
       })
@@ -117,10 +97,7 @@ export function createNetworkRequestComment(
 
     dispatch(
       createComment(time, executionPoint, recordingId, {
-        position: null,
         hasFrames: false,
-        sourceLocation: null,
-        networkRequestId: request.id,
         type: COMMENT_TYPE_NETWORK_REQUEST,
         typeData: createTypeDataForNetworkRequestComment(
           request.id,

--- a/src/ui/state/comments.ts
+++ b/src/ui/state/comments.ts
@@ -18,13 +18,6 @@ export type CommentOptions = {
   hasFrames: boolean;
   type: CommentType;
   typeData: any | null;
-
-  // TODO [FE-2251]Remove these legacy attributes
-  networkRequestId?: string;
-  position: CommentPosition | null;
-  primaryLabel?: string | null;
-  secondaryLabel?: string | null;
-  sourceLocation: SourceLocation | null;
 };
 
 export interface Remark {


### PR DESCRIPTION
These were long ago replaced by the `type` and `typeData` fields.