### PR TITLE
Edge case: Improve focus window precision

### DIFF
--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -591,7 +591,14 @@ export function requestFocusWindow(
           replayClient,
           focusWindow.begin.time
         );
-        begin = pointsBoundingTime.before;
+
+        // If there is an exact match, use it;
+        // else use the nearest point before the requested time
+        // This avoids unintentionally clipping out something the user wanted to include
+        begin =
+          focusWindow.begin.time === pointsBoundingTime.after.time
+            ? pointsBoundingTime.after
+            : pointsBoundingTime.before;
       }
     } else {
       begin = currentFocusWindow.begin;
@@ -606,7 +613,14 @@ export function requestFocusWindow(
           replayClient,
           focusWindow.end.time
         );
-        end = pointsBoundingTime.after;
+
+        // If there is an exact match, use it;
+        // else use the nearest point after the requested time
+        // This avoids unintentionally clipping out something the user wanted to include
+        end =
+          focusWindow.end.time === pointsBoundingTime.before.time
+            ? pointsBoundingTime.before
+            : pointsBoundingTime.after;
       }
     } else {
       end = currentFocusWindow.end;


### PR DESCRIPTION
See comments on Replay [a7bf7444-c406-4256-b238-299ee5f8625c](https://legacy.replay.io/recording/replay-breakpoints-not-displaying-focus-resize-issue--a7bf7444-c406-4256-b238-299ee5f8625c) for an example of what this PR is fixing.

Our logic before was this:
* The user requests a focus region for times A...B
* Ask the backend for the execution points nearest times A and B
* Request a focus region for the nearest execution point that was **before** time A and **after** time B
  * We did this because it seemed better to set a slightly larger focus window than the user requested than to set a slight smaller one (potentially clipping something important out of the focus window)

However the code didn't account for the case where there was an exact match (as happened in the recording linked above).

I'm not sure of how to write an e2e test for this. Suggestions welcome.