### PR TITLE
Fix tilt config to allow running deps in parallel

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,3 +1,3 @@
-def devtools(working_directory=config.main_dir, api='https://api.replay.io/v1/graphql', subscriptions='wss://api.replay.io/v1/graphql', dispatch='wss://dispatch.replay.io'):
-  local_resource("devtools deps", "yarn install", deps=["package.json"], dir=working_directory)
-  local_resource("devtools webpack", serve_cmd="rm -rf .next && yarn dev", deps=[], resource_deps=["devtools deps"], serve_dir=working_directory, serve_env={"NEXT_PUBLIC_API_URL": api, "NEXT_PUBLIC_DISPATCH_URL": dispatch, "NEXT_PUBLIC_API_SUBSCRIPTION_URL": subscriptions})
+def devtools(working_directory=config.main_dir, api='https://api.replay.io/v1/graphql', subscriptions='wss://api.replay.io/v1/graphql', dispatch='wss://dispatch.replay.io', resource_deps=[]):
+  local_resource("devtools deps", "yarn install", deps=["package.json"], dir=working_directory, allow_parallel=True)
+  local_resource("devtools webpack", serve_cmd="rm -rf .next && yarn dev", deps=[], resource_deps=["devtools deps"] + resource_deps, serve_dir=working_directory, serve_env={"NEXT_PUBLIC_API_URL": api, "NEXT_PUBLIC_DISPATCH_URL": dispatch, "NEXT_PUBLIC_API_SUBSCRIPTION_URL": subscriptions})


### PR DESCRIPTION
Improves the tile config for devtools:
* Allows the dependencies to be installed immediately alongside the backend deps
* Supports providing `resource_deps` to the webpack task so it can wait on graphql