### PR TITLE
Harden Timeline current time/pause state

### DIFF
--- a/packages/e2e-tests/helpers/timeline.ts
+++ b/packages/e2e-tests/helpers/timeline.ts
@@ -150,6 +150,8 @@ export async function seekToTimePercent(page: Page, timePercent: number) {
   const width = timelineBoundingBox!.width;
   const x = Math.min(width * (timePercent / 100), width - 1);
   const y = timelineBoundingBox!.height / 2;
+
+  await debugPrint(page, `Clicking timeline at ${x}, ${y}`, "seekToTimePercent");
   await timeline.click({
     position: { x, y },
   });

--- a/packages/e2e-tests/tests/repaint-05.test.ts
+++ b/packages/e2e-tests/tests/repaint-05.test.ts
@@ -1,6 +1,7 @@
 import { openDevToolsTab, startTest } from "../helpers";
 import { getGraphicsPixelColor, waitForGraphicsToLoad } from "../helpers/screenshot";
 import { seekToTimePercent, setFocusRange } from "../helpers/timeline";
+import { delay } from "../helpers/utils";
 import test, { Page, expect } from "../testFixture";
 
 test.use({ exampleKey: "paint_at_intervals.html" });
@@ -21,11 +22,19 @@ test("repaint-05: prefers current time if pause creation failed outside of the f
     startTimeString: "0:03",
   });
 
-  const color = await getGraphicsPixelColor(page, 0, 0);
+  const finalColor = await getGraphicsPixelColor(page, 0, 0);
 
