### PR TITLE
[RUN-3224] Remove `authenticated/comments-03` from blacklist

### DIFF
--- a/packages/e2e-tests/scripts/buildkite_run_fe_tests.ts
+++ b/packages/e2e-tests/scripts/buildkite_run_fe_tests.ts
@@ -21,8 +21,6 @@ let TestFileOverrideList = [];
 
 // Disable some tests that we know to be problematic.
 const TestFileBlackList = new Set([
-  // https://linear.app/replay/issue/RUN-3224/
-  "authenticated/comments-03.test.ts",
   // https://linear.app/replay/issue/RUN-3274/
   "tests/repaint-01.test.ts",
 ]);


### PR DESCRIPTION
I think someone paper'ed over the missing favicon for now, so we can re-enable the test.
* https://linear.app/replay/issue/RUN-3224/re-enable-authenticatedcomments-03