### PR TITLE
Add more info to (Test Suites) test run graph tooltips

### DIFF
--- a/src/ui/components/Library/Team/View/TestRuns/TestRunListPanel/TestRunsStats.module.css
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunListPanel/TestRunsStats.module.css
@@ -32,3 +32,9 @@
   border-radius: 0.25rem;
   z-index: var(--z-index-1--tooltip);
 }
+
+.Tooltip {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}

--- a/src/ui/components/Library/Team/View/TestRuns/TestRunListPanel/TestRunsStats.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunListPanel/TestRunsStats.tsx
@@ -1,20 +1,16 @@
-import groupBy from "lodash/groupBy";
 import { useContext, useLayoutEffect, useMemo, useRef, useState } from "react";
 import AutoSizer from "react-virtualized-auto-sizer";
 
 import useTooltip from "replay-next/src/hooks/useTooltip";
 import { TestRun } from "shared/test-suites/TestRun";
 import { useTheme } from "shared/theme/useTheme";
+import { drawChart } from "ui/components/Library/Team/View/TestRuns/TestRunListPanel/drawChart";
+import { generateChartData } from "ui/components/Library/Team/View/TestRuns/TestRunListPanel/generateChartData";
+import { getChartTooltip } from "ui/components/Library/Team/View/TestRuns/TestRunListPanel/getChartTooltip";
 import { TimeFilterContext } from "ui/components/Library/Team/View/TimeFilterContextRoot";
 
 import { useTestRunsSuspends } from "../hooks/useTestRunsSuspends";
 import styles from "./TestRunsStats.module.css";
