### PR TITLE
Only render the React details panel when the wall is updated to the current pauseId

### DIFF
--- a/src/ui/components/SecondaryToolbox/react-devtools/ReplayWall.ts
+++ b/src/ui/components/SecondaryToolbox/react-devtools/ReplayWall.ts
@@ -35,6 +35,8 @@ export class ReplayWall implements Wall {
   private setProtocolCheckFailed: (failed: boolean) => void;
   private unhighlightNode: () => void;
 
+  private pauseIdListeners = new Set<() => void>();
+
   // HACK The Wall requires the Store and the Store requires the Wall
   // So this value is set by the caller after initialization
   public store: StoreWithInternals | null = null;
@@ -65,8 +67,20 @@ export class ReplayWall implements Wall {
     this.unhighlightNode = unhighlightNode;
   }
 
+  getPauseId() {
+    return this.pauseId;
+  }
+
   setPauseId(pauseId: string) {
     this.pauseId = pauseId;
+    for (const listener of this.pauseIdListeners) {
+      listener();
+    }
+  }
+
+  subscribeToPauseIdChange(callback: () => void) {
+    this.pauseIdListeners.add(callback);
+    return () => this.pauseIdListeners.delete(callback);
   }
 
   // called by the frontend to register a listener for receiving backend messages

--- a/src/ui/components/SecondaryToolbox/react-devtools/components/ReactDevToolsPanel.tsx
+++ b/src/ui/components/SecondaryToolbox/react-devtools/components/ReactDevToolsPanel.tsx
@@ -135,6 +135,12 @@ function ReactDevToolsPanelInner({
     wall,
   });
 
+  const wallPauseId = useSyncExternalStore(
+    callback => wall.subscribeToPauseIdChange(callback),
+    () => wall.getPauseId(),
+    () => wall.getPauseId()
+  );
+
   if (isPlaying) {
     return (
       <div className={styles.DisabledDuringPlaybackMessage} data-test-id="ReactDevToolsPanel">
@@ -241,7 +247,7 @@ function ReactDevToolsPanelInner({
           order={2}
           ref={rightPanelRef}
         >
-          {listData && pauseId && selectedElementForDetailsPanel ? (
+          {listData && pauseId && wallPauseId === pauseId && selectedElementForDetailsPanel ? (
             <InlineErrorBoundary
               fallback={
                 <SelectedElementErrorBoundaryFallback element={selectedElementForDetailsPanel} />

--- a/src/ui/components/SecondaryToolbox/react-devtools/hooks/useReactDevToolsAnnotations.ts
+++ b/src/ui/components/SecondaryToolbox/react-devtools/hooks/useReactDevToolsAnnotations.ts
@@ -79,8 +79,6 @@ export function useReactDevToolsAnnotations({
           ? annotations.slice(0, firstExcludedAnnotationIndex)
           : annotations;
 
-      wall.setPauseId(currentPauseId);
-
       // We keep the one RDT UI component instance alive, but operations are additive over time.
       // In order to reset the displayed component tree, we first need to generate a set of fake
       // "remove this React root" operations based on where we _were_ paused, and inject those.
@@ -101,6 +99,8 @@ export function useReactDevToolsAnnotations({
           wall.sendAnnotation(contents);
         }
       }
+
+      wall.setPauseId(currentPauseId);
 
       cacheRendererIdsToFiberIds(currentPauseId, wall.store!);
 


### PR DESCRIPTION
This is a possible fix for FE-2325, it's not the cleanest one but it's simple.