### PR TITLE
Fix cypress test following j2c

### DIFF
--- a/packages/e2e-tests/tests/cypress-04_menu-commands.test.ts
+++ b/packages/e2e-tests/tests/cypress-04_menu-commands.test.ts
@@ -59,7 +59,7 @@ test("cypress-04: Test Step buttons and menu item", async ({
 
   await waitForSelectedSource(page, "Link.js");
   await waitFor(async () => {
-    const lineNumber = await getSelectedLineNumber(page, false);
+    const lineNumber = await getSelectedLineNumber(page, true);
     expect(lineNumber).toBe(38);
   });
 


### PR DESCRIPTION
The current logic introduced a race condition in which the test would only pass if the expect() ran before the app determined that the highlighted line was in fact on the current point and re-rendered.

I'm guessing a bit on this but the test passes with this change. Here's the step passing in this run and the result seems reasonable but I might be misunderstanding the flow.

https://app.replay.io/recording/cypress-04-test-step-buttons-and-menu-item--241d1d6c-6707-4355-8d4a-1aa3d80ce0bb?commentId=&focusWindow=eyJiZWdpbiI6eyJwb2ludCI6IjM1Njk3MDQwOTA0ODc5NTE1Mjc1MjUyMTY5NjMwMDI2MzIiLCJ0aW1lIjoxNjY3fSwiZW5kIjp7InBvaW50IjoiNTU0OTI2NzI2OTM1MTIxMTU4ODY0MjMwNDMzMDc3NDM0OTYiLCJ0aW1lIjoyMzg5M319&point=29206669834914220954500565437517548&primaryPanel=cypress&secondaryPanel=console&time=12318&viewMode=non-dev