### PR TITLE
Add readme docs for playwright plugin test example

### DIFF
--- a/packages/e2e-tests/README.md
+++ b/packages/e2e-tests/README.md
@@ -148,6 +148,8 @@ If you want to update those to fresher recording IDs, open up the team workspace
 
 You'll also probably need to specifically share that recording as "Public", especially since it's in a Test Suites workspace that would normally not allow anonymous users to view recordings.
 
+We use 1 specific Playwright test recording which is a replay of the breakpoints-05 test from this repo. Similar to the instructions above, to update this to a more recent version, you can visit the dashboard for FE E2E Tests and select a more recent recording ID for that test.
+
 We also now have a "golden recording" of one of our own `breakpoints-01` E2E test runs. This serves as a testbed for checking more advanced behaviors like the React and Redux routines. If we ever need to update this, just copy-paste the recording ID from a test run in our "Frontend E2E tests" workspace.
 
 ### Test Suite Dashboard Tests


### PR DESCRIPTION
Long overdue readme note on the replay used for testing the playwright integration