### PR TITLE
Show Redux actions loading and possible timeout messages

### DIFF
--- a/packages/replay-next/components/IndeterminateLoader.module.css
+++ b/packages/replay-next/components/IndeterminateLoader.module.css
@@ -28,9 +28,13 @@
 .LoadingLabel {
   flex: 1 1 auto;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+  text-align: center;
+  gap: 0.5rem;
   color: var(--color-dim);
+  padding: 1rem;
 }
 
 @keyframes animation {

--- a/packages/replay-next/components/IndeterminateLoader.tsx
+++ b/packages/replay-next/components/IndeterminateLoader.tsx
@@ -1,3 +1,5 @@
+import { ReactNode } from "react";
+
 import styles from "./IndeterminateLoader.module.css";
 
 export function IndeterminateProgressBar() {
@@ -8,11 +10,11 @@ export function IndeterminateProgressBar() {
   );
 }
 
-export default function IndeterminateLoader() {
+export default function IndeterminateLoader({ message = "Loading..." }: { message?: ReactNode }) {
   return (
     <div className={styles.Loader} data-testid="indeterminate-loader">
       <IndeterminateProgressBar />
-      <div className={styles.LoadingLabel}>Loading...</div>
+      <div className={styles.LoadingLabel}>{message}</div>
     </div>
   );
 }

--- a/src/ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsPanel.module.css
+++ b/src/ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsPanel.module.css
@@ -22,3 +22,7 @@
   height: 100%;
   overflow-y: auto;
 }
+
+.TimeoutPossibleErrorMessage {
+  color: var(--color-error);
+}


### PR DESCRIPTION
While loading annotations, we will now show the following text:
![Screenshot 2024-02-27 at 9 09 35 AM](https://github.com/replayio/devtools/assets/29597/f55ba9ca-b4bb-4f69-b653-be33b6928315)

If annotations take longer than 30s to load, we'll update the text to also show a possible error message:
![Screenshot 2024-02-27 at 9 09 20 AM](https://github.com/replayio/devtools/assets/29597/c60c8bd3-39f2-44b8-a0f5-2db28ed12df8)

Note that even after showing the above message, we'll continue waiting on a response (in case one eventually comes back). Based on my understanding of the current routines API, this is probably the best we can do for now.

cc @jonbell-lot23 