### PR TITLE
Update TypeScript dep from 5.3.3 to 5.4.2 (latest) - take 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "tailwindcss": "^3.2.4",
     "ts-node": "^10.7.0",
     "tsconfig-paths": "^3.14.1",
-    "typescript": "^5.3.3",
+    "typescript": "^5.4.2",
     "utf-8-validate": "^5.0.8",
     "uuid": "^7.0.3",
     "v8-to-istanbul": "^9.0.1",
@@ -226,7 +226,7 @@
     "@auth0/auth0-react": "1.2.0",
     "react-is": "18.2.0",
     "ts-invariant": "0.10.3",
-    "typescript": "5.3.3",
+    "typescript": "5.4.2",
     "react-json-view@1.21.3": "patch:react-json-view@npm:1.21.3#.yarn/patches/react-json-view-npm-1.21.3-7827bb54c4.patch"
   },
   "importSort": {

--- a/packages/e2e-tests/examples/rdt-react-versions/package.json
+++ b/packages/e2e-tests/examples/rdt-react-versions/package.json
@@ -23,7 +23,7 @@
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
     "@vitejs/plugin-react-swc": "^3.3.2",
-    "typescript": "^5.0.2",
+    "typescript": "^5.4.2",
     "vite": "^4.4.5"
   },
   "workspaces": [

--- a/packages/e2e-tests/examples/rdt-react-versions/react-15-app/package.json
+++ b/packages/e2e-tests/examples/rdt-react-versions/react-15-app/package.json
@@ -17,7 +17,7 @@
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
     "@vitejs/plugin-react-swc": "^3.3.2",
-    "typescript": "^5.0.2",
+    "typescript": "^5.4.2",
     "vite": "^4.4.5"
   }
 }

--- a/packages/e2e-tests/examples/rdt-react-versions/react-16-app/package.json
+++ b/packages/e2e-tests/examples/rdt-react-versions/react-16-app/package.json
@@ -17,7 +17,7 @@
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
     "@vitejs/plugin-react-swc": "^3.3.2",
-    "typescript": "^5.0.2",
+    "typescript": "^5.4.2",
     "vite": "^4.4.5"
   }
 }

--- a/packages/e2e-tests/examples/rdt-react-versions/react-17-app/package.json
+++ b/packages/e2e-tests/examples/rdt-react-versions/react-17-app/package.json
@@ -17,7 +17,7 @@
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
     "@vitejs/plugin-react-swc": "^3.3.2",
-    "typescript": "^5.0.2",
+    "typescript": "^5.4.2",
     "vite": "^4.4.5"
   }
 }

--- a/packages/e2e-tests/examples/rdt-react-versions/yarn.lock
+++ b/packages/e2e-tests/examples/rdt-react-versions/yarn.lock
@@ -1936,7 +1936,7 @@ __metadata:
     "@vitejs/plugin-react-swc": ^3.3.2
     react: ^18.2.0
     react-dom: ^18.2.0
-    typescript: ^5.0.2
+    typescript: ^5.4.2
     vite: ^4.4.5
   languageName: unknown
   linkType: soft
@@ -1951,7 +1951,7 @@ __metadata:
     "@vitejs/plugin-react-swc": ^3.3.2
     react: ^15
     react-dom: ^15
-    typescript: ^5.0.2
+    typescript: ^5.4.2
     vite: ^4.4.5
   languageName: unknown
   linkType: soft
@@ -1966,7 +1966,7 @@ __metadata:
     "@vitejs/plugin-react-swc": ^3.3.2
     react: ^16
     react-dom: ^16
-    typescript: ^5.0.2
+    typescript: ^5.4.2
     vite: ^4.4.5
   languageName: unknown
   linkType: soft
@@ -1981,7 +1981,7 @@ __metadata:
     "@vitejs/plugin-react-swc": ^3.3.2
     react: ^17
     react-dom: ^17
-    typescript: ^5.0.2
+    typescript: ^5.4.2
     vite: ^4.4.5
   languageName: unknown
   linkType: soft
