### PR TITLE
Pass testScope through GraphQL Subscription Request

### DIFF
--- a/packages/shared/graphql/apolloClient.tsx
+++ b/packages/shared/graphql/apolloClient.tsx
@@ -141,7 +141,7 @@ function createHttpLink(token: string | undefined, testScope: string | null) {
   const wsLink = new GraphQLWsLink(
     createClient({
       url: process.env.NEXT_PUBLIC_API_SUBSCRIPTION_URL!,
-      connectionParams: { token },
+      connectionParams: { token, testScope },
     })
   );
 


### PR DESCRIPTION
In order to properly scope comments we need to have the testScope available on the websocket request. Headers on websocket requests are weird, you are not really supposed to use them, so we pass it through the same way we do the auth details.

This is a noop on the backend right now, but soon it will be used.

Related: https://github.com/replayio/backend/pull/9676