### PR TITLE
[RUN-3292] separately targetable steps for e2e on linux-x86_64 and macos-arm64

### DIFF
--- a/.buildkite/runtime-tests.yml
+++ b/.buildkite/runtime-tests.yml
@@ -6,6 +6,7 @@ steps:
       - "be_cmd run_tests -- ts-node ./packages/e2e-tests/scripts/buildkite_run_fe_tests_from_artifact-macos-arm64.ts"
     agents:
       - "os=macos"
+      - "arch=arm64"
       - "queue=default"
       - "runtimeType=test"
     plugins:

--- a/.buildkite/runtime-tests.yml
+++ b/.buildkite/runtime-tests.yml
@@ -1,6 +1,6 @@
 steps:
   - label: "Runtime e2e tests (linux-x86_64)"
-    if: build.env("OS") == "linux" && build.env("ARCH") == "x86_64"
+    if: (build.env("OS") == "linux" && build.env("ARCH") == "x86_64") || (build.env("OS") == null && build.env("ARCH") == null)
     timeout_in_minutes: 60
     commands:
       - "mkdir -p /mnt/data/replay"

--- a/.buildkite/runtime-tests.yml
+++ b/.buildkite/runtime-tests.yml
@@ -28,7 +28,7 @@ steps:
             RUNTIME_TEAM_API_KEY: runtime-replay-api-key
             BUILDEVENT_APIKEY: honeycomb-api-key
             BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
-      - replayio/buildevents#76b6f57: ~
+      - replayio/buildevents#0c2adb2: ~
       - "ssh://git@github.com/replayio/fly-buildkite-plugin.git#v0.77":
           # This image's source code is here https://github.com/replayio/backend-e2e-base-image
           image: "registry.fly.io/buildkite-backend-e2e-tests:v14"
@@ -75,7 +75,7 @@ steps:
             RUNTIME_TEAM_API_KEY: runtime-replay-api-key
             BUILDEVENT_APIKEY: honeycomb-api-key
             BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
-      - replayio/buildevents#adb8a05: ~
+      - replayio/buildevents#0c2adb2: ~
     env:
       DISPLAY: ":1"
       PLAYWRIGHT_HEADLESS: "true"

--- a/.buildkite/runtime-tests.yml
+++ b/.buildkite/runtime-tests.yml
@@ -2,7 +2,7 @@ steps:
   - label: "Runtime e2e tests (macos-arm64)"
     key: "runtime-fe-e2e-tests-macos_arm64"
     commands:
-      - "be_cmd node_deps -- yarn install"
+      - "be_cmd node_deps -- npx yarn install"
       - "be_cmd run_tests -- ts-node ./packages/e2e-tests/scripts/buildkite_run_fe_tests_from_artifact-macos-arm64.ts"
     agents:
       - "os=macos"

--- a/.buildkite/runtime-tests.yml
+++ b/.buildkite/runtime-tests.yml
@@ -1,6 +1,62 @@
 steps:
