### PR TITLE
Fix IDP auth error message

### DIFF
--- a/src/ui/components/shared/Login/Login.tsx
+++ b/src/ui/components/shared/Login/Login.tsx
@@ -204,6 +204,7 @@ function AuthError({ error }: { error: any }) {
     case "IDP_CONFIGURATION_ERROR":
       message =
         "Failed to log in due to a configuration problem with your Replay account. Support has been notified!";
+      break;
     case "IDP_UNEXPECTED_ERROR":
       message = "Failed to login. Please try logging in with SSO.";
       break;


### PR DESCRIPTION
Add missing a `break` on `IDP_CONFIGURATION_ERROR` switch case. Bug was in https://github.com/replayio/devtools/pull/10360