### PR TITLE
Adjusting default timeline color

### DIFF
--- a/packages/replay-next/pages/variables.css
+++ b/packages/replay-next/pages/variables.css
@@ -378,7 +378,7 @@
   */
 
   /* src/devtools/client/debugger/src/components/SecondaryPanes/FrameTimeline.css */
-  --progressbar-background: var(--theme-base-90);
+  --progressbar-background: var(--theme-base-85);
   --progressbar-unfocused-background: #8fa7be;
   --replay-head-background: var(--theme-highlight-purple);
 


### PR DESCRIPTION
**Old**

<img width="553" alt="image" src="https://github.com/replayio/devtools/assets/9154902/d8d88853-3dc5-416c-9c61-f54e3e0d4b1b">

**New:**

<img width="553" alt="image" src="https://github.com/replayio/devtools/assets/9154902/041b0da8-dfad-4176-8a84-08355a7a0bb3">

**Comparing to light theme:**

<img width="553" alt="image" src="https://github.com/replayio/devtools/assets/9154902/7a700370-04d9-4030-954e-e610cb028bab">
