### PR TITLE
Make inspector-elements-05 test deterministic. Insert iframe dynamically.

### DIFF
--- a/packages/e2e-tests/examples.json
+++ b/packages/e2e-tests/examples.json
@@ -56,8 +56,8 @@
     "buildId": "linux-gecko-20230919-abf2e86b2910-4d0a9f5b9de2"
   },
   "doc_inspector_basic.html": {
-    "recording": "498b77ef-ae2e-4b0f-ab0c-abdeed2959eb",
-    "buildId": "linux-chromium-20240204-6ab95298ce0b-11bb013e140b"
+    "recording": "32fc05b0-4bb5-4240-82f3-c6eb58c819f3",
+    "buildId": "linux-chromium-20240208-e6ff39de2177-11bb013e140b"
   },
   "doc_inspector_shorthand.html": {
     "recording": "384e8ce6-6475-49f4-9fc5-55fc1f742b25",

--- a/packages/e2e-tests/tests/highlighter.test.ts
+++ b/packages/e2e-tests/tests/highlighter.test.ts
@@ -16,7 +16,7 @@ test("highlighter: element highlighter works everywhere", async ({
   await warpToMessage(page, "ExampleFinished");
   await openElementsPanel(page);
 
-  await selectElementsListRow(page, { text: "myiframe" });
+  await selectElementsListRow(page, { text: 'iframe id="myiframe"', type: "opening" });
 
   const highlighter = page.locator("#box-model-content");
   await highlighter.waitFor();

--- a/packages/e2e-tests/tests/inspector-elements-05_search.test.ts
+++ b/packages/e2e-tests/tests/inspector-elements-05_search.test.ts
@@ -19,7 +19,7 @@ test(`inspector-elements-05_search: element picker and iframe behavior`, async (
   await openElementsPanel(page);
 
   // This search string should not match anything initially
-  await seekToTimePercent(page, 50);
+  await warpToMessage(page, "waiting for iframe");
   await searchElementsPanel(page, "inner-body");
   await verifySearchResults(page, { currentNumber: 0, totalNumber: 0 });
 

--- a/public/test/examples/doc_inspector_basic.html
+++ b/public/test/examples/doc_inspector_basic.html
@@ -14,6 +14,17 @@ function iframeFinished() {
   console.log("iframeFinished");
   window.setTimeout(foo);
 }
+
+function createIFrame() {
+  var iframe = document.createElement("iframe");
+  iframe.id = "myiframe";
+  iframe.src = "./iframe.html";
+  document.getElementById("iframehost").appendChild(iframe);
+}
+
+console.log("waiting for iframe");
+window.setTimeout(createIFrame);
+
 </script>
 <div id="div1">
   <div id="div2">
@@ -23,7 +34,8 @@ function iframeFinished() {
   </div>
   <div id="div4" some-attribute="STUFF"></div>
 </div>
-<iframe src="iframe.html" id="myiframe"></iframe>
+<div id="iframehost">
+</div>
 
 <script>
   function printCenter(id) {
@@ -41,6 +53,5 @@ function iframeFinished() {
   }
 
   printCenter("maindiv");
-  printCenter("myiframe");
 </script>
 </body>


### PR DESCRIPTION
There's no reason to assume that halfway through the recording the iframe won't be there, so make that logic dependable. 