### PR TITLE
[RUN-3257] Enable some JS_ASSERTS

### DIFF
--- a/packages/e2e-tests/scripts/buildkite_run_fe_tests.ts
+++ b/packages/e2e-tests/scripts/buildkite_run_fe_tests.ts
@@ -240,6 +240,11 @@ export default function run_fe_tests(CHROME_BINARY_PATH, runInCI = true, nWorker
             PLAYWRIGHT_TEST_BASE_URL: "https://app.replay.io",
             REPLAY_API_KEY: process.env.RUNTIME_TEAM_API_KEY,
             REPLAY_UPLOAD: "1",
+
+            // [RUN-3257]Enable JS ASSERTS:
+            RECORD_REPLAY_JS_OBJECT_ASSERTS: "1",
+            RECORD_REPLAY_JS_PROGRESS_ASSERTS: "1",
+            RECORD_REPLAY_JS_PROGRESS_CHECKS: "1"
           },
         }
       );

--- a/packages/e2e-tests/scripts/buildkite_run_fe_tests.ts
+++ b/packages/e2e-tests/scripts/buildkite_run_fe_tests.ts
@@ -241,10 +241,10 @@ export default function run_fe_tests(CHROME_BINARY_PATH, runInCI = true, nWorker
             REPLAY_API_KEY: process.env.RUNTIME_TEAM_API_KEY,
             REPLAY_UPLOAD: "1",
 
-            // [RUN-3257]Enable JS ASSERTS:
+            // [RUN-3257] Enable JS ASSERTS:
             RECORD_REPLAY_JS_OBJECT_ASSERTS: "1",
             RECORD_REPLAY_JS_PROGRESS_ASSERTS: "1",
-            RECORD_REPLAY_JS_PROGRESS_CHECKS: "1"
+            RECORD_REPLAY_JS_PROGRESS_CHECKS: "1",
           },
         }
       );


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-3257/start-fuzzing-fe-e2e-tests-with-js-asserts-enabled