### PR TITLE
Remove "protocol_chromiumRepaints" experimental setting

### DIFF
--- a/packages/replay-next/src/suspense/BuildIdCache.ts
+++ b/packages/replay-next/src/suspense/BuildIdCache.ts
@@ -109,7 +109,7 @@ function getRecordingCapabilities(
         supportsElementsInspector: true,
         supportsEventTypes: true,
         supportsNetworkRequests: false,
-        supportsRepaintingGraphics: userData.get("protocol_chromiumRepaints"),
+        supportsRepaintingGraphics: true,
         supportsPureEvaluation: false,
         supportsObjectIdLookupsInEvaluations,
         maxRecordingDurationForRoutines: MAX_RECORDING_DURATION_FOR_ROUTINES_MS,

--- a/packages/shared/user-data/GraphQL/config.ts
+++ b/packages/shared/user-data/GraphQL/config.ts
@@ -260,11 +260,6 @@ export const config = {
     defaultValue: Boolean(true),
     legacyKey: null,
   },
-  protocol_chromiumRepaints: {
-    defaultValue: Boolean(true),
-    label: "Enable repaintGraphics for Chrome.",
-    legacyKey: "devtools.features.chromiumRepaints",
-  },
   protocol_repaintEvaluations: {
     defaultValue: Boolean(false),
     legacyKey: "devtools.features.repaintEvaluations",

--- a/src/ui/components/shared/UserSettingsModal/panels/Advanced.tsx
+++ b/src/ui/components/shared/UserSettingsModal/panels/Advanced.tsx
@@ -9,7 +9,6 @@ export const PREFERENCES: PreferencesKey[] = [
   "feature_protocolTimeline",
   "feature_protocolPanel",
   "backend_newControllerOnRefresh",
-  "protocol_chromiumRepaints",
   "backend_profileWorkerThreads",
   "backend_disableCache",
   "backend_disableScanDataCache",


### PR DESCRIPTION
The concept of whether a runtime "supported repaint" was originally added in back in 2022 (#7713). At that time, the Chromium platform did not yet support paints (or it was very unstable) so we added an experimental setting for it. Then later on we flipped that setting on by default and forgot about it.

This doesn't make sense to track as an experimental setting anymore, as that feature is stable. What's more, it recently caused @jcmorrow some confusion when he accidentally turned it off and then found that the video panel was missing for Chromium recordings.