+
+  - label: "Runtime e2e tests (linux-x86_64)"
+    if: build.env("OS") == "linux" && build.env("ARCH") == "x86_64"
+    timeout_in_minutes: 60
+    commands:
+      - "mkdir -p /mnt/data/replay"
+      - "be_cmd node_deps -- npx yarn install"
+      - "be_cmd run_tests -- ts-node ./packages/e2e-tests/scripts/buildkite_run_fe_tests_from_artifact-linux-x86_64.ts"
+    agents:
+      - "deploy=true"
+    plugins:
+      - seek-oss/aws-sm#v2.3.1:
+          region: us-east-2
+          env:
+            AUTOMATED_TEST_SECRET: "graphql-automated-test-secret"
+            RECORD_REPLAY_API_KEY: "runtime-record-replay-api-key"
+            FLY_API_TOKEN: "prod/fly-api-token"
+            BUILDKITE_AGENT_TOKEN: "prod/buildkite-agent-token"
+            SSH_PRIVATE_RSA_KEY_B64: "prod/buildkite-ssh-private-key"
+            TAILSCALE_AUTHKEY: "dev/fly-e2e-test-runner-tailscale-auth-key"
+            HASURA_ADMIN_SECRET: "prod/hasura-admin-secret"
+            BUILD_USER_ACCESS_KEY_ID:
+              secret-id: "prod/build-user"
+              json-key: ".access_key_id"
+            BUILD_USER_SECRET_ACCESS_KEY:
+              secret-id: "prod/build-user"
+              json-key: ".secret_access_key"
+            RUNTIME_TEAM_API_KEY: runtime-replay-api-key
+            BUILDEVENT_APIKEY: honeycomb-api-key
+            BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
+      - replayio/buildevents#76b6f57: ~
+      - "ssh://git@github.com/replayio/fly-buildkite-plugin.git#v0.77":
+          # This image's source code is here https://github.com/replayio/backend-e2e-base-image
+          image: "registry.fly.io/buildkite-backend-e2e-tests:v14"
+          organization: "replay"
+          cpus: 4
+          memory: 4096
+          storage: 20
+          secrets:
+            BUILDKITE_AGENT_TOKEN: BUILDKITE_AGENT_TOKEN
+            SSH_PRIVATE_RSA_KEY_B64: SSH_PRIVATE_RSA_KEY_B64
+            FLY_API_TOKEN: FLY_API_TOKEN
+            TAILSCALE_AUTHKEY: TAILSCALE_AUTHKEY
+            HASURA_ADMIN_SECRET: HASURA_ADMIN_SECRET
+            AWS_SECRET_ACCESS_KEY: BUILD_USER_SECRET_ACCESS_KEY
+            AWS_ACCESS_KEY_ID: BUILD_USER_ACCESS_KEY_ID
+            AUTOMATED_TEST_SECRET: AUTOMATED_TEST_SECRET
+            RECORD_REPLAY_API_KEY: RECORD_REPLAY_API_KEY
+            RUNTIME_TEAM_API_KEY: RUNTIME_TEAM_API_KEY
+          env:
+            DISPLAY: ":1"
+            PLAYWRIGHT_HEADLESS: "true"
+            PLAYWRIGHT_CHROMIUM: "true"
+            RECORD_REPLAY_DIRECTORY: "/mnt/data/replay"
+
   - label: "Runtime e2e tests (macos-arm64)"
-    key: "runtime-fe-e2e-tests-macos_arm64"
+    if: build.env("OS") == "macos" && build.env("ARCH") == "arm64"
+    timeout_in_minutes: 60
     commands:
       - "be_cmd node_deps -- npx yarn install"
       - "be_cmd run_tests -- ts-node ./packages/e2e-tests/scripts/buildkite_run_fe_tests_from_artifact-macos-arm64.ts"

--- a/.buildkite/runtime-tests.yml
+++ b/.buildkite/runtime-tests.yml
@@ -3,8 +3,7 @@ steps:
     key: "runtime-fe-e2e-tests-macos_arm64"
     commands:
       - "be_cmd node_deps -- yarn install"
-      #- "be_cmd run_tests -- ts-node ./packages/e2e-tests/scripts/buildkite_run_fe_tests_from_artifact-macos-arm64.ts"
-      - "be_cmd run_tests -- true"
+      - "be_cmd run_tests -- ts-node ./packages/e2e-tests/scripts/buildkite_run_fe_tests_from_artifact-macos-arm64.ts"
     agents:
       - "os=macos"
       - "queue=default"

--- a/.buildkite/runtime-tests.yml
+++ b/.buildkite/runtime-tests.yml
@@ -12,11 +12,11 @@ steps:
       - seek-oss/aws-sm#v2.3.1:
           region: us-east-2
           env:
-            # AUTOMATED_TEST_SECRET: "graphql-automated-test-secret"
-            # RECORD_REPLAY_API_KEY: "runtime-record-replay-api-key"
-            # SSH_PRIVATE_RSA_KEY_B64: "prod/buildkite-ssh-private-key"
+            BUILDKITE_AGENT_TOKEN: "prod/buildkite-agent-token"
+            AUTOMATED_TEST_SECRET: "graphql-automated-test-secret"
+            RECORD_REPLAY_API_KEY: "runtime-record-replay-api-key"
             HASURA_ADMIN_SECRET: "prod/hasura-admin-secret"
