### PR TITLE
Fix ObjectRenderer bug that caused ellipsis to sometimes not render for truncated properties lists

### DIFF
--- a/packages/e2e-tests/examples.json
+++ b/packages/e2e-tests/examples.json
@@ -108,8 +108,8 @@
     "buildId": "linux-chromium-20240227-947bd2cd266d-e0f1462455a7"
   },
   "doc_rr_objects.html": {
-    "recording": "98dbe82e-e368-45a7-940b-6fa4df7b2f5f",
-    "buildId": "linux-chromium-20240314-e73ebfb4548b-4a8e18719042"
+    "recording": "c49ade92-7b5d-456e-ade8-ff31d6d7df3e",
+    "buildId": "macOS-chromium-20240327-5f5e32f649a5-4a8e18719042"
   },
   "doc_rr_preview.html": {
     "recording": "e39e2dcb-be59-4387-bfc4-8bb11167f09c",

--- a/packages/e2e-tests/tests/object_preview-08.test.ts
+++ b/packages/e2e-tests/tests/object_preview-08.test.ts
@@ -1,0 +1,33 @@
+import { openDevToolsTab, startTest } from "../helpers";
+import { findConsoleMessage, waitForTerminal, warpToMessage } from "../helpers/console-panel";
+import test, { expect } from "../testFixture";
+
+test.use({ exampleKey: "doc_rr_objects.html" });
+
+test(`object_preview-08: should render ellipsis for collapsed objects with truncated properties`, async ({
+  pageWithMeta: { page, recordingId },
+  exampleKey,
+}) => {
+  await startTest(page, recordingId);
+  await openDevToolsTab(page);
+  await waitForTerminal(page);
+
+  await warpToMessage(page, "Done");
+
+  {
+    // Properties truncated by the Protocol (overflow)
+    const message = await findConsoleMessage(
+      page,
+      "{a: 0, a0: 0, a1: 1, a2: 2, a3: 3, …}",
+      "console-log"
+    );
+    await expect(message).toBeVisible();
+  }
+
+  {
+    // Properties truncated by the client (no overflow)
+    const message = await findConsoleMessage(page, "76objectWithSixProperties", "console-log");
+    const textContent = await message.textContent();
+    expect(textContent).toContain("{a: 1, b: 2, c: 3, d: 4, e: 5, …}");
+  }
+});

--- a/packages/e2e-tests/tests/stepping-07.test.ts
+++ b/packages/e2e-tests/tests/stepping-07.test.ts
@@ -36,5 +36,5 @@ test("stepping-07: Test quick stepping using the keyboard", async ({
   }
 
   // after all steps have been executed we should be paused on line 60
-  await waitForPaused(page, 60);
+  await waitForPaused(page, 67);
 });

--- a/packages/replay-next/components/inspector/values/ObjectRenderer.tsx
+++ b/packages/replay-next/components/inspector/values/ObjectRenderer.tsx
@@ -16,7 +16,8 @@ export default function ObjectRenderer({ context, object, pauseId }: ObjectPrevi
   const properties = preview?.properties?.slice(0, MAX_PROPERTIES_TO_PREVIEW) ?? [];
   let propertiesList: ReactNode[] | null = null;
   if (context !== "nested") {
-    const showOverflowMarker = preview?.overflow || properties.length > MAX_PROPERTIES_TO_PREVIEW;
+    const showOverflowMarker =
+      preview?.overflow || (preview?.properties?.length ?? 0) > MAX_PROPERTIES_TO_PREVIEW;
 
     propertiesList = properties.map((property, index) => (
       <span key={index} className={styles.Value}>

--- a/public/test/examples/doc_rr_objects.html
+++ b/public/test/examples/doc_rr_objects.html
@@ -47,6 +47,14 @@ var o = Symbol();
 var p = Symbol("symbol");
 var q = { [o]: 42, [p]: o };
 var r = { _foo: new C(), get foo() { return this._foo; } }
+const objectWithSixProperties = {
+  a: 1,
+  b: 2,
+  c: 3,
+  d: 4,
+  e: 5,
+  f: 6,
+};
 console.log(a);
 console.log(b);
 console.log(c);
@@ -65,6 +73,7 @@ console.log(o);
 console.log(p);
 console.log(q);
 console.log(r);
+console.log('objectWithSixProperties:', objectWithSixProperties)
 console.log("Done");
 window.setTimeout(recordingFinished);
 }


### PR DESCRIPTION
Looks like this regressed in a refactor PR #10248

I added a new e2e test for this edge case