### PR TITLE
Switch inspector-elements-03/04 to Chromium example

### DIFF
--- a/packages/e2e-tests/examples.json
+++ b/packages/e2e-tests/examples.json
@@ -132,8 +132,8 @@
     "buildId": "linux-gecko-20230919-abf2e86b2910-4d0a9f5b9de2"
   },
   "doc_stacking_chromium.html": {
-    "recording": "fa5a2a8b-a095-44ef-83ca-324da9f7bde8",
-    "buildId": "linux-chromium-20240126-c9de98d17d37-50d01be708a2"
+    "recording": "6c3a6dd4-6880-4bfc-ace6-690013421ac3",
+    "buildId": "linux-chromium-20240227-947bd2cd266d-e0f1462455a7"
   },
   "flake/adding-spec.ts": {
     "recording": "a667c000-8432-45d7-b08d-a7e4f5002ecb",

--- a/packages/e2e-tests/tests/inspector-elements-03_nested-node-selection.test.ts
+++ b/packages/e2e-tests/tests/inspector-elements-03_nested-node-selection.test.ts
@@ -19,7 +19,7 @@ import {
 import { debugPrint, waitFor } from "../helpers/utils";
 import test from "../testFixtureCloneRecording";
 
-test.use({ exampleKey: "doc_stacking.html" });
+test.use({ exampleKey: "doc_stacking_chromium.html" });
 // ref: `doc_stacking.html`
 // note the lack of a `>` on each tag string, due to how
 // the elements tree constructs the text for each node
@@ -91,7 +91,7 @@ test("inspector-elements-03: Nested node picker and selection behavior", async (
     `<div style="width: 40px; height: 20px; overflow: hidden;"`
   );
   await typeKeyAndVerifySelectedElement(page, "ArrowUp", `<div style="left: 200px; top: 300px;"`);
-  await typeKeyAndVerifySelectedElement(page, "ArrowUp", bodyChildDomNodes[15]);
+  await typeKeyAndVerifySelectedElement(page, "ArrowUp", "</div>");
 
   // Searching for a nested node should expand everything above it
   await searchElementsPanel(page, "Foo");


### PR DESCRIPTION
I had to update the navigation that the test does in the elements panel because it now expands all elements by default.