-  for (let index = 0; index < 1; index += 0.25) {
-    await seekToTimePercentAndWaitForPaint(page, index);
+  let previousColor;
+
+  const percents = [10, 40, 60];
+  for (let index = 0; index < percents.length; index++) {
+    const percent = percents[index];
+    await seekToTimePercentAndWaitForPaint(page, percent);
+    await delay(100);
     const newColor = await getGraphicsPixelColor(page, 0, 0);
-    await expect(newColor).not.toBe(color);
+    await expect(newColor).not.toBe(finalColor);
+    await expect(newColor).not.toBe(previousColor);
+
+    previousColor = newColor;
   }
 });

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -291,7 +291,7 @@ export function seek({
 
         const timeStampedPoint = await replayClient.getPointNearTime(clampedTime);
         if (getSeekLock(getState()) !== seekLock) {
-          // someone requested seeking to a different point while we were waiting
+          // Someone requested seeking to a different point while we were waiting
           return;
         }
 
@@ -414,25 +414,19 @@ export function startPlayback(
   };
 }
 
-export function stopPlayback(updateTime: boolean = true): UIThunkAction {
+export function stopPlayback(): UIThunkAction {
   return async (dispatch, getState) => {
-    dispatch(setTimelineState({ playback: null }));
-
-    if (updateTime) {
-      const playback = getPlayback(getState());
-
-      if (playback) {
-        dispatch(seek({ time: playback.time }));
-      }
+    const playback = getPlayback(getState());
+    if (playback) {
+      dispatch(setTimelineState({ playback: null }));
+      dispatch(seek({ time: playback.time }));
     }
   };
 }
 
-export function replayPlayback(): UIThunkAction {
-  return (dispatch, getState) => {
-    const beginTime = 0;
-
-    dispatch(seek({ openSource: true, time: beginTime }));
+export function replayFromBeginning(): UIThunkAction {
+  return dispatch => {
+    dispatch(seek({ openSource: true, time: 0 }));
   };
 }
 

--- a/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
@@ -40,7 +40,6 @@ export function TestSectionRow({
   testRunnerName: TestRunnerName | null;
   testSectionName: TestSectionName;
 }) {
-  const { range: focusWindow } = useContext(FocusContext);
   const { executionPoint: currentExecutionPoint } = useContext(TimelineContext);
   const replayClient = useContext(ReplayClientContext);
   const { recordingId } = useContext(SessionContext);

--- a/src/ui/components/Timeline/PlaybackControls.tsx
+++ b/src/ui/components/Timeline/PlaybackControls.tsx
@@ -1,6 +1,6 @@
 import { motion } from "framer-motion";
 
-import { replayPlayback, startPlayback, stopPlayback } from "ui/actions/timeline";
+import { replayFromBeginning, startPlayback, stopPlayback } from "ui/actions/timeline";
 import { selectors } from "ui/reducers";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { trackEvent } from "ui/utils/telemetry";
@@ -20,7 +20,7 @@ export default function PlayPauseButton() {
     icon = "/images/playback-refresh.svg";
     onClick = () => {
       trackEvent("timeline.replay");
-      dispatch(replayPlayback());
+      dispatch(replayFromBeginning());
     };
   } else if (playback) {
     icon = "/images/playback-pause.svg";

--- a/src/ui/components/Video/imperative/runVideoPlayback.ts
+++ b/src/ui/components/Video/imperative/runVideoPlayback.ts
@@ -52,7 +52,7 @@ export async function runVideoPlayback({
     );
 
     if (nextTimelineTime >= endTime) {
-      reduxStore.dispatch(stopPlayback(true));
+      reduxStore.dispatch(stopPlayback());
       reduxStore.dispatch(seek({ executionPoint: endPoint || undefined, time: endTime }));
 
       break playbackLoop;

--- a/src/ui/reducers/timeline.ts
+++ b/src/ui/reducers/timeline.ts
@@ -29,7 +29,6 @@ function initialTimelineState(): TimelineState {
     timelineDimensions: { left: 1, top: 1, width: 1 },
     /** @deprecated This appears to be obsolete for now? */
     zoomRegion: { beginTime: 0, endTime: 0, scale: 1 },
-    dragging: false,
   };
 }
 
@@ -37,9 +36,6 @@ const timelineSlice = createSlice({
   name: "timeline",
   initialState: initialTimelineState,
   reducers: {
-    setDragging(state, action: PayloadAction<boolean>) {
-      state.dragging = action.payload;
-    },
     setTimelineState(state, action: PayloadAction<Partial<TimelineState>>) {
       // This is poor action design and we should avoid this :(
       Object.assign(state, action.payload);
@@ -63,7 +59,6 @@ const timelineSlice = createSlice({
 });
 
 export const {
-  setDragging,
   setHoveredItem,
   setMarkTimeStampPoint,
   setPlaybackFocusWindow,
@@ -80,7 +75,6 @@ export const getHoverTime = (state: UIState) => state.timeline.hoverTime;
 export const getPlayback = (state: UIState) => state.timeline.playback;
 export const getShowFocusModeControls = (state: UIState) => state.timeline.showFocusModeControls;
 export const getShowHoverTimeGraphics = (state: UIState) => state.timeline.showHoverTimeGraphics;
-export const isDragging = (state: UIState) => state.timeline.dragging;
 export const isPlaying = (state: UIState) => state.timeline.playback !== null;
 export const getRecordingDuration = (state: UIState) => state.timeline.recordingDuration;
 export const getTimelineDimensions = (state: UIState) => state.timeline.timelineDimensions;

--- a/src/ui/state/timeline.ts
+++ b/src/ui/state/timeline.ts
@@ -13,7 +13,6 @@ export interface ZoomRegion {
 
 export interface TimelineState {
   currentTime: number;
-  dragging: boolean;
   focusWindow: TimeRange | null;
   hoveredItem: HoveredItem | null;
   hoverTime: number | null;


### PR DESCRIPTION
[Loom overview/demo](https://www.loom.com/share/f97b09cfb7834c36bdf993ea77cc8d4f?from_recorder=1&focus_title=1)

- [x] Fixed a logic error in `stopPlayback` that caused it to null out playback state _before_ checking if it was null (🤡)
  * I think this was the core of the bugfix
- [x] Move Timeline move-move and mouse-up handlers to the `body` element, to ensure that dragging past the timeline's boundaries updates the current time appropriately
  * This was making it difficult to scrub the playback time to the beginning of a recording, for example
- [x] Remove no-longer-used "dragging" state from Redux
- [x] Remove no-longer-used `updateTime` param to Redux `stopPlayback` action

Please give this a close look. Our timeline logic is kind of complicated, and I just want to be double checked. :)