### PR TITLE
Don't reset page title after a root-level error

### DIFF
--- a/packages/shared/graphql/Recording.ts
+++ b/packages/shared/graphql/Recording.ts
@@ -1,0 +1,40 @@
+import { gql, useQuery } from "@apollo/client";
+import { RecordingId } from "@replayio/protocol";
+
+import { query } from "shared/graphql/apolloClient";
+import { GetRecording, GetRecordingVariables } from "shared/graphql/generated/GetRecording";
+
+export const GET_RECORDING_TITLE = gql`
+  query GetRecordingUserId($recordingId: UUID!) {
+    recording(uuid: $recordingId) {
+      title
+    }
+  }
+`;
+export async function getRecordingTitle(recordingId: RecordingId) {
+  const result = await query<GetRecording, GetRecordingVariables>({
+    query: GET_RECORDING_TITLE,
+    variables: { recordingId },
+  });
+
+  return result.data?.recording?.title;
+}
+
+export function useGetRecordingTitle(recordingId: RecordingId | null | undefined): {
+  title: string | undefined;
+  loading: boolean;
+} {
+  const { data, error, loading, refetch } = useQuery<GetRecording, GetRecordingVariables>(
+    GET_RECORDING_TITLE,
+    {
+      variables: { recordingId },
+      skip: !recordingId,
+    }
+  );
+
+  if (error) {
+    console.error("Apollo error while getting the recording", error);
+  }
+
+  return { loading, title: data?.recording?.title || undefined };
+}

--- a/src/ui/components/Errors/RootErrorBoundary.tsx
+++ b/src/ui/components/Errors/RootErrorBoundary.tsx
@@ -4,6 +4,7 @@ import { ErrorBoundary, ErrorBoundaryProps } from "react-error-boundary";
 import { UnexpectedErrorForm } from "replay-next/components/errors/UnexpectedErrorForm";
 import { ReplayClientInterface } from "shared/client/types";
 import { setExpectedError, setUnexpectedError } from "ui/actions/errors";
+import { RootErrorDocumentTitle } from "ui/components/Errors/RootErrorDocumentTitle";
 import { useGetUserInfo } from "ui/hooks/users";
 import { getExpectedError, getUnexpectedError } from "ui/reducers/app";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
@@ -50,22 +51,28 @@ export function RootErrorBoundary({
 
   if (expectedError) {
     return (
-      <ExpectedErrorModal
-        action={expectedError.action ?? "refresh"}
-        details={expectedError.content ?? ""}
-        title={expectedError.message ?? "Error"}
-      />
+      <>
+        <RootErrorDocumentTitle />
+        <ExpectedErrorModal
+          action={expectedError.action ?? "refresh"}
+          details={expectedError.content ?? ""}
+          title={expectedError.message ?? "Error"}
+        />
+      </>
     );
   } else if (unexpectedError) {
     return (
-      <UnexpectedErrorForm
-        currentUserEmail={currentUserInfo?.email ?? null}
-        currentUserId={currentUserInfo?.id ?? null}
-        currentUserName={currentUserInfo?.name ?? null}
-        details={unexpectedError.content ?? ""}
-        replayClient={replayClient}
-        title={unexpectedError.message ?? "Session error"}
-      />
+      <>
+        <RootErrorDocumentTitle />
+        <UnexpectedErrorForm
+          currentUserEmail={currentUserInfo?.email ?? null}
+          currentUserId={currentUserInfo?.id ?? null}
+          currentUserName={currentUserInfo?.name ?? null}
+          details={unexpectedError.content ?? ""}
+          replayClient={replayClient}
+          title={unexpectedError.message ?? "Session error"}
+        />
+      </>
     );
   } else {
     return (

--- a/src/ui/components/Errors/RootErrorDocumentTitle.tsx
+++ b/src/ui/components/Errors/RootErrorDocumentTitle.tsx
@@ -1,0 +1,14 @@
+import Head from "next/head";
+
+import { useGetRecordingTitle } from "shared/graphql/Recording";
+import { getRecordingId } from "shared/utils/recording";
+
+export function RootErrorDocumentTitle() {
+  const { title = "Replay" } = useGetRecordingTitle(getRecordingId());
+
+  return (
+    <Head>
+      <title>{title}</title>
+    </Head>
+  );
+}


### PR DESCRIPTION
[Loom demo and explanation](https://www.loom.com/share/2f6e61f8d5c843b2ba678d2de5651cf4)

I am open to other ways of doing this. I don't really like this approach, nor the way that our some of our code is currently organized so that it can't reference other parts.

I am not sure how I feel about this PR to be honest. Posting it for discussion purposes. An alternative route would be to remove this default title from the parent layout:

https://github.com/replayio/devtools/blob/ec3b9e7cddb555368b55c2b11f31e9ecbe96d762/pages/_app.tsx#L106-L112

Although we would have to be sure to manually add the title to individual pages (like Library). I think I might prefer _that_ fix.

Note to test this change I did...
```diff
diff --git a/packages/protocol/socket.ts b/packages/protocol/socket.ts
index 540701f38..e08f5fc00 100644
--- a/packages/protocol/socket.ts
+++ b/packages/protocol/socket.ts
@@ -143,7 +143,11 @@ export async function createSession(
 ) {
   const { sessionId } = await sendMessage("Recording.createSession", {
     recordingId,
-    experimentalSettings,
+    experimentalSettings: {
+      ...experimentalSettings,
+      inactivityTerminationTimeout: 0.2,
+      inactivityNotificationTimeout: 0.1,
+    },
     focusRequest: focusWindow,
   });
 
```