### PR TITLE
Fetch breakpoint positions in buckets and split up position caches

### DIFF
--- a/packages/replay-next/components/sources/SourceList.tsx
+++ b/packages/replay-next/components/sources/SourceList.tsx
@@ -19,8 +19,8 @@ import { FocusContext } from "replay-next/src/contexts/FocusContext";
 import { PointsContext } from "replay-next/src/contexts/points/PointsContext";
 import { SourcesContext } from "replay-next/src/contexts/SourcesContext";
 import {
-  BreakpointPositionsResult,
-  breakpointPositionsCache,
+  BreakpointPositionsByLine,
+  breakpointPositionsByLineCache,
 } from "replay-next/src/suspense/BreakpointPositionsCache";
 import { getCachedMinMaxSourceHitCounts } from "replay-next/src/suspense/SourceHitCountsCache";
 import { Source } from "replay-next/src/suspense/SourcesCache";
@@ -33,7 +33,7 @@ import SourceListRow from "./SourceListRow";
 import getScrollbarWidth from "./utils/getScrollbarWidth";
 import styles from "./SourceList.module.css";
 
-const NO_BREAKABLE_POSITIONS: BreakpointPositionsResult = [[], new Map()];
+const NO_BREAKABLE_POSITIONS: BreakpointPositionsByLine = new Map();
 
 // render a few placeholder lines of text so that the source viewer isn't empty.
 const STREAMING_IN_PROGRESS_PLACEHOLDER_LINE_COUNT = 10;