-            # RUNTIME_TEAM_API_KEY: runtime-replay-api-key
+            RUNTIME_TEAM_API_KEY: runtime-replay-api-key
             BUILDEVENT_APIKEY: honeycomb-api-key
             BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
       - replayio/buildevents#adb8a05: ~

--- a/.buildkite/runtime-tests.yml
+++ b/.buildkite/runtime-tests.yml
@@ -1,4 +1,41 @@
 steps:
+  - label: "Runtime e2e tests (macos-arm64)"
+    key: "runtime-fe-e2e-tests-macos_arm64"
+    commands:
+      - "be_cmd install_yarn -- npm i -g yarn"
+      - "be_cmd node_deps -- yarn install"
+      - "be_cmd run_tests -- ts-node ./packages/e2e-tests/scripts/buildkite_run_fe_tests_from_artifact-macos-arm64.ts"
+    agents:
+      - "os=macos"
+      - "queue=default"
+      - "runtimeType=test"
+    plugins:
+      - seek-oss/aws-sm#v2.3.1:
+          region: us-east-2
+          env:
+            AUTOMATED_TEST_SECRET: "graphql-automated-test-secret"
+            RECORD_REPLAY_API_KEY: "runtime-record-replay-api-key"
+            FLY_API_TOKEN: "prod/fly-api-token"
+            BUILDKITE_AGENT_TOKEN: "prod/buildkite-agent-token"
+            SSH_PRIVATE_RSA_KEY_B64: "prod/buildkite-ssh-private-key"
+            TAILSCALE_AUTHKEY: "dev/fly-e2e-test-runner-tailscale-auth-key"
+            HASURA_ADMIN_SECRET: "prod/hasura-admin-secret"
+            BUILD_USER_ACCESS_KEY_ID:
+              secret-id: "prod/build-user"
+              json-key: ".access_key_id"
+            BUILD_USER_SECRET_ACCESS_KEY:
+              secret-id: "prod/build-user"
+              json-key: ".secret_access_key"
+            RUNTIME_TEAM_API_KEY: runtime-replay-api-key
+            BUILDEVENT_APIKEY: honeycomb-api-key
+            BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
+      - replayio/buildevents#adb8a05: ~
+    env:
+      DISPLAY: ":1"
+      PLAYWRIGHT_HEADLESS: "true"
+      PLAYWRIGHT_CHROMIUM: "true"
+      ARCHITECTURE: "arm64"
+
   - label: "Runtime e2e tests (linux-x86_64)"
     timeout_in_minutes: 60
     key: "runtime-fe-e2e-tests-linux_x86_64"

--- a/.buildkite/runtime-tests.yml
+++ b/.buildkite/runtime-tests.yml
@@ -1,5 +1,4 @@
 steps:
-
   - label: "Runtime e2e tests (linux-x86_64)"
     if: build.env("OS") == "linux" && build.env("ARCH") == "x86_64"
     timeout_in_minutes: 60

--- a/.buildkite/runtime-tests.yml
+++ b/.buildkite/runtime-tests.yml
@@ -2,7 +2,6 @@ steps:
   - label: "Runtime e2e tests (macos-arm64)"
     key: "runtime-fe-e2e-tests-macos_arm64"
     commands:
-      - "be_cmd install_yarn -- npm i -g yarn"
       - "be_cmd node_deps -- yarn install"
       #- "be_cmd run_tests -- ts-node ./packages/e2e-tests/scripts/buildkite_run_fe_tests_from_artifact-macos-arm64.ts"
       - "be_cmd run_tests -- true"

--- a/.buildkite/runtime-tests.yml
+++ b/.buildkite/runtime-tests.yml
@@ -4,7 +4,8 @@ steps:
     commands:
       - "be_cmd install_yarn -- npm i -g yarn"
       - "be_cmd node_deps -- yarn install"
