### PR TITLE
Show stalled processing message if stuck for > 30s

### DIFF
--- a/src/ui/components/DevToolsProcessingScreen.tsx
+++ b/src/ui/components/DevToolsProcessingScreen.tsx
@@ -1,18 +1,38 @@
+import { useEffect, useState } from "react";
+
 import LoadingScreen from "ui/components/shared/LoadingScreen";
 import { getProcessingProgress } from "ui/reducers/app";
 import { useAppSelector } from "ui/setup/hooks";
 
+const SHOW_STALLED_MESSAGE_AFTER_MS = 30_000;
+
 export function DevToolsProcessingScreen() {
   const processingProgress = useAppSelector(getProcessingProgress);
 
-  return (
-    <LoadingScreen
-      message={
-        processingProgress == null
-          ? "Processing..."
-          : `Processing... (${Math.round(processingProgress)}%)`
-      }
-      secondaryMessage="This could take a while, depending on the complexity and length of the replay."
-    />
-  );
+  const [showStalledMessage, setShowStalledMessage] = useState(false);
+
+  useEffect(() => {
+    if (processingProgress == null) {
+      const timeout = setTimeout(() => {
+        setShowStalledMessage(true);
+      }, SHOW_STALLED_MESSAGE_AFTER_MS);
+
+      return () => {
+        clearTimeout(timeout);
+      };
+    } else {
+      setShowStalledMessage(false);
+    }
+  }, [processingProgress]);
+
+  let message = "Determining length of replay...";
+  let secondaryMessage =
+    "This could take a while, depending on the complexity and length of the replay.";
+  if (showStalledMessage) {
+    secondaryMessage = "There may be a problem. This is taking much longer than expected.";
+  } else if (processingProgress != null) {
+    message = `Processing... (${Math.round(processingProgress)}%)`;
+  }
+
+  return <LoadingScreen message={message} secondaryMessage={secondaryMessage} />;
 }


### PR DESCRIPTION
### Happy path

[Kapture 2024-02-28 at 10.55.12.webm](https://github.com/replayio/devtools/assets/29597/dba4555c-1dae-4398-97b0-91ae5cef0ef8)

### Stalled path
Note that in this example, I reduced the threshold to 3 seconds to the message would show

[Kapture 2024-02-28 at 10.56.19.webm](https://github.com/replayio/devtools/assets/29597/2d3dce57-597c-4f80-948c-1adbabdfd9a4)

cc @jonbell-lot23 