### PR TITLE
Remove leading "$" from comment tooltip

### DIFF
--- a/src/ui/components/Comments/TranscriptComments/SourceCodePreview.tsx
+++ b/src/ui/components/Comments/TranscriptComments/SourceCodePreview.tsx
@@ -43,7 +43,7 @@ export default function SourceCodePreview({ comment }: { comment: SourceCodeComm
 
     location = (
       <div>
-        ${fileName}:{lineNumber}
+        {fileName}:{lineNumber}
       </div>
     );
   }


### PR DESCRIPTION
Likely because this was originally a string (`${fileName}:${lineNumber}`) and then later got refactored to JSX text (`<div>{fileName}:{lineNumber}</div>`) and one of the "$" didn't get removed.

### Before
![Screenshot 2024-04-08 at 10 19 45 AM](https://github.com/replayio/devtools/assets/29597/0b063841-0760-4c37-833a-91a84df00ebe)

### After
![Screenshot 2024-04-08 at 10 19 32 AM](https://github.com/replayio/devtools/assets/29597/d358cc47-5f02-4058-8142-fa1bd5cc37d1)