### PR TITLE
Fix repaint-05 e2e test flakiness

### DIFF
--- a/packages/e2e-tests/helpers/timeline.ts
+++ b/packages/e2e-tests/helpers/timeline.ts
@@ -47,6 +47,10 @@ export async function saveFocusRange(page: Page): Promise<void> {
   await debugPrint(page, "Saving focus range", "setFocusRange");
 
   await page.locator('[data-test-id="SaveFocusModeButton"]').click();
+  await expect(page.locator('[data-test-id="EditFocusButton"]')).toHaveAttribute(
+    "data-test-state",
+    "off"
+  );
 }
 
 export async function setFocusRange(

--- a/packages/e2e-tests/tests/repaint-05.test.ts
+++ b/packages/e2e-tests/tests/repaint-05.test.ts
@@ -1,13 +1,22 @@
 import { openDevToolsTab, startTest } from "../helpers";
-import { getGraphicsPixelColor, waitForGraphicsToLoad } from "../helpers/screenshot";
+import {
+  getGraphicsPixelColor,
+  getGraphicsTime,
+  waitForGraphicsToLoad,
+} from "../helpers/screenshot";
 import { seekToTimePercent, setFocusRange } from "../helpers/timeline";
-import { delay } from "../helpers/utils";
+import { delay, waitFor } from "../helpers/utils";
 import test, { Page, expect } from "../testFixture";
 
 test.use({ exampleKey: "paint_at_intervals.html" });
 
 async function seekToTimePercentAndWaitForPaint(page: Page, percent: number) {
+  const currentTime = await getGraphicsTime(page);
   await seekToTimePercent(page, percent);
+  await waitFor(async () => {
+    const newTime = await getGraphicsTime(page);
+    expect(newTime).not.toBe(currentTime);
+  });
   await waitForGraphicsToLoad(page);
 }
 


### PR DESCRIPTION
- wait for the `data-time` attribute on the video element to change before waiting for the graphics to load
- wait for the focus window change to be saved before continuing the test