### PR TITLE
Don't override null fallback in InlineErrorBoundary

### DIFF
--- a/packages/replay-next/components/errors/InlineErrorBoundary.tsx
+++ b/packages/replay-next/components/errors/InlineErrorBoundary.tsx
@@ -44,7 +44,7 @@ export function InlineErrorBoundary({
 
   return (
     <ErrorBoundary
-      fallback={fallback ?? <InlineErrorFallback />}
+      fallback={fallback !== undefined ? fallback : <InlineErrorFallback />}
       onError={onError}
       resetKeys={resetKey ? [resetKey] : undefined}
       {...rest}


### PR DESCRIPTION
In FE-2292 / BAC-4627, the default `<InlineErrorFallback>` was shown for a failing component even though [its error boundary](https://github.com/replayio/devtools/blob/fc64bb6774c32427f62badeeb3331e394760f229/src/ui/components/Timeline/PreviewMarkers.tsx#L33) has a `fallback={null}` prop.
`<InlineErrorBoundary>` should only show the `<InlineErrorFallback>` if its `fallback` prop is `undefined`.