### PR TITLE
Update TypeScript dep from 5.0.2 to 5.3.3 (latest)

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "tailwindcss": "^3.2.4",
     "ts-node": "^10.7.0",
     "tsconfig-paths": "^3.14.1",
-    "typescript": "^5.0.4",
+    "typescript": "^5.3.3",
     "utf-8-validate": "^5.0.8",
     "uuid": "^7.0.3",
     "v8-to-istanbul": "^9.0.1",
@@ -229,7 +229,7 @@
     "react-dom": "0.0.0-experimental-953cb02f6-20230907",
     "react-is": "18.2.0",
     "ts-invariant": "0.10.3",
-    "typescript": "5.0.2",
+    "typescript": "5.3.3",
     "react-json-view@1.21.3": "patch:react-json-view@npm:1.21.3#.yarn/patches/react-json-view-npm-1.21.3-7827bb54c4.patch"
   },
   "importSort": {

--- a/src/devtools/client/debugger/src/utils/pause/frames/annotateFrames.ts
+++ b/src/devtools/client/debugger/src/utils/pause/frames/annotateFrames.ts
@@ -29,7 +29,6 @@ function annotateFrame(frame: PauseFrame, frames: PauseFrame[]) {
 
 function annotateBabelAsyncFrames(frames: PauseFrame[]) {
   const babelFrameIndexes = getBabelFrameIndexes(frames);
-  // @ts-expect-error doesn't like searching for numbers in a PauseFrame[]
   const isBabelFrame = (frameIndex: number) => babelFrameIndexes.includes(frameIndex);
 
   return frames.map((frame, frameIndex) =>

--- a/src/devtools/shared/event-emitter.ts
+++ b/src/devtools/shared/event-emitter.ts
@@ -173,7 +173,6 @@ export class EventEmitter implements EmitterTarget {
         return rv;
       };
 
-      // @ts-expect-error who knows
       newListener[onceOriginalListener] = listener;
       EventEmitter.on(target, type, newListener);
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -15147,7 +15147,7 @@ __metadata:
     tailwindcss: ^3.2.4
     ts-node: ^10.7.0
     tsconfig-paths: ^3.14.1
-    typescript: ^5.0.4
+    typescript: ^5.3.3
     use-context-menu: 0.4.13
     utf-8-validate: ^5.0.8
     uuid: ^7.0.3
@@ -17287,23 +17287,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.0.2":
-  version: 5.0.2
-  resolution: "typescript@npm:5.0.2"
+"typescript@npm:5.3.3":
+  version: 5.3.3
+  resolution: "typescript@npm:5.3.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: bef1dcd166acfc6934b2ec4d72f93edb8961a5fab36b8dd2aaf6f4f4cd5c0210f2e0850aef4724f3b4913d5aef203a94a28ded731b370880c8bcff7e4ff91fc1
+  checksum: 2007ccb6e51bbbf6fde0a78099efe04dc1c3dfbdff04ca3b6a8bc717991862b39fd6126c0c3ebf2d2d98ac5e960bcaa873826bb2bb241f14277034148f41f6a2
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.0.2#~builtin<compat/typescript>":
-  version: 5.0.2
-  resolution: "typescript@patch:typescript@npm%3A5.0.2#~builtin<compat/typescript>::version=5.0.2&hash=7ad353"
+"typescript@patch:typescript@npm%3A5.3.3#~builtin<compat/typescript>":
+  version: 5.3.3
+  resolution: "typescript@patch:typescript@npm%3A5.3.3#~builtin<compat/typescript>::version=5.3.3&hash=7ad353"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: bdbf3d0aac0d6cf010fbe0536753dc19f278eb4aba88140dcd25487dfe1c56ca8b33abc0dcd42078790a939b08ebc4046f3e9bb961d77d3d2c3cfa9829da4d53
+  checksum: f61375590b3162599f0f0d5b8737877ac0a7bc52761dbb585d67e7b8753a3a4c42d9a554c4cc929f591ffcf3a2b0602f65ae3ce74714fd5652623a816862b610
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I'm not sure why #9006 pinned us to 5.0.2 but this commit updates us to the latest. (This fixes a TypeScript TS7022 error I was seeing on another branch.)