### PR TITLE
Replace log point capsule <input> with Lexical plug-in

### DIFF
--- a/packages/e2e-tests/helpers/lexical.ts
+++ b/packages/e2e-tests/helpers/lexical.ts
@@ -16,13 +16,13 @@ type InputAndTypeAheadOptions =
     };
 
 export async function clearText(page: Page, selector: string) {
-  await focus(page, selector);
-
   const input = page.locator(selector);
 
   // Timing awkwardness;
   // Make sure we clear all of the text (and not just most of it)
   while (((await input.textContent()) || "").trim() !== "") {
+    await focus(page, selector);
+
     await delay(100);
 
     await page.keyboard.press(`${getCommandKey()}+A`);
@@ -32,8 +32,10 @@ export async function clearText(page: Page, selector: string) {
 
 export async function focus(page: Page, selector: string) {
   // For some reason, locator.focus() does not work as expected;
-  // Lexical's own Playwright tests use page.focus(selector) though and it works.
-  await page.focus(selector);
+  // Lexical's own Playwright tests use page.focus(selector)
+  // though it seems that .click() works more reliably
+  const element = page.locator(selector);
+  await element.click();
 }
 
 export async function hideTypeAheadSuggestions(page: Page, options: InputAndTypeAheadOptions) {

--- a/packages/e2e-tests/helpers/source-panel.ts
+++ b/packages/e2e-tests/helpers/source-panel.ts
@@ -3,7 +3,7 @@ import chalk from "chalk";
 
 import { Badge } from "shared/client/types";
 
-import { hideTypeAheadSuggestions, typeLogPoint as typeLexical } from "./lexical";
+import { clearText, focus, hideTypeAheadSuggestions, typeLogPoint as typeLexical } from "./lexical";
 import { findPoints, openPauseInformationPanel, removePoint } from "./pause-information-panel";
 import { openSource } from "./source-explorer-panel";
 import { clearTextArea, debugPrint, delay, getByTestName, getCommandKey, waitFor } from "./utils";
@@ -153,11 +153,12 @@ export async function jumpToLogPointHit(
     "jumpToLogPointHit"
   );
 
+  await focus(page, '[data-test-name="LogPointCurrentStepInput"]');
+
   const input = page.locator('[data-test-name="LogPointCurrentStepInput"]');
-  await input.focus();
-  await clearTextArea(page, input);
-  await page.keyboard.type(`${number}`);
-  await page.keyboard.press("Enter");
+  await input.press(`${getCommandKey()}+A`);
+  await input.type(`${number}`);
+  await input.press("Enter");
 }
 
 export async function scrollUntilLineIsVisible(page: Page, lineNumber: number) {
@@ -753,7 +754,7 @@ export async function verifyLogpointStep(
     const currentStepInputLocator = lineLocator.locator(
       '[data-test-name="LogPointCurrentStepInput"]'
     );
-    const currentStep = await currentStepInputLocator.inputValue();
+    const currentStep = await currentStepInputLocator.getAttribute("data-value");
     const denominatorLocator = lineLocator.locator('[data-test-name="LogPointDenominator"]');
     const denominator = await denominatorLocator.textContent();
 
@@ -811,7 +812,7 @@ export async function verifyLogPointPanelContent(
 
     if (hitPointsBadge != null) {
       const input = line.locator('[data-test-name="LogPointCurrentStepInput"]');
-      const inputValue = await input.getAttribute("value");
+      const inputValue = await input.getAttribute("data-value");
       const capsule = await line.locator('[data-test-name="LogPointDenominator"]');
       const capsuleText = await capsule.textContent();
       await expect(`${inputValue}/${capsuleText}`).toBe(hitPointsBadge);

--- a/packages/replay-next/components/lexical/CodeEditor.tsx
+++ b/packages/replay-next/components/lexical/CodeEditor.tsx
@@ -145,11 +145,9 @@ function CodeEditor({
   }, [editorRef, dataTestId, dataTestName]);
 
   const onFormCancel = (_: EditorState) => {
-    if (onCancel === undefined) {
-      return;
+    if (onCancel != undefined) {
+      onCancel();
     }
-
-    onCancel();
 
     const editor = editorRef.current;
     if (editor) {
@@ -159,7 +157,6 @@ function CodeEditor({
           editor.setEditorState(editorState);
         }
       });
-      editor.setEditable(false);
     }
   };
 

--- a/packages/replay-next/components/lexical/CommentEditor.tsx
+++ b/packages/replay-next/components/lexical/CommentEditor.tsx
@@ -193,7 +193,6 @@ export default function CommentEditor({
           editor.setEditorState(editorState);
         }
       });
-      editor.setEditable(false);
     }
   }, []);
 
@@ -205,11 +204,6 @@ export default function CommentEditor({
       onDelete();
     } else {
       onSave(editorState.toJSON());
-
-      const editor = editorRef.current;
-      if (editor) {
-        editor.setEditable(false);
-      }
 
       backupEditorStateRef.current = editorState;
     }

--- a/packages/replay-next/components/lexical/NumberEditor.tsx
+++ b/packages/replay-next/components/lexical/NumberEditor.tsx
@@ -56,6 +56,7 @@ type Props = Omit<HTMLAttributes<HTMLDivElement>, "onChange"> & {
 
 function NumberEditorWithForwardedRef({
   autoFocus,
+  className = "",
   defaultValue,
   editable = true,
   maxValue,
@@ -162,7 +163,7 @@ function NumberEditorWithForwardedRef({
   };
 
   return (
-    <div className={styles.Editor} {...rest}>
+    <div {...rest} className={`${className} ${styles.Editor}`}>
       <LexicalComposer initialConfig={createInitialConfig(defaultValue, editable)}>
         <LexicalEditorRefSetter editorRef={editorRef} />
         <>

--- a/packages/replay-next/components/lexical/NumberEditor.tsx
+++ b/packages/replay-next/components/lexical/NumberEditor.tsx
@@ -1,0 +1,243 @@
+import assert from "assert";
+import { AutoFocusPlugin } from "@lexical/react/LexicalAutoFocusPlugin";
+import { LexicalComposer } from "@lexical/react/LexicalComposer";
+import { ContentEditable } from "@lexical/react/LexicalContentEditable";
+import LexicalErrorBoundary from "@lexical/react/LexicalErrorBoundary";
+import { HistoryPlugin, createEmptyHistoryState } from "@lexical/react/LexicalHistoryPlugin";
+import { PlainTextPlugin } from "@lexical/react/LexicalPlainTextPlugin";
+import { $rootTextContent } from "@lexical/text";
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  EditorState,
+  Klass,
+  LexicalEditor,
+  LexicalNode,
+  ParagraphNode,
+  TextNode,
+} from "lexical";
+import {
+  ForwardedRef,
+  HTMLAttributes,
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+} from "react";
+
+import LexicalEditorRefSetter from "replay-next/components/lexical/LexicalEditorRefSetter";
+import NumberPlugin from "replay-next/components/lexical/plugins/number/NumberPlugin";
+import { parseNumberFromTextContent } from "replay-next/components/lexical/plugins/number/utils/parseNumberFromTextContent";
+import { updateEditorValue } from "replay-next/components/lexical/plugins/number/utils/updateEditorValue";
+
+import FormPlugin from "./plugins/form/FormPlugin";
+import styles from "./styles.module.css";
+
+const NODES: Array<Klass<LexicalNode>> = [ParagraphNode, TextNode];
+
+export interface NumberEditorHandle {
+  getValue(): number;
+  setValue: (value: number) => void;
+}
+
+type Props = Omit<HTMLAttributes<HTMLDivElement>, "onChange"> & {
+  autoFocus?: boolean;
+  defaultValue: number;
+  editable?: boolean;
+  maxValue: number;
+  minValue: number;
+  onCancel?: () => void;
+  onChange?: (value: number) => void;
+  onSave: (value: number) => void;
+  placeholder?: string;
+  step?: number;
+};
+
+function NumberEditorWithForwardedRef({
+  autoFocus,
+  defaultValue,
+  editable = true,
+  maxValue,
+  minValue,
+  onCancel,
+  onChange,
+  onSave,
+  placeholder,
+  forwardedRef,
+  step = 1,
+  ...rest
+}: Props & {
+  forwardedRef: ForwardedRef<NumberEditorHandle>;
+}) {
+  const committedValuesRef = useRef<{
+    defaultValue: number;
+    maxValue?: number;
+    minValue?: number;
+    step: number;
+  }>({
+    defaultValue,
+    maxValue,
+    minValue,
+    step,
+  });
+  useEffect(() => {
+    committedValuesRef.current.defaultValue = defaultValue;
+    committedValuesRef.current.maxValue = maxValue;
+    committedValuesRef.current.minValue = minValue;
+    committedValuesRef.current.step = step;
+  });
+
+  const historyState = useMemo(() => createEmptyHistoryState(), []);
+
+  assert(minValue <= maxValue, `Invalid minValue (${minValue}) and maxValue (${maxValue}) props`);
+
+  const editorRef = useRef<LexicalEditor>(null);
+  const backupEditorStateRef = useRef<EditorState | null>(null);
+
+  useImperativeHandle(
+    forwardedRef,
+    () => ({
+      getValue: () => {
+        const { defaultValue, maxValue, minValue, step } = committedValuesRef.current;
+
+        const editor = editorRef.current;
+        assert(editor !== null, "Editor is not initialized");
+
+        const editorState = editor.getEditorState();
+
+        return editorState.read(() => {
+          return parseNumberFromTextContent({
+            defaultValue,
+            maxValue,
+            minValue,
+            step,
+            textContent: $rootTextContent(),
+          });
+        });
+      },
+      setValue: (value: number) => {
+        const editor = editorRef.current;
+        assert(editor !== null, "Editor is not initialized");
+
+        updateEditorValue(editor, value);
+      },
+    }),
+    []
+  );
+
+  const onFormCancel = (_: EditorState) => {
+    if (onCancel !== undefined) {
+      onCancel();
+    }
+
+    const editor = editorRef.current;
+    if (editor) {
+      editor.update(() => {
+        const editorState = backupEditorStateRef.current;
+        if (editorState) {
+          editor.setEditorState(editorState);
+        }
+      });
+    }
+  };
+
+  const onFormChange = (editorState: EditorState) => {
+    if (typeof onChange === "function") {
+      editorState.read(() => {
+        const number = parseNumberFromTextContent({
+          defaultValue,
+          maxValue,
+          minValue,
+          step,
+          textContent: $rootTextContent(),
+        });
+
+        onChange(number);
+      });
+    }
+  };
+
+  const onFormSubmit = (editorState: EditorState) => {
+    const editor = editorRef.current;
+    if (editor !== null) {
+      const number = parseNumberFromTextContent({
+        defaultValue,
+        maxValue,
+        minValue,
+        step,
+        textContent: $rootTextContent(),
+      });
+
+      onSave(number);
+
+      backupEditorStateRef.current = editorState;
+    }
+  };
+
+  return (
+    <div className={styles.Editor} {...rest}>
+      <LexicalComposer initialConfig={createInitialConfig(defaultValue, editable)}>
+        <LexicalEditorRefSetter editorRef={editorRef} />
+        <>
+          {autoFocus && <AutoFocusPlugin />}
+          <HistoryPlugin externalHistoryState={historyState} />
+          <NumberPlugin
+            defaultValue={defaultValue}
+            minValue={minValue}
+            maxValue={maxValue}
+            step={step}
+          />
+          <PlainTextPlugin
+            contentEditable={<ContentEditable className={styles.ContentEditable} />}
+            placeholder={<div className={styles.Placeholder}>{placeholder}</div>}
+            ErrorBoundary={LexicalErrorBoundary}
+          />
+          <FormPlugin onCancel={onFormCancel} onChange={onFormChange} onSubmit={onFormSubmit} />
+        </>
+      </LexicalComposer>
+    </div>
+  );
+}
+
+export const NumberEditor = forwardRef<NumberEditorHandle, Props>(
+  (props: Props, ref: ForwardedRef<NumberEditorHandle>) => (
+    <NumberEditorWithForwardedRef {...props} forwardedRef={ref} />
+  )
+);
+
+NumberEditor.displayName = "NumberEditor";
+NumberEditorWithForwardedRef.displayName = "forwardRef(NumberEditor)";
+
+function createInitialConfig(defaultValue: number, editable: boolean) {
+  return {
+    editable,
+    editorState: () => {
+      const root = $getRoot();
+      if (root.getFirstChild() === null) {
+        const paragraphNode = $createParagraphNode();
+        paragraphNode.append($createTextNode("" + defaultValue));
+
+        root.append(paragraphNode);
+      }
+    },
+    namespace: "NumberEditor",
+    nodes: NODES,
+    onError: (error: Error) => {
+      throw error;
+    },
+    theme: LexicalTheme,
+  };
+}
+
+const LexicalTheme = {
+  text: {
+    bold: styles.LexicalBold,
+    code: styles.LexicalCode,
+    italic: styles.LexicalItalic,
+    strikethrough: styles.LexicalStrikethrough,
+    underline: styles.LexicalUnderline,
+    underlineStrikethrough: styles.LexicalUnderlineStrikethrough,
+  },
+};

--- a/packages/replay-next/components/lexical/plugins/number/NumberPlugin.tsx
+++ b/packages/replay-next/components/lexical/plugins/number/NumberPlugin.tsx
@@ -1,0 +1,165 @@
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { $rootTextContent } from "@lexical/text";
+import { mergeRegister } from "@lexical/utils";
+import {
+  $createTextNode,
+  COMMAND_PRIORITY_LOW,
+  KEY_ARROW_DOWN_COMMAND,
+  KEY_ARROW_UP_COMMAND,
+  TextNode,
+} from "lexical";
+import { useEffect, useRef } from "react";
+
+import { parseNumberFromTextContent } from "replay-next/components/lexical/plugins/number/utils/parseNumberFromTextContent";
+import { updateEditorValue } from "replay-next/components/lexical/plugins/number/utils/updateEditorValue";
+
+import { UpdateListener } from "lexical/LexicalEditor";
+
+export default function NumberPlugin({
+  defaultValue,
+  maxValue,
+  minValue,
+  step,
+}: {
+  defaultValue: number;
+  maxValue?: number;
+  minValue?: number;
+  step: number;
+}): null {
+  const [editor] = useLexicalComposerContext();
+
+  const committedValuesRef = useRef<{
+    defaultValue: number;
+    maxValue?: number;
+    minValue?: number;
+    step: number;
+  }>({
+    defaultValue,
+    maxValue,
+    minValue,
+    step,
+  });
+  useEffect(() => {
+    committedValuesRef.current.defaultValue = defaultValue;
+    committedValuesRef.current.maxValue = maxValue;
+    committedValuesRef.current.minValue = minValue;
+    committedValuesRef.current.step = step;
+  });
+
+  useEffect(() => {
+    function onArrowDownCommand(event: KeyboardEvent) {
+      const { defaultValue, maxValue, minValue, step } = committedValuesRef.current;
+
+      if (minValue == null) {
+        return false;
+      }
+
+      let result = false;
+
+      editor.update(() => {
+        let number = parseNumberFromTextContent({
+          defaultValue,
+          maxValue,
+          minValue,
+          step,
+          textContent: $rootTextContent(),
+        });
+
+        if (number > minValue) {
+          number = Math.max(minValue, number - step);
+
+          updateEditorValue(editor, number);
+
+          event.preventDefault();
+
+          result = true;
+        }
+      });
+
+      return result;
+    }
+
+    function onArrowUpCommand(event: KeyboardEvent) {
+      const { defaultValue, maxValue, minValue, step } = committedValuesRef.current;
+
+      if (maxValue == null) {
+        return false;
+      }
+
+      let result = false;
+
+      editor.update(() => {
+        let number = parseNumberFromTextContent({
+          defaultValue,
+          maxValue,
+          minValue,
+          step,
+          textContent: $rootTextContent(),
+        });
+
+        if (number < maxValue) {
+          number = Math.min(maxValue, number + step);
+
+          updateEditorValue(editor, number);
+
+          event.preventDefault();
+
+          result = true;
+        }
+      });
+
+      return result;
+    }
+
+    function onTextNodeTransform(node: TextNode) {
+      const { defaultValue, maxValue, minValue, step } = committedValuesRef.current;
+
+      if (minValue == null && maxValue == null) {
+        return;
+      } else if (!node.isAttached()) {
+        return false;
+      }
+
+      const textContent = node.getTextContent() ?? "";
+      const number = parseNumberFromTextContent({
+        defaultValue,
+        maxValue,
+        minValue,
+        step,
+        textContent,
+      });
+
+      const stringValue = "" + number;
+      if (stringValue !== textContent) {
+        const newNode = $createTextNode(stringValue);
+        node.replace(newNode);
+      }
+    }
+
+    function onUpdate({ editorState, prevEditorState }: Parameters<UpdateListener>[0]) {
+      const value = editorState.read(() => {
+        return $rootTextContent();
+      });
+      if (value === "") {
+        const prevValue = prevEditorState.read(() => {
+          return $rootTextContent();
+        });
+
+        if (prevValue !== "") {
+          editor.update(() => {
+            editor.setEditorState(prevEditorState);
+          });
+        }
+      }
+    }
+
+    return mergeRegister(
+      editor.registerCommand(KEY_ARROW_DOWN_COMMAND, onArrowDownCommand, COMMAND_PRIORITY_LOW),
+      editor.registerCommand(KEY_ARROW_UP_COMMAND, onArrowUpCommand, COMMAND_PRIORITY_LOW),
+      editor.registerNodeTransform(TextNode, onTextNodeTransform),
+      editor.registerUpdateListener(onUpdate)
+    );
+  }, [editor]);
+
+  return null;
+}

--- a/packages/replay-next/components/lexical/plugins/number/utils/parseNumberFromTextContent.ts
+++ b/packages/replay-next/components/lexical/plugins/number/utils/parseNumberFromTextContent.ts
@@ -1,30 +1,26 @@
 export function parseNumberFromTextContent({
-  defaultValue,
   maxValue,
   minValue,
   step,
   textContent,
 }: {
-  defaultValue: number;
   maxValue?: number;
   minValue?: number;
   step: number;
   textContent: string;
-}) {
+}): number | undefined {
   const maybeNumber =
     Math.round(step) === step ? parseInt(textContent, 10) : parseFloat(textContent);
 
-  let number: number;
-  if (maybeNumber == null || isNaN(maybeNumber)) {
-    number = minValue ?? maxValue ?? defaultValue;
-  } else {
+  let number: number | undefined;
+  if (!isNaN(maybeNumber)) {
     number = maybeNumber;
-  }
 
-  if (minValue != null && number < minValue) {
-    number = minValue;
-  } else if (maxValue != null && number > maxValue) {
-    number = maxValue;
+    if (minValue != null && number < minValue) {
+      number = minValue;
+    } else if (maxValue != null && number > maxValue) {
+      number = maxValue;
+    }
   }
 
   return number;

--- a/packages/replay-next/components/lexical/plugins/number/utils/parseNumberFromTextContent.ts
+++ b/packages/replay-next/components/lexical/plugins/number/utils/parseNumberFromTextContent.ts
@@ -1,0 +1,31 @@
+export function parseNumberFromTextContent({
+  defaultValue,
+  maxValue,
+  minValue,
+  step,
+  textContent,
+}: {
+  defaultValue: number;
+  maxValue?: number;
+  minValue?: number;
+  step: number;
+  textContent: string;
+}) {
+  const maybeNumber =
+    Math.round(step) === step ? parseInt(textContent, 10) : parseFloat(textContent);
+
+  let number: number;
+  if (maybeNumber == null || isNaN(maybeNumber)) {
+    number = minValue ?? maxValue ?? defaultValue;
+  } else {
+    number = maybeNumber;
+  }
+
+  if (minValue != null && number < minValue) {
+    number = minValue;
+  } else if (maxValue != null && number > maxValue) {
+    number = maxValue;
+  }
+
+  return number;
+}

--- a/packages/replay-next/components/lexical/plugins/number/utils/updateEditorValue.ts
+++ b/packages/replay-next/components/lexical/plugins/number/utils/updateEditorValue.ts
@@ -1,0 +1,14 @@
+import { $createParagraphNode, $createTextNode, $getRoot, LexicalEditor } from "lexical";
+
+export function updateEditorValue(editor: LexicalEditor, value: number) {
+  editor.update(() => {
+    const root = $getRoot();
+    const firstChild = root.getFirstChild();
+    if (firstChild) {
+      const paragraphNode = $createParagraphNode();
+      paragraphNode.append($createTextNode("" + value));
+
+      firstChild.replace(paragraphNode);
+    }
+  });
+}

--- a/packages/replay-next/components/sources/log-point-panel/Capsule.module.css
+++ b/packages/replay-next/components/sources/log-point-panel/Capsule.module.css
@@ -40,17 +40,6 @@
 
 .CurrentIndex {
   color: var(--point-panel-timeline-label-unselected-color);
-  padding: 0;
-  line-height: 1;
-  overflow: hidden;
-  background-color: transparent;
-  border: none;
-  appearance: none;
-  font-size: inherit;
-  text-align: right;
-
-  /* Even if all text is deleted, don't shrink smaller than a single digit */
-  min-width: 1;
 }
 .CurrentIndex[data-exact] {
   color: var(--point-panel-timeline-label-selected-color);
@@ -61,8 +50,6 @@
 .CurrentIndex:focus {
   background-color: var(--point-panel-timeline-label-edit-hover-background-color);
   color: var(--point-panel-timeline-label-edit-color);
-  outline: none;
-  box-shadow: none;
 }
 .Label:hover .CurrentIndex:not(:disabled) {
   background-color: var(--point-panel-timeline-label-edit-hover-background-color);

--- a/packages/replay-next/components/sources/log-point-panel/Capsule.tsx
+++ b/packages/replay-next/components/sources/log-point-panel/Capsule.tsx
@@ -103,6 +103,7 @@ export default function Capsule({
           onClick={onClickFocusContentEditable}
         >
           <NumberEditor
+            className={styles.CurrentIndex}
             data-exact={currentHitPoint !== null || undefined}
             data-test-name="LogPointCurrentStepInput"
             data-too-many-points-to-find={tooManyPointsToFind || undefined}

--- a/packages/replay-next/components/sources/log-point-panel/Capsule.tsx
+++ b/packages/replay-next/components/sources/log-point-panel/Capsule.tsx
@@ -62,8 +62,8 @@ export default function Capsule({
 
   const badgeStyle = getBadgeStyleVars(point.badge);
 
-  const onSave = (number: number) => {
-    goToIndex(number - 1);
+  const onSave = (number: number | undefined) => {
+    goToIndex((number ?? 1) - 1);
   };
 
   // Don't show "0/0" while hit points are loading.

--- a/packages/replay-next/components/sources/log-point-panel/Capsule.tsx
+++ b/packages/replay-next/components/sources/log-point-panel/Capsule.tsx
@@ -1,5 +1,5 @@
 import { TimeStampedPoint } from "@replayio/protocol";
-import { CSSProperties, useLayoutEffect, useRef } from "react";
+import { CSSProperties, MouseEvent, useLayoutEffect, useRef } from "react";
 
 import { NumberEditor, NumberEditorHandle } from "replay-next/components/lexical/NumberEditor";
 import Spinner from "replay-next/components/Spinner";
@@ -80,6 +80,16 @@ export default function Capsule({
     );
   }
 
+  const onClickFocusContentEditable = (event: MouseEvent) => {
+    const target = event.currentTarget;
+    if (target instanceof HTMLElement) {
+      const focusable = target.querySelector("[contenteditable]");
+      if (focusable instanceof HTMLElement) {
+        focusable.focus();
+      }
+    }
+  };
+
   return (
     <>
       <div
@@ -90,6 +100,7 @@ export default function Capsule({
         <div
           className={styles.Label}
           data-test-state={tooManyPointsToFind ? "too-many-points" : "valid"}
+          onClick={onClickFocusContentEditable}
         >
           <NumberEditor
             data-exact={currentHitPoint !== null || undefined}


### PR DESCRIPTION
This is a prerequisite for FE-2315, as it will allow us to use the strategy described in that issue to prevent any inputs in the log point panel from being selected. (I am not aware of any way to achieve the same with an `<input>` element.)

- [x] Add new `NumberEditor` Lexical component with min/max support (basically a drop-in replacement for `<input type="number">`
- [x] Replace the `<input>` in the log point panel with this new plug-in
- [x] Update e2e test helpers to account for the change from `HTMLInputElement` to Lexical editor
- [x] Revisit decision to disallow temporarily empty input value