### PR TITLE
Update object_preview-04 to check for appropriate scoped values.

### DIFF
--- a/packages/e2e-tests/examples.json
+++ b/packages/e2e-tests/examples.json
@@ -84,8 +84,8 @@
     "buildId": "linux-chromium-20240126-c9de98d17d37-50d01be708a2"
   },
   "doc_prod_bundle.html": {
-    "recording": "f21d0b74-71a0-43ba-8e4a-db2f736ab8d5",
-    "buildId": "linux-chromium-20240206-0e5b896139cc-11bb013e140b"
+    "recording": "8285987e-0003-4efb-8b95-163cae8806a9",
+    "buildId": "macOS-chromium-20240208-e6ff39de2177-11bb013e140b"
   },
   "doc_recursion.html": {
     "recording": "7b3cc0d6-39a1-42d6-babd-861fd78cf6e3",

--- a/packages/e2e-tests/tests/object_preview-04.test.ts
+++ b/packages/e2e-tests/tests/object_preview-04.test.ts
@@ -37,6 +37,9 @@ test(`object_preview-04: Test scope mapping and switching between generated/orig
   await waitForPaused(page, 12);
 
   await expandAllScopesBlocks(page);
-  await waitForScopeValue(page, "e", "(3) [");
-  await waitForScopeValue(page, "o", "{…}");
+  await waitForScopeValue(page, "e", "ƒe()");
+  await waitForScopeValue(page, "n", "(3) [5, 6");
+  // N.B. the two different o's, one a closure, the other an object.
+  await waitForScopeValue(page, "o", "ƒo()");
+  await waitForScopeValue(page, "o", "{barprop1: 2, barprop2: 3");
 });


### PR DESCRIPTION
While investigating `object_preview-04`, I believe it's just a test that's rotted somewhat.  The final checks expands all scope blocks (in then un-source-mapped view.)  Looking at the inspector, we see two different `o` values, one a closure, the other an object.  `e` is a closure, and `n` is an array.  I've updated the test here to reflect this.  Here's the generated code, for reference (the test runs at line 12.)

@hbenl Could I beg of you to update the examples.json again?  I don't see the API key in our password manager. 


```
(() => {
  function o() {
    const o = {
        barprop1: 2,
        barprop2: 3,
        nested: {
          nestedprop1: 4
        }
      },
      n = [5, 6, o];
    var t;
    return console.log(o), t = n, o.barprop1 = "updated", t.push("new"),
      console.log(o), setTimeout(e, 500), n  // <<<==== Here is where we're doing our inspection.
  }
  function e() {
    console.log("ExampleFinished")
  }
  setTimeout((function() {
    console.log(o())
  }), 0), window.bar = o
})();
```
