### PR TITLE
Dont swallow error when recording e2e tests

### DIFF
--- a/packages/e2e-tests/scripts/record-playwright.ts
+++ b/packages/e2e-tests/scripts/record-playwright.ts
@@ -41,9 +41,7 @@ export async function recordPlaywright(
   });
   const page = await context.newPage();
   try {
-    return await script(page as any, expect);
-  } catch (err) {
-    console.error("PLAYWRIGHT ERROR", err);
+    return await script(page, expect);
   } finally {
     await page.close();
     await context.close();


### PR DESCRIPTION
An extra safe-guard against failures here. This should stop the whole script from executing. it would potentially help out people investigating issues like the ones araised from https://github.com/replayio/devtools/pull/10428 . I tested this out locally to confirm that this would fail the script.