@@ -2511,23 +2511,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.0.2":
-  version: 5.2.2
-  resolution: "typescript@npm:5.2.2"
+"typescript@npm:^5.4.2":
+  version: 5.4.2
+  resolution: "typescript@npm:5.4.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 7912821dac4d962d315c36800fe387cdc0a6298dba7ec171b350b4a6e988b51d7b8f051317786db1094bd7431d526b648aba7da8236607febb26cf5b871d2d3c
+  checksum: 96d80fde25a09bcb04d399082fb27a808a9e17c2111e43849d2aafbd642d835e4f4ef0de09b0ba795ec2a700be6c4c2c3f62bf4660c05404c948727b5bbfb32a
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^5.0.2#~builtin<compat/typescript>":
-  version: 5.2.2
-  resolution: "typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=7ad353"
+"typescript@patch:typescript@^5.4.2#~builtin<compat/typescript>":
+  version: 5.4.2
+  resolution: "typescript@patch:typescript@npm%3A5.4.2#~builtin<compat/typescript>::version=5.4.2&hash=7ad353"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 07106822b4305de3f22835cbba949a2b35451cad50888759b6818421290ff95d522b38ef7919e70fb381c5fe9c1c643d7dea22c8b31652a717ddbd57b7f4d554
+  checksum: c1b669146bca5529873aae60870e243fa8140c85f57ca32c42f898f586d73ce4a6b4f6bb02ae312729e214d7f5859a0c70da3e527a116fdf5ad00c9fc733ecc6
   languageName: node
   linkType: hard
 

--- a/packages/e2e-tests/examples/redux-fundamentals/package.json
+++ b/packages/e2e-tests/examples/redux-fundamentals/package.json
@@ -25,7 +25,7 @@
     "@types/react-dom": "^18.2.7",
     "@vitejs/plugin-react-swc": "^3.3.2",
     "msw": "^1.3.0",
