### PR TITLE
Revert "Add switch accounts interstitial to login flow"

### DIFF
--- a/src/ui/components/shared/Login/Login.tsx
+++ b/src/ui/components/shared/Login/Login.tsx
@@ -1,7 +1,6 @@
 import { gql } from "@apollo/client";
 import { ExclamationIcon } from "@heroicons/react/outline";
 import Link from "next/link";
-import { useRouter } from "next/router";
 import { ReactNode, useEffect, useState } from "react";
 
 import { Button } from "replay-next/components/Button";
@@ -9,13 +8,11 @@ import { query } from "shared/graphql/apolloClient";
 import { GetConnection, GetConnectionVariables } from "shared/graphql/generated/GetConnection";
 import { getReadOnlyParamsFromURL } from "shared/utils/environment";
 import { isMacOS } from "shared/utils/os";
-import { UserInfo, useGetUserInfo } from "ui/hooks/users";
 import { getAuthClientId, getAuthHost } from "ui/utils/auth";
 import { requestBrowserLogin, setUserInBrowserPrefs } from "ui/utils/browser";
 import { isTeamMemberInvite } from "ui/utils/onboarding";
 import { sendTelemetryEvent } from "ui/utils/telemetry";
 import useAuth0 from "ui/utils/useAuth0";
-import useToken from "ui/utils/useToken";
 
 import { OnboardingContentWrapper, OnboardingModalContainer } from "../Onboarding";
 
@@ -126,35 +123,6 @@ function LoginMessaging() {
         )}
       </div>
     </>
-  );
-}
-
-function SwitchAccountMessage({
-  user,
-  onSwitch,
-  onCancel,
-}: {
-  user: UserInfo;
-  onCancel: () => void;
-  onSwitch: () => void;
-}) {
-  return (
-    <div className="space-y-6">
-      <p className="text-center text-base">
-        You are already logged in as <strong>{user.email}</strong>.
-      </p>
-      <Button className="w-full justify-center" onClick={onCancel} size="large">
-        Continue to Library
-      </Button>
-      <Button
-        className="w-full justify-center text-sm font-bold text-primaryAccent underline"
-        onClick={onSwitch}
-        size="large"
-        variant="outline"
-      >
-        Switch Accounts
-      </Button>
-    </div>
   );
 }
 
@@ -274,12 +242,8 @@ export default function Login({
   challenge?: string;
   state?: string;
 }) {
-  const router = useRouter();
   const { loginWithRedirect, error } = useAuth0();
   const [sso, setSSO] = useState(false);
-  const [continueToLogin, setContinueToLogin] = useState(false);
-  const token = useToken();
-  const user = useGetUserInfo();
 
   const url = new URL(returnToPath, window.location.origin);
   if (url.pathname === "/login" || (url.pathname === "/" && url.searchParams.has("state"))) {
@@ -309,13 +273,7 @@ export default function Login({
   return (
     <OnboardingModalContainer theme="light">
       <OnboardingContentWrapper overlay>
-        {token.token && user.email && !continueToLogin ? (
-          <SwitchAccountMessage
-            user={user}
-            onSwitch={() => setContinueToLogin(true)}
-            onCancel={() => router.push("/")}
-          />
-        ) : global.__IS_RECORD_REPLAY_RUNTIME__ && isOSX ? (
+        {global.__IS_RECORD_REPLAY_RUNTIME__ && isOSX ? (
           <ReplayBrowserLogin />
         ) : sso ? (
           <SSOLogin onLogin={onLogin} />


### PR DESCRIPTION
Reverts replayio/devtools#10431

Caused a regression when launching login from the Replay browser. I didn't see it in testing because the browser was always launching to app.replay.io for login so the new local code wasn't triggered.

https://www.loom.com/share/001be5bac6af48cd957e32948feb9f83?sid=6940f0ab-9937-4058-8254-d5ff27151562