### PR TITLE
Fix loading request and response bodies

### DIFF
--- a/packages/replay-next/src/suspense/NetworkRequestsCache.ts
+++ b/packages/replay-next/src/suspense/NetworkRequestsCache.ts
@@ -193,6 +193,10 @@ export const networkRequestBodyCache = createStreamingCache<
       update(requestBodyData);
     });
 
+    if (requestBodyData.length === 0) {
+      update(requestBodyData);
+    }
+
     resolve();
   },
 });
@@ -213,6 +217,10 @@ export const networkResponseBodyCache = createStreamingCache<
 
       update(responseBodyData);
     });
+
+    if (responseBodyData.length === 0) {
+      update(responseBodyData);
+    }
 
     resolve();
   },

--- a/src/ui/actions/network.ts
+++ b/src/ui/actions/network.ts
@@ -75,8 +75,12 @@ export function selectNetworkRequest(requestId: RequestId): UIThunkAction {
       payload: { frames: formattedFrames, point: record.timeStampedPoint.point },
     });
 
-    networkRequestBodyCache.prefetch(replayClient, requestId);
-    networkResponseBodyCache.prefetch(replayClient, requestId);
+    if (record.events.bodyEvent) {
+      networkRequestBodyCache.prefetch(replayClient, requestId);
+    }
+    if (record.events.responseBodyEvent) {
+      networkResponseBodyCache.prefetch(replayClient, requestId);
+    }
   };
 }
 


### PR DESCRIPTION
- don't try to load a request or response body if we know it doesn't exist - this was causing protocol errors
- update the streaming value if loading a body succeeds without any events (i.e. we received an empty body) so that the network panel stops showing the body as loading

We could show an error message in the second case but I'm not sure if an empty request/response body is necessarily an error.

STR:
- open one of our FE E2E test recordings
- select one of the requests for `https://vitals.vercel-insights.com/v1/vitals`
- without this PR you can see a failed request for the response body in the protocol viewer and selecting the "Request" tab shows an indefinite loader. With this PR there are no failed protocol requests and the "Request" tab shows an empty body