-    "typescript": "^5.0.2",
+    "typescript": "^5.4.2",
     "vite": "^4.4.5"
   },
   "msw": {

--- a/packages/e2e-tests/examples/redux-fundamentals/tests/example-script.ts
+++ b/packages/e2e-tests/examples/redux-fundamentals/tests/example-script.ts
@@ -60,7 +60,10 @@ function getFiltersPanel(page: Page) {
   return page.locator('div.filters')
 }
 
-export async function testFunction(page: Page, expect: typeof expectType) {
+export default async function testFunction(
+  page: Page,
+  expect: typeof expectType
+) {
   const listItems = getTodoListItems(page)
 
   async function waitForListItemsCount(count: number) {

--- a/packages/e2e-tests/examples/redux-fundamentals/tests/example-script.ts
+++ b/packages/e2e-tests/examples/redux-fundamentals/tests/example-script.ts
@@ -60,10 +60,7 @@ function getFiltersPanel(page: Page) {
   return page.locator('div.filters')
 }
 
-export default async function testFunction(
-  page: Page,
-  expect: typeof expectType
-) {
+export async function testFunction(page: Page, expect: typeof expectType) {
   const listItems = getTodoListItems(page)
 
   async function waitForListItemsCount(count: number) {
@@ -143,5 +140,5 @@ export default async function testFunction(
 
   // add a little delay to ensure that the last click was added
   // to the recording, see [FE-2286] and [RUN-3258]
-  await delay(500);
+  await delay(500)
 }

--- a/packages/e2e-tests/examples/redux-fundamentals/tests/playwright-example.test.ts
+++ b/packages/e2e-tests/examples/redux-fundamentals/tests/playwright-example.test.ts
@@ -1,6 +1,6 @@
 import { Locator, Page, expect, test } from '@playwright/test'
 
-import { testFunction } from './example-script'
+import testFunction from './example-script'
 
 test('Basic todo app mouse and keyboard interactions', async ({ page }) => {
   await page.goto('http://localhost:5173')

--- a/packages/e2e-tests/examples/redux-fundamentals/yarn.lock
+++ b/packages/e2e-tests/examples/redux-fundamentals/yarn.lock
@@ -2528,7 +2528,7 @@ __metadata:
     react-dom: ^18.2.0
     react-redux: ^8.1.2
     seedrandom: ^3.0.5
-    typescript: ^5.0.2
+    typescript: ^5.4.2
     vite: ^4.4.5
   languageName: unknown
   linkType: soft
@@ -3055,23 +3055,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.0.2":
-  version: 5.2.2
-  resolution: "typescript@npm:5.2.2"
+"typescript@npm:^5.4.2":
+  version: 5.4.2
+  resolution: "typescript@npm:5.4.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 7912821dac4d962d315c36800fe387cdc0a6298dba7ec171b350b4a6e988b51d7b8f051317786db1094bd7431d526b648aba7da8236607febb26cf5b871d2d3c
+  checksum: 96d80fde25a09bcb04d399082fb27a808a9e17c2111e43849d2aafbd642d835e4f4ef0de09b0ba795ec2a700be6c4c2c3f62bf4660c05404c948727b5bbfb32a
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^5.0.2#~builtin<compat/typescript>":
-  version: 5.2.2
-  resolution: "typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=7ad353"
+"typescript@patch:typescript@^5.4.2#~builtin<compat/typescript>":
+  version: 5.4.2
+  resolution: "typescript@patch:typescript@npm%3A5.4.2#~builtin<compat/typescript>::version=5.4.2&hash=7ad353"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 07106822b4305de3f22835cbba949a2b35451cad50888759b6818421290ff95d522b38ef7919e70fb381c5fe9c1c643d7dea22c8b31652a717ddbd57b7f4d554
+  checksum: c1b669146bca5529873aae60870e243fa8140c85f57ca32c42f898f586d73ce4a6b4f6bb02ae312729e214d7f5859a0c70da3e527a116fdf5ad00c9fc733ecc6
   languageName: node
   linkType: hard
 

--- a/packages/e2e-tests/scripts/save-examples.ts
+++ b/packages/e2e-tests/scripts/save-examples.ts
@@ -4,8 +4,8 @@
 // Use the API key for the "Frontend E2E Test Team" that we have set up in admin,
 // as that should let us mark these recordings as public.
 
-import { execSync } from "child_process";
 import { existsSync, writeFileSync } from "fs";
+import assert from "node:assert/strict";
 import { join } from "path";
 import type { Page, expect as expectFunction } from "@playwright/test";
 import { removeRecording, uploadRecording } from "@replayio/replay";
@@ -176,15 +176,22 @@ async function saveExamples(
     }
 
     if (category === examplesTarget) {
+      let resolvedPlaywrightScript: PlaywrightScript | undefined;
+      if (playwrightScript) {
+        const playwrightScriptModule = require(join("..", playwrightScript));
+        assert(
+          typeof playwrightScriptModule.default === "function",
+          `Expected default export to be a function in ${playwrightScript}`
+        );
+        resolvedPlaywrightScript = playwrightScriptModule.default;
+      }
       examplesToRun.push({
         buildId,
         category,
         filename: key,
         folder,
         runtime: runtime as TestExampleFile["runtime"],
-        playwrightScript: playwrightScript
-          ? require(join("..", playwrightScript)).default
-          : undefined,
+        playwrightScript: resolvedPlaywrightScript,
       });
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15091,7 +15091,7 @@ __metadata:
     tailwindcss: ^3.2.4
     ts-node: ^10.7.0
     tsconfig-paths: ^3.14.1
-    typescript: ^5.3.3
+    typescript: ^5.4.2
     use-context-menu: 0.4.13
     utf-8-validate: ^5.0.8
     uuid: ^7.0.3
@@ -17208,23 +17208,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.3.3":
-  version: 5.3.3
-  resolution: "typescript@npm:5.3.3"
+"typescript@npm:5.4.2":
+  version: 5.4.2
+  resolution: "typescript@npm:5.4.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 2007ccb6e51bbbf6fde0a78099efe04dc1c3dfbdff04ca3b6a8bc717991862b39fd6126c0c3ebf2d2d98ac5e960bcaa873826bb2bb241f14277034148f41f6a2
+  checksum: 96d80fde25a09bcb04d399082fb27a808a9e17c2111e43849d2aafbd642d835e4f4ef0de09b0ba795ec2a700be6c4c2c3f62bf4660c05404c948727b5bbfb32a
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.3.3#~builtin<compat/typescript>":
-  version: 5.3.3
-  resolution: "typescript@patch:typescript@npm%3A5.3.3#~builtin<compat/typescript>::version=5.3.3&hash=7ad353"
+"typescript@patch:typescript@npm%3A5.4.2#~builtin<compat/typescript>":
+  version: 5.4.2
+  resolution: "typescript@patch:typescript@npm%3A5.4.2#~builtin<compat/typescript>::version=5.4.2&hash=7ad353"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: f61375590b3162599f0f0d5b8737877ac0a7bc52761dbb585d67e7b8753a3a4c42d9a554c4cc929f591ffcf3a2b0602f65ae3ce74714fd5652623a816862b610
+  checksum: c1b669146bca5529873aae60870e243fa8140c85f57ca32c42f898f586d73ce4a6b4f6bb02ae312729e214d7f5859a0c70da3e527a116fdf5ad00c9fc733ecc6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The previous attempt failed runtimes tests. The reason was that I adjusted one of the exports in one of the example's playwright script. It was a default export but imported using a named export. This was flagged by TS as a problem and I've verified today that it was actually a problem - it prevented us from running this playwright script manually. I fixed this correctly this time in https://github.com/replayio/devtools/pull/10442/commits/6b96f2bf4e47f47d2808a8f40882ec963ba44aef

The extra problem here was that this script was exporting a function that was implicitly depended upon by the `save-examples.ts` script. It loads configuration from a JSON file and each example might configure its own `playwrightScript` that is then required. I broke this by changing the export type to match that other script and thus `save-examples.ts` just used the default script. I made it now to fail fast when the required module doesn't have the correct shape: https://github.com/replayio/devtools/pull/10442/commits/84149835e2b36920382e6d02d0ce14b86c418ba2