### PR TITLE
Improve HTMLElement type detection and rendering

### DIFF
--- a/packages/replay-next/src/utils/protocol.ts
+++ b/packages/replay-next/src/utils/protocol.ts
@@ -130,7 +130,7 @@ export async function protocolValueToClientValue(
     }
 
     if (objectId) {
-      const object = await objectCache.readAsync(client, pauseId, objectId, "none");
+      const object = await objectCache.readAsync(client, pauseId, objectId, "canOverflow");
       const className = object.className;
 
       let preview: string | undefined;

--- a/packages/replay-next/src/utils/protocol.ts
+++ b/packages/replay-next/src/utils/protocol.ts
@@ -130,7 +130,7 @@ export async function protocolValueToClientValue(
     }
 
     if (objectId) {
-      const object = await objectCache.readAsync(client, pauseId, objectId, "canOverflow");
+      const object = await objectCache.readAsync(client, pauseId, objectId, "none");
       const className = object.className;
 
       let preview: string | undefined;
@@ -180,6 +180,23 @@ export async function protocolValueToClientValue(
               object.preview?.properties?.find(property => property.name === "message")
             ) {
               type = "error";
+            }
+
+            if (object.preview == null) {
+              // At this point, the information we have could only tell us that the value is some type of object.
+              // We specifically can't detect HTMLElements because that requires preview information.
+              // In order to properly render those value types, we need to fetch some preview info.
+              // Hopefully the impact of this should be minor since (a) in many cases we'll already have a preview
+              // and (b) this doesn't affect many value types (above) nor primitive types (with no objectId)
+              const objectWithPreview = await objectCache.readAsync(
+                client,
+                pauseId,
+                objectId,
+                "canOverflow"
+              );
+              if (objectWithPreview.preview?.node?.nodeType === Node.ELEMENT_NODE) {
+                type = "html-element";
+              }
             }
             break;
         }


### PR DESCRIPTION
| Before | After |
| :--- | :--- |
| ![Screenshot 2024-03-26 at 3 29 10 PM](https://github.com/replayio/devtools/assets/29597/b82711dc-a566-4e28-8084-28318ad43fe6) | ![Screenshot 2024-03-26 at 3 28 21 PM](https://github.com/replayio/devtools/assets/29597/dc6e098a-fdc9-4a61-86d1-822766a328bd) |

It's been over a year since this code was written, so my recollection is a bit foggy. I believe the reasons I specified a preview level of `"none"` initially were:
1. It's less data to fetch in a hot part of our code
2. Most value types don't require a preview; only HTML elements do

That being said, the result of this approach was that HTML elements _may_ render incorrectly depending on the context they were fetched in. (If they are a nested value, they may not have preview information.)

We could change the initial request to always fetch some preview information (`"canOverflow"`) but I'm not sure how much of a performance impact that may have, so instead I opted to only fallback to fetching preview information when we've ruled out all other possible value types.