### PR TITLE
Graphics should fallback to displaying the current time if Pause creation fails

### DIFF
--- a/src/ui/components/Video/useImperativeVideoPlayback.ts
+++ b/src/ui/components/Video/useImperativeVideoPlayback.ts
@@ -3,7 +3,7 @@ import { Deferred, createDeferred } from "suspense";
 
 import { waitForTime } from "protocol/utils";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
-import { stopPlayback } from "ui/actions/timeline";
+import { seek, stopPlayback } from "ui/actions/timeline";
 import { getPlayback, setTimelineState } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 
@@ -86,6 +86,10 @@ export function useImperativeVideoPlayback(): [
 
     return () => {
       stop = true;
+
+      // Jump to the nearest recorded event (mouse or paint)
+      // so that Redux state is updated with approximately the same time as playback was stopped at
+      dispatch(seek({ time: previousTime }));
 
       setPlaybackTime(null);
     };

--- a/src/ui/components/Video/useSmartTimeAndExecutionPoint.ts
+++ b/src/ui/components/Video/useSmartTimeAndExecutionPoint.ts
@@ -10,41 +10,38 @@ import {
 import { useAppSelector } from "ui/setup/hooks";
 
 export function useSmartTimeAndExecutionPoint() {
-  const playback = useAppSelector(getPlayback);
+  const playbackState = useAppSelector(getPlayback);
   const hoverTime = useAppSelector(getHoverTime);
+  const preferHoverTime = useAppSelector(getShowHoverTimeGraphics);
   const pauseExecutionPoint = useAppSelector(getExecutionPoint);
   const pauseTime = useAppSelector(getTime);
   const currentTime = useAppSelector(getCurrentTime);
-  const preferHoverTime = useAppSelector(getShowHoverTimeGraphics);
-  const preferPlaybackTime = playback != null;
+
+  // The "current time" represents the time shown on the Timeline
+  // This is the time the user sets when scrubbing the timeline as well as when playback is active
+  //
+  // The "pause time" is a higher-fidelity version of the current time
+  // It is often accompanied by an execution point and a pause id (which can be used to inspect values in the debugger)
+  //
+  // When possible, it is better to use the "pause time" for displaying graphics
+  // because it enables us to display a more up-to-date screenshot from DOM.repaintGraphics
+  //
+  // There are situations where we should not use this value though
+  // For instance, if the user scrubs the timeline outside of the focus window, a Pause can't be created
+  // In that case, we should show the lower-fidelity playback time so the screenshot and timeline line up
+  //
+  // A heuristic for detecting this case is comparing how close the two values are
+  const preferCurrentTime = playbackState != null || Math.abs(pauseTime - currentTime) > 0.05;
 
   let executionPoint: string | null = null;
   let time = 0;
-  if (preferPlaybackTime) {
+  if (preferCurrentTime) {
     time = currentTime;
   } else if (preferHoverTime && hoverTime != null) {
     time = hoverTime;
   } else {
-    // The "current time" represents the time shown on the Timeline
-    // This is the time the user sets when scrubbing the timeline as well as when playback is active
-    //
-    // The "pause time" is a higher-fidelity version of the current time
-    // It is often accompanied by an execution point and a pause id (which can be used to inspect values in the debugger)
-    //
-    // When possible, it is better to use the "pause time" for displaying graphics
-    // because it enables us to display a more up-to-date screenshot from DOM.repaintGraphics
-    //
-    // There are situations where we should not use this value though
-    // For instance, if the user scrubs the timeline outside of the focus window, a Pause can't be created
-    // In that case, we should show the lower-fidelity playback time so the screenshot and timeline line up
-    //
-    // A heuristic for detecting this case is comparing how close the two values are
-    if (Math.abs(pauseTime - currentTime) <= 0.05) {
-      time = pauseTime;
-      executionPoint = pauseExecutionPoint;
-    } else {
-      time = currentTime;
-    }
+    time = pauseTime;
+    executionPoint = pauseExecutionPoint;
   }
 
   return useDeferredValue({ executionPoint, time });

--- a/src/ui/components/Video/useSmartTimeAndExecutionPoint.ts
+++ b/src/ui/components/Video/useSmartTimeAndExecutionPoint.ts
@@ -14,19 +14,37 @@ export function useSmartTimeAndExecutionPoint() {
   const hoverTime = useAppSelector(getHoverTime);
   const pauseExecutionPoint = useAppSelector(getExecutionPoint);
   const pauseTime = useAppSelector(getTime);
-  const playbackTime = useAppSelector(getCurrentTime);
+  const currentTime = useAppSelector(getCurrentTime);
   const preferHoverTime = useAppSelector(getShowHoverTimeGraphics);
   const preferPlaybackTime = playback != null;
 
   let executionPoint: string | null = null;
   let time = 0;
   if (preferPlaybackTime) {
-    time = playbackTime;
-  } else if (hoverTime != null && preferHoverTime) {
+    time = currentTime;
+  } else if (preferHoverTime && hoverTime != null) {
     time = hoverTime;
   } else {
-    time = pauseTime;
-    executionPoint = pauseExecutionPoint;
+    // The "current time" represents the time shown on the Timeline
+    // This is the time the user sets when scrubbing the timeline as well as when playback is active
+    //
+    // The "pause time" is a higher-fidelity version of the current time
+    // It is often accompanied by an execution point and a pause id (which can be used to inspect values in the debugger)
+    //
+    // When possible, it is better to use the "pause time" for displaying graphics
+    // because it enables us to display a more up-to-date screenshot from DOM.repaintGraphics
+    //
+    // There are situations where we should not use this value though
+    // For instance, if the user scrubs the timeline outside of the focus window, a Pause can't be created
+    // In that case, we should show the lower-fidelity playback time so the screenshot and timeline line up
+    //
+    // A heuristic for detecting this case is comparing how close the two values are
+    if (Math.abs(pauseTime - currentTime) <= 0.05) {
+      time = pauseTime;
+      executionPoint = pauseExecutionPoint;
+    } else {
+      time = currentTime;
+    }
   }
 
   return useDeferredValue({ executionPoint, time });


### PR DESCRIPTION
For more background information, check out the comments on [go/r/2cabb59e-7cd0-44fc-b75b-d4bd9dbb6c80](http://go/r/2cabb59e-7cd0-44fc-b75b-d4bd9dbb6c80) and [go/r/412ebfce-3d25-41e8-a270-880d04709548](http://go/r/412ebfce-3d25-41e8-a270-880d04709548).

# Before

https://github.com/replayio/devtools/assets/29597/e8060195-dc6f-44e3-8e10-aee9ba11df48

# After

https://github.com/replayio/devtools/assets/29597/0d6cdfef-5356-4721-b5df-e4ee79e5b1c9
