### PR TITLE
Use RCA v3 data and split up RCA GraphQL queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "checks": "npm run typecheck && npm run lint",
     "typecheck:watch": "yarn typecheck --watch",
     "gql:schema": "gq https://graphql.replay.io/v1/graphql -H \"X-Hasura-Admin-Secret: $HASURA_KEY\" --introspect > schema.graphql",
-    "gql:gen": "apollo codegen:generate --localSchemaFile=schema.graphql --includes='{packages/shared,src}/**/*.{ts,tsx}' --target=typescript --tagName=gql --outputFlat packages/shared/graphql/generated",
+    "gql:gen": "apollo codegen:generate --localSchemaFile=schema.graphql --includes='{packages/shared,src}/**/*.{ts,tsx}' --excludes='*src/**/TestRuns/graphql/RootCauseAnalysisGraphQL.ts' --target=typescript --tagName=gql --outputFlat packages/shared/graphql/generated",
     "gql": "yarn gql:schema && yarn gql:gen"
   },
   "dependencies": {

--- a/packages/shared/graphql/generated/GetTestRunRecordings.ts
+++ b/packages/shared/graphql/generated/GetTestRunRecordings.ts
@@ -47,13 +47,6 @@ export interface GetTestRunRecordings_node_Workspace_testRuns_edges_node_tests_e
   user: GetTestRunRecordings_node_Workspace_testRuns_edges_node_tests_executions_recordings_comments_user | null;
 }
 
