### PR TITLE
Fix Session.mayDestroy event listener

### DIFF
--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -6,6 +6,7 @@ import {
   CommandRequest,
   CommandResponse,
   ExperimentalSettings,
+  addEventListener,
   createSession,
   listenForSessionDestroyed,
 } from "protocol/socket";


### PR DESCRIPTION
I forgot to import `addEventListener` from `socket.ts` and so this file used the DOM `addEventListener` instead.