### PR TITLE
Scale visual comment screenshots

### DIFF
--- a/packages/replay-next/components/sources/utils/comments.ts
+++ b/packages/replay-next/components/sources/utils/comments.ts
@@ -3,6 +3,7 @@ import { SourceId } from "@replayio/protocol";
 import { assert } from "protocol/utils";
 import { getSourceAsync } from "replay-next/src/suspense/SourcesCache";
 import { streamingSyntaxParsingCache } from "replay-next/src/suspense/SyntaxParsingCache";
+import { scaleImage } from "replay-next/src/utils/image";
 import { getSourceFileName } from "replay-next/src/utils/source";
 import { ParsedToken } from "replay-next/src/utils/syntax-parser";
 import { ReplayClientInterface } from "shared/client/types";
@@ -147,7 +148,12 @@ export async function createTypeDataForVisualComment(
   pageX: number | null,
   pageY: number | null
 ): Promise<VisualCommentTypeData> {
-  const encodedImage = image instanceof HTMLImageElement ? image.src : null;
+  let encodedImage: string | null = null;
+  if (image instanceof HTMLImageElement) {
+    const scaledImage = scaleImage({ imageElement: image, maxHeight: 300, maxWidth: 300 });
+
+    encodedImage = scaledImage.src;
+  }
 
   let scaledX: number | null = null;
   let scaledY: number | null = null;

--- a/packages/replay-next/src/utils/image.ts
+++ b/packages/replay-next/src/utils/image.ts
@@ -1,3 +1,5 @@
+import assert from "assert";
+
 type Dimensions = { aspectRatio: number; height: number; width: number };
 
 export async function getDimensions(base64: string, mimeType: string): Promise<Dimensions> {
@@ -35,4 +37,41 @@ export function fitImageToContainer({
   const ratio = Math.min(containerWidth / imageWidth, containerHeight / imageHeight);
 
   return { width: imageWidth * ratio, height: imageHeight * ratio };
+}
+
+export function scaleImage(options: {
+  imageElement: HTMLImageElement;
+  maxHeight: number;
+  maxWidth: number;
+}) {
+  const { imageElement, maxHeight, maxWidth } = options;
+  let { height, width } = imageElement;
+
+  if (height < maxHeight && width < maxWidth) {
+    return imageElement;
+  }
+
+  if (width > maxWidth) {
+    height *= maxWidth / width;
+    width = maxWidth;
+  }
+
+  if (height > maxHeight) {
+    width *= maxHeight / height;
+    height = maxHeight;
+  }
+
+  const tempCanvas = document.createElement("canvas");
+  tempCanvas.width = width;
+  tempCanvas.height = height;
+
+  const context = tempCanvas.getContext("2d");
+  assert(context);
+
+  context.drawImage(imageElement, 0, 0, width, height);
+
+  const scaledImage = document.createElement("img");
+  scaledImage.src = tempCanvas.toDataURL();
+
+  return scaledImage;
 }


### PR DESCRIPTION
This regressed in #10255; we used to scale image data down before creating a visual comment. Now we do again.

## Before
![Screenshot 2024-02-12 at 2 07 24 PM](https://github.com/replayio/devtools/assets/29597/48311eb3-ba9e-4ad0-9fc4-0b57e5efdec9)

## After
![Screenshot 2024-02-12 at 2 05 18 PM](https://github.com/replayio/devtools/assets/29597/bdb4bc65-d48a-4884-adda-42c94e039415)
