### PR TITLE
Always show prev screenshot regardless of seek direction

### DIFF
--- a/src/ui/components/Video/useDisplayedScreenShot.ts
+++ b/src/ui/components/Video/useDisplayedScreenShot.ts
@@ -24,13 +24,7 @@ export function useDisplayedScreenShot(screenShot: ScreenShot | undefined, time:
     }
   }, [screenShot, preferHoverTime, time]);
 
-  let screenShotToRender = screenShot;
-  if (screenShotToRender == null && time >= prevScreenShotData.time) {
-    // If we're seeking (or playing) forward, continue to show the previous screenshot
-    // This prevents "flickering" while the new one loads
-    // It doesn't make sense to do this when seeking backwards though
-    screenShotToRender = prevScreenShotData.screenShot;
-  }
-
-  return screenShotToRender;
+  // If we're seeking (or playing) forward, continue to show the previous screenshot
+  // This prevents "flickering" while the new one loads
+  return screenShot ?? prevScreenShotData.screenShot;
 }


### PR DESCRIPTION
Initially, I only showed the previous screenshot if you were seeking forward. This kind of makes sense, but could result in a "flickering" as described by Jason if you were scrubbing backward. There's not a really strong reason for limiting the behavior to forward-only, so this PR changes it so that we show the prior screenshot when seeking forward _or_ backward.

---

Jason confirmed that the preview branch from this PR fixes the flickering issue he reported initially too, which is good.