### PR TITLE
Hide React panel and show custom messaging during playback

### DIFF
--- a/src/ui/components/SecondaryToolbox/react-devtools/components/ReactDevToolsPanel.module.css
+++ b/src/ui/components/SecondaryToolbox/react-devtools/components/ReactDevToolsPanel.module.css
@@ -77,20 +77,23 @@
   flex: 1 1 auto;
 }
 
-.ProtocolFailedPanel {
-  display: flex;
-  align-items: flex-start;
-}
-
+.DisabledDuringPlaybackMessage,
 .NotMountedYetMessage,
 .ProtocolFailedMessage {
   width: 100%;
   display: flex;
   flex-direction: column;
+  color: var(--color-dim);
   gap: 0.5rem;
   padding: 0.5rem;
   border-radius: 0.25rem;
   font-size: var(--font-size-regular);
+}
+.DisabledDuringPlaybackMessage,
+.NotMountedYetMessage {
+  height: 100%;
+  align-items: center;
+  justify-content: center;
 }
 .ProtocolFailedMessage {
   margin: 0.5rem;

--- a/src/ui/components/SecondaryToolbox/react-devtools/components/ReactDevToolsPanel.tsx
+++ b/src/ui/components/SecondaryToolbox/react-devtools/components/ReactDevToolsPanel.tsx
@@ -32,6 +32,7 @@ import { useReactDevToolsAnnotations } from "ui/components/SecondaryToolbox/reac
 import { useReplayWall } from "ui/components/SecondaryToolbox/react-devtools/hooks/useReplayWall";
 import { ReactDevToolsListData } from "ui/components/SecondaryToolbox/react-devtools/ReactDevToolsListData";
 import { getDefaultSelectedReactElementId } from "ui/reducers/app";
+import { isPlaying as isPlayingSelector } from "ui/reducers/timeline";
 import { useAppSelector } from "ui/setup/hooks";
 import {
   ParsedReactDevToolsAnnotation,
@@ -79,6 +80,7 @@ function ReactDevToolsPanelInner({
   const [protocolCheckFailed, setProtocolCheckFailed] = useState(false);
 
   const defaultSelectedReactElementId = useAppSelector(getDefaultSelectedReactElementId);
+  const isPlaying = useAppSelector(isPlayingSelector);
 
   const leftPanelRef = useRef<ImperativePanelHandle>(null);
   const rightPanelRef = useRef<ImperativePanelHandle>(null);
@@ -133,13 +135,17 @@ function ReactDevToolsPanelInner({
     wall,
   });
 
-  if (!hasReactMounted) {
+  if (isPlaying) {
     return (
-      <div className={styles.ProtocolFailedPanel} data-test-id="ReactDevToolsPanel">
-        <div className={styles.NotMountedYetMessage}>
-          <div>React application has not been mounted.</div>
-          <div>Try picking a different point on the timeline.</div>
-        </div>
+      <div className={styles.DisabledDuringPlaybackMessage} data-test-id="ReactDevToolsPanel">
+        This panel is disabled during playback.
+      </div>
+    );
+  } else if (!hasReactMounted) {
+    return (
+      <div className={styles.NotMountedYetMessage} data-test-id="ReactDevToolsPanel">
+        <div>React application has not been mounted.</div>
+        <div>Try picking a different point on the timeline.</div>
       </div>
     );
   }
@@ -174,13 +180,11 @@ function ReactDevToolsPanelInner({
 
   if (protocolCheckFailed) {
     return (
-      <div className={styles.ProtocolFailedPanel} data-test-id="ReactDevToolsPanel">
-        <div className={styles.ProtocolFailedMessage}>
-          <div>React DevTools could not be initialized.</div>
-          <div>
-            Try picking a different point on the timeline or reloading the page. If the problem
-            persists, try creating a new recording with the latest version of the Replay browser.
-          </div>
+      <div className={styles.ProtocolFailedMessage} data-test-id="ReactDevToolsPanel">
+        <div>React DevTools could not be initialized.</div>
+        <div>
+          Try picking a different point on the timeline or reloading the page. If the problem
+          persists, try creating a new recording with the latest version of the Replay browser.
         </div>
       </div>
     );


### PR DESCRIPTION
Here are the React panel states as of this PR:
| State | Screenshot |
| :-- | :-- |
| No annotations | ![Screenshot 2024-02-27 at 10 15 22 AM](https://github.com/replayio/devtools/assets/29597/779f10de-74d2-4a88-8ea9-3943d8969907) |
| Before mount | ![Screenshot 2024-02-27 at 10 15 46 AM](https://github.com/replayio/devtools/assets/29597/c4c54cd3-c595-4d80-bd47-ed256715b50a) |
| Playing | ![Screenshot 2024-02-27 at 10 15 35 AM](https://github.com/replayio/devtools/assets/29597/335852a0-06cb-4676-8dde-a1e5e72f5f6b) |
| Normal | ![Screenshot 2024-02-27 at 10 15 12 AM](https://github.com/replayio/devtools/assets/29597/fe38841c-961f-42bf-9e42-b1af9f3f9407) |

Here's what the UX feels like now:
https://github.com/replayio/devtools/assets/29597/c40e0b72-49b0-4186-8051-61b64b964925

cc @jonbell-lot23 