### PR TITLE
Consider repaint graphics when finding the nearest paint

### DIFF
--- a/packages/protocol/PaintsCache.test.ts
+++ b/packages/protocol/PaintsCache.test.ts
@@ -6,6 +6,7 @@ import {
   findMostRecentPaint,
   findNextPaintEvent,
   findPreviousPaintEvent,
+  mergedPaintsAndRepaints,
 } from "protocol/PaintsCache";
 import { screenshotCache } from "replay-next/src/suspense/ScreenshotCache";
 
@@ -14,6 +15,8 @@ describe("PaintsCache", () => {
 
   beforeEach(() => {
     OriginalImage = window.Image;
+
+    mergedPaintsAndRepaints.splice(0);
 
     // jsdom does not load images; we mock it for our purposes to encode expected image dimensions in a JSON string
     // @ts-expect-error

--- a/packages/protocol/RepaintGraphicsCache.ts
+++ b/packages/protocol/RepaintGraphicsCache.ts
@@ -1,17 +1,22 @@
-import { PauseId, repaintGraphicsResult } from "@replayio/protocol";
+import { ExecutionPoint, repaintGraphicsResult } from "@replayio/protocol";
 import { Cache, createCache } from "suspense";
 
-import { paintHashCache } from "replay-next/src/suspense/ScreenshotCache";
-import { ReplayClientInterface } from "shared/client/types";
+import { mergedPaintsAndRepaints } from "protocol/PaintsCache";
+import { paintHashCache } from "replay-next/src/suspense/PaintHashCache";
+import { pauseIdCache } from "replay-next/src/suspense/PauseCache";
+import { insert } from "replay-next/src/utils/array";
+import { compareExecutionPoints } from "replay-next/src/utils/time";
+import { ReplayClientInterface, TimeStampedPointWithPaintHash } from "shared/client/types";
 
 export const RepaintGraphicsCache: Cache<
-  [replayClient: ReplayClientInterface, pauseId: PauseId],
+  [replayClient: ReplayClientInterface, time: number, executionPoint: ExecutionPoint],
   repaintGraphicsResult | null
 > = createCache({
   config: { immutable: true },
   debugLabel: "RepaintGraphicsCache",
-  getKey: ([replayClient, pauseId]) => pauseId,
-  load: async ([replayClient, pauseId]) => {
+  getKey: ([replayClient, time, executionPoint]) => executionPoint,
+  load: async ([replayClient, time, executionPoint]) => {
+    const pauseId = await pauseIdCache.readAsync(replayClient, executionPoint, time);
     const result = await replayClient.repaintGraphics(pauseId);
 
     let { description, screenShot } = result;
@@ -19,6 +24,17 @@ export const RepaintGraphicsCache: Cache<
     // The backend won't return a screenshot for a given hash more than once; see FE-2357
     if (screenShot) {
       paintHashCache.cacheValue(screenShot, description.hash);
+
+      // Merge repaint data with cached paint data so the find-nearest-paint methods can use both
+      insert(
+        mergedPaintsAndRepaints,
+        {
+          paintHash: description.hash,
+          point: executionPoint,
+          time: time,
+        } satisfies TimeStampedPointWithPaintHash,
+        (a, b) => compareExecutionPoints(a.point, b.point)
+      );
     } else {
       screenShot = paintHashCache.getValueIfCached(description.hash);
     }

--- a/packages/replay-next/src/suspense/PaintHashCache.ts
+++ b/packages/replay-next/src/suspense/PaintHashCache.ts
@@ -1,0 +1,9 @@
+import { ScreenShot } from "@replayio/protocol";
+import { createExternallyManagedCache } from "suspense";
+
+// The DOM.repaintGraphics API only returns screenshot data for a given paint hash once; see FE-2357
+export const paintHashCache = createExternallyManagedCache<[paintHash: string], ScreenShot>({
+  config: { immutable: true },
+  debugLabel: "paintHashCache",
+  getKey: ([paintHash]) => paintHash,
+});

--- a/packages/replay-next/src/suspense/ScreenshotCache.ts
+++ b/packages/replay-next/src/suspense/ScreenshotCache.ts
@@ -1,6 +1,7 @@
 import { ExecutionPoint, ScreenShot } from "@replayio/protocol";
-import { createCache, createExternallyManagedCache } from "suspense";
+import { createCache } from "suspense";
 
+import { paintHashCache } from "replay-next/src/suspense/PaintHashCache";
 import { ReplayClientInterface } from "shared/client/types";
 
 export const screenshotCache = createCache<
@@ -17,11 +18,4 @@ export const screenshotCache = createCache<
 
     return screenShot;
   },
-});
-
-// The backend won't return a screenshot for a given hash more than once; see FE-2357
-export const paintHashCache = createExternallyManagedCache<[paintHash: string], ScreenShot>({
-  config: { immutable: true },
-  debugLabel: "paintHashCache",
-  getKey: ([paintHash]) => paintHash,
 });


### PR DESCRIPTION
We have many layers of Suspense caching:
1. `PaintsCache` - caches results from one-time call to `Graphics.findPaints` (array of timestamps and paint hashes)
2. `RepaintGraphicsCache` - caches results from all calls to `DOM.repaintGraphics` (screenshots)
3. `screenshotCache` - caches results from all calls to `Graphics.getPaintContents` (screenshots for the paint hashes cached in the `PaintsCache`)
4. `paintHashCache` - caches screenshot data for paint hash (screenshots from `RepaintGraphicsCache` and `screenshotCache`) since the `DOM.repaintGraphics` API only sends screenshot data once per paint hash

This commit merges cached paints and repaint data into a single, sorted list and updates all of the various _findClosest_ and _findMostRecent_ methods to use the merged data source. This results in less flickering when stepping between cached paint points.

### Before

Graphics "flickers" when stepping because the most recent cached paint is displayed while a repaint is being fetched.

https://github.com/replayio/devtools/assets/29597/10eb506a-abe4-443f-be08-e21ebdeccd87

### After

No "flicker" when stepping because the nearest paint is now the recently loaded repaint.

https://github.com/replayio/devtools/assets/29597/87c18646-2758-4951-a321-842c209ffa29


