### PR TITLE
Show picker loading state until bounding rects are loaded

### DIFF
--- a/src/ui/components/NodePicker.tsx
+++ b/src/ui/components/NodePicker.tsx
@@ -40,18 +40,13 @@ export function NodePicker() {
         return;
       }
 
-      enable(
-        {
-          onSelected: (nodeId: ObjectId) => {
-            dispatch(setSelectedPanel("inspector"));
-            dispatch(selectNode(nodeId));
-          },
-          type: "domElement",
+      enable({
+        onSelected: (nodeId: ObjectId) => {
+          dispatch(setSelectedPanel("inspector"));
+          dispatch(selectNode(nodeId));
         },
-        async () => {
-          await boundingRectsCache.readAsync(replayClient, pauseId);
-        }
-      );
+        type: "domElement",
+      });
     }
   };
 


### PR DESCRIPTION
`NodePickerContext` set its state from `"initializing"` to `"active"` as soon as `await initializer()` finished. The React component picker didn't load the bounding rects in the initializer, so the picker went into `"active"` state before they finished loading.
Now `NodePickerContext` will wait for `boundingRectsCache.readAsync()` in parallel to `initializer()`.