### PR TITLE
Clear showHoverTimeGraphics after dragging or saving the focus window

### DIFF
--- a/src/ui/components/Timeline/Timeline.tsx
+++ b/src/ui/components/Timeline/Timeline.tsx
@@ -156,7 +156,7 @@ export default function Timeline() {
 
   return (
     <>
-      <FocusModePopout updateFocusWindowThrottled={updateFocusWindowThrottled} />
+      <FocusModePopout />
       <div
         className="timeline"
         data-protocol-timeline-enabled={showProtocolTimeline || undefined}
@@ -190,11 +190,7 @@ export default function Timeline() {
               <NonLoadingRegions />
               <UnfocusedRegion />
               {showLoadingProgress && <LoadingProgressBars />}
-              <Focuser
-                editMode={editMode}
-                setEditMode={setEditMode}
-                updateFocusWindowThrottled={updateFocusWindowThrottled}
-              />
+              <Focuser editMode={editMode} setEditMode={setEditMode} />
             </div>
           </div>
 
@@ -207,7 +203,3 @@ export default function Timeline() {
     </>
   );
 }
-
-const updateFocusWindowThrottled = throttle((dispatch: AppDispatch, begin: number, end: number) => {
-  return dispatch(setDisplayedFocusWindow({ begin, end }));
-}, 250);


### PR DESCRIPTION
- clear `hoverTime` and `showHoverTimeGraphics` when leaving focus edit mode
- clear `showHoverTimeGraphics` after dragging the focus window, its beginning or end
- remove `updateFocusWindowThrottled()`: this is no longer necessary (because we don't sync the "real" focus window to the displayed one during focus edit mode anymore) and was causing timing issues