### PR TITLE
Remove unnecessary WebPack plug-ins

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,4 @@
 const { patchWebpackConfig } = require("next-global-css");
-const { RetryChunkLoadPlugin } = require("webpack-retry-chunk-load-plugin");
 
 const withBundleAnalyzer = require("@next/bundle-analyzer")({
   enabled: process.env.ANALYZE === "true",
@@ -96,9 +95,7 @@ const baseNextConfig = {
    *   }
    * ) => import('webpack').Configuration}
    */
-  webpack: (config, { buildId, dev, isServer, defaultLoaders, webpack }) => {
-    config.plugins.push(new RetryChunkLoadPlugin({ retryDelay: 1000, maxRetries: 2 }));
-
+  webpack: (config, { isServer, webpack }) => {
     // Slim down the Sentry bundle slightly:
     // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/tree-shaking/
     config.plugins.push(
@@ -107,36 +104,6 @@ const baseNextConfig = {
         __SENTRY_TRACING__: false,
       })
     );
-
-    // Check for circular imports and throw errors, but only if the
-    // env variable is set.  Should only be true if manually defined
-    // in a local dev environment.
-    if (process.env.CHECK_CIRCULAR_IMPORTS) {
-      const CircularDependencyPlugin = require("circular-dependency-plugin");
-
-      let numCyclesDetected = 0;
-
-      config.plugins.push(
-        new CircularDependencyPlugin({
-          exclude: /node_modules/,
-          failOnError: true,
-          cwd: process.cwd(),
-          allowAsyncCycles: true,
-          onStart({ compilation }) {
-            numCyclesDetected = 0;
-          },
-          onDetected({ module: webpackModuleRecord, paths, compilation }) {
-            numCyclesDetected++;
-            compilation.warnings.push(new Error(paths.join(" -> ")));
-          },
-          onEnd({ compilation }) {
-            if (numCyclesDetected > 0) {
-              compilation.warnings.push(new Error(`Detected ${numCyclesDetected} cycles`));
-            }
-          },
-        })
-      );
-    }
 
     // Allow CSS imported from `node_modules`, to work around an error
     // from importing `<Editor>` from `@redux-devtools/ui`

--- a/package.json
+++ b/package.json
@@ -149,7 +149,6 @@
     "babel-plugin-add-react-displayname": "^0.0.5",
     "babel-plugin-transform-import-meta": "^2.1.1",
     "bufferutil": "^4.0.6",
-    "circular-dependency-plugin": "^5.2.2",
     "comlink": "^4.3.1",
     "css-loader": "^6.7.1",
     "eslint": "^8.13.0",
@@ -199,8 +198,7 @@
     "uuid": "^7.0.3",
     "v8-to-istanbul": "^9.0.1",
     "webpack": "^5.71.0",
-    "webpack-cli": "^4.9.2",
-    "webpack-retry-chunk-load-plugin": "^3.0.0"
+    "webpack-cli": "^4.9.2"
   },
   "browserslist": [
     "chrome 95"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6765,15 +6765,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"circular-dependency-plugin@npm:^5.2.2":
-  version: 5.2.2
-  resolution: "circular-dependency-plugin@npm:5.2.2"
-  peerDependencies:
-    webpack: ">=4.0.1"
-  checksum: d1a51e7f86e72d9e7a08c47234511cc7a5c3050781c2d6dcc77c0b22214f94f272702488c952e59b2af589c67944160ad1c9c0b7b3e0d4f89222f2a27ebf085e
-  languageName: node
-  linkType: hard
-
 "cjs-module-lexer@npm:^1.0.0":
   version: 1.2.2
   resolution: "cjs-module-lexer@npm:1.2.2"
@@ -14190,7 +14181,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^2.6.2, prettier@npm:^2.8.8":
+"prettier@npm:^2.8.8":
   version: 2.8.8
   resolution: "prettier@npm:2.8.8"
   bin:
@@ -14940,7 +14931,6 @@ __metadata:
     babel-plugin-add-react-displayname: ^0.0.5
     babel-plugin-transform-import-meta: ^2.1.1
     bufferutil: ^4.0.6
-    circular-dependency-plugin: ^5.2.2
     classnames: ^2.3.1
     comlink: ^4.3.1
     compare-versions: ^6.0.0-rc.1
@@ -15044,7 +15034,6 @@ __metadata:
     v8-to-istanbul: ^9.0.1
     webpack: ^5.71.0
     webpack-cli: ^4.9.2
-    webpack-retry-chunk-load-plugin: ^3.0.0
   languageName: unknown
   linkType: soft
 
@@ -17749,17 +17738,6 @@ __metadata:
     clone-deep: ^4.0.1
     wildcard: ^2.0.0
   checksum: 88786ab91013f1bd2a683834ff381be81c245a4b0f63304a5103e90f6653f44dab496a0768287f8531761f8ad957d1f9f3ccb2cb55df0de1bd9ee343e079da26
-  languageName: node
-  linkType: hard
-
-"webpack-retry-chunk-load-plugin@npm:^3.0.0":
-  version: 3.1.1
-  resolution: "webpack-retry-chunk-load-plugin@npm:3.1.1"
-  dependencies:
-    prettier: ^2.6.2
-  peerDependencies:
-    webpack: ">=5.0.0"
-  checksum: ea621b7317691378d93dbfa67737657e7628d51988ae5540e04a0bd8e91deeadcd5cb5ba8d8995c89b5eb532190c2d818029992b34305821ea72376296dcdf8d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This includes: `circular-dependency-plugin` and `webpack-retry-chunk-load-plugin`

Neither of these seem necessary and simplifying our WebPack config makes it that much easier to migrate to TurboPack.