### PR TITLE
Adds right margin for the secondary toolbox

### DIFF
--- a/src/ui/components/SecondaryToolbox/SecondaryToolbox.css
+++ b/src/ui/components/SecondaryToolbox/SecondaryToolbox.css
@@ -3,6 +3,7 @@
   flex-direction: column;
   flex: 1 1 auto;
   overflow: hidden;
+  margin-right: 10px;
 }
 
 .secondary-toolbox-header {


### PR DESCRIPTION

I noticed this visual bug while taking screenshots
<img width="915" alt="Screenshot 2024-04-08 at 4 16 04 PM" src="https://github.com/replayio/devtools/assets/254562/52cf7936-70e0-4bca-a817-9330e0fdd7e6">


small fix
<img width="628" alt="Screenshot 2024-04-08 at 4 16 50 PM" src="https://github.com/replayio/devtools/assets/254562/db1d61fe-9af4-445d-9fff-438ec00ed5d8">
