### PR TITLE
Fix handling of Control key in KeyboardModifiersContext

### DIFF
--- a/packages/replay-next/src/contexts/KeyboardModifiersContext.tsx
+++ b/packages/replay-next/src/contexts/KeyboardModifiersContext.tsx
@@ -57,7 +57,7 @@ export function KeyboardModifiersContextRoot({ children }: PropsWithChildren<{}>
     };
 
     const onMouseMove = (event: MouseEvent) => {
-      const nextMetaKeyActive = event.metaKey;
+      const nextMetaKeyActive = event.metaKey || event.ctrlKey;
       const nextShiftKeyActive = event.shiftKey;
       if (nextMetaKeyActive !== isMetaKeyActive || nextShiftKeyActive !== isShiftKeyActive) {
         startTransition(() => {


### PR DESCRIPTION
`KeyboardModifiersContext` treats the Control key as another Meta key (which is useful on Windows where the Meta key always opens the Windows menu). But the `onMouseMove` event handler didn't do that so `isMetaKeyActive` was reset to `false` when the mouse was moved while the Control key is pressed.