-      - "be_cmd run_tests -- ts-node ./packages/e2e-tests/scripts/buildkite_run_fe_tests_from_artifact-macos-arm64.ts"
+      #- "be_cmd run_tests -- ts-node ./packages/e2e-tests/scripts/buildkite_run_fe_tests_from_artifact-macos-arm64.ts"
+      - "be_cmd run_tests -- true"
     agents:
       - "os=macos"
       - "queue=default"
@@ -13,20 +14,11 @@ steps:
       - seek-oss/aws-sm#v2.3.1:
           region: us-east-2
           env:
-            AUTOMATED_TEST_SECRET: "graphql-automated-test-secret"
-            RECORD_REPLAY_API_KEY: "runtime-record-replay-api-key"
-            FLY_API_TOKEN: "prod/fly-api-token"
-            BUILDKITE_AGENT_TOKEN: "prod/buildkite-agent-token"
-            SSH_PRIVATE_RSA_KEY_B64: "prod/buildkite-ssh-private-key"
-            TAILSCALE_AUTHKEY: "dev/fly-e2e-test-runner-tailscale-auth-key"
+            # AUTOMATED_TEST_SECRET: "graphql-automated-test-secret"
+            # RECORD_REPLAY_API_KEY: "runtime-record-replay-api-key"
+            # SSH_PRIVATE_RSA_KEY_B64: "prod/buildkite-ssh-private-key"
             HASURA_ADMIN_SECRET: "prod/hasura-admin-secret"
-            BUILD_USER_ACCESS_KEY_ID:
-              secret-id: "prod/build-user"
-              json-key: ".access_key_id"
-            BUILD_USER_SECRET_ACCESS_KEY:
-              secret-id: "prod/build-user"
-              json-key: ".secret_access_key"
-            RUNTIME_TEAM_API_KEY: runtime-replay-api-key
+            # RUNTIME_TEAM_API_KEY: runtime-replay-api-key
             BUILDEVENT_APIKEY: honeycomb-api-key
             BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
       - replayio/buildevents#adb8a05: ~
@@ -35,59 +27,3 @@ steps:
       PLAYWRIGHT_HEADLESS: "true"
       PLAYWRIGHT_CHROMIUM: "true"
       ARCHITECTURE: "arm64"
-
-  - label: "Runtime e2e tests (linux-x86_64)"
-    timeout_in_minutes: 60
-    key: "runtime-fe-e2e-tests-linux_x86_64"
-    commands:
-      - "mkdir -p /mnt/data/replay"
-      - "be_cmd install_yarn -- npm i -g yarn"
-      - "be_cmd node_deps -- yarn install"
-      - "be_cmd run_tests -- ts-node ./packages/e2e-tests/scripts/buildkite_run_fe_tests_from_artifact-linux-x86_64.ts"
-    agents:
-      - "deploy=true"
-    plugins:
-      - seek-oss/aws-sm#v2.3.1:
-          region: us-east-2
-          env:
-            AUTOMATED_TEST_SECRET: "graphql-automated-test-secret"
-            RECORD_REPLAY_API_KEY: "runtime-record-replay-api-key"
-            FLY_API_TOKEN: "prod/fly-api-token"
-            BUILDKITE_AGENT_TOKEN: "prod/buildkite-agent-token"
-            SSH_PRIVATE_RSA_KEY_B64: "prod/buildkite-ssh-private-key"
-            TAILSCALE_AUTHKEY: "dev/fly-e2e-test-runner-tailscale-auth-key"
-            HASURA_ADMIN_SECRET: "prod/hasura-admin-secret"
-            BUILD_USER_ACCESS_KEY_ID:
-              secret-id: "prod/build-user"
-              json-key: ".access_key_id"
-            BUILD_USER_SECRET_ACCESS_KEY:
-              secret-id: "prod/build-user"
-              json-key: ".secret_access_key"
-            RUNTIME_TEAM_API_KEY: runtime-replay-api-key
-            BUILDEVENT_APIKEY: honeycomb-api-key
-            BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
-      - replayio/buildevents#76b6f57: ~
-      - "ssh://git@github.com/replayio/fly-buildkite-plugin.git#v0.77":
-          # This image's source code is here https://github.com/replayio/backend-e2e-base-image
-          image: "registry.fly.io/buildkite-backend-e2e-tests:v14"
-          organization: "replay"
-          cpus: 4
-          memory: 4096
-          storage: 20
-          secrets:
-            BUILDKITE_AGENT_TOKEN: BUILDKITE_AGENT_TOKEN
-            SSH_PRIVATE_RSA_KEY_B64: SSH_PRIVATE_RSA_KEY_B64
-            FLY_API_TOKEN: FLY_API_TOKEN
-            TAILSCALE_AUTHKEY: TAILSCALE_AUTHKEY
-            HASURA_ADMIN_SECRET: HASURA_ADMIN_SECRET
-            AWS_SECRET_ACCESS_KEY: BUILD_USER_SECRET_ACCESS_KEY
-            AWS_ACCESS_KEY_ID: BUILD_USER_ACCESS_KEY_ID
-            AUTOMATED_TEST_SECRET: AUTOMATED_TEST_SECRET
-            RECORD_REPLAY_API_KEY: RECORD_REPLAY_API_KEY
-            RUNTIME_TEAM_API_KEY: RUNTIME_TEAM_API_KEY
-
-          env:
-            DISPLAY: ":1"
-            PLAYWRIGHT_HEADLESS: "true"
-            PLAYWRIGHT_CHROMIUM: "true"
-            RECORD_REPLAY_DIRECTORY: "/mnt/data/replay"