-
-type ChartDataType = { failureRate: number; label: string };
-
-const LINE_WIDTH = 2;
-const PADDING = 4;
-const POINT_RADIUS = 4;
 
 export function TestRunsStats() {
   const { filteredSortedTestRuns: testRuns } = useTestRunsSuspends();
@@ -67,9 +63,7 @@ function ChartWithDimensions({
 
   let tooltipContent = null;
   if (hoverIndex !== null) {
-    const point = data[hoverIndex];
-
-    tooltipContent = `(${point.label}) ${Math.round(point.failureRate * 100)}%`;
+    tooltipContent = <div className={styles.Tooltip}>{getChartTooltip(data[hoverIndex])}</div>;
   }
 
   const { onMouseEnter, onMouseMove, onMouseLeave, tooltip } = useTooltip({
@@ -116,173 +110,4 @@ function ChartWithDimensions({
       {tooltip}
     </>
   );
-}
-
-function drawChart({
-  canvas,
-  data,
-  height,
-  highlightIndex,
-  width,
-}: {
-  canvas: HTMLCanvasElement;
-  data: ChartDataType[];
-  height: number;
-  highlightIndex: number | null;
-  width: number;
-}) {
-  const scale = window.devicePixelRatio;
-
-  const style = getComputedStyle(canvas);
-  const borderColor = style.getPropertyValue("--testsuites-graph-marker");
-  const markerColor = style.getPropertyValue("--testsuites-graph-gradient-stroke");
-  const gradientStartColor = style.getPropertyValue("--testsuites-graph-gradient-start");
-  const gradientEndColor = style.getPropertyValue("--testsuites-graph-gradient-end");
-  const highlightMarkerColor = style.getPropertyValue("--secondary-accent");
-
-  canvas.style.height = `${height}px`;
-  canvas.style.width = `${width}px`;
-  canvas.height = height * scale;
-  canvas.width = width * scale;
-
-  const context = canvas.getContext("2d") as CanvasRenderingContext2D;
-  context.scale(scale, scale);
-  context.clearRect(0, 0, width, height);
-
-  // Top and bottom lines
-  context.beginPath();
-  context.lineWidth = 1;
-  context.strokeStyle = borderColor;
-  context.moveTo(POINT_RADIUS, PADDING);
-  context.lineTo(width - POINT_RADIUS, PADDING);
-  context.stroke();
-  context.moveTo(POINT_RADIUS, height - PADDING);
-  context.lineTo(width - POINT_RADIUS, height - PADDING);
-  context.stroke();
-  context.closePath();
-
-  let prevX = 0;
-  let prevY = 0;
-
-  const gradient = context.createLinearGradient(0, 0, 0, height);
-  gradient.addColorStop(0, gradientStartColor);
-  gradient.addColorStop(1, gradientEndColor);
-
-  for (let index = 0; index < data.length; index++) {
-    const { x, y } = getCoordinates({ data, height, index, width });
-
-    if (index > 0) {
-      // Gradient under fill
-      context.beginPath();
-      context.fillStyle = gradient;
-      context.moveTo(prevX, prevY);
-      context.lineTo(x, y);
-      context.lineTo(x, height - PADDING);
-      context.lineTo(prevX, height - PADDING);
-      context.lineTo(prevX, prevY);
-      context.fill();
-      context.closePath();
-
-      // Connecting lines
-      context.beginPath();
-      context.lineWidth = LINE_WIDTH;
-      context.strokeStyle = markerColor;
-      context.moveTo(prevX, prevY);
-      context.lineTo(x, y);
-      context.stroke();
-      context.closePath();
-    }
-
-    prevX = x;
-    prevY = y;
-  }
-
-  for (let index = 0; index < data.length; index++) {
-    const { x, y } = getCoordinates({ data, height, index, width });
-
-    // Circles
-    context.beginPath();
-    context.arc(x, y, POINT_RADIUS, 0, 2 * Math.PI);
-    context.lineWidth = 0;
-    context.fillStyle = index === highlightIndex ? highlightMarkerColor : markerColor;
-    context.fill();
-    context.closePath();
-  }
-}
-
-function generateChartData(testRuns: TestRun[], days: number) {
-  const formatter = new Intl.DateTimeFormat("en-US", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  });
-
-  const runsGroupedByDay = groupBy(
-    testRuns.map(({ date: dateString, ...rest }) => {
-      const date = new Date(dateString);
-      const groupByKey = formatter.format(date);
-
-      return {
-        ...rest,
-        date,
-        __groupByKey: groupByKey,
-      };
-    }),
-    "__groupByKey"
-  );
-
-  const displayedDates: Date[] = [];
-  for (let i = 0; i < days; i++) {
-    const date = new Date(new Date().getTime() - i * (24 * 60 * 60 * 1000));
-
-    displayedDates.unshift(date);
-  }
-
-  return displayedDates.reduce((chartData: ChartDataType[], date: Date) => {
-    const groupByKey = formatter.format(date);
-    const runs = runsGroupedByDay[groupByKey];
-
-    let failureRate = 0;
-    if (runs != null) {
-      failureRate = runs.filter(r => r.results.counts.failed > 0).length / runs.length;
-    }
-
-    const label = `${date.toLocaleString("default", { month: "short" })} ${date.getDate()}`;
-
-    chartData.push({ failureRate, label });
-
-    return chartData;
-  }, []);
-}
-
-function getCoordinates({
-  data,
-  height,
-  index,
-  width,
-}: {
-  data: ChartDataType[];
-  index: number;
-  height: number;
-  width: number;
-}) {
-  const { failureRate } = data[index];
-
-  const availableHeight = height - PADDING * 2;
-  const availableWidth = width - PADDING * 2;
-  const offset = PADDING;
-
-  const y = height - offset - availableHeight * failureRate;
-
-  let x = 0;
-  if (data.length === 1) {
-    x = width / 2;
-  } else {
-    x = offset + index * (availableWidth / (data.length - 1));
-  }
-
-  return {
-    x,
-    y,
-  };
 }

--- a/src/ui/components/Library/Team/View/TestRuns/TestRunListPanel/drawChart.ts
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunListPanel/drawChart.ts
@@ -1,0 +1,98 @@
+import { getChartCoordinates } from "ui/components/Library/Team/View/TestRuns/TestRunListPanel/getChartCoordinates";
+import { ChartDataType } from "ui/components/Library/Team/View/TestRuns/TestRunListPanel/types";
+
+export const LINE_WIDTH = 2;
+export const PADDING = 4;
+export const POINT_RADIUS = 4;
+
+export function drawChart({
+  canvas,
+  data,
+  height,
+  highlightIndex,
+  width,
+}: {
+  canvas: HTMLCanvasElement;
+  data: ChartDataType[];
+  height: number;
+  highlightIndex: number | null;
+  width: number;
+}) {
+  const scale = window.devicePixelRatio;
+
+  const style = getComputedStyle(canvas);
+  const borderColor = style.getPropertyValue("--testsuites-graph-marker");
+  const markerColor = style.getPropertyValue("--testsuites-graph-gradient-stroke");
+  const gradientStartColor = style.getPropertyValue("--testsuites-graph-gradient-start");
+  const gradientEndColor = style.getPropertyValue("--testsuites-graph-gradient-end");
+  const highlightMarkerColor = style.getPropertyValue("--secondary-accent");
+
+  canvas.style.height = `${height}px`;
+  canvas.style.width = `${width}px`;
+  canvas.height = height * scale;
+  canvas.width = width * scale;
+
+  const context = canvas.getContext("2d") as CanvasRenderingContext2D;
+  context.scale(scale, scale);
+  context.clearRect(0, 0, width, height);
+
+  // Top and bottom lines
+  context.beginPath();
+  context.lineWidth = 1;
+  context.strokeStyle = borderColor;
+  context.moveTo(POINT_RADIUS, PADDING);
+  context.lineTo(width - POINT_RADIUS, PADDING);
+  context.stroke();
+  context.moveTo(POINT_RADIUS, height - PADDING);
+  context.lineTo(width - POINT_RADIUS, height - PADDING);
+  context.stroke();
+  context.closePath();
+
+  let prevX = 0;
+  let prevY = 0;
+
+  const gradient = context.createLinearGradient(0, 0, 0, height);
+  gradient.addColorStop(0, gradientStartColor);
+  gradient.addColorStop(1, gradientEndColor);
+
+  for (let index = 0; index < data.length; index++) {
+    const { x, y } = getChartCoordinates({ data, height, index, width });
+
+    if (index > 0) {
+      // Gradient under fill
+      context.beginPath();
+      context.fillStyle = gradient;
+      context.moveTo(prevX, prevY);
+      context.lineTo(x, y);
+      context.lineTo(x, height - PADDING);
+      context.lineTo(prevX, height - PADDING);
+      context.lineTo(prevX, prevY);
+      context.fill();
+      context.closePath();
+
+      // Connecting lines
+      context.beginPath();
+      context.lineWidth = LINE_WIDTH;
+      context.strokeStyle = markerColor;
+      context.moveTo(prevX, prevY);
+      context.lineTo(x, y);
+      context.stroke();
+      context.closePath();
+    }
+
+    prevX = x;
+    prevY = y;
+  }
+
+  for (let index = 0; index < data.length; index++) {
+    const { x, y } = getChartCoordinates({ data, height, index, width });
+
+    // Circles
+    context.beginPath();
+    context.arc(x, y, POINT_RADIUS, 0, 2 * Math.PI);
+    context.lineWidth = 0;
+    context.fillStyle = index === highlightIndex ? highlightMarkerColor : markerColor;
+    context.fill();
+    context.closePath();
+  }
+}

--- a/src/ui/components/Library/Team/View/TestRuns/TestRunListPanel/generateChartData.ts
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunListPanel/generateChartData.ts
@@ -1,0 +1,61 @@
+import groupBy from "lodash/groupBy";
+
+import { TestRun } from "shared/test-suites/TestRun";
+import { ChartDataType } from "ui/components/Library/Team/View/TestRuns/TestRunListPanel/types";
+
+export function generateChartData(testRuns: TestRun[], days: number) {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+
+  const runsGroupedByDay = groupBy(
+    testRuns.map(({ date: dateString, ...rest }) => {
+      const date = new Date(dateString);
+      const groupByKey = formatter.format(date);
+
+      return {
+        ...rest,
+        date,
+        __groupByKey: groupByKey,
+      };
+    }),
+    "__groupByKey"
+  );
+
+  const displayedDates: Date[] = [];
+  for (let i = 0; i < days; i++) {
+    const date = new Date(new Date().getTime() - i * (24 * 60 * 60 * 1000));
+
+    displayedDates.unshift(date);
+  }
+
+  return displayedDates.reduce((chartData: ChartDataType[], date: Date) => {
+    const groupByKey = formatter.format(date);
+    const runs = runsGroupedByDay[groupByKey];
+
+    let numRunsFailed = 0;
+    let numRunsPassed = 0;
+    let numTestsFailed = 0;
+    let numTestsPassed = 0;
+
+    if (runs != null) {
+      runs.forEach(run => {
+        const { failed, passed } = run.results.counts;
+        if (failed > 0) {
+          numRunsFailed++;
+        } else {
+          numRunsPassed++;
+        }
+
+        numTestsFailed += failed;
+        numTestsPassed += passed;
+      });
+    }
+
+    chartData.push({ date, numRunsFailed, numRunsPassed, numTestsFailed, numTestsPassed });
+
+    return chartData;
+  }, []);
+}

--- a/src/ui/components/Library/Team/View/TestRuns/TestRunListPanel/getChartCoordinates.ts
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunListPanel/getChartCoordinates.ts
@@ -1,0 +1,37 @@
+import { PADDING } from "ui/components/Library/Team/View/TestRuns/TestRunListPanel/drawChart";
+import { ChartDataType } from "ui/components/Library/Team/View/TestRuns/TestRunListPanel/types";
+
+export function getChartCoordinates({
+  data,
+  height,
+  index,
+  width,
+}: {
+  data: ChartDataType[];
+  index: number;
+  height: number;
+  width: number;
+}) {
+  const { numRunsFailed, numRunsPassed } = data[index];
+
+  const numRunsTotal = numRunsFailed + numRunsPassed;
+  const failureRate = numRunsTotal === 0 ? 0 : numRunsFailed / numRunsTotal;
+
+  const availableHeight = height - PADDING * 2;
+  const availableWidth = width - PADDING * 2;
+  const offset = PADDING;
+
+  const y = height - offset - availableHeight * failureRate;
+
+  let x = 0;
+  if (data.length === 1) {
+    x = width / 2;
+  } else {
+    x = offset + index * (availableWidth / (data.length - 1));
+  }
+
+  return {
+    x,
+    y,
+  };
+}

--- a/src/ui/components/Library/Team/View/TestRuns/TestRunListPanel/getChartTooltip.test.ts
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunListPanel/getChartTooltip.test.ts
@@ -1,0 +1,82 @@
+import { ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+import { act } from "react-dom/test-utils";
+
+import { getChartTooltip } from "ui/components/Library/Team/View/TestRuns/TestRunListPanel/getChartTooltip";
+import { ChartDataType } from "ui/components/Library/Team/View/TestRuns/TestRunListPanel/types";
+
+function createChartDataType(data: Partial<ChartDataType>) {
+  return {
+    date: new Date("2000-01-01"),
+    numRunsFailed: 0,
+    numRunsPassed: 0,
+    numTestsFailed: 0,
+    numTestsPassed: 0,
+    ...data,
+  };
+}
+
+function expectToContainText(tooltip: ReactNode, ...expectedTexts: string[]) {
+  const container = document.createElement("div");
+
+  act(() => {
+    const root = createRoot(container);
+    root.render(tooltip);
+  });
+
+  expectedTexts.forEach(expectedText => {
+    expect(container.textContent).toContain(expectedText);
+  });
+}
+
+describe("getChartTooltip", () => {
+  beforeEach(() => {
+    // @ts-ignore
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  it("should handle a day with no test runs", () => {
+    expectToContainText(getChartTooltip(createChartDataType({})), "No tests were run on this day");
+  });
+
+  it("should handle a day with only failed test runs", () => {
+    expectToContainText(
+      getChartTooltip(
+        createChartDataType({
+          numRunsFailed: 15,
+          numTestsFailed: 1575,
+        })
+      ),
+      "All 15 test runs contained at least one failing test",
+      "All 1,575 tests failed"
+    );
+  });
+
+  it("should handle a day with only passing test runs", () => {
+    expectToContainText(
+      getChartTooltip(
+        createChartDataType({
+          numRunsPassed: 1000,
+          numTestsPassed: 2500,
+        })
+      ),
+      "All 1,000 test runs passed",
+      "All 2,500 tests passed"
+    );
+  });
+
+  it("should handle a day with a mix of passing and failing test runs", () => {
+    expectToContainText(
+      getChartTooltip(
+        createChartDataType({
+          numRunsFailed: 11,
+          numRunsPassed: 40,
+          numTestsFailed: 166,
+          numTestsPassed: 5294,
+        })
+      ),
+      "22% of 51 test runs contained at least one failing test",
+      "166 tests failed out of 5,460 total tests"
+    );
+  });
+});

--- a/src/ui/components/Library/Team/View/TestRuns/TestRunListPanel/getChartTooltip.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunListPanel/getChartTooltip.tsx
@@ -1,0 +1,75 @@
+import { ReactNode } from "react";
+
+import { ChartDataType } from "ui/components/Library/Team/View/TestRuns/TestRunListPanel/types";
+
+export function getChartTooltip(chartData: ChartDataType): ReactNode {
+  const { date, numRunsFailed, numRunsPassed, numTestsFailed, numTestsPassed } = chartData;
+
+  const numRunsTotal = numRunsFailed + numRunsPassed;
+
+  let testRunLabel = null;
+  let testLabel = null;
+  if (numRunsTotal === 0) {
+    testRunLabel = "No tests were run on this day";
+  } else {
+    const numRunsTotal = numRunsFailed + numRunsPassed;
+
+    if (numRunsFailed === 0) {
+      testRunLabel = (
+        <p>
+          All <strong>{numRunsTotal.toLocaleString()}</strong> test runs passed
+        </p>
+      );
+    } else if (numRunsPassed === 0) {
+      testRunLabel = (
+        <p>
+          All <strong>{numRunsTotal.toLocaleString()}</strong> test runs contained at least one
+          failing test
+        </p>
+      );
+    } else {
+      const percentage = numRunsTotal === 0 ? 0 : Math.round((numRunsFailed / numRunsTotal) * 100);
+
+      testRunLabel = (
+        <p>
+          <strong>{percentage}%</strong> of <strong>{numRunsTotal.toLocaleString()}</strong> test
+          runs contained at least one failing test
+        </p>
+      );
+    }
+
+    const numTestsTotal = numTestsFailed + numTestsPassed;
+    if (numTestsTotal === 0) {
+      // Redundant with no test runs
+    } else if (numTestsFailed === 0) {
+      testLabel = (
+        <p>
+          All <strong>{numTestsTotal.toLocaleString()}</strong> tests passed
+        </p>
+      );
+    } else if (numTestsPassed === 0) {
+      testLabel = (
+        <p>
+          All <strong>{numTestsTotal.toLocaleString()}</strong> tests failed
+        </p>
+      );
+    } else {
+      testLabel = (
+        <p>
+          <strong>{numTestsFailed.toLocaleString()}</strong> tests failed out of{" "}
+          <strong>{numTestsTotal.toLocaleString()}</strong> total tests
+        </p>
+      );
+    }
+  }
+
+  return (
+    <>
+      <h2>
+        {date.toLocaleString("default", { month: "short" })} {date.getDate()}
+      </h2>
+      {testRunLabel}
+      {testLabel}
+    </>
+  );
+}

--- a/src/ui/components/Library/Team/View/TestRuns/TestRunListPanel/types.ts
+++ b/src/ui/components/Library/Team/View/TestRuns/TestRunListPanel/types.ts
@@ -1,0 +1,7 @@
+export type ChartDataType = {
+  date: Date;
+  numRunsFailed: number;
+  numRunsPassed: number;
+  numTestsFailed: number;
+  numTestsPassed: number;
+};


### PR DESCRIPTION
- [x] Split a few things into separate files because I was getting lost in the huge file
- [x] Add a new tooltip function (with unit tests) to generate a more detailed tooltip for the item you're hovering over

[Kapture 2024-02-27 at 18.30.30.webm](https://github.com/replayio/devtools/assets/29597/c653ca3f-70e9-4d18-9ec1-2b3ef7836510)

cc @jonbell-lot23 