### PR TITLE
Show better user-facing messaging when we fail to parse preview syntax

### DIFF
--- a/packages/replay-next/components/Popup.module.css
+++ b/packages/replay-next/components/Popup.module.css
@@ -5,11 +5,6 @@
   flex-direction: column;
   padding: 0;
 }
-.Popup[data-style="error"] {
-  --theme-popup-background-color: var(--background-color-error);
-  --theme-popup-border-color: var(--border-color-error);
-  --theme-popup-color: var(--color-error);
-}
 
 .UpArrow,
 .DownArrow {

--- a/packages/replay-next/components/Popup.tsx
+++ b/packages/replay-next/components/Popup.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, ReactNode, RefObject, useLayoutEffect, useRef } from "react";
+import { HTMLAttributes, MouseEvent, ReactNode, RefObject, useLayoutEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 
 import styles from "./Popup.module.css";
@@ -12,22 +12,19 @@ type Dismiss = () => void;
 
 export default function Popup({
   children,
+  className = "",
   clientX = null,
   containerRef = null,
-  dataTestId,
-  dataTestName = "Popup",
   dismiss,
   dismissOnMouseLeave = false,
   horizontalAlignment = "center",
   showTail = false,
-  style = "default",
   target,
-}: {
+  ...rest
+}: Omit<HTMLAttributes<HTMLDivElement>, "onClick"> & {
   children: ReactNode;
   clientX?: number | null;
   containerRef?: RefObject<HTMLElement> | null;
-  dataTestId?: string;
-  dataTestName?: string;
   dismiss: Dismiss;
   dismissOnMouseLeave?: boolean;
   horizontalAlignment?: "left" | "center" | "right";
@@ -218,12 +215,11 @@ export default function Popup({
 
   return createPortal(
     <div
-      className={styles.Popup}
-      data-style={style}
-      data-test-id={dataTestId}
-      data-test-name={dataTestName}
+      className={`${className} ${styles.Popup}`}
+      data-test-name="Popup"
       onClick={blockEvent}
       ref={popoverRef}
+      {...rest}
     >
       <svg ref={arrowRef as any} viewBox="0 0 16 8" preserveAspectRatio="none">
         <polygon className={styles.ArrowBackground} points="8,0 16,8 0,8"></polygon>

--- a/packages/replay-next/components/sources/PreviewPopup.module.css
+++ b/packages/replay-next/components/sources/PreviewPopup.module.css
@@ -21,4 +21,8 @@
   color: var(--theme-popup-color);
   font-family: var(--font-family-default);
   font-size: var(--font-size-regular);
+
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }

--- a/packages/replay-next/components/sources/PreviewPopup.module.css
+++ b/packages/replay-next/components/sources/PreviewPopup.module.css
@@ -1,4 +1,10 @@
-.Popup {
+.PopupErrorStyleOverride {
+  --theme-popup-background-color: var(--background-color-error);
+  --theme-popup-border-color: var(--border-color-error);
+  --theme-popup-color: var(--color-error);
+}
+
+.Wrapper {
   max-width: 400px;
   max-height: 400px;
   height: auto;

--- a/packages/replay-next/components/sources/PreviewPopup.tsx
+++ b/packages/replay-next/components/sources/PreviewPopup.tsx
@@ -1,4 +1,5 @@
 import { Value as ProtocolValue, SourceId } from "@replayio/protocol";
+import { DirectiveLocation } from "graphql";
 import { ReactNode, RefObject, Suspense, useContext, useEffect, useRef } from "react";
 
 import { InlineErrorBoundary } from "replay-next/components/errors/InlineErrorBoundary";
@@ -170,11 +171,9 @@ function SuspendingPreviewPopup({
         <div className={styles.Wrapper}>
           <div className={styles.UnavailableMessage}>
             <h2>Parsing error</h2>
+            <div>We're sorry. This expression could not be parsed.</div>
+            <div>This is likely a bug in the Replay UI.</div>
           </div>
-          <div className={styles.UnavailableMessage}>
-            We're sorry. This expression could not be parsed.
-          </div>
-          <div className={styles.UnavailableMessage}>This is likely a bug in the Replay UI.</div>
         </div>
       </Popup>
     );

--- a/packages/replay-next/components/sources/PreviewPopup.tsx
+++ b/packages/replay-next/components/sources/PreviewPopup.tsx
@@ -1,13 +1,5 @@
 import { Value as ProtocolValue, SourceId } from "@replayio/protocol";
-import {
-  PropsWithChildren,
-  ReactNode,
-  RefObject,
-  Suspense,
-  useContext,
-  useEffect,
-  useRef,
-} from "react";
+import { ReactNode, RefObject, Suspense, useContext, useEffect, useRef } from "react";
 
 import { InlineErrorBoundary } from "replay-next/components/errors/InlineErrorBoundary";
 import { SelectedFrameContext } from "replay-next/src/contexts/SelectedFrameContext";
@@ -22,7 +14,7 @@ import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { isPointInRegion } from "shared/utils/time";
 
 import SourcePreviewInspector from "../inspector/SourcePreviewInspector";
-import Popup, { PopupStyle } from "../Popup";
+import Popup from "../Popup";
 import styles from "./PreviewPopup.module.css";
 
 type Props = {
@@ -39,11 +31,11 @@ export default function PreviewPopup(props: Props) {
     <InlineErrorBoundary name="PreviewPopup">
       <Suspense
         fallback={
-          <PopupWithChildren {...props}>
+          <Popup {...props} showTail={true}>
             <div className={styles.Wrapper}>
               <div className={styles.LoadingMessage}>Loading...</div>
             </div>
-          </PopupWithChildren>
+          </Popup>
         }
       >
         <SuspendingPreviewPopup {...props} />
@@ -167,11 +159,12 @@ function SuspendingPreviewPopup({
   let children: ReactNode = null;
   if (likelyParsingError) {
     return (
-      <PopupWithChildren
+      <Popup
         className={styles.PopupErrorStyleOverride}
         clientX={clientX}
         containerRef={containerRef}
         dismiss={dismiss}
+        showTail={true}
         target={target}
       >
         <div className={styles.Wrapper}>
@@ -183,28 +176,30 @@ function SuspendingPreviewPopup({
           </div>
           <div className={styles.UnavailableMessage}>This is likely a bug in the Replay UI.</div>
         </div>
-      </PopupWithChildren>
+      </Popup>
     );
   } else if (valueUnavailableMessage !== null) {
     return (
-      <PopupWithChildren
+      <Popup
         className={styles.PopupErrorStyleOverride}
         clientX={clientX}
         containerRef={containerRef}
         dismiss={dismiss}
+        showTail={true}
         target={target}
       >
         <div className={styles.Wrapper}>
           <div className={styles.UnavailableMessage}>{valueUnavailableMessage}</div>
         </div>
-      </PopupWithChildren>
+      </Popup>
     );
   } else if (pauseId !== null && value !== null) {
     return (
-      <PopupWithChildren
+      <Popup
         clientX={clientX}
         containerRef={containerRef}
         dismiss={dismiss}
+        showTail={true}
         target={target}
       >
         <SourcePreviewInspector
@@ -213,44 +208,18 @@ function SuspendingPreviewPopup({
           protocolValue={value}
           ref={popupRef}
         />
-      </PopupWithChildren>
+      </Popup>
     );
   }
 
   return children !== null ? (
-    <PopupWithChildren
-      children={children}
-      clientX={clientX}
-      containerRef={containerRef}
-      dismiss={dismiss}
-      target={target}
-    />
-  ) : null;
-}
-
-function PopupWithChildren({
-  className,
-  children,
-  clientX,
-  containerRef,
-  dismiss,
-  target,
-}: PropsWithChildren & {
-  className?: string;
-  clientX?: number | null;
-  containerRef: RefObject<HTMLElement>;
-  dismiss: () => void;
-  target: HTMLElement;
-}) {
-  return (
     <Popup
       children={children}
       clientX={clientX}
       containerRef={containerRef}
       dismiss={dismiss}
-      className={className}
-      target={target}
       showTail={true}
+      target={target}
     />
-  );
+  ) : null;
 }


### PR DESCRIPTION
While I was working on #10378, I realized (a) that there are probably other syntaxes that our cheap parser doesn't support yet and (b) I don't think we're actually explicitly tracking them, so this PR does a few things:

- [x] Explicitly log failed evaluations to Sentry (so we can learn about other expressions we aren't handling)
- [x] Show better messaging for `SyntaxError` (since they're likely our fault)
- [x] Remove a weird one-off `style` attribute added to the `Popup` component back in #9719 

### Before
![Screenshot 2024-02-28 at 11 14 55 AM](https://github.com/replayio/devtools/assets/29597/b8af9375-f886-48e0-9df6-6223547258d3)

### After
![Screenshot 2024-02-28 at 1 10 50 PM](https://github.com/replayio/devtools/assets/29597/9c3239b9-a881-4aaf-86be-3ff83161365e)

cc @jonbell-lot23 