### PR TITLE
Improve repaint/graphics e2e test stability

### DIFF
--- a/packages/e2e-tests/helpers/screenshot.ts
+++ b/packages/e2e-tests/helpers/screenshot.ts
@@ -71,6 +71,8 @@ export async function hoverScreenshot(page: Page, xPercentage: number, yPercenta
 }
 
 export async function getGraphicsDataUrl(page: Page): Promise<string | null> {
+  await waitForGraphicsToLoad(page);
+
   return await page.evaluate(() => {
     const element = document.querySelector("#graphics") as HTMLImageElement;
     return element?.src ?? null;

--- a/packages/e2e-tests/helpers/screenshot.ts
+++ b/packages/e2e-tests/helpers/screenshot.ts
@@ -96,6 +96,8 @@ export async function getGraphicsTime(page: Page): Promise<number | null> {
 }
 
 export async function getGraphicsPixelColor(page: Page, x: number, y: number) {
+  await waitForGraphicsToLoad(page);
+
   return await page.evaluate(
     ([x, y]) => {
       const element = document.querySelector("#graphics") as HTMLImageElement;


### PR DESCRIPTION
I noticed some repaint e2e test failures recently. They aren't common, but when they occur, it seems like our logic of waiting for a screenshot to change is not robust enough to handle a delay in loading the _initial_ screenshot, which can cause subsequent comparisons to fail.

To reduce the likelihood of this, I've updated our test helper to explicitly wait for the current screenshot to finish loading before returning the graphics content. I think this should improve the stability of the various repaint related tests.