### PR TITLE
Fix the inspect_element nag and the passport-02 test

### DIFF
--- a/packages/e2e-tests/authenticated/passport-02.test.ts
+++ b/packages/e2e-tests/authenticated/passport-02.test.ts
@@ -1,9 +1,8 @@
 import { openDevToolsTab, startTest } from "../helpers";
 import { E2E_USER_1 } from "../helpers/authentication";
-import { showCommentsPanel } from "../helpers/comments";
 import { warpToMessage } from "../helpers/console-panel";
 import {
-  activateInspectorTool,
+  findElementCoordinates,
   inspectCanvasCoordinates,
   openElementsPanel,
   waitForElementsToLoad,
@@ -36,12 +35,8 @@ test(`authenticated/passport-02: Infrared inspection`, async ({
 
   await openElementsPanel(page);
   await waitForElementsToLoad(page);
-  await activateInspectorTool(page);
-  await inspectCanvasCoordinates(page, 0.05, 0.01);
-
-  // Clicking the canvas will add a comment which can cause timing complications with the passport check below
-  // Easiest way to avoid this is to explicitly wait for the comments panel to be shown before continuing
-  await showCommentsPanel(page);
+  const { x, y } = await findElementCoordinates(page, '<div id="root"');
+  await inspectCanvasCoordinates(page, x, y);
 
   await waitFor(async () =>
     expect(await isPassportItemCompleted(page, "Inspect UI elements")).toBeTruthy()

--- a/src/devtools/client/debugger/src/components/PrimaryPanes/index.tsx
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/index.tsx
@@ -1,9 +1,5 @@
 import classnames from "classnames";
-import { useEffect } from "react";
 
-// Add the necessary imports for nag functionality
-import { useNag } from "replay-next/src/hooks/useNag";
-import { Nag } from "shared/graphql/types";
 import { useGraphQLUserData } from "shared/user-data/GraphQL/useGraphQLUserData";
 
 import Outline from "../SourceOutline/SourceOutline";
@@ -18,13 +14,6 @@ export default function PrimaryPanes() {
   );
   const [sourcesCollapsed, setSourcesCollapsed] = useGraphQLUserData("layout_sourcesCollapsed");
   const [enableLargeText] = useGraphQLUserData("global_enableLargeText");
-
-  // Add the useNag hook and useEffect block
-  const [, dismissInspectElementNag] = useNag(Nag.INSPECT_ELEMENT);
-
-  useEffect(() => {
-    dismissInspectElementNag();
-  }, [dismissInspectElementNag]);
 
   return (
     <Accordion>


### PR DESCRIPTION
The passport-02 test didn't use the node picker correctly (it created a video comment instead). The reason why it didn't fail was that we were erroneously dismissing the `inspect_element` nag when the source explorer panel was opened.