### PR TITLE
Don't reset page title after a root-level error

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,9 +2,8 @@ import { useAuth0 } from "@auth0/auth0-react";
 import { Store } from "@reduxjs/toolkit";
 import type { AppContext, AppProps } from "next/app";
 import NextApp from "next/app";
-import Head from "next/head";
 import { useRouter } from "next/router";
-import React, { ReactNode, memo, useEffect, useState } from "react";
+import React, { ReactNode, useEffect, useState } from "react";
 import { Provider } from "react-redux";
 import "../src/global-css";
 import "../src/test-prep";
@@ -85,9 +84,13 @@ function Routing({ Component, pageProps }: AppProps) {
     return <MaintenanceModeScreen />;
   }
 
+  // Don't set a default title in this component
+  // Else it overrides the recording title when the root error boundary renders
+  // See FE-2041
   return (
     <Provider store={store}>
-      <MemoizedHeader />
+    <meta httpEquiv="Content-Type" content="text/html; charset=utf-8" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg" />
       <RootErrorBoundary replayClient={replayClient}>
         <_App>
           <InstallRouteListener />
@@ -99,19 +102,6 @@ function Routing({ Component, pageProps }: AppProps) {
     </Provider>
   );
 }
-
-// Ensure this component only renders once even if the parent component re-renders
-// Otherwise it can temporarily override titles set by child components,
-// causing the document title to flicker.
-const MemoizedHeader = memo(function MemoizedHeader() {
-  return (
-    <Head>
-      <meta httpEquiv="Content-Type" content="text/html; charset=utf-8" />
-      <link rel="icon" type="image/svg+xml" href="/images/favicon.svg" />
-      <title>Replay</title>
-    </Head>
-  );
-});
 
 const App = ({ apiKey, ...props }: AppProps & AuthProps) => {
   useAuthTelemetry();

--- a/src/ui/components/Library/Library.tsx
+++ b/src/ui/components/Library/Library.tsx
@@ -1,3 +1,4 @@
+import Head from "next/head";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
 
@@ -63,6 +64,9 @@ export default function LibraryLoader() {
   if (userSettingsLoading || userInfo.loading) {
     return (
       <div className="flex h-screen w-full items-center justify-center">
+        <Head>
+          <title>Replay</title>
+        </Head>
         <LibrarySpinner />
       </div>
     );
@@ -100,6 +104,9 @@ function Library({ userSettings, userInfo }: { userSettings: UserSettings; userI
 
   return (
     <div className="flex h-screen w-screen flex-row">
+      <Head>
+        <title>Replay</title>
+      </Head>
       <Navigation />
       <InlineErrorBoundary key={teamId} name="Library">
         <TeamPage />


### PR DESCRIPTION
Alternative to #10405

Are there other pages that will now be missing a title? Maybe onboarding flows?