### PR TITLE
Add ReplayWall.sendAtPauseId()

### DIFF
--- a/src/ui/components/SecondaryToolbox/react-devtools/components/InspectButton.tsx
+++ b/src/ui/components/SecondaryToolbox/react-devtools/components/InspectButton.tsx
@@ -1,13 +1,14 @@
-import { FrontendBridge } from "@replayio/react-devtools-inline";
 import { MouseEvent, useContext } from "react";
 
 import Icon from "replay-next/components/Icon";
+import { useMostRecentLoadedPause } from "replay-next/src/hooks/useMostRecentLoadedPause";
 import { NodePickerContext } from "ui/components/NodePickerContext";
 import { ReplayWall } from "ui/components/SecondaryToolbox/react-devtools/ReplayWall";
 
 import styles from "./InspectButton.module.css";
 
 export function InspectButton({ wall }: { wall: ReplayWall }) {
+  const { pauseId } = useMostRecentLoadedPause() ?? {};
   const { status, type } = useContext(NodePickerContext);
 
   let isActive = false;
@@ -35,10 +36,12 @@ export function InspectButton({ wall }: { wall: ReplayWall }) {
     event.preventDefault();
     event.stopPropagation();
 
-    if (isActive) {
-      wall.send("stopInspectingNative", null);
-    } else {
-      wall.send("startInspectingNative", null);
+    if (pauseId) {
+      if (isActive) {
+        wall.sendAtPauseId("stopInspectingNative", null, pauseId);
+      } else {
+        wall.sendAtPauseId("startInspectingNative", null, pauseId);
+      }
     }
   };
 

--- a/src/ui/components/SecondaryToolbox/react-devtools/suspense/inspectedElementCache.ts
+++ b/src/ui/components/SecondaryToolbox/react-devtools/suspense/inspectedElementCache.ts
@@ -69,13 +69,17 @@ export const inspectedElementCache = createCache<
       timeoutMessage: `Timed out while trying to inspect React element ${elementId}`,
     });
 
-    replayWall.send("inspectElement", {
-      forceFullData: true,
-      id: elementId,
-      path: null,
-      rendererID,
-      requestID,
-    });
+    replayWall.sendAtPauseId(
+      "inspectElement",
+      {
+        forceFullData: true,
+        id: elementId,
+        path: null,
+        rendererID,
+        requestID,
+      },
+      pauseId
+    );
 
     const result = await promise;
 


### PR DESCRIPTION
- `ReplayWall.sendAtPauseId()` should be used instead of `ReplayWall.send()` to ensure that the wall has been updated to the desired `pauseId`
- `useHighlightNativeElement` still uses `ReplayWall.send()` because it first gets an ID from the `store` which it then asks to be highlighted, so we don't want to wait for the store to be potentially updated
- I didn't bother updating `ReplayWall.getComponentLocation()` (which calls the private `ReplayWall.sendRequest()`) because it is only used by the legacy RDT panel