### PR TITLE
[FE-2255] `waitFor` ignores unrecoverable errors, including recorder crashes

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "trunk check",
     "lint:fix": "trunk check --fix",
     "typecheck": "tsc",
+    "checks": "npm run typecheck && npm run lint",
     "typecheck:watch": "yarn typecheck --watch",
     "gql:schema": "gq https://graphql.replay.io/v1/graphql -H \"X-Hasura-Admin-Secret: $HASURA_KEY\" --introspect > schema.graphql",
     "gql:gen": "apollo codegen:generate --localSchemaFile=schema.graphql --includes='{packages/shared,src}/**/*.{ts,tsx}' --target=typescript --tagName=gql --outputFlat packages/shared/graphql/generated",

--- a/packages/e2e-tests/helpers/utils.ts
+++ b/packages/e2e-tests/helpers/utils.ts
@@ -95,7 +95,7 @@ export async function waitForRecordingToFinishIndexing(page: Page): Promise<void
   try {
     await waitFor(
       async () => {
-        expect(await timelineCapsuleLocator.getAttribute("data-test-progress")).toBe("100");
+        expect(await timelineCapsuleLocator.getAttribute("data-test-progress"), "Recording did not finish processing").toBe("100");
       },
       {
         retryInterval: 1_000,
@@ -107,7 +107,7 @@ export async function waitForRecordingToFinishIndexing(page: Page): Promise<void
       if (await page.locator('[data-test-id="SupportForm"]').isVisible()) {
         const errorDetailsLocator = page.locator('[data-test-id="UnexpectedErrorDetails"]');
         if (await errorDetailsLocator.isVisible()) {
-          throw new Error(`Recording did not finish processing: ${await errorDetailsLocator.innerText()}`);
+          throw new Error(`Session failed: ${await errorDetailsLocator.innerText()}`);
         }
       }
     } finally {

--- a/packages/e2e-tests/helpers/utils.ts
+++ b/packages/e2e-tests/helpers/utils.ts
@@ -184,10 +184,15 @@ export async function waitFor(
 
       return;
     } catch (error) {
-      if (!error?.matcherResult && !isString(error)) {
-        // Not an `expect` error and not one of our thrown strings.
-        // → Probably not recoverable.
+      if (error?.message?.includes("crash")) {
+        // We have to resort to heuristics since:
+        // 1. We don't have access to the `Page` object, and
+        // 2. the Error object also has no special properties.
         throw error;
+      }
+      if (!error?.matcherResult) {
+        // Not an `expect` error: → Log it.
+        console.log("ERROR:", error?.stack || error);
       }
 
       if (performance.now() - startTime > timeout) {

--- a/packages/e2e-tests/helpers/utils.ts
+++ b/packages/e2e-tests/helpers/utils.ts
@@ -106,7 +106,7 @@ export async function waitForRecordingToFinishIndexing(page: Page): Promise<void
         timeout: 150_000,
       }
     );
-  } catch (err) {
+  } catch (err: any) {
     try {
       if (await page.locator('[data-test-id="SupportForm"]').isVisible()) {
         const errorDetailsLocator = page.locator('[data-test-id="UnexpectedErrorDetails"]');
@@ -115,7 +115,7 @@ export async function waitForRecordingToFinishIndexing(page: Page): Promise<void
         }
       }
     } finally {
-      // Page is in a faulty state or no more info available. Stop trying and only report original error.
+      // Page is in a faulty state or no more info available: Simply report original error.
       throw err;
     }
   }

--- a/packages/e2e-tests/helpers/utils.ts
+++ b/packages/e2e-tests/helpers/utils.ts
@@ -193,7 +193,7 @@ export async function waitFor(
       await callback();
 
       return;
-    } catch (error) {
+    } catch (error: any) {
       if (error?.message?.includes("crash")) {
         // We have to resort to heuristics since:
         // 1. We don't have access to the `Page` object, and

--- a/packages/e2e-tests/helpers/utils.ts
+++ b/packages/e2e-tests/helpers/utils.ts
@@ -1,8 +1,8 @@
 import { Locator, Page, expect } from "@playwright/test";
 import axios from "axios";
 import chalk from "chalk";
-import stripAnsi from "strip-ansi";
 import isString from "lodash/isString";
+import stripAnsi from "strip-ansi";
 
 import config from "../config";
 
@@ -96,7 +96,10 @@ export async function waitForRecordingToFinishIndexing(page: Page): Promise<void
   try {
     await waitFor(
       async () => {
-        expect(await timelineCapsuleLocator.getAttribute("data-test-progress"), "Recording did not finish processing").toBe("100");
+        expect(
+          await timelineCapsuleLocator.getAttribute("data-test-progress"),
+          "Recording did not finish processing"
+        ).toBe("100");
       },
       {
         retryInterval: 1_000,

--- a/packages/e2e-tests/helpers/utils.ts
+++ b/packages/e2e-tests/helpers/utils.ts
@@ -86,8 +86,17 @@ export async function mapLocators<T>(
 
 export async function getSupportFormErrorDetails(page: Page) {
   if (await page.locator('[data-test-id="SupportForm"]').isVisible()) {
-    const errorDetailsLocator = page.locator('[data-test-id="UnexpectedErrorDetails"]');
-    return (await errorDetailsLocator.innerText()) || "(support form is visible)";
+    let details: string = "";
+    try {
+      const errorDetailsLocator = page.locator('[data-test-id="UnexpectedErrorDetails"]');
+      if (await errorDetailsLocator.isVisible()) {
+        details = await errorDetailsLocator.innerText();
+      }
+    } catch (err) {
+      // Ignore locator errors.
+      console.error(`ERROR:`, err);
+    }
+    return details || "(support form is visible)";
   }
   return null;
 }

--- a/packages/e2e-tests/helpers/utils.ts
+++ b/packages/e2e-tests/helpers/utils.ts
@@ -1,7 +1,6 @@
 import { Locator, Page, expect } from "@playwright/test";
 import axios from "axios";
 import chalk from "chalk";
-import isString from "lodash/isString";
 import stripAnsi from "strip-ansi";
 
 import config from "../config";

--- a/packages/e2e-tests/helpers/utils.ts
+++ b/packages/e2e-tests/helpers/utils.ts
@@ -110,13 +110,10 @@ export async function waitForRecordingToFinishIndexing(page: Page): Promise<void
           throw new Error(`Recording did not finish processing: ${await errorDetailsLocator.innerText()}`);
         }
       }
-
-    } catch {
-      // Page is in a faulty state. Stop trying and only report original state.
-      throw new Error(`Recording did not finish processing:\n  ${err.stack}`);
+    } finally {
+      // Page is in a faulty state or no more info available. Stop trying and only report original error.
+      throw err;
     }
-
-    throw new Error(`Recording did not finish processing:\n  ${err.stack}`);
   }
 }
 

--- a/packages/e2e-tests/helpers/utils.ts
+++ b/packages/e2e-tests/helpers/utils.ts
@@ -2,6 +2,7 @@ import { Locator, Page, expect } from "@playwright/test";
 import axios from "axios";
 import chalk from "chalk";
 import stripAnsi from "strip-ansi";
+import isString from "lodash/isString";
 
 import config from "../config";
 
@@ -171,8 +172,9 @@ export async function waitFor(
 
       return;
     } catch (error) {
-      if (!error?.matcherResult) {
-        // Not an `expect` error → Probably not recoverable.
+      if (!error?.matcherResult && !isString(error)) {
+        // Not an `expect` error and not one of our thrown strings.
+        // → Probably not recoverable.
         throw error;
       }
 

--- a/packages/e2e-tests/testFixtureCloneRecording.ts
+++ b/packages/e2e-tests/testFixtureCloneRecording.ts
@@ -35,12 +35,6 @@ const testWithCloneRecording = base.extend<TestIsolatedRecordingFixture>({
         const { recording } = exampleRecordings[exampleKey];
         console.log("Cloning recording");
         newRecordingId = await cloneTestRecording(recording);
-
-        try {
-          await loadRecording(newRecordingId);
-        } catch (e) {
-          console.warn("Error processing recording; ignoring.");
-        }
       } catch (err: any) {
         if (axios.isAxiosError(err)) {
           console.error("Axios error cloning recording: ", {
@@ -53,11 +47,18 @@ const testWithCloneRecording = base.extend<TestIsolatedRecordingFixture>({
         throw err;
       }
 
+      try {
+        await loadRecording(newRecordingId);
+      } catch (e) {
+        console.warn("Error processing recording; ignoring.");
+      }
+
+      // Start coverage.
       await page.coverage.startJSCoverage({
         resetOnNavigation: false,
       });
 
-      // Run Test:
+      // Run test.
       await use({
         page,
         recordingId: newRecordingId,

--- a/packages/e2e-tests/testFixtureCloneRecording.ts
+++ b/packages/e2e-tests/testFixtureCloneRecording.ts
@@ -41,8 +41,6 @@ const testWithCloneRecording = base.extend<TestIsolatedRecordingFixture>({
             errors: err.response?.data?.errors,
             details: err.toJSON(),
           });
-        } else {
-          console.error("Error cloning recording: ", err);
         }
         throw err;
       }

--- a/packages/e2e-tests/testFixtureCloneRecording.ts
+++ b/packages/e2e-tests/testFixtureCloneRecording.ts
@@ -1,5 +1,5 @@
 import crypto from "crypto";
-import { Page, test as base, expect } from "@playwright/test";
+import { Page, test as base } from "@playwright/test";
 import axios from "axios";
 
 import { TestRecordingKey } from "./helpers";

--- a/packages/e2e-tests/testFixtureCloneRecording.ts
+++ b/packages/e2e-tests/testFixtureCloneRecording.ts
@@ -63,9 +63,8 @@ const testWithCloneRecording = base.extend<TestIsolatedRecordingFixture>({
         testScope,
       });
     } finally {
-      let jsCoverage: Awaited<ReturnType<Page["coverage"]["stopJSCoverage"]>> | undefined;
       try {
-        jsCoverage = await page.coverage.stopJSCoverage();
+        await page.coverage.stopJSCoverage();
       } catch (err: any) {
         console.error("Error stopping JS coverage: ", err);
       }

--- a/packages/e2e-tests/testFixtureCloneRecording.ts
+++ b/packages/e2e-tests/testFixtureCloneRecording.ts
@@ -1,5 +1,5 @@
 import crypto from "crypto";
-import { Page, test as base } from "@playwright/test";
+import { Page, test as base, expect } from "@playwright/test";
 import axios from "axios";
 
 import { TestRecordingKey } from "./helpers";
@@ -31,34 +31,38 @@ const testWithCloneRecording = base.extend<TestIsolatedRecordingFixture>({
     const testScope = crypto.randomUUID();
     let newRecordingId: string | undefined = undefined;
     try {
-      const { recording } = exampleRecordings[exampleKey];
-      console.log("Cloning recording");
-      newRecordingId = await cloneTestRecording(recording);
-
       try {
-        await loadRecording(newRecordingId);
-      } catch (e) {
-        console.warn("Error processing recording; ignoring.");
+        const { recording } = exampleRecordings[exampleKey];
+        console.log("Cloning recording");
+        newRecordingId = await cloneTestRecording(recording);
+
+        try {
+          await loadRecording(newRecordingId);
+        } catch (e) {
+          console.warn("Error processing recording; ignoring.");
+        }
+      } catch (err: any) {
+        if (axios.isAxiosError(err)) {
+          console.error("Axios error cloning recording: ", {
+            errors: err.response?.data?.errors,
+            details: err.toJSON(),
+          });
+        } else {
+          console.error("Error cloning recording: ", err);
+        }
+        throw err;
       }
 
       await page.coverage.startJSCoverage({
         resetOnNavigation: false,
       });
+
+      // Run Test:
       await use({
         page,
         recordingId: newRecordingId,
         testScope,
       });
-    } catch (err: any) {
-      if (axios.isAxiosError(err)) {
-        console.error("Axios error cloning recording: ", {
-          errors: err.response?.data?.errors,
-          details: err.toJSON(),
-        });
-      } else {
-        console.error("Error cloning recording: ", err);
-      }
-      throw err;
     } finally {
       let jsCoverage: Awaited<ReturnType<Page["coverage"]["stopJSCoverage"]>> | undefined;
       try {


### PR DESCRIPTION
* https://linear.app/replay/issue/FE-2255/waitfor-ignores-unrecoverable-errors-including-recorder-crashes