### PR TITLE
Manually update unsupported gecko e2e recordings

### DIFF
--- a/packages/e2e-tests/examples.json
+++ b/packages/e2e-tests/examples.json
@@ -40,8 +40,8 @@
     "buildId": "linux-chromium-20240126-c9de98d17d37-50d01be708a2"
   },
   "doc_control_flow_firefox.html": {
-    "recording": "8b024e1a-1e84-4424-97bd-3c2c528642fd",
-    "buildId": "macOS-gecko-20220722-76bf615bc154-b7eae18423ef"
+    "recording": "cbebda3e-17c3-486e-bff4-41c78cb01b34",
+    "buildId": "macOS-gecko-20230919-abf2e86b2910-4d0a9f5b9de2"
   },
   "doc_debugger_statements.html": {
     "recording": "0ada5d1e-9f3d-4cab-a67e-879b9162d71d",
@@ -52,32 +52,32 @@
     "buildId": "linux-chromium-20240126-c9de98d17d37-50d01be708a2"
   },
   "doc_exceptions.html": {
-    "recording": "11d683a6-30bb-46c2-ab55-f8d990bffa9e",
-    "buildId": "macOS-gecko-20220722-76bf615bc154-b7eae18423ef"
+    "recording": "e15d8515-9420-4fd5-a5c0-40421c8f95bf",
+    "buildId": "macOS-gecko-20230919-abf2e86b2910-4d0a9f5b9de2"
   },
   "doc_exceptions_bundle.html": {
-    "recording": "d0282dfc-b7ca-42d8-ab51-f634904623e8",
-    "buildId": "macOS-gecko-20220722-76bf615bc154-b7eae18423ef"
+    "recording": "4d1a5250-6d26-4ae5-8312-c7f713d8a97d",
+    "buildId": "macOS-gecko-20230919-abf2e86b2910-4d0a9f5b9de2"
   },
   "doc_inspector_basic.html": {
     "recording": "498b77ef-ae2e-4b0f-ab0c-abdeed2959eb",
     "buildId": "linux-chromium-20240204-6ab95298ce0b-11bb013e140b"
   },
   "doc_inspector_shorthand.html": {
-    "recording": "28f3f493-c7cb-43bb-a8fc-c0f661e9096d",
-    "buildId": "macOS-gecko-20220722-76bf615bc154-b7eae18423ef"
+    "recording": "e031abf4-c533-4641-9b08-70fe69477d5b",
+    "buildId": "macOS-gecko-20230919-abf2e86b2910-4d0a9f5b9de2"
   },
   "doc_inspector_sourcemapped.html": {
-    "recording": "a2a944b7-3851-4210-b38a-cb3487f829d4",
-    "buildId": "macOS-gecko-20220722-76bf615bc154-b7eae18423ef"
+    "recording": "3bd40de7-1e19-4269-bda5-6b7dd7c0d14e",
+    "buildId": "macOS-gecko-20230919-abf2e86b2910-4d0a9f5b9de2"
   },
   "doc_inspector_styles.html": {
-    "recording": "bba66ce8-5020-461c-88f4-446f67af64bf",
-    "buildId": "macOS-gecko-20220722-76bf615bc154-b7eae18423ef"
+    "recording": "710634e2-0e98-4ad3-93f7-a5e772a9c9fb",
+    "buildId": "macOS-gecko-20230919-abf2e86b2910-4d0a9f5b9de2"
   },
   "doc_minified.html": {
-    "recording": "61b41122-dbbd-4e5d-9da9-a273475dc3f9",
-    "buildId": "macOS-gecko-20220722-76bf615bc154-b7eae18423ef"
+    "recording": "13143bf4-84a0-4e91-9943-271bd347a399",
+    "buildId": "macOS-gecko-20230919-abf2e86b2910-4d0a9f5b9de2"
   },
   "doc_minified_chromium.html": {
     "recording": "0296c6a8-77af-4a66-9fbd-1f36da70f10e",
@@ -116,8 +116,8 @@
     "buildId": "linux-chromium-20240126-c9de98d17d37-50d01be708a2"
   },
   "doc_rr_logs.html": {
-    "recording": "1a735f4e-dc3f-4fcf-a41c-9bee22c7ba77",
-    "buildId": "macOS-gecko-20220722-76bf615bc154-b7eae18423ef"
+    "recording": "799c7329-6862-4179-9bc9-36e68edf24fb",
+    "buildId": "macOS-gecko-20230919-abf2e86b2910-4d0a9f5b9de2"
   },
   "doc_rr_objects.html": {
     "recording": "6c84bf92-d620-42ed-be36-3bce451de1d2",
@@ -140,8 +140,8 @@
     "buildId": "linux-chromium-20240126-c9de98d17d37-50d01be708a2"
   },
   "doc_stacking.html": {
-    "recording": "233a22c5-428e-46f8-a1ac-4b2488ac517e",
-    "buildId": "macOS-gecko-20220722-76bf615bc154-b7eae18423ef"
+    "recording": "409016e7-9db2-4a52-9f60-c6f090243eb6",
+    "buildId": "macOS-gecko-20230919-abf2e86b2910-4d0a9f5b9de2"
   },
   "doc_stacking_chromium.html": {
     "recording": "fa5a2a8b-a095-44ef-83ca-324da9f7bde8",


### PR DESCRIPTION
Re-record all `macOS-gecko-20220722` e2e test recordings with `macOS-gecko-20230919`