### PR TITLE
Add switch accounts interstitial to login flow (take 2)

### DIFF
--- a/src/ui/components/shared/Login/Login.tsx
+++ b/src/ui/components/shared/Login/Login.tsx
@@ -295,6 +295,9 @@ export default function Login({
     if (challenge && state) {
       const authHost = getAuthHost();
       const clientId = getAuthClientId();
+      // when continueToLogin was selected, the user was previously logged in
+      // and wanted to select a different account so force the login prompt by
+      // passing prompt=login to auth0
       window.location.href = `https://${authHost}/authorize?response_type=code&code_challenge_method=S256&code_challenge=${challenge}&client_id=${clientId}&redirect_uri=${returnToPath}&scope=openid profile offline_access&state=${state}&audience=https://api.replay.io&connection=${connection}&prompt=${
         continueToLogin ? "login" : ""
       }`;

--- a/src/ui/components/shared/Login/Login.tsx
+++ b/src/ui/components/shared/Login/Login.tsx
@@ -148,14 +148,16 @@ function SwitchAccountMessage({
       <Button className="w-full justify-center" onClick={onCancel} size="large">
         {label}
       </Button>
-      <Button
-        className="w-full justify-center text-sm font-bold text-primaryAccent underline"
-        onClick={onSwitch}
-        size="large"
-        variant="outline"
-      >
-        Switch Accounts
-      </Button>
+      {global.__IS_RECORD_REPLAY_RUNTIME__ ? null : (
+        <Button
+          className="w-full justify-center text-sm font-bold text-primaryAccent underline"
+          onClick={onSwitch}
+          size="large"
+          variant="outline"
+        >
+          Switch Accounts
+        </Button>
+      )}
     </div>
   );
 }
@@ -283,7 +285,9 @@ export default function Login({
   const token = useToken();
   const userInfo = useGetUserInfo();
 
-  const isExternalAuth = Boolean(userInfo && challenge && state);
+  // `true` when we're in the process of completing the auth flow from the
+  // Replay browser
+  const isCompletingBrowserAuth = Boolean(userInfo && challenge && state);
 
   const url = new URL(returnToPath, window.location.origin);
   if (url.pathname === "/login" || (url.pathname === "/" && url.searchParams.has("state"))) {
@@ -312,7 +316,7 @@ export default function Login({
   };
 
   const handleUseCurrentAuth = async () => {
-    if (isExternalAuth) {
+    if (isCompletingBrowserAuth && connection) {
       await onLogin(connection);
     } else {
       router.push("/");
@@ -328,7 +332,7 @@ export default function Login({
       <OnboardingContentWrapper overlay>
         {token.token && userInfo.email && !continueToLogin ? (
           <SwitchAccountMessage
-            label={isExternalAuth ? "Continue with this account" : "Continue to Library"}
+            label={isCompletingBrowserAuth ? "Continue with this account" : "Continue to Library"}
             user={userInfo}
             onSwitch={() => setContinueToLogin(true)}
             onCancel={() => handleUseCurrentAuth()}

--- a/src/ui/utils/useAuth0.ts
+++ b/src/ui/utils/useAuth0.ts
@@ -7,11 +7,13 @@ import { useGetUserInfo } from "ui/hooks/users";
 import { setAccessTokenInBrowserPrefs } from "./browser";
 import useToken from "./useToken";
 
+export type AuthContext = Auth0ContextInterface | typeof TEST_AUTH;
+
 const TEST_AUTH = {
   error: undefined,
   isLoading: false,
   isAuthenticated: true,
-  connection: "auth0",
+  connection: "TEST",
   user: {
     sub: "auth0|60351bdaa6afe80068af126e",
     name: "e2e-testing@replay.io",
@@ -24,8 +26,6 @@ const TEST_AUTH = {
   logout: () => {},
   getAccessTokenSilently: () => Promise.resolve(),
 };
-
-export type AuthContext = Auth0ContextInterface | typeof TEST_AUTH;
 
 // TODO [hbenl, ryanjduffy] This function should `useMemo` to memoize the "user" object it returns.
 // As it is, this hooks prevents components like CommentTool from limiting how often their effects run.
@@ -49,7 +49,7 @@ export default function useAuth0() {
       error: undefined,
       isLoading: loading,
       isAuthenticated: true,
-      connection: "external",
+      connection: "EXTERNAL",
       user: loading
         ? undefined
         : {
@@ -75,8 +75,11 @@ export default function useAuth0() {
   // for social logins, the connection (e.g. google-oauth2) is the prefix. For
   // SAML logins, the connection is the client-specific code after the samlp
   // prefix (samlp|client-name|user-id).
-  const parts = auth.user.sub.split("|");
-  const connection = parts[0] === "samlp" ? parts[1] : parts[0];
+  let connection: string | undefined;
+  if (auth.user) {
+    const parts = auth.user.sub.split("|") ?? [];
+    connection = parts[0] === "samlp" ? parts[1] : parts[0];
+  }
 
   return { ...auth, connection, loginAndReturn };
 }

--- a/src/ui/utils/useAuth0.ts
+++ b/src/ui/utils/useAuth0.ts
@@ -72,6 +72,9 @@ export default function useAuth0() {
     return TEST_AUTH;
   }
 
+  // for social logins, the connection (e.g. google-oauth2) is the prefix. For
+  // SAML logins, the connection is the client-specific code after the samlp
+  // prefix (samlp|client-name|user-id).
   const parts = auth.user.sub.split("|");
   const connection = parts[0] === "samlp" ? parts[1] : parts[0];
 

--- a/src/ui/utils/useAuth0.ts
+++ b/src/ui/utils/useAuth0.ts
@@ -11,6 +11,7 @@ const TEST_AUTH = {
   error: undefined,
   isLoading: false,
   isAuthenticated: true,
+  connection: "auth0",
   user: {
     sub: "auth0|60351bdaa6afe80068af126e",
     name: "e2e-testing@replay.io",
@@ -48,6 +49,7 @@ export default function useAuth0() {
       error: undefined,
       isLoading: loading,
       isAuthenticated: true,
+      connection: "external",
       user: loading
         ? undefined
         : {
@@ -70,5 +72,8 @@ export default function useAuth0() {
     return TEST_AUTH;
   }
 
-  return { ...auth, loginAndReturn };
+  const parts = auth.user.sub.split("|");
+  const connection = parts[0] === "samlp" ? parts[1] : parts[0];
+
+  return { ...auth, connection, loginAndReturn };
 }


### PR DESCRIPTION
* Adds an interstitial if you navigate to /login and are already logged in. This more often occurs from the Replay browser if when the user doesn't launch back to it from the external browser login flow.
* Fixes "Switch Accounts" to prompt for auth when choosing the same type of auth
* Ensures that landing on `/login` from the replay browser messages to "Continue with this account" and completes the auth + launch flow vs the "continue to library" message

https://www.loom.com/share/5ca627ab3199454d8b8ad63657c01a9e

p.s. that I mention in the loom:
* we should remove "switch accounts" when in the replay browser  - I fixed in this pr
* a question about why I don't land in the library when launching back to the browser. this is working as designed in gecko right now which only opens a new tab with the library if no tab is open. Fortunately, the changes in this PR mean that if you happen to be on `/login`, you'll now see a "Continue to Library" button instead of a "Login" button so users are less likely to get confused or stuck in a login loop.