-export interface GetTestRunRecordings_node_Workspace_testRuns_edges_node_tests_executions_recordings_rootCauseAnalysis {
-  __typename: "RootCauseAnalysis";
-  id: string;
-  version: number | null;
-  result: any | null;
-}
-
 export interface GetTestRunRecordings_node_Workspace_testRuns_edges_node_tests_executions_recordings {
   __typename: "Recording";
   uuid: any;
@@ -61,7 +54,6 @@ export interface GetTestRunRecordings_node_Workspace_testRuns_edges_node_tests_e
   isProcessed: boolean | null;
   createdAt: any;
   comments: GetTestRunRecordings_node_Workspace_testRuns_edges_node_tests_executions_recordings_comments[];
-  rootCauseAnalysis: GetTestRunRecordings_node_Workspace_testRuns_edges_node_tests_executions_recordings_rootCauseAnalysis | null;
 }
 
 export interface GetTestRunRecordings_node_Workspace_testRuns_edges_node_tests_executions {

--- a/packages/shared/graphql/types.ts
+++ b/packages/shared/graphql/types.ts
@@ -3,8 +3,6 @@ import { ExecutionPoint } from "@replayio/protocol";
 
 import { AnyGroupedTestCases } from "shared/test-suites/RecordingTestMetadata";
 
-import { GetTestRunRecordings_node_Workspace_testRuns_edges_node_tests_executions_recordings_rootCauseAnalysis } from "./generated/GetTestRunRecordings";
-
 export enum Nag {
   ADD_COMMENT = "add_comment",
   ADD_COMMENT_TO_LINE = "add_comment_to_line",
@@ -219,7 +217,6 @@ export interface Recording {
   userRole?: RecordingRole;
   workspace?: Workspace;
   testRunId: string | null;
-  rootCauseAnalysis?: GetTestRunRecordings_node_Workspace_testRuns_edges_node_tests_executions_recordings_rootCauseAnalysis | null;
 }
 
 export type PlaywrightTestSources = {

--- a/packages/shared/root-cause-analysis/RootCauseAnalysisData.ts
+++ b/packages/shared/root-cause-analysis/RootCauseAnalysisData.ts
@@ -142,6 +142,7 @@ export namespace RootCauseAnalysisDataV3 {
     startingLineNumber: number;
     sourceLines: string[];
     hitCounts: number[];
+    breakableLines: boolean[];
     exceptions?: Exception[];
   }
 
@@ -346,9 +347,15 @@ export namespace RootCauseAnalysisDataV3 {
   }
 
   export interface RootCauseAnalysisDatabaseJson {
-    recordingId: string;
+    id: string;
     result: RootCauseAnalysisDatabaseResultV3;
     version: 3;
+  }
+
+  export interface RootCauseAnalysisGraphQLWrapperv3 {
+    recording: {
+      rootCauseAnalysis: RootCauseAnalysisDatabaseJson;
+    };
   }
 }
 
@@ -379,7 +386,7 @@ export function isRootCauseAnalysisDataV3(
   data: unknown
 ): data is RootCauseAnalysisDataV3.RootCauseAnalysisDatabaseJson {
   if (data !== null && typeof data === "object") {
-    return "version" in data && data.version === 3;
+    return "version" in data && data.version === 3 && "result" in data;
   }
 
   return false;

--- a/packages/shared/root-cause-analysis/RootCauseAnalysisData.ts
+++ b/packages/shared/root-cause-analysis/RootCauseAnalysisData.ts
@@ -100,231 +100,7 @@ export enum AnalysisResult {
   Skipped = "Skipped",
 }
 
-export namespace RootCauseAnalysisDataV1 {
-  export enum ReactComponentChange {
-    Add = "Add",
-    Remove = "Remove",
-  }
-
-  // Information about a change to a react component.
-  export interface ReactComponent extends DiscrepancyEvent {
-    nodeName: string;
-    change: ReactComponentChange;
-  }
-
-  // Information about a statement that executed within a recording.
-  export interface ExecutedStatement extends DiscrepancyEvent {
-    // Location of the statement.
-    location: MappedLocation;
-  }
-
-  export interface LocationDescription {
-    url: string | undefined;
-    line: number;
-    column: number;
-    frame: Frame;
-    functionText?: string[];
-    functionOutline?: FunctionOutline;
-    text?: string;
-  }
-
-  interface Frame {
-    functionName: string;
-    points: FramePoint[];
-    otherPoints: FramePoint[];
-  }
-
-  export interface FramePoint {
-    hits: number;
-    location: Location;
-    breakable: boolean;
-    text: string;
-  }
-
-  // Reported discrepancies for executed statements include a description of the
-  // statement which is either extra or missing in the failed run.
-  interface ExecutedStatementWithDescription extends ExecutedStatement {
-    description?: LocationDescription;
-  }
-
-  export interface NetworkEventContentsRequest {
-    kind: "Request";
-    requestUrl: string;
-    requestMethod: string;
-    requestTag?: string;
-    responseCode?: number;
-    initiator?: RequestInitiator;
-  }
-
-  export interface NetworkEventContentsResponseJSON {
-    kind: "ResponseJSON";
-
-    // Information about the associated request.
-    requestUrl: string;
-    requestTag?: string;
-
-    // Path to the JSON value being described.
-    path: string;
-
-    // Value in the JSON at the associated path.
-    value: ComparableValue;
-  }
-
-  export type NetworkEventContents = NetworkEventContentsRequest | NetworkEventContentsResponseJSON;
-
-  export interface NetworkEvent extends DiscrepancyEvent {
-    requestId: string;
-    data: NetworkEventContents;
-  }
-
-  // Reported discrepancies for the contents of network requests/responses include
-  // a description of what the corresponding content is in the other run.
-  interface NetworkEventWithAlternate extends NetworkEvent {
-    alternate?: NetworkEventContents;
-  }
-
-  interface ExecutedStatementDiscrepancySpec {
-    kind: "ExecutedStatement";
-    discrepancyKind: DiscrepancyKind;
-    key: string;
-    url: string;
-  }
-
-  interface ReactComponentDiscrepancySpec {
-    kind: "ReactComponent";
-    discrepancyKind: DiscrepancyKind;
-    key: string;
-  }
-
-  interface NetworkEventDiscrepancySpec {
-    kind: "NetworkEvent";
-    discrepancyKind: DiscrepancyKind;
-    key: string;
-  }
-
-  // Discrepancy in the result of a global evaluation at the failure point in the
-  // failed vs. passing recordings.
-  interface CustomSpecGlobalEval {
-    kind: "GlobalEval";
-    expression: string;
-  }
-
-  // Discrepancy in the result of evaluating an expression at the last time some
-  // statement executed before the failure.
-  interface CustomSpecFrameEval {
-    kind: "FrameEval";
-    expression: string;
-
-    // URL where we should look for the source to evaluate the expression.
-    url: string;
-
-    // Text for the statement within the URL to evaluate the expression at.
-    fragment: string;
-  }
-
-  // Specification for a custom discrepancy to check for.
-  export type CustomSpec = CustomSpecGlobalEval | CustomSpecFrameEval;
-
-  // Information about an event associated with a custom discrepancy spec.
-  export interface CustomEvent extends DiscrepancyEvent {
-    // Discrepancy which we checked for.
-    custom: CustomSpec;
-
-    // Any value produced by an evaluation in the discrepancy.
-    value?: ComparableValue;
-  }
-
-  export type ExecutedStatementDiscrepancy = Discrepancy<ExecutedStatementWithDescription>;
-  export type ReactComponentDiscrepancy = Discrepancy<ReactComponent>;
-  export type NetworkEventDiscrepancy = Discrepancy<NetworkEventWithAlternate>;
-  export type CustomEventDiscrepancy = Discrepancy<CustomEvent>;
-
-  export type AnyDiscrepancy =
-    | ExecutedStatementDiscrepancy
-    | ReactComponentDiscrepancy
-    | NetworkEventDiscrepancy
-    | CustomEventDiscrepancy;
-
-  // Discrepancies in a signature can be custom specs or describe discrepancies
-  // automatically found by the RCA.
-  export type DiscrepancySpec =
-    | CustomSpec
-    | ExecutedStatementDiscrepancySpec
-    | ReactComponentDiscrepancySpec
-    | NetworkEventDiscrepancySpec;
-
-  export interface TestFailureSignature {
-    // Description and associated URL to use for failures matching this signature.
-    title: string;
-    url: string;
-
-    // Associated priority, with lower numbers being higher priority. If a failure
-    // matches multiple signatures then the label used will be the highest priority,
-    // or the first one in the signatures array in the case of tied priorities.
-    priority: number;
-
-    // Specs for discrepancies matching this signature.
-    discrepancies: DiscrepancySpec[];
-  }
-
-  // Unique identifier for a test.
-  export interface TestId {
-    recordingId: string;
-    testId: number;
-    attempt: number;
-  }
-
-  // Describes a test run handled by the root cause analysis.
-  export interface TestRunInfo {
-    // Test which was analyzed.
-    id: TestId;
-
-    // Range of the recording in which the test ran.
-    start: TimeStampedPoint;
-    end: TimeStampedPoint;
-
-    // Any earlier endpoint for the range which was analyzed.
-    analyzeEndpoint?: TimeStampedPoint;
-
-    // In a failed recording, the endpoint at which the last steps were repeated
-    // the same number of times as in each passing recording.
-    failureRepeatEndpoint?: TimeStampedPoint;
-  }
-
-  // Encodes the result of analyzing a flaky test failure.
-  export interface RootCauseAnalysisResult {
-    // The failed test run which was analyzed.
-    failedRun: TestRunInfo;
-
-    // A particular successful run which the discrepancies will be in relation to.
-    successRun: TestRunInfo;
-
-    // Additional successful runs which were analyzed.
-    additionalSuccessRuns: TestRunInfo[];
-
-    // Discrepancies found while analyzing the failure.
-    discrepancies: AnyDiscrepancy[];
-
-    // The highest priority signature which matches this failure, if any.
-    matchingSignature?: TestFailureSignature;
-  }
-
-  export interface RootCauseAnalysisDatabaseResultV1 {
-    branch: string | undefined;
-    result: AnalysisResult;
-    skipReason: string | undefined;
-    error: Record<string, unknown> | undefined;
-    discrepancies: RootCauseAnalysisResult[] | undefined;
-  }
-
-  export interface RootCauseAnalysisDatabaseJson {
-    id: string;
-    result: RootCauseAnalysisDatabaseResultV1;
-    version: 1;
-  }
-}
-
-export namespace RootCauseAnalysisDataV2 {
+export namespace RootCauseAnalysisDataV3 {
   export enum ReactComponentChange {
     Add = "Add",
     Remove = "Remove",
@@ -359,25 +135,26 @@ export namespace RootCauseAnalysisDataV2 {
     error?: ProtocolObject;
   }
 
-  // Information about a location within a frame.
-  interface Frame {
+  export interface FormattedFrame {
+    key: string;
+    sourceId: string;
     functionName: string;
-    points: FramePoint[];
+    startingLineNumber: number;
+    sourceLines: string[];
+    hitCounts: number[];
     exceptions?: Exception[];
   }
 
-  // Information about a location within a frame, but with an attached key for the location.
-  export interface FrameData extends Frame {
-    key: string;
-  }
-
-  // Information about a location within a frame.
+  // Left over from v1/v2 - can be dropped when we rewrite `<ExecutedStatement>`
+  // to be line-oriented.
   export interface FramePoint {
     hits: number;
     location: Location;
     breakable: boolean;
     text: string;
   }
+
+  // Information about a location within a frame, but with an attached key for the location.
 
   // Reported discrepancies for executed statements include a description of the
   // statement which is either extra or missing in the failed run.
@@ -544,16 +321,16 @@ export namespace RootCauseAnalysisDataV2 {
     discrepancies: AnyDiscrepancy[];
 
     // Frame data for the failing run.
-    failingFrames: FrameData[];
+    failingFrames: FormattedFrame[];
 
     // Frame data for the passing run.
-    passingFrames: FrameData[];
+    passingFrames: FormattedFrame[];
 
     // The highest priority signature which matches this failure, if any.
     matchingSignature?: TestFailureSignature;
   }
 
-  export interface RootCauseAnalysisDatabaseResultV2 {
+  export interface RootCauseAnalysisDatabaseResultV3 {
     branch: string | undefined;
     result: AnalysisResult;
     skipReason: string | undefined;
@@ -561,38 +338,48 @@ export namespace RootCauseAnalysisDataV2 {
     discrepancies: RootCauseAnalysisResult[] | undefined;
   }
 
-  export interface RootCauseAnalysisDatabaseJson {
+  export interface RootCauseAnalysisDatabaseSummary {
     id: string;
-    result: RootCauseAnalysisDatabaseResultV2;
-    version: 2;
+    analysisStatus: RootCauseAnalysisDatabaseResultV3["result"];
+    analysisSkipReason: RootCauseAnalysisDatabaseResultV3["skipReason"];
+    version: 3;
+  }
+
+  export interface RootCauseAnalysisDatabaseJson {
+    recordingId: string;
+    result: RootCauseAnalysisDatabaseResultV3;
+    version: 3;
   }
 }
 
 export type AnyRootCauseAnalysisDatabaseJson =
-  | RootCauseAnalysisDataV1.RootCauseAnalysisDatabaseJson
-  | RootCauseAnalysisDataV2.RootCauseAnalysisDatabaseJson;
+  RootCauseAnalysisDataV3.RootCauseAnalysisDatabaseJson;
 
 export type AnyRootCauseAnalysisDatabaseResult =
-  | RootCauseAnalysisDataV1.RootCauseAnalysisDatabaseResultV1
-  | RootCauseAnalysisDataV2.RootCauseAnalysisDatabaseResultV2;
+  RootCauseAnalysisDataV3.RootCauseAnalysisDatabaseResultV3;
 
-export type AnyRootCauseAnalysisResult =
-  | RootCauseAnalysisDataV1.RootCauseAnalysisResult
-  | RootCauseAnalysisDataV2.RootCauseAnalysisResult;
+export type AnyRootCauseAnalysisResult = RootCauseAnalysisDataV3.RootCauseAnalysisResult;
 
-export function isRootCauseAnalysisDataV1(
+export function isRootCauseAnalysisSummaryV3(
   data: unknown
-): data is RootCauseAnalysisDataV1.RootCauseAnalysisDatabaseJson {
-  return data !== null && typeof data === "object" && "version" in data && data.version === 1;
+): data is RootCauseAnalysisDataV3.RootCauseAnalysisDatabaseJson {
+  if (data !== null && typeof data === "object") {
+    return (
+      "version" in data &&
+      data.version === 3 &&
+      "analysisStatus" in data &&
+      "analysisSkipReason" in data
+    );
+  }
+
+  return false;
 }
 
-export function isRootCauseAnalysisDataV2(
+export function isRootCauseAnalysisDataV3(
   data: unknown
-): data is RootCauseAnalysisDataV2.RootCauseAnalysisDatabaseJson {
+): data is RootCauseAnalysisDataV3.RootCauseAnalysisDatabaseJson {
   if (data !== null && typeof data === "object") {
-    const isActuallyV2 = "version" in data && data.version === 2;
-    const isV2WithoutBumpedVersion = "failingFrames" in data && "passingFrames" in data;
-    return isActuallyV2 || isV2WithoutBumpedVersion;
+    return "version" in data && data.version === 3;
   }
 
   return false;

--- a/src/ui/components/Library/Team/View/TestRuns/RootCause/ExecutedStatement.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/RootCause/ExecutedStatement.tsx
@@ -247,10 +247,11 @@ function frameToFramePoints(
   const numLines = endLine - beginLine;
   const lineHits = frame.hitCounts.slice(firstArrayIndex, firstArrayIndex + numLines);
   const sourceLines = frame.sourceLines.slice(firstArrayIndex, firstArrayIndex + numLines);
+  const breakableLines = frame.breakableLines.slice(firstArrayIndex, firstArrayIndex + numLines);
   return lineHits.map((h, i) => ({
     hits: h,
     text: sourceLines[i],
-    breakable: false,
+    breakable: breakableLines[i] ?? false,
     location: {
       sourceId: frame.sourceId,
       line: beginLine + i,

--- a/src/ui/components/Library/Team/View/TestRuns/RootCause/NetworkEvent.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/RootCause/NetworkEvent.tsx
@@ -2,7 +2,7 @@ import { useContext } from "react";
 
 import {
   EventKind,
-  RootCauseAnalysisDataV2,
+  RootCauseAnalysisDataV3,
   Sequence,
 } from "shared/root-cause-analysis/RootCauseAnalysisData";
 
@@ -13,7 +13,7 @@ import { RootCauseContext } from "./RootCause";
 export function NetworkEventSequences({
   sequences,
 }: {
-  sequences: Sequence<RootCauseAnalysisDataV2.NetworkEventDiscrepancy>[];
+  sequences: Sequence<RootCauseAnalysisDataV3.NetworkEventDiscrepancy>[];
 }) {
   return (
     <div className="flex flex-col gap-2">
@@ -26,7 +26,7 @@ export function NetworkEventSequences({
 function NetworkEventSequence({
   group,
 }: {
-  group: Sequence<RootCauseAnalysisDataV2.NetworkEventDiscrepancy>;
+  group: Sequence<RootCauseAnalysisDataV3.NetworkEventDiscrepancy>;
 }) {
   return (
     <div className="pl-4">
@@ -155,7 +155,7 @@ function MissingRequest({
 function NetworkEventDiscrepancyDisplay({
   discrepancy,
 }: {
-  discrepancy: RootCauseAnalysisDataV2.NetworkEventDiscrepancy;
+  discrepancy: RootCauseAnalysisDataV3.NetworkEventDiscrepancy;
 }) {
   const {
     kind,
@@ -166,8 +166,8 @@ function NetworkEventDiscrepancyDisplay({
   if (kind == "Extra") {
     if (data.kind === "ResponseJSON") {
       const { data, alternate } = discrepancy.event as {
-        data: RootCauseAnalysisDataV2.NetworkEventContentsResponseJSON;
-        alternate?: RootCauseAnalysisDataV2.NetworkEventContentsResponseJSON;
+        data: RootCauseAnalysisDataV3.NetworkEventContentsResponseJSON;
+        alternate?: RootCauseAnalysisDataV3.NetworkEventContentsResponseJSON;
       };
 
       content = (

--- a/src/ui/components/Library/Team/View/TestRuns/RootCause/ReactComponent.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/RootCause/ReactComponent.tsx
@@ -1,7 +1,7 @@
 import { useContext } from "react";
 
 import {
-  RootCauseAnalysisDataV2,
+  RootCauseAnalysisDataV3,
   Sequence,
 } from "shared/root-cause-analysis/RootCauseAnalysisData";
 
@@ -12,7 +12,7 @@ import { RootCauseContext } from "./RootCause";
 export function ReactComponentSequences({
   sequences,
 }: {
-  sequences: Sequence<RootCauseAnalysisDataV2.ReactComponentDiscrepancy>[];
+  sequences: Sequence<RootCauseAnalysisDataV3.ReactComponentDiscrepancy>[];
 }) {
   return (
     <div className="flex flex-col gap-2 pl-4">
@@ -25,7 +25,7 @@ export function ReactComponentSequences({
 function ReactComponentSequence({
   group,
 }: {
-  group: Sequence<RootCauseAnalysisDataV2.ReactComponentDiscrepancy>;
+  group: Sequence<RootCauseAnalysisDataV3.ReactComponentDiscrepancy>;
 }) {
   const { failedId, successId } = useContext(RootCauseContext);
   const recordingId = group.kind === "Extra" ? failedId : successId;
@@ -53,7 +53,7 @@ function ReactComponentSequence({
 function ReactComponentDiscrepancyDisplay({
   discrepancy,
 }: {
-  discrepancy: RootCauseAnalysisDataV2.ReactComponentDiscrepancy;
+  discrepancy: RootCauseAnalysisDataV3.ReactComponentDiscrepancy;
 }) {
   return <div>nodeName: {discrepancy.event.nodeName}</div>;
 }

--- a/src/ui/components/Library/Team/View/TestRuns/RootCause/RootCause.tsx
+++ b/src/ui/components/Library/Team/View/TestRuns/RootCause/RootCause.tsx
@@ -1,7 +1,7 @@
 import { createContext } from "react";
 
 import {
-  RootCauseAnalysisDataV2,
+  RootCauseAnalysisDataV3,
   Sequence,
 } from "shared/root-cause-analysis/RootCauseAnalysisData";
 
@@ -11,13 +11,13 @@ import { NetworkEventSequences } from "./NetworkEvent";
 import { ReactComponentSequences } from "./ReactComponent";
 
 interface GroupedSequences {
-  ExecutedStatement: Record<string, Sequence<RootCauseAnalysisDataV2.ExecutedStatementDiscrepancy>>;
-  NetworkEvent: Record<string, Sequence<RootCauseAnalysisDataV2.NetworkEventDiscrepancy>>;
-  ReactComponent: Record<string, Sequence<RootCauseAnalysisDataV2.ReactComponentDiscrepancy>>;
-  CustomEvent: Record<string, Sequence<RootCauseAnalysisDataV2.CustomEventDiscrepancy>>;
+  ExecutedStatement: Record<string, Sequence<RootCauseAnalysisDataV3.ExecutedStatementDiscrepancy>>;
+  NetworkEvent: Record<string, Sequence<RootCauseAnalysisDataV3.NetworkEventDiscrepancy>>;
+  ReactComponent: Record<string, Sequence<RootCauseAnalysisDataV3.ReactComponentDiscrepancy>>;
+  CustomEvent: Record<string, Sequence<RootCauseAnalysisDataV3.CustomEventDiscrepancy>>;
 }
 
-function groupSequences(discrepancies: RootCauseAnalysisDataV2.AnyDiscrepancy[]) {
+function groupSequences(discrepancies: RootCauseAnalysisDataV3.AnyDiscrepancy[]) {
   const grouped: GroupedSequences = {
     ExecutedStatement: {},
     NetworkEvent: {},
@@ -56,7 +56,7 @@ export const RootCauseContext = createContext<RootCauseContextType>(null as any)
 export function RootCause({
   discrepancy,
 }: {
-  discrepancy: RootCauseAnalysisDataV2.RootCauseAnalysisResult;
+  discrepancy: RootCauseAnalysisDataV3.RootCauseAnalysisResult;
 }) {
   const testFailure = discrepancy;
   const failedId = testFailure.failedRun.id.recordingId;

--- a/src/ui/components/Library/Team/View/TestRuns/graphql/RootCauseAnalysisGraphQL.ts
+++ b/src/ui/components/Library/Team/View/TestRuns/graphql/RootCauseAnalysisGraphQL.ts
@@ -1,26 +1,14 @@
 import { gql } from "@apollo/client";
 
-export const GET_RECORDING_ROOT_CAUSE_ANALYSIS_SUMMARY = gql`
-  query GetRecordingRootCauseAnalysis($recordingId: uuid!) {
-    root_cause_analysis_results(where: { recording_id: { _eq: $recordingId } }) {
-      created_at
-      recording_id
-      resultSummary: result(path: "$.result")
-      resultSkipReason: result(path: "$.skipReason")
-      result
-      version
-    }
-  }
-`;
-
-export const GET_RECORDING_ROOT_CAUSE_ANALYSIS_FULL = gql`
-  query GetRecordingRootCauseAnalysis($recordingId: uuid!) {
-    root_cause_analysis_results(where: { recording_id: { _eq: $recordingId } }) {
-      created_at
-      recording_id
-      updated_at
-      result
-      version
+export const GET_RECORDING_ROOT_CAUSE_ANALYSIS = gql`
+  query GetRecordingRootCauseAnalysisSummary($recordingId: UUID!) {
+    recording(uuid: $recordingId) {
+      uuid
+      rootCauseAnalysis {
+        id
+        version
+        result
+      }
     }
   }
 `;

--- a/src/ui/components/Library/Team/View/TestRuns/graphql/RootCauseAnalysisGraphQL.ts
+++ b/src/ui/components/Library/Team/View/TestRuns/graphql/RootCauseAnalysisGraphQL.ts
@@ -1,0 +1,26 @@
+import { gql } from "@apollo/client";
+
+export const GET_RECORDING_ROOT_CAUSE_ANALYSIS_SUMMARY = gql`
+  query GetRecordingRootCauseAnalysis($recordingId: uuid!) {
+    root_cause_analysis_results(where: { recording_id: { _eq: $recordingId } }) {
+      created_at
+      recording_id
+      resultSummary: result(path: "$.result")
+      resultSkipReason: result(path: "$.skipReason")
+      result
+      version
+    }
+  }
+`;
+
+export const GET_RECORDING_ROOT_CAUSE_ANALYSIS_FULL = gql`
+  query GetRecordingRootCauseAnalysis($recordingId: uuid!) {
+    root_cause_analysis_results(where: { recording_id: { _eq: $recordingId } }) {
+      created_at
+      recording_id
+      updated_at
+      result
+      version
+    }
+  }
+`;

--- a/src/ui/components/Library/Team/View/TestRuns/graphql/TestRunsGraphQL.ts
+++ b/src/ui/components/Library/Team/View/TestRuns/graphql/TestRunsGraphQL.ts
@@ -64,11 +64,6 @@ const GET_TEST_RUN_RECORDINGS = gql`
                         id
                       }
                     }
-                    rootCauseAnalysis {
-                      id
-                      version
-                      result
-                    }
                   }
                 }
               }

--- a/src/ui/hooks/recordings.ts
+++ b/src/ui/hooks/recordings.ts
@@ -39,7 +39,6 @@ import {
   GetRecordingUserId,
   GetRecordingUserIdVariables,
 } from "shared/graphql/generated/GetRecordingUserId";
-import { GetTestRunRecordings_node_Workspace_testRuns_edges_node_tests_executions_recordings } from "shared/graphql/generated/GetTestRunRecordings";
 import { GetTestsRun_node_Workspace_testRuns_edges_node_tests_recordings } from "shared/graphql/generated/GetTestsRun";
 import {
   GetWorkspaceRecordings,
@@ -280,7 +279,6 @@ export function convertRecording(
     | GetWorkspaceRecordings_node_Workspace_recordings_edges_node
     | GetTestsRun_node_Workspace_testRuns_edges_node_tests_recordings
     | GetWorkspaceTestExecutions_node_Workspace_tests_edges_node_executions_recordings
-    | GetTestRunRecordings_node_Workspace_testRuns_edges_node_tests_executions_recordings
 ): Recording {
   const recording: Recording = {
     buildId: "buildId" in rec ? rec.buildId : undefined,
@@ -299,7 +297,6 @@ export function convertRecording(
     userRole: "userRole" in rec ? (rec.userRole as RecordingRole) : undefined,
     isTest: "isTest" in rec ? rec.isTest : undefined,
     isInTestWorkspace: "isInTestWorkspace" in rec ? rec.isInTestWorkspace : undefined,
-    rootCauseAnalysis: "rootCauseAnalysis" in rec ? rec.rootCauseAnalysis : undefined,
     testRunId: null,
   };
 


### PR DESCRIPTION
- stopped including `rootCauseAnalysis` in recording entries
- made one query to pull just the `result` and `skipReason` status fields per RCA recording entry to figure out if we even _ought_ to get the rest of the blob data. `<TestRunListItem>` will query that individually
- another GraphQL query to get the whole blob
- Apollo CodeGen does not like generating TS types when I use the Hasura `path()` command. I've put those queries in a new file and am excluding it from codegen. I have the types written out by hand anyway.  (fwiw, Apollo Codegen appears to be long-deprecated and now you should use `graphql-codegen` instead, but ain't no way I'm touching _that_ tooling change right now)
- Switched to using the "RCA v3" data format, which rewrites the `failingFrames/passingFrames` fields to shrink data size