--- a/.buildkite/runtime-tests.yml
+++ b/.buildkite/runtime-tests.yml
@@ -7,7 +7,7 @@ steps:
     agents:
       - "os=macos"
       - "arch=arm64"
-      - "queue=default"
+      - "queue=runtime"
       - "runtimeType=test"
     plugins:
       - seek-oss/aws-sm#v2.3.1:

--- a/packages/e2e-tests/scripts/build_products.ts
+++ b/packages/e2e-tests/scripts/build_products.ts
@@ -45,9 +45,9 @@ export function install_build_products(RUNTIME_BUILD_ID, PLATFORM, ARCHITECTURE)
 
   // Set Chrome binary path based on OS
   let CHROME_BINARY;
-  if (PLATFORM === "linux") {
+  if (os.platform() === "linux") {
     CHROME_BINARY = path.join(TMP_DIR, "build", "replay-chromium", "chrome");
-  } else if (PLATFORM === "darwin") {
+  } else if (os.platform() === "darwin") {
     CHROME_BINARY = path.join(
       TMP_DIR,
       "build",
@@ -56,10 +56,10 @@ export function install_build_products(RUNTIME_BUILD_ID, PLATFORM, ARCHITECTURE)
       "MacOS",
       "Chromium"
     );
-  } else if (PLATFORM === "win32") {
+  } else if (os.platform() === "win32") {
     CHROME_BINARY = path.join(TMP_DIR, "build", "replay-chromium", "chrome.exe");
   } else {
-    throw new Error(`Unsupported platform: ${PLATFORM}`);
+    throw new Error(`Unsupported platform: ${os.platform()}`);
   }
   return CHROME_BINARY;
 }

--- a/packages/e2e-tests/scripts/buildkite_run_fe_tests.ts
+++ b/packages/e2e-tests/scripts/buildkite_run_fe_tests.ts
@@ -1,10 +1,10 @@
 /* Copyright 2024 Record Replay Inc. */
 
 import { exec, execSync } from "child_process";
+import http from "http";
 import os from "os";
 import path from "path";
 import chalk from "chalk";
-import http from "http";
 import difference from "lodash/difference";
 import size from "lodash/size";
 
