### PR TITLE
Recorded cursor scale and position

### DIFF
--- a/src/ui/components/Video/RecordedCursor.tsx
+++ b/src/ui/components/Video/RecordedCursor.tsx
@@ -22,15 +22,19 @@ export function RecordedCursor({ time }: { time: number }) {
     if (mouseEvent) {
       // Imperatively position and scale these graphics to avoid "render lag" when resizes occur
       return subscribe(state => {
-        const { localScale, recordingScale } = state;
+        const { height, localScale, recordingScale, width } = state;
 
-        const scale = recordingScale / localScale;
-        let mouseX = mouseEvent.clientX / scale;
-        let mouseY = mouseEvent.clientY / scale;
+        const originalHeight = height / localScale;
+        const originalWidth = width / localScale;
+
+        const mouseX = (mouseEvent.clientX / originalWidth) * width;
+        const mouseY = (mouseEvent.clientY / originalHeight) * height;
+
+        const cursorScale = Math.min(1, Math.max(0.25, localScale * recordingScale));
 
         element.style.left = `${mouseX}px`;
         element.style.top = `${mouseY}px`;
-        element.style.transform = `scale(${localScale})`;
+        element.style.transform = `scale(${cursorScale})`;
       });
     }
   }, [mouseEvent]);


### PR DESCRIPTION
For visual comparison, comparing [before](https://devtools-8j2594g99-recordreplay.vercel.app/recording/replay-viewer-is-erratic-and-i-cant-add-comments--a95019b2-fb3d-4e31-947c-4d74bf56ca2f?commentId=&focusWindow=eyJiZWdpbiI6eyJwb2ludCI6IjAiLCJ0aW1lIjowfSwiZW5kIjp7InBvaW50IjoiOTkzMDI2Nzc0Mjg3MTM1MTA3NzY0MjcyMTA5NTg5NjI2ODgiLCJ0aW1lIjozMjYzNX19&point=84050305406448599187540294571660636&primaryPanel=comments&secondaryPanel=console&time=27851&viewMode=non-dev) my graphics refactor landed to after this change:

https://github.com/replayio/devtools/assets/29597/e3d82fa4-3e75-4fb3-82c9-a3ea38d332c0