@@ -84,12 +84,13 @@ export default function SourceList({
   const { data } = useStreamingValue(streamingParser);
   const lineCount = data?.lineCount;
 
-  const { value: breakablePositionsValue = NO_BREAKABLE_POSITIONS } = useImperativeCacheValue(
-    breakpointPositionsCache,
+  const { value: breakablePositionsByLine = NO_BREAKABLE_POSITIONS } = useImperativeCacheValue(
+    breakpointPositionsByLineCache,
     client,
-    sourceId
+    sourceId,
+    visibleLines?.start.line ?? 0,
+    visibleLines?.end.line ?? 0
   );
-  const [, breakablePositionsByLine] = breakablePositionsValue;
 
   useLayoutEffect(
     () => () => {

--- a/packages/replay-next/src/utils/source.ts
+++ b/packages/replay-next/src/utils/source.ts
@@ -6,14 +6,35 @@ import { Source } from "../suspense/SourcesCache";
 
 const VISIBLE_LINES_BUCKET_SIZE = 100;
 
+// This should be more than large enough to fetch breakpoints
+// for any typical source file in one request, while also
+// being smaller than giant files that would cause the backend
+// to choke on serializing the entire file's data.
+const BREAKPOINT_POSITIONS_LINE_BUCKET_SIZE = 5000;
+
 export function bucketVisibleLines(
   startLineIndex: number,
   stopLineIndex: number
 ): [startLineIndex: number, stopLineIndex: number] {
-  const startBucket = Math.floor(startLineIndex / VISIBLE_LINES_BUCKET_SIZE);
-  const stopBucket = Math.floor(stopLineIndex / VISIBLE_LINES_BUCKET_SIZE) + 1;
+  return bucketLines(startLineIndex, stopLineIndex, VISIBLE_LINES_BUCKET_SIZE);
+}
 
-  return [startBucket * VISIBLE_LINES_BUCKET_SIZE, stopBucket * VISIBLE_LINES_BUCKET_SIZE - 1];
+export function bucketBreakpointLines(
+  startLineIndex: number,
+  stopLineIndex: number
+): [startLineIndex: number, stopLineIndex: number] {
+  return bucketLines(startLineIndex, stopLineIndex, BREAKPOINT_POSITIONS_LINE_BUCKET_SIZE);
+}
+
+export function bucketLines(
+  startLineIndex: number,
+  stopLineIndex: number,
+  bucketSize: number
+): [startLineIndex: number, stopLineIndex: number] {
+  const startBucket = Math.floor(startLineIndex / bucketSize);
+  const stopBucket = Math.floor(stopLineIndex / bucketSize) + 1;
+
+  return [startBucket * bucketSize, stopBucket * bucketSize - 1];
 }
 
 export function getSourceFileName(source: Source, appendIndex: boolean = false): string | null {

--- a/src/devtools/client/debugger/src/components/Editor/Footer.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Footer.tsx
@@ -3,18 +3,14 @@ import { Suspense, memo, useContext } from "react";
 import { InlineErrorBoundary } from "replay-next/components/errors/InlineErrorBoundary";
 import { SourcesContext } from "replay-next/src/contexts/SourcesContext";
 
+import { CursorPosition } from "../../utils/sourceVisualizations";
 import SourcemapToggleSuspends from "./SourcemapToggle";
 import SourcemapVisualizerLinkSuspends from "./SourcemapVisualizerLink";
-
-export type CursorPosition = {
-  readonly column: number;
-  readonly line: number;
-};
 
 function SourceFooter() {
   const { cursorColumnIndex, cursorLineIndex } = useContext(SourcesContext);
 
-  const cursorPosition = {
+  const cursorPosition: CursorPosition = {
     column: cursorColumnIndex || 0,
     line: cursorLineIndex || 0,
   };

--- a/src/devtools/client/debugger/src/components/Editor/SourcemapToggle.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/SourcemapToggle.tsx
@@ -8,8 +8,7 @@ import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 
 import { showAlternateSource } from "../../actions/sources/select";
 import { getSelectedFrameId } from "../../reducers/pause";
-import { getAlternateSourceIdSuspense } from "../../utils/sourceVisualizations";
-import { CursorPosition } from "./Footer";
+import { CursorPosition, getAlternateSourceIdSuspense } from "../../utils/sourceVisualizations";
 import Toggle from "./Toggle";
 
 function SourcemapError({ why }: { why: "no-sourcemap" | "not-unique" | undefined }) {

--- a/src/devtools/client/debugger/src/components/Editor/SourcemapVisualizerLink.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/SourcemapVisualizerLink.tsx
@@ -9,8 +9,10 @@ import { useAppSelector } from "ui/setup/hooks";
 import { trackEvent } from "ui/utils/telemetry";
 
 import { getSelectedFrameId } from "../../reducers/pause";
-import { getSourcemapVisualizerURLSuspense } from "../../utils/sourceVisualizations";
-import { CursorPosition } from "./Footer";
+import {
+  CursorPosition,
+  getSourcemapVisualizerURLSuspense,
+} from "../../utils/sourceVisualizations";
 
 export default function SourcemapVisualizerLinkSuspends({
   cursorPosition,

--- a/src/devtools/client/debugger/src/utils/sourceVisualizations.ts
+++ b/src/devtools/client/debugger/src/utils/sourceVisualizations.ts
@@ -17,8 +17,10 @@ import { getPauseFrameSuspense } from "ui/suspense/frameCache";
 import { PauseAndFrameId } from "../reducers/pause";
 import { isBowerComponent, isNodeModule } from "./source";
 
-// TODO
-type CursorPosition = any;
+export type CursorPosition = {
+  readonly column: number;
+  readonly line: number;
+};
 
 export function getSourceIDsToSearch(
   sourcesById: Map<string, SourceDetails>,

--- a/src/devtools/client/debugger/src/utils/sourceVisualizations.ts
+++ b/src/devtools/client/debugger/src/utils/sourceVisualizations.ts
@@ -1,10 +1,11 @@
 import { Dictionary } from "@reduxjs/toolkit";
-import type { SourceId } from "@replayio/protocol";
+import type { SameLineSourceLocations, SourceId } from "@replayio/protocol";
 import sortBy from "lodash/sortBy";
 
 import { assert } from "protocol/utils";
-import { breakpointPositionsCache } from "replay-next/src/suspense/BreakpointPositionsCache";
+import { breakpointPositionsIntervalCache } from "replay-next/src/suspense/BreakpointPositionsCache";
 import { mappedLocationCache } from "replay-next/src/suspense/MappedLocationCache";
+import { bucketBreakpointLines } from "replay-next/src/utils/source";
 import { ReplayClientInterface } from "shared/client/types";
 import {
   SourceDetails,
@@ -198,40 +199,28 @@ function getAlternateSourceIdForPositionSuspense(
   position: CursorPosition,
   sourcesById: Dictionary<SourceDetails>
 ) {
-  const [breakablePositions, breakablePositionsByLine] = breakpointPositionsCache.read(
+  const [startLine, endLine] = bucketBreakpointLines(position.line, position.line);
+  const breakablePositions = breakpointPositionsIntervalCache.read(
+    startLine,
+    endLine,
     client,
     source.id
   );
 
   // We want to find the first breakable line starting from the given cursor location,
   // so that we can translate that position into an alternate mapped location.
-  let firstBreakableLineAfterPosition: number | null = null;
+  let firstBreakableLineAfterPosition = breakablePositions.find(bp => bp.line > position.line);
 
-  // Grab the last line off the array. It's possible there might _not_ be any breakable lines.
-  const [lastBreakableLine] = breakablePositions.slice(-1);
-
-  // We have a Map with line numbers as keys. Rather than check the entire array,
-  // start from the position's line and check succeeding line numbers to find the
-  // next line number that has a breakable position.
-  for (let lineToCheck = position.line; lineToCheck <= lastBreakableLine?.line; lineToCheck++) {
-    if (breakablePositionsByLine.has(lineToCheck)) {
-      firstBreakableLineAfterPosition = lineToCheck;
-      break;
-    }
-  }
-
-  if (firstBreakableLineAfterPosition === null) {
+  if (!firstBreakableLineAfterPosition) {
     return undefined;
   }
 
-  const breakableLineLocations = breakablePositionsByLine.get(firstBreakableLineAfterPosition)!;
-
   // Now we can ask the backend for alternate locations with that line.
-  let breakableColumn = breakableLineLocations.columns[0];
+  let breakableColumn = firstBreakableLineAfterPosition.columns[0];
 
   const mappedLocation = mappedLocationCache.read(client, {
     sourceId: source.id,
-    line: breakableLineLocations.line,
+    line: firstBreakableLineAfterPosition.line,
     column: breakableColumn,
   });
   return source.isSourceMapped


### PR DESCRIPTION
This PR:

- Fixes a `CursorPosition` type that had been `any`
- Updates our breakpoint position caches:
  - Splits into two separate caches, an interval cache (for fetching chunks of per-line data), and a cache that returns a `Map` keyed by lines for that chunk (and relies on the interval cache for its data, to avoid duplicate fetching)
  - Adds a "bucket these line numbers" util that reuses the same logic we did for hit counts, but with a different bucket size. I've opted for 5000 lines for now - that is more than big enough to still fetch all positions for most source files in a single request, but small enough that we don't fetch an entire bundle's worth at once (and thus avoid the backend's serialization cost issue). Can totally tweak this if desired.
  - Updated all usage locations to use the new caches appropriately, including dropping one or two usages of the `Map`

At this point there's only one section of the client that still relies on the `Map` cache, and that's in the source viewer components. That gets passed through 3-4 levels of list components, so I didn't want to mess with that for now. Realistically we could probably change it to be fetching the breakpoints bucket for the current line and be passing that down through context, and get rid of the `Map` entirely.