### PR TITLE
Fix support for team settings urls in parser

### DIFF
--- a/src/ui/components/Library/Team/utils.ts
+++ b/src/ui/components/Library/Team/utils.ts
@@ -12,7 +12,9 @@ export function parseQueryParams(query: ParsedUrlQuery) {
   let testRunId: string | undefined;
   let testId: string | undefined;
 
-  assert(!view || view === "runs" || view === "tests" || view === "recordings");
+  assert(
+    !view || view === "runs" || view === "tests" || view === "recordings" || view === "settings"
+  );
 
   switch (view) {
     case "runs": {


### PR DESCRIPTION
The query params parser was missing support for `/team/<id>/settings` to support redirect to the settings modal causing the "Update Subscription" button to fail.