@@ -144,12 +144,12 @@ function waitForHTTPStatus(
   url: string,
   statusCode: number = 200, // by default we wait for OK
   timeoutMs = 15000, // keep waiting for 15s total
-  retryTime = 1000, // retry after 1s
+  retryTime = 1000 // retry after 1s
 ): Promise<void> {
   const startTime = Date.now();
   return new Promise((resolve, reject) => {
     function attemptConnection() {
-      const request = http.get(url, (res) => {
+      const request = http.get(url, res => {
         if (res.statusCode === statusCode) {
           resolve();
           return;
@@ -158,15 +158,17 @@ function waitForHTTPStatus(
         console.error(`Server is up, but responded with status code ${res.statusCode}`);
 
         if (Date.now() - startTime >= timeoutMs) {
-          reject(new Error(`Server did not respond with 200 OK within ${timeoutMs / 1000} seconds`));
+          reject(
+            new Error(`Server did not respond with 200 OK within ${timeoutMs / 1000} seconds`)
+          );
           return;
         }
 
         setTimeout(attemptConnection, 1000); // Retry after 1 second
       });
 
-      request.on('error', (err: Error) => {
-        if (err["code"] === 'ECONNREFUSED') {
+      request.on("error", (err: Error) => {
+        if (err["code"] === "ECONNREFUSED") {
           if (Date.now() - startTime >= timeoutMs) {
             reject(new Error(`Failed to connect to the server within ${timeoutMs / 1000} seconds`));
             return;
@@ -255,7 +257,7 @@ export default async function run_fe_tests(
 
     // make sure the dev server is up and running.
     console.log("waiting for dev server to start up");
-    await waitForHTTPStatus("http://localhost:8080/")
+    await waitForHTTPStatus("http://localhost:8080/");
     console.log("dev server up, continuing with test");
   }
 

--- a/packages/e2e-tests/scripts/buildkite_run_fe_tests.ts
+++ b/packages/e2e-tests/scripts/buildkite_run_fe_tests.ts
@@ -1,6 +1,7 @@
 /* Copyright 2024 Record Replay Inc. */
 
 import { exec, execSync } from "child_process";
+import os from "os";
 import path from "path";
 import chalk from "chalk";
 import difference from "lodash/difference";
@@ -150,7 +151,7 @@ export default function run_fe_tests(
   console.group("START");
   console.time("START time");
 
-  const envWrapper = runInCI ? "xvfb-run" : "";
+  const envWrapper = runInCI && os.platform() === "linux" ? "xvfb-run" : "";
   const TestRootPath = path.join(
     process.env.REPLAY_DIR ? path.join(process.env.REPLAY_DIR, "devtools") : ".",
     "packages/e2e-tests"

--- a/packages/e2e-tests/scripts/buildkite_run_fe_tests.ts
+++ b/packages/e2e-tests/scripts/buildkite_run_fe_tests.ts
@@ -239,7 +239,7 @@ export default async function run_fe_tests(
     });
 
     // Start the webserver.
-    webProc = exec("yarn dev", (error, stdout, stderr) => {
+    webProc = exec("npx yarn dev", (error, stdout, stderr) => {
       if (error) {
         console.error(`yarn dev exec ERROR: ${error}`);
       }

--- a/packages/e2e-tests/scripts/buildkite_run_fe_tests_from_artifact-macos-arm64.ts
+++ b/packages/e2e-tests/scripts/buildkite_run_fe_tests_from_artifact-macos-arm64.ts
@@ -2,4 +2,4 @@
 
 import run_fe_tests_from_artifact from "./buildkite_run_fe_tests_from_artifact";
 
-run_fe_tests_from_artifact("macos", "arm64");
+run_fe_tests_from_artifact("macOS", "arm64");

--- a/packages/e2e-tests/scripts/buildkite_run_fe_tests_from_artifact-macos-arm64.ts
+++ b/packages/e2e-tests/scripts/buildkite_run_fe_tests_from_artifact-macos-arm64.ts
@@ -1,0 +1,5 @@
+/* Copyright 2024 Record Replay Inc. */
+
+import run_fe_tests_from_artifact from "./buildkite_run_fe_tests_from_artifact";
+
+run_fe_tests_from_artifact("macos", "arm64");


### PR DESCRIPTION
Support running the e2e tests on both platforms, since we've had issues affecting only macos-arm64 in the past.

In an effort to not wait on both chromium builds before starting the tests, make each step targetable using env vars.  The corresponding PR in chromium (https://github.com/replayio/chromium/pull/1142) waits on a single build and then triggers this pipeline with the proper env vars.  This could also be done with multiple buildkite pipelines and/or multiple .yml files, but this seemed the best choice to keep things together.