### PR TITLE
Disable repaint-01 e2e test

### DIFF
--- a/packages/e2e-tests/examples.json
+++ b/packages/e2e-tests/examples.json
@@ -36,8 +36,8 @@
     "buildId": "linux-chromium-20240126-c9de98d17d37-50d01be708a2"
   },
   "doc_control_flow.html": {
-    "recording": "73be1d20-519f-49a0-ae8b-439c9f6fe187",
-    "buildId": "linux-chromium-20240126-c9de98d17d37-50d01be708a2"
+    "recording": "fbc98458-f75d-4243-8b82-f8b507b24b2b",
+    "buildId": "macOS-chromium-20240304-902a6e1f57cc-e0f1462455a7"
   },
   "doc_debugger_statements.html": {
     "recording": "0ada5d1e-9f3d-4cab-a67e-879b9162d71d",

--- a/packages/e2e-tests/tests/repaint-01.test.ts
+++ b/packages/e2e-tests/tests/repaint-01.test.ts
@@ -7,7 +7,7 @@ import { test } from "../testFixture";
 
 test.use({ exampleKey: "doc_control_flow.html" });
 
-test("repaint-01: repaints the screen screen when stepping over code that modifies the DOM", async ({
+test.skip("repaint-01: repaints the screen screen when stepping over code that modifies the DOM", async ({
   pageWithMeta: { page, recordingId },
   exampleKey,
 }) => {


### PR DESCRIPTION
Looks like this test is expected to be unreliable until RUN-2196 has been fixed.