### PR TITLE
Fix the passport-02 and inspector-elements-02 tests

### DIFF
--- a/packages/e2e-tests/helpers/elements-panel.ts
+++ b/packages/e2e-tests/helpers/elements-panel.ts
@@ -2,7 +2,6 @@ import assert from "assert";
 import { Locator, Page, expect } from "@playwright/test";
 import chalk from "chalk";
 
-import { getGraphicsElementScale } from "./screenshot";
 import { debugPrint, delay, waitFor } from "./utils";
 
 type ElementsListRowOptions = {
@@ -294,9 +293,6 @@ export async function inspectCanvasCoordinates(
 
   await activateInspectorTool(page);
 
-  const pickerButton = page.locator('[title="Select an element in the video to inspect it"]')!;
-  await pickerButton.click();
-
   const graphicsElement = page.locator("#graphics");
   const { width, height } = (await graphicsElement.boundingBox())!;
 
@@ -309,9 +305,8 @@ export async function inspectCanvasCoordinates(
     "inspectCanvasCoordinates"
   );
 
-  const scale = await getGraphicsElementScale(page);
-  const x = xPercentage * width * scale;
-  const y = yPercentage * height * scale;
+  const x = xPercentage * width;
+  const y = yPercentage * height;
 
   await debugPrint(
     page,

--- a/packages/e2e-tests/tests/inspector-elements-02_node-picker.test.ts
+++ b/packages/e2e-tests/tests/inspector-elements-02_node-picker.test.ts
@@ -5,6 +5,7 @@ import {
   getElementsListRow,
   inspectCanvasCoordinates,
   openElementsPanel,
+  selectElementsListRow,
   waitForElementsToLoad,
 } from "../helpers/elements-panel";
 import test, { expect } from "../testFixture";
@@ -28,6 +29,9 @@ test(`inspector-elements-02_node-picker: element picker and iframe behavior`, as
   // Click on a DIV element and verify the selection
   {
     const { x, y } = await findElementCoordinates(page, 'id="maindiv"');
+    // findElementCoordinates() will select the element, so we need to select
+    // a different one first to test if selecting the element using the picker works
+    await selectElementsListRow(page, { text: "<body>" });
     await inspectCanvasCoordinates(page, x, y);
 
     const selectedRow = await getElementsListRow(page, { isSelected: true });
@@ -37,6 +41,9 @@ test(`inspector-elements-02_node-picker: element picker and iframe behavior`, as
   // Click on the content inside of an iframe and verify the selection
   {
     const { x, y } = await findElementCoordinates(page, 'data-test-id="inner-body"');
+    // findElementCoordinates() will select the element, so we need to select
+    // a different one first to test if selecting the element using the picker works
+    await selectElementsListRow(page, { text: "<body>" });
     await inspectCanvasCoordinates(page, x, y);
 
     const selectedRow = await getElementsListRow(page, { isSelected: true });


### PR DESCRIPTION
`inspectCanvasCoordinates()` clicked the `NodePicker` button twice, so the picker was immediately disabled again
- in `passport-02` the following click on the screenshot added a comment, which opened the comments panel and that made the test flaky
- `inspector-elements-02` should have failed because it also created comments instead of picking an element. But the element was already selected by `findElementCoordinates()`, so the test passed even though the element was not selected by the picker. Now the test selects a different element after `findElementCoordinates()` to ensure that we actually test selecting an element with the picker