### PR TITLE
Fix detection of session timeouts

### DIFF
--- a/packages/e2e-tests/tests/session-destroyed.test.ts
+++ b/packages/e2e-tests/tests/session-destroyed.test.ts
@@ -4,7 +4,7 @@ import test from "../testFixture";
 
 test.use({ exampleKey: "doc_control_flow.html" });
 
-test(`session-timeout: errors caused by session failure should bubble to the root`, async ({
+test(`session-destroyed: errors caused by session failure should bubble to the root`, async ({
   pageWithMeta: { page, recordingId },
   exampleKey,
 }) => {
@@ -19,8 +19,8 @@ test(`session-timeout: errors caused by session failure should bubble to the roo
   });
 
   await verifyErrorDialog(page, {
-    expectedDetails: "This replay timed out to reduce server load.",
-    expectedTitle: "Ready when you are!",
-    expectedType: "expected",
+    expectedDetails: "The session was destroyed unexpectedly. Please refresh the page.",
+    expectedTitle: "Unexpected end of session",
+    expectedType: "unexpected",
   });
 });

--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -11,7 +11,7 @@ import * as inspectorReducers from "devtools/client/inspector/reducers";
 // eslint-disable-next-line no-restricted-imports
 import { addEventListener, initSocket } from "protocol/socket";
 // eslint-disable-next-line no-restricted-imports
-import { listenForSessionDestroyed, client as protocolClient } from "protocol/socket";
+import { client as protocolClient } from "protocol/socket";
 import { assert } from "protocol/utils";
 import { buildIdCache, parseBuildIdComponents } from "replay-next/src/suspense/BuildIdCache";
 import { networkRequestsCache } from "replay-next/src/suspense/NetworkRequestsCache";
@@ -20,7 +20,6 @@ import { ReplayClientInterface } from "shared/client/types";
 import { CONSOLE_SETTINGS_DATABASE, POINTS_DATABASE } from "shared/user-data/IndexedDB/config";
 import { IDBOptions } from "shared/user-data/IndexedDB/types";
 import { UIStore, actions } from "ui/actions";
-import { getDisconnectionError } from "ui/actions/session";
 import { selectors } from "ui/reducers";
 import app from "ui/reducers/app";
 import network from "ui/reducers/network";
@@ -178,10 +177,6 @@ export default async function setupDevtools(store: AppStore, replayClient: Repla
       window.app.socket = socket;
     }
   }
-
-  listenForSessionDestroyed(() => {
-    store.dispatch(actions.setExpectedError(getDisconnectionError()));
-  });
 
   addEventListener("Recording.uploadedData", (data: uploadedData) =>
     store.dispatch(actions.onUploadedData(data))


### PR DESCRIPTION
- listen for `Session.willDestroy` events to show the expected session timeout modal
- don't show an error modal for `SessionDestroyed` errors (these should only happen after we received a `Session.willDestroy` event)
- show an unexpected error modal for other events indicating the session was destroyed