### PR TITLE
Redirect Gecko recordings to legacy.replay.io

### DIFF
--- a/packages/e2e-tests/config.ts
+++ b/packages/e2e-tests/config.ts
@@ -1,14 +1,10 @@
 import { join } from "path";
 
-export type BrowserName = "firefox" | "chromium";
-
 export default {
   backendUrl: process.env.DISPATCH_ADDRESS || "wss://dispatch.replay.io",
   graphqlUrl: process.env.GRAPHQL_ADDRESS || "https://api.replay.io/v1/graphql",
   browserExamplesPath: join(__dirname, "../../public/test/examples"),
-  browserName: (process.env.RECORD_REPLAY_TARGET === "chromium"
-    ? "chromium"
-    : "firefox") as BrowserName,
+  browserName: "chromium",
   browserPath: process.env.RECORD_REPLAY_PATH,
   devtoolsUrl: process.env.PLAYWRIGHT_TEST_BASE_URL || "http://localhost:8080",
   driverPath: process.env.RECORD_REPLAY_DRIVER,

--- a/packages/e2e-tests/scripts/record-cypress.ts
+++ b/packages/e2e-tests/scripts/record-cypress.ts
@@ -1,9 +1,9 @@
 import { listAllRecordings, uploadRecording } from "@replayio/replay";
 import cypress from "cypress";
 
-import config, { BrowserName } from "../config";
+import config from "../config";
 
-export async function recordCypress(browserName: BrowserName, exampleFilename: string) {
+export async function recordCypress(exampleFilename: string) {
   const specName = `cypress/e2e/${exampleFilename}.cy.ts`;
   const exampleUrl = `${config.devtoolsUrl}/test/examples`;
 
@@ -12,7 +12,7 @@ export async function recordCypress(browserName: BrowserName, exampleFilename: s
     "run",
     "-q",
     "--browser",
-    browserName === "chromium" ? "replay-chromium" : "replay-firefox",
+    "replay-chromium",
     "--spec",
     specName,
   ]);

--- a/packages/e2e-tests/scripts/save-examples.ts
+++ b/packages/e2e-tests/scripts/save-examples.ts
@@ -44,7 +44,7 @@ const argv = yargs
     alias: "r",
     default: "",
     description: "Override runtime specified in test config",
-    choices: ["", "chromium", "firefox", "node"],
+    choices: ["", "chromium", "node"],
   })
   .option("target", {
     alias: "t",
@@ -68,7 +68,7 @@ type TestExampleFile = {
   category: "browser" | "node";
   filename: string;
   folder: string;
-  runtime: "firefox" | "chromium" | "node";
+  runtime: "chromium" | "node";
   playwrightScript?: PlaywrightScript;
 };
 const examplesJsonPath = join(__dirname, "..", "examples.json");

--- a/packages/e2e-tests/tests/inspector-rules-02_sourcemapped-rules.test.ts
+++ b/packages/e2e-tests/tests/inspector-rules-02_sourcemapped-rules.test.ts
@@ -9,7 +9,7 @@ import test from "../testFixture";
 
 test.use({ exampleKey: "doc_inspector_sourcemapped.html" });
 
-test("inspector-rules-02: Sourcemapped rules should be viewed", async ({
+test.skip("inspector-rules-02: Sourcemapped rules should be viewed", async ({
   pageWithMeta: { page, recordingId },
   exampleKey,
 }) => {

--- a/packages/replay-next/src/suspense/BuildIdCache.ts
+++ b/packages/replay-next/src/suspense/BuildIdCache.ts
@@ -70,7 +70,7 @@ export function parseBuildIdComponents(buildId: string): BuildComponents | null 
   return null;
 }
 
-function getRecordingTarget(buildId: string): RecordingTarget {
+export function getRecordingTarget(buildId: string): RecordingTarget {
   if (buildId.includes("gecko")) {
     return RecordingTarget.gecko;
   }

--- a/packages/shared/graphql/generated/GetMyRecordings.ts
+++ b/packages/shared/graphql/generated/GetMyRecordings.ts
@@ -53,6 +53,7 @@ export interface GetMyRecordings_viewer_recordings_edges_node_collaborators {
 
 export interface GetMyRecordings_viewer_recordings_edges_node {
   __typename: "Recording";
+  buildId: string | null;
   uuid: any;
   url: string | null;
   title: string | null;

--- a/packages/shared/graphql/types.ts
+++ b/packages/shared/graphql/types.ts
@@ -194,6 +194,7 @@ export enum RecordingRole {
 }
 
 export interface Recording {
+  buildId?: string | null;
   collaborators?: string[];
   collaboratorRequests?: CollaboratorRequest[] | null;
   comments?: any;

--- a/packages/shared/utils/recording.ts
+++ b/packages/shared/utils/recording.ts
@@ -1,5 +1,6 @@
 import slugify from "slugify";
 
+import { RecordingTarget, getRecordingTarget } from "replay-next/src/suspense/BuildIdCache";
 import { Recording } from "shared/graphql/types";
 import { SLUG_SEPARATOR, extractIdAndSlug } from "shared/utils/slug";
 
@@ -9,12 +10,21 @@ export const showDurationWarning = (recording: Recording) =>
   !!recording.duration && recording.duration > WARNING_MS;
 
 export function getRecordingURL(recording: Recording): string {
+  const target = recording.buildId ? getRecordingTarget(recording.buildId) : undefined;
+
+  let useLegacyURL = false;
+  switch (target) {
+    case RecordingTarget.gecko:
+      useLegacyURL = true;
+      break;
+  }
+
   let id = recording.id;
   if (recording.title) {
     id = slugify(recording.title, { strict: true }).toLowerCase() + SLUG_SEPARATOR + recording.id;
   }
 
-  return `/recording/${id}`;
+  return useLegacyURL ? `https://legacy.replay.io/recording/${id}` : `/recording/${id}`;
 }
 
 export function getRecordingId(): string | undefined {

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -15,6 +15,7 @@ import { ExpandablesContextRoot } from "replay-next/src/contexts/ExpandablesCont
 import { PointsContextRoot } from "replay-next/src/contexts/points/PointsContext";
 import { SelectedFrameContextRoot } from "replay-next/src/contexts/SelectedFrameContext";
 import usePreferredFontSize from "replay-next/src/hooks/usePreferredFontSize";
+import { recordingTargetCache } from "replay-next/src/suspense/BuildIdCache";
 import { setDefaultTags } from "replay-next/src/utils/telemetry";
 import { ReplayClientInterface } from "shared/client/types";
 import { getTestEnvironment } from "shared/test-suites/RecordingTestMetadata";
@@ -28,6 +29,7 @@ import { NodePickerContextRoot } from "ui/components/NodePickerContext";
 import { RecordingDocumentTitle } from "ui/components/RecordingDocumentTitle";
 import TerminalContextAdapter from "ui/components/SecondaryToolbox/TerminalContextAdapter";
 import { TestSuiteContextRoot } from "ui/components/TestSuite/views/TestSuiteContext";
+import { UnsupportedTarget } from "ui/components/UnsupportedTarget";
 import { useGetRecording, useGetRecordingId } from "ui/hooks/recordings";
 import { useTrackLoadingIdleTime } from "ui/hooks/tracking";
 import { useGetUserInfo, useUserIsAuthor } from "ui/hooks/users";
@@ -167,6 +169,23 @@ function _DevTools({
   const { id: userId, email: userEmail, loading: userLoading, name: userName } = useGetUserInfo();
   const processing = useAppSelector(getProcessing);
 
+  // Sanity check to make sure we aren't viewing a recording from an unsupported target
+  const [unsupportedTarget, setUnsupportedTarget] = useState<null | string>(null);
+  useEffect(() => {
+    (async () => {
+      const target = await recordingTargetCache.readAsync(replayClient);
+      switch (target) {
+        case "chromium":
+        case "node":
+          break;
+        case "gecko":
+        default:
+          setUnsupportedTarget(target);
+          break;
+      }
+    })();
+  });
+
   const isExternalRecording = useMemo(
     () => recording?.user && !recording.user.internal,
     [recording]
@@ -263,6 +282,10 @@ function _DevTools({
   const dismissSupportForm = () => {
     dispatch(setShowSupportForm(false));
   };
+
+  if (unsupportedTarget) {
+    return <UnsupportedTarget target={unsupportedTarget} />;
+  }
 
   if (!loadingFinished) {
     return processing ? <DevToolsProcessingScreen /> : <DevToolsDynamicLoadingMessage />;

--- a/src/ui/components/UnsupportedTarget.tsx
+++ b/src/ui/components/UnsupportedTarget.tsx
@@ -1,0 +1,19 @@
+export function UnsupportedTarget({ target }: { target: string }) {
+  const url = new URL(window.location.href);
+  url.pathname + url.search;
+
+  return (
+    <div className="flex h-full items-center justify-center space-y-4">
+      <div>
+        Recordings made with <strong>{target}</strong> must be viewed at{" "}
+        <a
+          className="pointer-hand underline"
+          href={`https://legacy.replay.io${url.pathname + url.search}`}
+        >
+          legacy.replay.io
+        </a>
+        .
+      </div>
+    </div>
+  );
+}

--- a/src/ui/hooks/recordings.ts
+++ b/src/ui/hooks/recordings.ts
@@ -138,6 +138,7 @@ const GET_MY_RECORDINGS = gql`
       recordings(filter: $filter) {
         edges {
           node {
+            buildId
             uuid
             url
             title
@@ -280,6 +281,7 @@ export function convertRecording(
     | GetWorkspaceTestExecutions_node_Workspace_tests_edges_node_executions_recordings
 ): Recording {
   const recording: Recording = {
+    buildId: "buildId" in rec ? rec.buildId : undefined,
     id: rec.uuid,
     user: "owner" in rec ? rec.owner : undefined,
     userId: "owner" in rec ? rec.owner?.id : undefined,


### PR DESCRIPTION
Resolves FE-2107, FE-2132, and FE-2133

- [x] Dashboard links directly to legacy.replay.io
- [x] If a Gecko recording is opened on app.replay.io, show a redirect UI
- [x] Update e2e test recording scripts to remove "firefox" as a target
- [x] Temporarily disabled the last remaining Firefox e2e test (`inspector-rules-02`)