### PR TITLE
Recorded Protocol requests viewer sends Linear recorded (not live) ids

### DIFF
--- a/packages/shared/utils/recording.ts
+++ b/packages/shared/utils/recording.ts
@@ -19,11 +19,16 @@ export function getRecordingURL(recording: Recording): string {
 
 export function getRecordingId(): string | undefined {
   if (typeof window !== "undefined" && window != null) {
-    const parts = window.location.pathname.split("/");
-    if (parts[1] === "recording") {
-      return extractIdAndSlug(parts.slice(2)).id;
-    }
-
-    return undefined;
+    const pathname = window.location.pathname;
+    return extractRecordingIdFromPathname(pathname);
   }
+}
+
+export function extractRecordingIdFromPathname(pathname: string): string | undefined {
+  const parts = pathname.split("/");
+  if (parts[1] === "recording") {
+    return extractIdAndSlug(parts.slice(2)).id;
+  }
+
+  return undefined;
 }

--- a/src/ui/components/ProtocolViewer/ProtocolViewerPanel.tsx
+++ b/src/ui/components/ProtocolViewer/ProtocolViewerPanel.tsx
@@ -74,7 +74,14 @@ export function LiveProtocolRequests() {
   const requestMap = useAppSelector(getProtocolRequestMap);
   const responseMap = useAppSelector(getProtocolResponseMap);
 
-  return <ProtocolViewer errorMap={errorMap} requestMap={requestMap} responseMap={responseMap} />;
+  return (
+    <ProtocolViewer
+      errorMap={errorMap}
+      requestMap={requestMap}
+      responseMap={responseMap}
+      scope="live"
+    />
+  );
 }
 
 const NO_MESSAGES: RecordedProtocolData[] = [];
@@ -129,5 +136,12 @@ function RecordedProtocolRequests() {
 
   const { requestMap, responseMap, errorMap } = groupedMessageData;
 
-  return <ProtocolViewer errorMap={errorMap} requestMap={requestMap} responseMap={responseMap} />;
+  return (
+    <ProtocolViewer
+      errorMap={errorMap}
+      requestMap={requestMap}
+      responseMap={responseMap}
+      scope="recorded"
+    />
+  );
 }

--- a/src/ui/components/ProtocolViewer/components/ProtocolViewer.tsx
+++ b/src/ui/components/ProtocolViewer/components/ProtocolViewer.tsx
@@ -1,6 +1,9 @@
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 
-import { ProtocolViewerContextRoot } from "ui/components/ProtocolViewer/components/ProtocolViewerContext";
+import {
+  ProtocolViewerContextRoot,
+  ProtocolViewerScope,
+} from "ui/components/ProtocolViewer/components/ProtocolViewerContext";
 import { ProtocolViewerList } from "ui/components/ProtocolViewer/components/ProtocolViewerList";
 import { RequestDetails } from "ui/components/ProtocolViewer/components/RequestDetails";
 import {
@@ -15,16 +18,19 @@ export function ProtocolViewer({
   errorMap,
   requestMap,
   responseMap,
+  scope,
 }: {
   errorMap: ProtocolErrorMap;
   requestMap: ProtocolRequestMap;
   responseMap: ProtocolResponseMap;
+  scope: ProtocolViewerScope;
 }) {
   return (
     <ProtocolViewerContextRoot
       errorMap={errorMap}
       requestMap={requestMap}
       responseMap={responseMap}
+      scope={scope}
     >
       <PanelGroup autoSaveId="ProtocolViewer" className={styles.Container} direction="vertical">
         <Panel id="list" minSize={20}>

--- a/src/ui/components/ProtocolViewer/components/ProtocolViewerContext.tsx
+++ b/src/ui/components/ProtocolViewer/components/ProtocolViewerContext.tsx
@@ -16,6 +16,8 @@ import {
 
 export type FilterByCategory = "failed" | "pending" | "slow";
 
+export type ProtocolViewerScope = "live" | "recorded";
+
 export type ProtocolViewerContextType = {
   clearCurrentRequests: () => void;
   errorMap: ProtocolErrorMap;
@@ -25,6 +27,7 @@ export type ProtocolViewerContextType = {
   longestRequestDuration: number;
   requestMap: ProtocolRequestMap;
   responseMap: ProtocolResponseMap;
+  scope: ProtocolViewerScope;
   selectedRequestId: number | null;
   selectRequest: (id: number | null) => void;
   updateFilterByCategory: (category: FilterByCategory | null) => void;
@@ -38,10 +41,12 @@ export function ProtocolViewerContextRoot({
   errorMap,
   requestMap,
   responseMap,
+  scope,
 }: PropsWithChildren & {
   errorMap: ProtocolErrorMap;
   requestMap: ProtocolRequestMap;
   responseMap: ProtocolResponseMap;
+  scope: ProtocolViewerScope;
 }) {
   const [filterByCategory, updateFilterByCategory] = useState<FilterByCategory | null>(null);
   const [filterByText, updateFilterByText] = useState("");
@@ -148,6 +153,7 @@ export function ProtocolViewerContextRoot({
       longestRequestDuration,
       requestMap,
       responseMap,
+      scope,
       selectedRequestId,
       selectRequest,
       updateFilterByCategory,
@@ -162,6 +168,7 @@ export function ProtocolViewerContextRoot({
       longestRequestDuration,
       requestMap,
       responseMap,
+      scope,
       selectedRequestId,
     ]
   );

--- a/src/ui/components/ProtocolViewer/components/RequestDetails.tsx
+++ b/src/ui/components/ProtocolViewer/components/RequestDetails.tsx
@@ -1,6 +1,7 @@
-import { useContext, useMemo } from "react";
+import { Suspense, useContext, useMemo } from "react";
 
 import Icon from "replay-next/components/Icon";
+import { LoadingProgressBar } from "replay-next/components/LoadingProgressBar";
 import { JsonViewer } from "replay-next/components/SyntaxHighlighter/JsonViewer";
 import { useJsonViewerContextMenu } from "replay-next/components/SyntaxHighlighter/useJsonViewerContextMenu";
 import { ProtocolViewerContext } from "ui/components/ProtocolViewer/components/ProtocolViewerContext";
@@ -14,6 +15,14 @@ const SYNTAX_HIGHLIGHT_MAX_LENGTH = 1_000;
 const PLAIN_TEXT_MAX_LENGTH = 100_000;
 
 export function RequestDetails() {
+  return (
+    <Suspense fallback={<LoadingProgressBar />}>
+      <RequestDetailsSuspends />
+    </Suspense>
+  );
+}
+
+function RequestDetailsSuspends() {
   const { errorMap, requestMap, responseMap, selectedRequestId } =
     useContext(ProtocolViewerContext);
 

--- a/src/ui/components/ProtocolViewer/hooks/useBugReportLink.ts
+++ b/src/ui/components/ProtocolViewer/hooks/useBugReportLink.ts
@@ -1,20 +1,53 @@
 import { useContext } from "react";
 
 import { SessionContext } from "replay-next/src/contexts/SessionContext";
+import { useMostRecentLoadedPause } from "replay-next/src/hooks/useMostRecentLoadedPause";
+import { getClosestPointForTimeSuspense } from "replay-next/src/suspense/ExecutionPointsCache";
+import { pauseEvaluationsCache, pauseIdCache } from "replay-next/src/suspense/PauseCache";
+import { ReplayClientContext } from "shared/client/ReplayClientContext";
+import { extractRecordingIdFromPathname } from "shared/utils/recording";
 import { ProtocolViewerContext } from "ui/components/ProtocolViewer/components/ProtocolViewerContext";
 import { useGetUserInfo } from "ui/hooks/users";
 import { getSessionId } from "ui/reducers/app";
 import { useAppSelector } from "ui/setup/hooks";
 
 export function useBugReportLink() {
-  const { requestMap, selectedRequestId } = useContext(ProtocolViewerContext);
-  const { recordingId } = useContext(SessionContext);
-  const sessionId = useAppSelector(getSessionId);
+  const { requestMap, scope, selectedRequestId } = useContext(ProtocolViewerContext);
+  const replayClient = useContext(ReplayClientContext);
+  const { recordingId: liveRecordingId } = useContext(SessionContext);
+  const liveSessionId = useAppSelector(getSessionId);
+  const { pauseId } = useMostRecentLoadedPause() ?? {};
 
   const { internal: isInternalUser } = useGetUserInfo();
   if (isInternalUser) {
     if (selectedRequestId !== null) {
       const request = requestMap[selectedRequestId];
+
+      let recordingId;
+      let sessionId;
+      if (scope === "live") {
+        sessionId = liveSessionId;
+        recordingId = liveRecordingId;
+      } else if (pauseId) {
+        const sessionIdResponse = pauseEvaluationsCache.read(
+          replayClient,
+          pauseId,
+          null,
+          "sessionId"
+        );
+        const pathnameResponse = pauseEvaluationsCache.read(
+          replayClient,
+          pauseId,
+          null,
+          "window.location.pathname"
+        );
+        const pathname = pathnameResponse.returned?.value;
+
+        sessionId = sessionIdResponse.returned?.value;
+        recordingId = pathname
+          ? extractRecordingIdFromPathname(pathnameResponse.returned?.value)
+          : null;
+      }
 
       // https://linear.app/docs/create-new-issue-urls
       const url = new URL(`https://linear.app/replay/team/BAC/new`);


### PR DESCRIPTION
This was an oversight from back whenever we split this panel into two, I guess.

Alternately we could just hide the bug report button for that tab.

I manually tested this by opening a few live and recorded request links locally and it seems okay.