### PR TITLE
Remove unneeded comment code

### DIFF
--- a/packages/shared/graphql/generated/GetComments.ts
+++ b/packages/shared/graphql/generated/GetComments.ts
@@ -36,16 +36,11 @@ export interface GetComments_recording_comments {
   id: string;
   isPublished: boolean | null;
   content: string;
-  primaryLabel: string | null;
-  secondaryLabel: string | null;
   createdAt: any;
   updatedAt: any;
   hasFrames: boolean;
-  sourceLocation: any | null;
   time: number;
   point: string;
-  position: any | null;
-  networkRequestId: string | null;
   type: string | null;
   typeData: any | null;
   user: GetComments_recording_comments_user | null;

--- a/packages/shared/graphql/generated/GetRecording.ts
+++ b/packages/shared/graphql/generated/GetRecording.ts
@@ -41,16 +41,11 @@ export interface GetRecording_recording_comments {
   id: string;
   isPublished: boolean | null;
   content: string;
-  primaryLabel: string | null;
-  secondaryLabel: string | null;
   createdAt: any;
   updatedAt: any;
   hasFrames: boolean;
-  sourceLocation: any | null;
   time: number;
   point: string;
-  position: any | null;
-  networkRequestId: string | null;
   user: GetRecording_recording_comments_user | null;
   replies: GetRecording_recording_comments_replies[];
 }

--- a/packages/shared/graphql/generated/GetTestRunRecordings.ts
+++ b/packages/shared/graphql/generated/GetTestRunRecordings.ts
@@ -8,7 +8,7 @@
 // ====================================================
 
 export interface GetTestRunRecordings_node_Recording {
-  __typename: "Recording";
+  __typename: "Recording" | "RootCauseAnalysis";
 }
 
 export interface GetTestRunRecordings_node_Workspace_testRuns_edges_node_results_counts {
@@ -66,14 +66,14 @@ export interface GetTestRunRecordings_node_Workspace_testRuns_edges_node_tests {
   __typename: "TestRunTest";
   id: string;
   testId: string;
-  index: number;
-  attempt: number;
   title: string;
   scope: string[];
   sourcePath: string;
   result: string;
   errors: string[] | null;
   durationMs: number;
+  index: number;
+  attempt: number;
   executions: GetTestRunRecordings_node_Workspace_testRuns_edges_node_tests_executions[];
 }
 

--- a/packages/shared/graphql/generated/GetTestsRunsForWorkspace.ts
+++ b/packages/shared/graphql/generated/GetTestsRunsForWorkspace.ts
@@ -8,7 +8,7 @@
 // ====================================================
 
 export interface GetTestsRunsForWorkspace_node_Recording {
-  __typename: "Recording";
+  __typename: "Recording" | "RootCauseAnalysis";
 }
 
 export interface GetTestsRunsForWorkspace_node_Workspace_testRuns_edges_node_results_counts {

--- a/packages/shared/graphql/generated/GetWorkspaceApiKeys.ts
+++ b/packages/shared/graphql/generated/GetWorkspaceApiKeys.ts
@@ -8,7 +8,7 @@
 // ====================================================
 
 export interface GetWorkspaceApiKeys_node_Recording {
-  __typename: "Recording";
+  __typename: "Recording" | "RootCauseAnalysis";
 }
 
 export interface GetWorkspaceApiKeys_node_Workspace_apiKeys {

--- a/packages/shared/graphql/generated/GetWorkspaceMembers.ts
+++ b/packages/shared/graphql/generated/GetWorkspaceMembers.ts
@@ -8,7 +8,7 @@
 // ====================================================
 
 export interface GetWorkspaceMembers_node_Recording {
-  __typename: "Recording";
+  __typename: "Recording" | "RootCauseAnalysis";
 }
 
 export interface GetWorkspaceMembers_node_Workspace_members_edges_node_WorkspacePendingEmailMember {

--- a/packages/shared/graphql/generated/GetWorkspaceRecordings.ts
+++ b/packages/shared/graphql/generated/GetWorkspaceRecordings.ts
@@ -8,7 +8,7 @@
 // ====================================================
 
 export interface GetWorkspaceRecordings_node_Recording {
-  __typename: "Recording";
+  __typename: "Recording" | "RootCauseAnalysis";
 }
 
 export interface GetWorkspaceRecordings_node_Workspace_recordings_edges_node_comments_user {

--- a/packages/shared/graphql/generated/GetWorkspaceSubscription.ts
+++ b/packages/shared/graphql/generated/GetWorkspaceSubscription.ts
@@ -8,7 +8,7 @@
 // ====================================================
 
 export interface GetWorkspaceSubscription_node_Recording {
-  __typename: "Recording";
+  __typename: "Recording" | "RootCauseAnalysis";
 }
 
 export interface GetWorkspaceSubscription_node_Workspace_subscription_paymentMethods_card {

--- a/packages/shared/graphql/generated/GetWorkspaceTestExecutions.ts
+++ b/packages/shared/graphql/generated/GetWorkspaceTestExecutions.ts
@@ -8,7 +8,7 @@
 // ====================================================
 
 export interface GetWorkspaceTestExecutions_node_Recording {
-  __typename: "Recording";
+  __typename: "Recording" | "RootCauseAnalysis";
 }
 
 export interface GetWorkspaceTestExecutions_node_Workspace_tests_edges_node_executions_recordings {

--- a/packages/shared/graphql/generated/GetWorkspaceTests.ts
+++ b/packages/shared/graphql/generated/GetWorkspaceTests.ts
@@ -8,7 +8,7 @@
 // ====================================================
 
 export interface GetWorkspaceTests_node_Recording {
-  __typename: "Recording";
+  __typename: "Recording" | "RootCauseAnalysis";
 }
 
 export interface GetWorkspaceTests_node_Workspace_tests_edges_node_stats {

--- a/packages/shared/graphql/generated/SubscribeRecording.ts
+++ b/packages/shared/graphql/generated/SubscribeRecording.ts
@@ -36,16 +36,11 @@ export interface SubscribeRecording_recording_comments {
   id: string;
   isPublished: boolean | null;
   content: string;
-  primaryLabel: string | null;
-  secondaryLabel: string | null;
   createdAt: any;
   updatedAt: any;
   hasFrames: boolean;
-  sourceLocation: any | null;
   time: number;
   point: string;
-  position: any | null;
-  networkRequestId: string | null;
   user: SubscribeRecording_recording_comments_user | null;
   replies: SubscribeRecording_recording_comments_replies[];
 }

--- a/packages/shared/graphql/generated/UpdateCommentContent.ts
+++ b/packages/shared/graphql/generated/UpdateCommentContent.ts
@@ -20,5 +20,4 @@ export interface UpdateCommentContentVariables {
   newContent: string;
   newIsPublished: boolean;
   commentId: string;
-  newPosition?: any | null;
 }

--- a/src/ui/graphql/comments.ts
+++ b/src/ui/graphql/comments.ts
@@ -8,16 +8,11 @@ export const GET_COMMENTS = gql`
         id
         isPublished
         content
-        primaryLabel
-        secondaryLabel
         createdAt
         updatedAt
         hasFrames
-        sourceLocation
         time
         point
-        position
-        networkRequestId
         type
         typeData
         user {

--- a/src/ui/graphql/recordings.ts
+++ b/src/ui/graphql/recordings.ts
@@ -36,16 +36,11 @@ export const GET_RECORDING = gql`
         id
         isPublished
         content
-        primaryLabel
-        secondaryLabel
         createdAt
         updatedAt
         hasFrames
-        sourceLocation
         time
         point
-        position
-        networkRequestId
         user {
           id
           name
@@ -137,16 +132,11 @@ export const SUBSCRIBE_RECORDING = gql`
         id
         isPublished
         content
-        primaryLabel
-        secondaryLabel
         createdAt
         updatedAt
         hasFrames
-        sourceLocation
         time
         point
-        position
-        networkRequestId
         user {
           id
           name


### PR DESCRIPTION
Before we can deploy https://github.com/replayio/backend/pull/9495 we have to stop requesting these fields from GraphQL. I tested this in cloud dev and it seemed to work, but I'm not making any strong claims that I did this correctly 😛 . Also, I hand-edited the apollo fixtures, which might be wrong, and I did *not* hand-edit `globalTypes.ts`, but I also do not know how to automatically update it.