### PR TITLE
Improve paint/repaint behavior

### DIFF
--- a/packages/e2e-tests/helpers/screenshot.ts
+++ b/packages/e2e-tests/helpers/screenshot.ts
@@ -84,6 +84,11 @@ export async function getGraphicsExecutionPoint(page: Page): Promise<string | nu
   return await element.getAttribute("data-execution-point");
 }
 
+export async function getGraphicsScreenshotType(page: Page): Promise<string | null> {
+  const element = getVideoElement(page);
+  return await element.getAttribute("data-screenshot-type");
+}
+
 export async function getGraphicsStatus(page: Page): Promise<string | null> {
   const element = getVideoElement(page);
   return await element.getAttribute("data-status");
@@ -133,5 +138,13 @@ export async function waitForGraphicsToLoad(page: Page) {
 
   await waitFor(async () => {
     await expect(await getGraphicsStatus(page)).toBe("loaded");
+  });
+}
+
+export async function waitForRepaintGraphicsToLoad(page: Page) {
+  await debugPrint(page, `Waiting for repaint graphics to load...`, "waitForRepaintGraphicsToLoad");
+
+  await waitFor(async () => {
+    await expect(await getGraphicsScreenshotType(page)).toBe("repaint");
   });
 }

--- a/packages/e2e-tests/tests/repaint-06.test.ts
+++ b/packages/e2e-tests/tests/repaint-06.test.ts
@@ -1,0 +1,126 @@
+import { openDevToolsTab, startTest } from "../helpers";
+import { findConsoleMessage, seekToConsoleMessage } from "../helpers/console-panel";
+import { stepOver } from "../helpers/pause-information-panel";
+import { getGraphicsDataUrl, waitForRepaintGraphicsToLoad } from "../helpers/screenshot";
+import { debugPrint } from "../helpers/utils";
+import { expect, test } from "../testFixture";
+
+test.use({ exampleKey: "doc_control_flow.html" });
+
+test.skip("repaint-06: repaints the screen screen when stepping over code that modifies the DOM", async ({
+  pageWithMeta: { page, recordingId },
+  exampleKey,
+}) => {
+  await startTest(page, recordingId);
+  await openDevToolsTab(page);
+
+  const printedStrings = [
+    "catch",
+    "afterCatch",
+    "finally",
+    "yield 1",
+    "generated 1",
+    "yield 2",
+    "generated 2",
+    "after timer 1",
+    "after timer 2",
+    "after throw timer 1",
+    "after throw timer 2",
+    "within iterator",
+  ];
+
+  const paints: {
+    [key: string]: {
+      before: string | null;
+      after: string | null;
+    };
+  } = {};
+
+  {
+    await debugPrint(page, "Testing repaint graphics");
+
+    let graphicsDataUrl: string | null = null;
+    let previousGraphicsDataUrl: string | null = null;
+
+    for (let index = 0; index < printedStrings.length; index++) {
+      const string = printedStrings[index];
+      const text = `updateText("${string}")`;
+
+      const locator = await findConsoleMessage(page, text, "console-log");
+      await seekToConsoleMessage(page, locator);
+
+      // Step to "Element text before..."
+      await stepOver(page);
+      await stepOver(page);
+
+      await waitForRepaintGraphicsToLoad(page);
+
+      graphicsDataUrl = await getGraphicsDataUrl(page);
+      expect(
+        graphicsDataUrl,
+        `Expected graphics before "${string}" not to match previous after graphics`
+      ).not.toEqual(previousGraphicsDataUrl);
+      previousGraphicsDataUrl = graphicsDataUrl;
+
+      const cachedPaints = {
+        before: graphicsDataUrl,
+        after: "" as string | null,
+      };
+
+      // Step to "Element text after..."
+      await stepOver(page);
+      await stepOver(page);
+
+      await waitForRepaintGraphicsToLoad(page);
+
+      graphicsDataUrl = await getGraphicsDataUrl(page);
+      expect(
+        graphicsDataUrl,
+        `Expected graphics after "${string}" not to match the graphics before`
+      ).not.toEqual(previousGraphicsDataUrl);
+      previousGraphicsDataUrl = graphicsDataUrl;
+
+      cachedPaints.after = graphicsDataUrl;
+
+      paints[string] = cachedPaints;
+    }
+  }
+
+  {
+    await debugPrint(page, "Testing screenshot caching");
+
+    let graphicsDataUrl: string | null = null;
+
+    for (let index = 0; index < printedStrings.length; index++) {
+      const string = printedStrings[index];
+      const text = `updateText("${string}")`;
+
+      const locator = await findConsoleMessage(page, text, "console-log");
+      await seekToConsoleMessage(page, locator);
+
+      // Step to "Element text before..."
+      await stepOver(page);
+      await stepOver(page);
+
+      await waitForRepaintGraphicsToLoad(page);
+
+      graphicsDataUrl = await getGraphicsDataUrl(page);
+      expect(
+        graphicsDataUrl,
+        `Expected graphics before "${string}" to match previous cached graphics`
+      ).toEqual(paints[string]?.before);
+
+      // Step to "Element text after..."
+      await stepOver(page);
+      await stepOver(page);
+
+      await waitForRepaintGraphicsToLoad(page);
+
+      graphicsDataUrl = await getGraphicsDataUrl(page);
+      expect(
+        graphicsDataUrl,
+        `Expected graphics after "${string}" to match previous cached graphics`
+      ).toEqual(paints[string]?.after);
+    }
+  }
+});

--- a/src/ui/components/Video/Video.tsx
+++ b/src/ui/components/Video/Video.tsx
@@ -71,6 +71,7 @@ export default function Video() {
 
       // The data attributes are sed for e2e tests
       containerElement.setAttribute("data-execution-point", nextState.currentExecutionPoint ?? "");
+      containerElement.setAttribute("data-screenshot-type", "" + nextState.screenShotType);
       containerElement.setAttribute("data-status", "" + nextState.status);
       containerElement.setAttribute("data-time", "" + nextState.currentTime);
       graphicsElement.setAttribute("data-scale", nextState.localScale.toString());

--- a/src/ui/components/Video/imperative/subscribeToMutableSources.ts
+++ b/src/ui/components/Video/imperative/subscribeToMutableSources.ts
@@ -86,11 +86,9 @@ export function subscribeToMutableSources({
         });
       }
     } else {
-      if (didStopPlaying) {
-        if (abortController != null) {
-          abortController.abort();
-          abortController = null;
-        }
+      if (abortController != null) {
+        abortController.abort();
+        abortController = null;
       }
 
       abortController = new AbortController();


### PR DESCRIPTION
Makes several small changes to graphics related code to improve interruption and better handle caching edge cases. I would appreciate a very close review of `updateGraphics`. It _looks_ like it could be simplified but I don't think it can without missing some cases.

I wrote a new, more low-level repaint test (`repaint-06`) but it currently fails in many places due to a suspected RUN issue which Klochek is looking into (RUN-3397). For now, I have _disabled_ that test and filed a follow up issue (FE-2363).