### PR TITLE
Add testScope to all e2e tests

### DIFF
--- a/packages/e2e-tests/authenticated/comments-01.test.ts
+++ b/packages/e2e-tests/authenticated/comments-01.test.ts
@@ -11,7 +11,7 @@ test(`authenticated/comments-01: Test add, edit, and delete comment functionalit
   exampleKey,
   testUsers,
 }) => {
-  await startTest(page, recordingId, { apiKey: testUsers![0].apiKey, testScope });
+  await startTest(page, recordingId, testScope, testUsers![0].apiKey);
   await openDevToolsTab(page);
   await openSource(page, exampleKey);
 

--- a/packages/e2e-tests/authenticated/comments-02.test.ts
+++ b/packages/e2e-tests/authenticated/comments-02.test.ts
@@ -12,7 +12,7 @@ import test, { Page } from "../testFixture";
 const url = "authenticated_comments.html";
 
 async function load(page: Page, recordingId: string, apiKey: string, testScope: string) {
-  await startTest(page, recordingId, { apiKey, testScope });
+  await startTest(page, recordingId, testScope, apiKey);
   await page.coverage.startJSCoverage();
 
   await openDevToolsTab(page);

--- a/packages/e2e-tests/authenticated/comments-03.test.ts
+++ b/packages/e2e-tests/authenticated/comments-03.test.ts
@@ -18,7 +18,7 @@ test(`authenticated/comments-03: Comment previews`, async ({
   exampleKey: url,
   testUsers,
 }) => {
-  await startTest(page, recordingId, { apiKey: testUsers![0].apiKey, testScope });
+  await startTest(page, recordingId, testScope, testUsers![0].apiKey);
   await openDevToolsTab(page);
 
   // Add and verify source code comment previews

--- a/packages/e2e-tests/authenticated/logpoints-01.test.ts
+++ b/packages/e2e-tests/authenticated/logpoints-01.test.ts
@@ -16,7 +16,7 @@ const url = "authenticated_logpoints.html";
 const lineNumber = 14;
 
 async function load(page: Page, recordingId: string, apiKey: string, testScope: string) {
-  await startTest(page, recordingId, { apiKey, testScope });
+  await startTest(page, recordingId, testScope, apiKey);
   await page.coverage.startJSCoverage();
 
   await openDevToolsTab(page);

--- a/packages/e2e-tests/authenticated/passport-01.test.ts
+++ b/packages/e2e-tests/authenticated/passport-01.test.ts
@@ -15,7 +15,7 @@ test(`authenticated/passport-01: Time travel`, async ({
   pageWithMeta: { page, recordingId, testScope },
   testUsers,
 }) => {
-  await startTest(page, recordingId, { apiKey: testUsers![0].apiKey, testScope });
+  await startTest(page, recordingId, testScope, testUsers![0].apiKey);
 
   await enablePassport(page);
   await showPassport(page);

--- a/packages/e2e-tests/authenticated/passport-02.test.ts
+++ b/packages/e2e-tests/authenticated/passport-02.test.ts
@@ -21,7 +21,7 @@ test(`authenticated/passport-02: Infrared inspection`, async ({
   pageWithMeta: { page, recordingId, testScope },
   testUsers,
 }) => {
-  await startTest(page, recordingId, { apiKey: testUsers![0].apiKey, testScope });
+  await startTest(page, recordingId, testScope, testUsers![0].apiKey);
 
   await enablePassport(page);
 

--- a/packages/e2e-tests/authenticated/passport-03.test.ts
+++ b/packages/e2e-tests/authenticated/passport-03.test.ts
@@ -13,7 +13,7 @@ test(`authenticated/passport-03: Swiss army knife`, async ({
   pageWithMeta: { page, recordingId, testScope },
   testUsers,
 }) => {
-  await startTest(page, recordingId, { apiKey: testUsers![0].apiKey, testScope });
+  await startTest(page, recordingId, testScope, testUsers![0].apiKey);
 
   await enablePassport(page);
 

--- a/packages/e2e-tests/authenticated/passport-04.test.ts
+++ b/packages/e2e-tests/authenticated/passport-04.test.ts
@@ -13,7 +13,7 @@ test(`authenticated/passport-04: Multiplayer`, async ({
   exampleKey,
   testUsers,
 }) => {
-  await startTest(page, recordingId, { apiKey: testUsers![0].apiKey, testScope });
+  await startTest(page, recordingId, testScope, testUsers![0].apiKey);
 
   await enablePassport(page);
 

--- a/packages/e2e-tests/helpers/index.ts
+++ b/packages/e2e-tests/helpers/index.ts
@@ -123,7 +123,8 @@ export interface AuthInfo {
 export async function startTest(
   page: Page,
   recordingId: string,
-  auth?: AuthInfo,
+  testScope: string,
+  apiKey?: string,
   additionalQueryParams?: URLSearchParams,
   shouldWaitForIndexing: boolean = true
 ) {
@@ -131,10 +132,10 @@ export async function startTest(
 
   const params = new URLSearchParams();
   params.append("e2e", "1");
-  if (auth) {
-    params.append("apiKey", auth.apiKey);
-    params.append("testScope", auth.testScope);
+  if (apiKey) {
+    params.append("apiKey", apiKey);
   }
+  params.append("testScope", testScope);
 
   if (additionalQueryParams) {
     for (const [key, value] of additionalQueryParams) {

--- a/packages/e2e-tests/tests/breakpoints-01.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-01.test.ts
@@ -7,10 +7,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_rr_basic.html" });
 
 test(`breakpoints-01: Test basic breakpoint functionality`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await addBreakpoint(page, { lineNumber: 21, url: exampleKey });

--- a/packages/e2e-tests/tests/breakpoints-02.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-02.test.ts
@@ -7,10 +7,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_rr_basic.html" });
 
 test(`breakpoints-02: Test unhandled divergence while evaluating at a breakpoint`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await addBreakpoint(page, { lineNumber: 21, url: exampleKey });

--- a/packages/e2e-tests/tests/breakpoints-03.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-03.test.ts
@@ -7,10 +7,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_rr_basic.html" });
 
 test(`breakpoints-03: Test stepping forward through breakpoints when rewound before the first one`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await addBreakpoint(page, { lineNumber: 9, url: exampleKey });

--- a/packages/e2e-tests/tests/breakpoints-04.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-04.test.ts
@@ -7,10 +7,10 @@ test.use({ exampleKey: "doc_control_flow.html" });
 
 // Test hitting breakpoints when using tricky control flow constructs:
 test(`breakpoints-04: catch, finally, generators, and async/await`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await rewindToBreakpoint(page, 10);

--- a/packages/e2e-tests/tests/breakpoints-05.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-05.test.ts
@@ -10,10 +10,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_debugger_statements.html" });
 
 test(`breakpoints-05: Test interaction of breakpoints with debugger statements`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
   await openPauseInformationPanel(page);
   // wait for the recording to be fully loaded

--- a/packages/e2e-tests/tests/breakpoints-06.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-06.test.ts
@@ -12,10 +12,10 @@ async function checkMessageLocation(page: Page, text: string, location: string) 
 test.use({ exampleKey: "doc_prod_bundle.html" });
 
 test(`breakpoints-06: Test log point in a sourcemapped file`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   // Log point added to line 15 should map to line 15

--- a/packages/e2e-tests/tests/breakpoints-07.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-07.test.ts
@@ -21,10 +21,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_navigate.html" });
 
 test(`breakpoints-07: rewind and seek using command bar and console messages`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await quickOpen(page, "bundle_input.js");

--- a/packages/e2e-tests/tests/breakpoints-08.test.ts
+++ b/packages/e2e-tests/tests/breakpoints-08.test.ts
@@ -11,10 +11,10 @@ import test, { expect } from "../testFixture";
 test.use({ exampleKey: "doc_navigate.html" });
 
 test(`breakpoints-08: should be temporarily disabled`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   // Add breakpoint and verify text in console

--- a/packages/e2e-tests/tests/console-expressions-01.test.ts
+++ b/packages/e2e-tests/tests/console-expressions-01.test.ts
@@ -15,10 +15,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_async.html" });
 
 test("console-expressions-01: should cache input eager eval and terminal expressions per instance", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
   await openConsolePanel(page);
 

--- a/packages/e2e-tests/tests/console_async_eval.test.ts
+++ b/packages/e2e-tests/tests/console_async_eval.test.ts
@@ -12,10 +12,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_async.html" });
 
 test("console_async: support console evaluations in async frames", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
   await openConsolePanel(page);
 

--- a/packages/e2e-tests/tests/console_dock.test.ts
+++ b/packages/e2e-tests/tests/console_dock.test.ts
@@ -9,10 +9,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_rr_basic.html" });
 
 test("console_dock: Should show the correct docking behavior for recordings with video", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   // Verify default docking position

--- a/packages/e2e-tests/tests/console_errors.test.ts
+++ b/packages/e2e-tests/tests/console_errors.test.ts
@@ -10,10 +10,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_exceptions_bundle.html" });
 
 test("console_errors: Test that errors and warnings from various sources are shown in the console", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
   await openConsolePanel(page);
 

--- a/packages/e2e-tests/tests/console_eval.test.ts
+++ b/packages/e2e-tests/tests/console_eval.test.ts
@@ -9,10 +9,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_rr_basic.html" });
 
 test("console_eval: support console evaluations", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
   await openConsolePanel(page);
 

--- a/packages/e2e-tests/tests/console_warp-01.test.ts
+++ b/packages/e2e-tests/tests/console_warp-01.test.ts
@@ -15,10 +15,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_rr_error.html" });
 
 test(`console_warp-01: should support warping to console messages`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
   await openConsolePanel(page);
 

--- a/packages/e2e-tests/tests/console_warp-02.test.ts
+++ b/packages/e2e-tests/tests/console_warp-02.test.ts
@@ -12,10 +12,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_rr_logs.html" });
 
 test("console_warp-02: support pausing, warping, stepping and evaluating console messages", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
   await openConsolePanel(page);
 

--- a/packages/e2e-tests/tests/cypress-01_basic-panel.test.ts
+++ b/packages/e2e-tests/tests/cypress-01_basic-panel.test.ts
@@ -24,9 +24,9 @@ import test, { expect } from "../testFixture";
 test.use({ exampleKey: "flake/adding-spec.ts" });
 
 test("cypress-01: Basic Test Suites panel functionality", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await openCypressTestPanel(page);

--- a/packages/e2e-tests/tests/cypress-02_test-step-timelines.test.ts
+++ b/packages/e2e-tests/tests/cypress-02_test-step-timelines.test.ts
@@ -13,10 +13,10 @@ import test, { expect } from "../testFixture";
 test.use({ exampleKey: "flake/adding-spec.ts" });
 
 test("cypress-02: Test Step timeline behavior", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openViewerTab(page);
 
   await openCypressTestPanel(page);

--- a/packages/e2e-tests/tests/cypress-03_test-step-interactions.test.ts
+++ b/packages/e2e-tests/tests/cypress-03_test-step-interactions.test.ts
@@ -16,8 +16,10 @@ import test, { expect } from "../testFixture";
 
 test.use({ exampleKey: "flake/adding-spec.ts" });
 
-test("cypress-03: Test Step interactions", async ({ pageWithMeta: { page, recordingId } }) => {
-  await startTest(page, recordingId);
+test("cypress-03: Test Step interactions", async ({
+  pageWithMeta: { page, recordingId, testScope },
+}) => {
+  await startTest(page, recordingId, testScope);
   await openViewerTab(page);
 
   await openCypressTestPanel(page);

--- a/packages/e2e-tests/tests/cypress-04_menu-commands.test.ts
+++ b/packages/e2e-tests/tests/cypress-04_menu-commands.test.ts
@@ -14,10 +14,10 @@ import test, { expect } from "../testFixture";
 test.use({ exampleKey: "cypress-realworld/bankaccounts.spec.js" });
 
 test("cypress-04: Test Step buttons and menu item", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openViewerTab(page);
 
   await openCypressTestPanel(page);

--- a/packages/e2e-tests/tests/cypress-05_hover-dom-previews.test.ts
+++ b/packages/e2e-tests/tests/cypress-05_hover-dom-previews.test.ts
@@ -12,10 +12,10 @@ import test, { expect } from "../testFixture";
 test.use({ exampleKey: "cypress-realworld/bankaccounts.spec.js" });
 
 test("cypress-05: Test DOM node preview on user action step hover", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openViewerTab(page);
 
   await openCypressTestPanel(page);

--- a/packages/e2e-tests/tests/deleted-recording.test.ts
+++ b/packages/e2e-tests/tests/deleted-recording.test.ts
@@ -5,7 +5,7 @@ import { startTest } from "../helpers";
 import { verifyErrorDialog } from "../helpers/errors";
 
 test("deleted-recording: Show error message for deleted recording", async ({ page }) => {
-  await startTest(page, examples["deleted-replay"].recording, undefined, undefined, false);
+  await startTest(page, examples["deleted-replay"].recording, "", undefined, undefined, false);
 
   await verifyErrorDialog(page, {
     expectedDetails: "This recording has been deleted.",

--- a/packages/e2e-tests/tests/elements-search.test.ts
+++ b/packages/e2e-tests/tests/elements-search.test.ts
@@ -15,10 +15,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_stacking.html" });
 
 test("elements-search: Element panel should support basic and advanced search modes", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
   await warpToMessage(page, "ExampleFinished");
   await openElementsPanel(page);

--- a/packages/e2e-tests/tests/file-search-01.test.ts
+++ b/packages/e2e-tests/tests/file-search-01.test.ts
@@ -13,8 +13,10 @@ import test from "../testFixture";
 
 test.use({ exampleKey: "cra/dist/index.html" });
 
-test("file-search-01: should search files", async ({ pageWithMeta: { page, recordingId } }) => {
-  await startTest(page, recordingId);
+test("file-search-01: should search files", async ({
+  pageWithMeta: { page, recordingId, testScope },
+}) => {
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
   await openFileSearchPanel(page);
 

--- a/packages/e2e-tests/tests/focus_mode-01.test.ts
+++ b/packages/e2e-tests/tests/focus_mode-01.test.ts
@@ -15,10 +15,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_rr_region_loading.html" });
 
 test("focus_mode-01: should filter messages as regions based on the active focus mode", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await openSource(page, exampleKey);

--- a/packages/e2e-tests/tests/highlighter.test.ts
+++ b/packages/e2e-tests/tests/highlighter.test.ts
@@ -6,10 +6,10 @@ import test, { expect } from "../testFixture";
 test.use({ exampleKey: "doc_inspector_basic.html" });
 
 test("highlighter: element highlighter works everywhere", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
 
   await openDevToolsTab(page);
   await openConsolePanel(page);

--- a/packages/e2e-tests/tests/inspector-computed-01_basic-styles.test.ts
+++ b/packages/e2e-tests/tests/inspector-computed-01_basic-styles.test.ts
@@ -13,10 +13,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_inspector_styles.html" });
 
 test("inspector-computed-01: Basic computed styles can be viewed", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
   await openConsolePanel(page);
   await warpToMessage(page, "ExampleFinished");

--- a/packages/e2e-tests/tests/inspector-computed-02_complex-styles.test.ts
+++ b/packages/e2e-tests/tests/inspector-computed-02_complex-styles.test.ts
@@ -12,10 +12,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_inspector_shorthand.html" });
 
 test("inspector-computed-02: Complex computed styles can be viewed", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
   await openConsolePanel(page);
   await warpToMessage(page, "ExampleFinished");

--- a/packages/e2e-tests/tests/inspector-elements-01_basic-dom-tree.test.ts
+++ b/packages/e2e-tests/tests/inspector-elements-01_basic-dom-tree.test.ts
@@ -17,10 +17,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_inspector_basic.html" });
 
 test("inspector-elements-01: Basic DOM tree node display", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await openConsolePanel(page);

--- a/packages/e2e-tests/tests/inspector-elements-02_node-picker.test.ts
+++ b/packages/e2e-tests/tests/inspector-elements-02_node-picker.test.ts
@@ -13,10 +13,10 @@ import test, { expect } from "../testFixture";
 test.use({ exampleKey: "doc_inspector_basic.html" });
 
 test(`inspector-elements-02_node-picker: element picker and iframe behavior`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   // DOM/document may not be available at the end of the recording;

--- a/packages/e2e-tests/tests/inspector-elements-03_nested-node-selection.test.ts
+++ b/packages/e2e-tests/tests/inspector-elements-03_nested-node-selection.test.ts
@@ -45,10 +45,10 @@ const bodyChildDomNodes = [
 ];
 
 test("inspector-elements-03: Nested node picker and selection behavior", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await warpToMessage(page, "ExampleFinished");

--- a/packages/e2e-tests/tests/inspector-elements-04_key-shortcuts.test.ts
+++ b/packages/e2e-tests/tests/inspector-elements-04_key-shortcuts.test.ts
@@ -39,10 +39,10 @@ const bodyChildDomNodes = [
 ];
 
 test("inspector-elements-04: Keyboard shortcuts should select the right DOM nodes", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await warpToMessage(page, "ExampleFinished");

--- a/packages/e2e-tests/tests/inspector-elements-05_search.test.ts
+++ b/packages/e2e-tests/tests/inspector-elements-05_search.test.ts
@@ -11,10 +11,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_inspector_basic.html" });
 
 test(`inspector-elements-05_search: element picker and iframe behavior`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
   await openElementsPanel(page);
 

--- a/packages/e2e-tests/tests/inspector-rules-01_basic-rules.test.ts
+++ b/packages/e2e-tests/tests/inspector-rules-01_basic-rules.test.ts
@@ -10,10 +10,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_inspector_styles.html" });
 
 test("inspector-rules-01: Basic CSS rules should be viewed", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
   await openConsolePanel(page);
   await warpToMessage(page, "ExampleFinished");

--- a/packages/e2e-tests/tests/inspector-rules-02_sourcemapped-rules.test.ts
+++ b/packages/e2e-tests/tests/inspector-rules-02_sourcemapped-rules.test.ts
@@ -10,10 +10,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_inspector_sourcemapped.html" });
 
 test.skip("inspector-rules-02: Sourcemapped rules should be viewed", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
   await openConsolePanel(page);
   await warpToMessage(page, "ExampleFinished");

--- a/packages/e2e-tests/tests/inspector-rules-03_shorthand-rules.test.ts
+++ b/packages/e2e-tests/tests/inspector-rules-03_shorthand-rules.test.ts
@@ -11,10 +11,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_inspector_shorthand.html" });
 
 test("inspector-rules-03: Shorthand CSS rules should be viewed", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
   await openConsolePanel(page);
   await warpToMessage(page, "ExampleFinished");

--- a/packages/e2e-tests/tests/jump-to-code-01_basic.test.ts
+++ b/packages/e2e-tests/tests/jump-to-code-01_basic.test.ts
@@ -65,7 +65,7 @@ async function checkForJumpButton(eventLocator: Locator, shouldBeEnabled: boolea
 }
 
 test(`jump-to-code-01: Test basic jumping functionality`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
   const queryParams = new URLSearchParams();
@@ -73,7 +73,7 @@ test(`jump-to-code-01: Test basic jumping functionality`, async ({
   // See pref names in packages/shared/user-data/GraphQL/config.ts
   // queryParams.set("features", "backend_rerunRoutines");
 
-  await startTest(page, recordingId, undefined, queryParams);
+  await startTest(page, recordingId, testScope, undefined, queryParams);
   await openDevToolsTab(page);
 
   await openSourceExplorerPanel(page);

--- a/packages/e2e-tests/tests/logpoints-01.test.ts
+++ b/packages/e2e-tests/tests/logpoints-01.test.ts
@@ -15,10 +15,10 @@ import test, { expect } from "../testFixture";
 test.use({ exampleKey: "doc_rr_basic.html" });
 
 test(`logpoints-01: log-points appear in the correct order and allow time warping`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await addBreakpoint(page, { lineNumber: 20, url: exampleKey });

--- a/packages/e2e-tests/tests/logpoints-02.test.ts
+++ b/packages/e2e-tests/tests/logpoints-02.test.ts
@@ -16,10 +16,10 @@ import test, { expect } from "../testFixture";
 test.use({ exampleKey: "doc_rr_basic.html" });
 
 test(`logpoints-02: conditional log-points`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await addLogpoint(page, {

--- a/packages/e2e-tests/tests/logpoints-03.test.ts
+++ b/packages/e2e-tests/tests/logpoints-03.test.ts
@@ -9,10 +9,10 @@ import test, { expect } from "../testFixture";
 test.use({ exampleKey: "doc_events.html" });
 
 test(`logpoints-03: should display event properties in the console`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await addEventListenerLogpoints(page, [{ eventType: "click", categoryKey: "mouse" }]);

--- a/packages/e2e-tests/tests/logpoints-04.test.ts
+++ b/packages/e2e-tests/tests/logpoints-04.test.ts
@@ -12,10 +12,10 @@ import test, { expect } from "../testFixture";
 test.use({ exampleKey: "doc_exceptions.html" });
 
 test(`logpoints-04: should display exceptions in the console`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await openConsolePanel(page);

--- a/packages/e2e-tests/tests/logpoints-05.test.ts
+++ b/packages/e2e-tests/tests/logpoints-05.test.ts
@@ -9,10 +9,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "log_points_and_block_scope.html" });
 
 test(`logpoints-05: should auto-complete based on log point location`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await addLogpoint(page, { lineNumber: 5, url: exampleKey });

--- a/packages/e2e-tests/tests/logpoints-06.test.ts
+++ b/packages/e2e-tests/tests/logpoints-06.test.ts
@@ -18,10 +18,10 @@ const lineNumber = 5;
 test.use({ exampleKey: "log_points_and_block_scope.html" });
 
 test(`logpoints-06: should be temporarily disabled`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   let MESSAGE = "Test log point";

--- a/packages/e2e-tests/tests/logpoints-07.test.ts
+++ b/packages/e2e-tests/tests/logpoints-07.test.ts
@@ -16,10 +16,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "cra/dist/index.html" });
 
 test(`logpoints-07: should use the correct scope in auto-complete`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   let url = "App.js";

--- a/packages/e2e-tests/tests/logpoints-08.test.ts
+++ b/packages/e2e-tests/tests/logpoints-08.test.ts
@@ -6,10 +6,10 @@ import test, { expect } from "../testFixture";
 test.use({ exampleKey: "doc_rr_basic.html" });
 
 test(`logpoints-08: should support jumping directly to a hit point via the capsule input`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await addLogpoint(page, {

--- a/packages/e2e-tests/tests/logpoints-09.test.ts
+++ b/packages/e2e-tests/tests/logpoints-09.test.ts
@@ -6,10 +6,10 @@ const lineNumber = 20;
 test.use({ exampleKey: "doc_rr_basic.html" });
 
 test(`logpoints-09: should support pending edits`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await addLogpoint(page, {

--- a/packages/e2e-tests/tests/logpoints-10_too_many_points_to_find.test.ts
+++ b/packages/e2e-tests/tests/logpoints-10_too_many_points_to_find.test.ts
@@ -19,10 +19,10 @@ const lineNumber = 150;
 test.use({ exampleKey: "breakpoints-01" });
 
 test(`logpoints-10: too-many-points-to-find UX`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await quickOpen(page, sourceUrl);

--- a/packages/e2e-tests/tests/logpoints-11_too_many_points_to_run_analysis.test.ts
+++ b/packages/e2e-tests/tests/logpoints-11_too_many_points_to_run_analysis.test.ts
@@ -19,10 +19,10 @@ const lineNumber = 248;
 test.use({ exampleKey: "breakpoints-01" });
 
 test(`logpoints-11: too-many-points-to-run-analysis UX`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await quickOpen(page, sourceUrl);

--- a/packages/e2e-tests/tests/network-01.test.ts
+++ b/packages/e2e-tests/tests/network-01.test.ts
@@ -11,10 +11,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "flake/adding-spec.ts" });
 
 test(`network-01: should filter requests by type and text`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
   await openNetworkPanel(page);
 

--- a/packages/e2e-tests/tests/network-02.test.ts
+++ b/packages/e2e-tests/tests/network-02.test.ts
@@ -12,10 +12,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "flake/adding-spec.ts" });
 
 test(`network-02: should show details for the selected request`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
   await openNetworkPanel(page);
 

--- a/packages/e2e-tests/tests/network-03.test.ts
+++ b/packages/e2e-tests/tests/network-03.test.ts
@@ -11,10 +11,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "flake/adding-spec.ts" });
 
 test(`network-03: should sync and display the current time in relation to the network requests`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
   await openNetworkPanel(page);
 

--- a/packages/e2e-tests/tests/node_console-01.test.ts
+++ b/packages/e2e-tests/tests/node_console-01.test.ts
@@ -10,10 +10,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "node/basic.js" });
 
 test("node_console-01: Basic node console behavior", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openConsolePanel(page);
 
   await warpToMessage(page, "HELLO 1");

--- a/packages/e2e-tests/tests/node_console-02.test.ts
+++ b/packages/e2e-tests/tests/node_console-02.test.ts
@@ -6,10 +6,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "node/error.js" });
 
 test("node_console-02: uncaught exceptions should show up", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openConsolePanel(page);
 
   await warpToMessage(page, "ReferenceError: b is not defined");

--- a/packages/e2e-tests/tests/node_console_dock.test.ts
+++ b/packages/e2e-tests/tests/node_console_dock.test.ts
@@ -9,10 +9,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "node/basic.js" });
 
 test("node_console_dock: Should show the correct docking behavior for recordings without video", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   // Verify default docking position

--- a/packages/e2e-tests/tests/node_control_flow.test.ts
+++ b/packages/e2e-tests/tests/node_control_flow.test.ts
@@ -12,12 +12,12 @@ async function resumeToBreakpoint(page: Page, line: number) {
 test.use({ exampleKey: "node/control_flow.js" });
 
 test("node_control_flow: catch, finally, generators, and async/await", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
   // Default timeout is 30s. Mostly taking 40s in local dev. Bump to 120s.
   test.setTimeout(120000);
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
 
   await openSource(page, "control_flow.js");
 

--- a/packages/e2e-tests/tests/node_logpoint-01.test.ts
+++ b/packages/e2e-tests/tests/node_logpoint-01.test.ts
@@ -12,10 +12,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "node/basic.js" });
 
 test("node_logpoint-01: Basic node logpoints", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
 
   await openConsolePanel(page);
 

--- a/packages/e2e-tests/tests/node_logpoint-02.test.ts
+++ b/packages/e2e-tests/tests/node_logpoint-02.test.ts
@@ -14,10 +14,10 @@ import test, { expect } from "../testFixture";
 test.use({ exampleKey: "node/exceptions.js" });
 
 test.skip("node_logpoint-02: Node exception logpoints", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
 
   await openConsolePanel(page);
   await toggleSideFilters(page, true);

--- a/packages/e2e-tests/tests/node_object_preview-01.test.ts
+++ b/packages/e2e-tests/tests/node_object_preview-01.test.ts
@@ -10,10 +10,10 @@ import test, { expect } from "../testFixture";
 test.use({ exampleKey: "node/objects.js" });
 
 test("node_object_preview: Showing console objects in node", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
 
   await openConsolePanel(page);
 

--- a/packages/e2e-tests/tests/node_quick_open_modal-01.test.ts
+++ b/packages/e2e-tests/tests/node_quick_open_modal-01.test.ts
@@ -6,10 +6,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "node/basic.js" });
 
 test("node_quick_open_modal-01: Test basic searching functionality", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await openSource(page, "basic.js");

--- a/packages/e2e-tests/tests/node_spawn-01.test.ts
+++ b/packages/e2e-tests/tests/node_spawn-01.test.ts
@@ -6,10 +6,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "node/spawn.js" });
 
 test("node_spawn: Basic subprocess spawning", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
 
   await openConsolePanel(page);
 

--- a/packages/e2e-tests/tests/node_stepping-01.test.ts
+++ b/packages/e2e-tests/tests/node_stepping-01.test.ts
@@ -15,10 +15,10 @@ import test, { Page, expect } from "../testFixture";
 test.use({ exampleKey: "node/async.js" });
 
 test("node_stepping-01: Test stepping in async frames and async call stacks", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
 
   await openPauseInformationPanel(page);
 

--- a/packages/e2e-tests/tests/node_worker-01.test.ts
+++ b/packages/e2e-tests/tests/node_worker-01.test.ts
@@ -7,10 +7,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "node/run_worker.js" });
 
 test("node_worker-01: make sure node workers don't cause crashes", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
 
   await openConsolePanel(page);
 

--- a/packages/e2e-tests/tests/object_preview-01.test.ts
+++ b/packages/e2e-tests/tests/object_preview-01.test.ts
@@ -14,10 +14,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_rr_objects.html" });
 
 test(`object_preview-01: expressions in the console after time warping`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
   await openConsolePanel(page);
 

--- a/packages/e2e-tests/tests/object_preview-02.test.ts
+++ b/packages/e2e-tests/tests/object_preview-02.test.ts
@@ -14,10 +14,10 @@ import test, { expect } from "../testFixture";
 test.use({ exampleKey: "doc_rr_objects.html" });
 
 test(`object_preview-02: should allow objects in scope to be inspected`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
   await waitForTerminal(page);
 

--- a/packages/e2e-tests/tests/object_preview-03.test.ts
+++ b/packages/e2e-tests/tests/object_preview-03.test.ts
@@ -21,10 +21,10 @@ test.use({ exampleKey: "doc_rr_preview.html" });
 // frame timeline percentages are different in the test below.
 
 test(`object_preview-03: Test previews when switching between frames and stepping`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   const target = await getRecordingTarget(page);

--- a/packages/e2e-tests/tests/object_preview-04.test.ts
+++ b/packages/e2e-tests/tests/object_preview-04.test.ts
@@ -11,10 +11,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_prod_bundle.html" });
 
 test(`object_preview-04: Test scope mapping and switching between generated/original sources`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await addBreakpoint(page, { lineNumber: 15, url: "bundle_input.js" });

--- a/packages/e2e-tests/tests/object_preview-05.test.ts
+++ b/packages/e2e-tests/tests/object_preview-05.test.ts
@@ -9,10 +9,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_prod_bundle.html" });
 
 test(`object_preview-05: Should support logging objects as values`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await warpToMessage(page, "ExampleFinished");

--- a/packages/e2e-tests/tests/object_preview-06.test.ts
+++ b/packages/e2e-tests/tests/object_preview-06.test.ts
@@ -12,10 +12,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_rr_objects.html" });
 
 test(`object_preview-06: HTML elements`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
   await openConsolePanel(page);
 

--- a/packages/e2e-tests/tests/object_preview-07.test.ts
+++ b/packages/e2e-tests/tests/object_preview-07.test.ts
@@ -10,10 +10,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_rr_console.html" });
 
 test(`object_preview-07: inspect objects in the console while paused somewhere else`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await verifyConsoleMessageObjectContents(page, "Iteration 3", [

--- a/packages/e2e-tests/tests/object_preview-08.test.ts
+++ b/packages/e2e-tests/tests/object_preview-08.test.ts
@@ -5,10 +5,10 @@ import test, { expect } from "../testFixture";
 test.use({ exampleKey: "doc_rr_objects.html" });
 
 test(`object_preview-08: should render ellipsis for collapsed objects with truncated properties`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
   await waitForTerminal(page);
 

--- a/packages/e2e-tests/tests/playwright-01_basic-panel.test.ts
+++ b/packages/e2e-tests/tests/playwright-01_basic-panel.test.ts
@@ -24,10 +24,10 @@ import test, { expect } from "../testFixture";
 test.use({ exampleKey: "playwright/breakpoints-05" });
 
 test("playwright-01: Basic Test Suites panel functionality", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await openPlaywrightTestPanel(page);

--- a/packages/e2e-tests/tests/playwright-02_test-step-timelines.test.ts
+++ b/packages/e2e-tests/tests/playwright-02_test-step-timelines.test.ts
@@ -13,10 +13,10 @@ import test, { expect } from "../testFixture";
 test.use({ exampleKey: "playwright/breakpoints-05" });
 
 test("playwright-02: Test Step timeline behavior", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openViewerTab(page);
 
   await openPlaywrightTestPanel(page);

--- a/packages/e2e-tests/tests/playwright-03_test-step-interactions.test.ts
+++ b/packages/e2e-tests/tests/playwright-03_test-step-interactions.test.ts
@@ -17,10 +17,10 @@ import test, { expect } from "../testFixture";
 test.use({ exampleKey: "playwright/breakpoints-05" });
 
 test("playwright-03: Test Step interactions", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openViewerTab(page);
 
   await openPlaywrightTestPanel(page);

--- a/packages/e2e-tests/tests/playwright-04_menu-commands.test.ts
+++ b/packages/e2e-tests/tests/playwright-04_menu-commands.test.ts
@@ -18,10 +18,10 @@ import test, { expect } from "../testFixture";
 test.use({ exampleKey: "playwright/breakpoints-05" });
 
 test("playwright-04: Test Step buttons and menu item", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openViewerTab(page);
 
   await openPlaywrightTestPanel(page);

--- a/packages/e2e-tests/tests/playwright-05_hover-dom-previews.test.ts
+++ b/packages/e2e-tests/tests/playwright-05_hover-dom-previews.test.ts
@@ -12,10 +12,10 @@ import test, { expect } from "../testFixture";
 test.use({ exampleKey: "playwright/breakpoints-05" });
 
 test("playwright-05: Test DOM node previews on user action step hover", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openViewerTab(page);
 
   await openPlaywrightTestPanel(page);

--- a/packages/e2e-tests/tests/react_devtools-01-basic.test.ts
+++ b/packages/e2e-tests/tests/react_devtools-01-basic.test.ts
@@ -24,7 +24,7 @@ import test, { expect } from "../testFixture";
 test.use({ exampleKey: "cra/dist/index.html" });
 
 test("react_devtools-01: Basic RDT behavior", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
   const queryParams = new URLSearchParams();
@@ -32,7 +32,7 @@ test("react_devtools-01: Basic RDT behavior", async ({
   // See pref names in packages/shared/user-data/GraphQL/config.ts
   queryParams.set("features", "backend_rerunRoutines");
 
-  await startTest(page, recordingId, undefined, queryParams);
+  await startTest(page, recordingId, testScope, undefined, queryParams);
 
   await openDevToolsTab(page);
 

--- a/packages/e2e-tests/tests/react_devtools-02-integrations.test.ts
+++ b/packages/e2e-tests/tests/react_devtools-02-integrations.test.ts
@@ -20,7 +20,7 @@ import test, { expect } from "../testFixture";
 test.use({ exampleKey: "breakpoints-01" });
 
 test("react_devtools-02: RDT integrations (Chromium)", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
   const queryParams = new URLSearchParams();
@@ -28,7 +28,7 @@ test("react_devtools-02: RDT integrations (Chromium)", async ({
   // See pref names in packages/shared/user-data/GraphQL/config.ts
   queryParams.set("features", "backend_rerunRoutines");
 
-  await startTest(page, recordingId, undefined, queryParams);
+  await startTest(page, recordingId, testScope, undefined, queryParams);
 
   await openDevToolsTab(page);
 

--- a/packages/e2e-tests/tests/react_devtools-03-multiple-versions.test.ts
+++ b/packages/e2e-tests/tests/react_devtools-03-multiple-versions.test.ts
@@ -20,14 +20,14 @@ import test, { expect } from "../testFixture";
 test.use({ exampleKey: "rdt-react-versions/dist/index.html" });
 
 test("react_devtools-03: process and display multiple React versions in page", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
 }) => {
   const queryParams = new URLSearchParams();
   // Force this test to always re-run the RDT (and other) routines
   // See pref names in packages/shared/user-data/GraphQL/config.ts
   queryParams.set("features", "backend_rerunRoutines");
 
-  await startTest(page, recordingId, undefined, queryParams);
+  await startTest(page, recordingId, testScope, undefined, queryParams);
 
   await openDevToolsTab(page);
 

--- a/packages/e2e-tests/tests/react_devtools-04-seeking.test.ts
+++ b/packages/e2e-tests/tests/react_devtools-04-seeking.test.ts
@@ -11,11 +11,11 @@ import test from "../testFixture";
 test.use({ exampleKey: "cra/dist/index.html" });
 
 test("react_devtools-04: Component selection is maintained when seeking to a new point", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
 }) => {
   const queryParams = new URLSearchParams();
 
-  await startTest(page, recordingId, undefined, queryParams);
+  await startTest(page, recordingId, testScope, undefined, queryParams);
   await openDevToolsTab(page);
 
   // Seek to the first console message and check that the initial tree has 3 components

--- a/packages/e2e-tests/tests/redux_devtools.test.ts
+++ b/packages/e2e-tests/tests/redux_devtools.test.ts
@@ -10,10 +10,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "redux/dist/index.html" });
 
 test("redux_devtools: Test Redux DevTools.", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await openReduxDevtoolsPanel(page);

--- a/packages/e2e-tests/tests/regression-fe-1875-cypress-jump-to-code.test.ts
+++ b/packages/e2e-tests/tests/regression-fe-1875-cypress-jump-to-code.test.ts
@@ -7,10 +7,10 @@ import test, { expect } from "../testFixture";
 test.use({ exampleKey: "React Hook Form/conditionalField.cy.ts" });
 
 test("fe-1875 :: verify that steps go to the right point in time", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openViewerTab(page);
 
   await openCypressTestPanel(page);

--- a/packages/e2e-tests/tests/repaint-01.test.ts
+++ b/packages/e2e-tests/tests/repaint-01.test.ts
@@ -8,10 +8,10 @@ import { test } from "../testFixture";
 test.use({ exampleKey: "doc_control_flow.html" });
 
 test("repaint-01: repaints the screen screen when stepping over code that modifies the DOM", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await addBreakpoint(page, { lineNumber: 50, url: exampleKey });

--- a/packages/e2e-tests/tests/repaint-02.test.ts
+++ b/packages/e2e-tests/tests/repaint-02.test.ts
@@ -6,8 +6,10 @@ import test, { expect } from "../testFixture";
 
 test.use({ exampleKey: "playwright/breakpoints-05" });
 
-test("repaint-02: repaints on hover", async ({ pageWithMeta: { page, recordingId } }) => {
-  await startTest(page, recordingId);
+test("repaint-02: repaints on hover", async ({
+  pageWithMeta: { page, recordingId, testScope },
+}) => {
+  await startTest(page, recordingId, testScope);
 
   const initialScreenShot = await getGraphicsDataUrl(page);
 

--- a/packages/e2e-tests/tests/repaint-03.test.ts
+++ b/packages/e2e-tests/tests/repaint-03.test.ts
@@ -7,8 +7,8 @@ import test, { expect } from "../testFixture";
 
 test.use({ exampleKey: "playwright/breakpoints-05" });
 
-test("repaint-03: repaints on seek", async ({ pageWithMeta: { page, recordingId } }) => {
-  await startTest(page, recordingId);
+test("repaint-03: repaints on seek", async ({ pageWithMeta: { page, recordingId, testScope } }) => {
+  await startTest(page, recordingId, testScope);
 
   const endingScreenShot = await getGraphicsDataUrl(page);
   const initialFocusBeginTime = await getFocusBeginTime(page);

--- a/packages/e2e-tests/tests/repaint-04.test.ts
+++ b/packages/e2e-tests/tests/repaint-04.test.ts
@@ -11,9 +11,9 @@ async function warpToMessageAndWaitForPaint(page: Page, message: string) {
 }
 
 test("repaint-04: prefers nearest (<=) paint when seeking between paints", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   let currentColor: string | null = null;

--- a/packages/e2e-tests/tests/repaint-05.test.ts
+++ b/packages/e2e-tests/tests/repaint-05.test.ts
@@ -21,9 +21,9 @@ async function seekToTimePercentAndWaitForPaint(page: Page, percent: number) {
 }
 
 test("repaint-05: prefers current time if pause creation failed outside of the focus window", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await setFocusRange(page, {

--- a/packages/e2e-tests/tests/repaint-06.test.ts
+++ b/packages/e2e-tests/tests/repaint-06.test.ts
@@ -8,10 +8,10 @@ import { expect, test } from "../testFixture";
 test.use({ exampleKey: "doc_control_flow.html" });
 
 test("repaint-06: repaints the screen screen when stepping over code that modifies the DOM", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   // TODO [FE-2363] Some of these points fail repaint, so they're disabled until RUN-3397 has been fixed

--- a/packages/e2e-tests/tests/resizable-panels-01.test.ts
+++ b/packages/e2e-tests/tests/resizable-panels-01.test.ts
@@ -25,10 +25,10 @@ async function waitForPanelSize(page: Page, expectedSize: number) {
 test.use({ exampleKey: "doc_rr_basic.html" });
 
 test("resizable-panels-01: Left side Toolbar and Video should be collapsible", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
 
   const button = page.locator('[data-test-name="ToolbarButton-ExpandSidePanel"]');
   const resizeHandle = page.locator('[data-panel-resize-handle-id="PanelResizeHandle-SidePanel"]');

--- a/packages/e2e-tests/tests/restart-session.test.ts
+++ b/packages/e2e-tests/tests/restart-session.test.ts
@@ -5,10 +5,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_control_flow.html" });
 
 test(`restart-session: restart debugging session`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
   await commandPalette(page, "restart session");
   await page.waitForURL(/restart=true/);

--- a/packages/e2e-tests/tests/scopes_rerender.test.ts
+++ b/packages/e2e-tests/tests/scopes_rerender.test.ts
@@ -6,10 +6,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_recursion.html" });
 
 test("scopes_rerender: Test that scopes are rerendered", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
   await openConsolePanel(page);
 

--- a/packages/e2e-tests/tests/session-destroyed.test.ts
+++ b/packages/e2e-tests/tests/session-destroyed.test.ts
@@ -5,10 +5,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_control_flow.html" });
 
 test(`session-destroyed: errors caused by session failure should bubble to the root`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await page.evaluate(() => {

--- a/packages/e2e-tests/tests/source-line-highlights.test.ts
+++ b/packages/e2e-tests/tests/source-line-highlights.test.ts
@@ -17,13 +17,13 @@ import test, { expect } from "../testFixture";
 test.use({ exampleKey: "doc_rr_blackbox.html" });
 
 test(`source-line-highlights: Test source line highlighting`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
   const firstSource = exampleKey;
   const secondSource = "blackbox.js";
 
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await addBreakpoint(page, { lineNumber: 16, url: firstSource });

--- a/packages/e2e-tests/tests/sourcemap_stacktrace.test.ts
+++ b/packages/e2e-tests/tests/sourcemap_stacktrace.test.ts
@@ -11,10 +11,10 @@ import test, { expect } from "../testFixture";
 test.use({ exampleKey: "cra/dist/index.html" });
 
 test("sourcemap_stacktrace: Test that stacktraces are sourcemapped", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
   await openConsolePanel(page);
 

--- a/packages/e2e-tests/tests/stacking.test.ts
+++ b/packages/e2e-tests/tests/stacking.test.ts
@@ -12,10 +12,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_stacking.html" });
 
 test("stacking: Element highlighter selects the correct element when they overlap", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await warpToMessage(page, "ExampleFinished");

--- a/packages/e2e-tests/tests/stepping-01.test.ts
+++ b/packages/e2e-tests/tests/stepping-01.test.ts
@@ -12,10 +12,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_rr_basic.html" });
 
 test("stepping-01: Test basic step-over/back functionality", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   // Open doc_rr_basic.html

--- a/packages/e2e-tests/tests/stepping-02.test.ts
+++ b/packages/e2e-tests/tests/stepping-02.test.ts
@@ -14,10 +14,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_rr_basic.html" });
 
 test("stepping-02: Test fixes for some simple stepping bugs", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   // Open doc_rr_basic.html

--- a/packages/e2e-tests/tests/stepping-03.test.ts
+++ b/packages/e2e-tests/tests/stepping-03.test.ts
@@ -12,10 +12,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_rr_basic.html" });
 
 test(`stepping-03: Stepping past the beginning or end of a frame should act like a step-out`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   // Open doc_rr_basic.html

--- a/packages/e2e-tests/tests/stepping-04.test.ts
+++ b/packages/e2e-tests/tests/stepping-04.test.ts
@@ -8,10 +8,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_rr_basic.html" });
 
 test("stepping-04: Test stepping in a frame other than the top frame", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   // Open doc_rr_basic.html

--- a/packages/e2e-tests/tests/stepping-05.test.ts
+++ b/packages/e2e-tests/tests/stepping-05.test.ts
@@ -17,11 +17,11 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_minified.html" });
 
 test(`stepping-05: Test stepping in pretty-printed code`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
   page.setDefaultTimeout(120000);
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await addBreakpoint(page, { url: "bundle_input.js", lineNumber: 4 });

--- a/packages/e2e-tests/tests/stepping-06.test.ts
+++ b/packages/e2e-tests/tests/stepping-06.test.ts
@@ -16,10 +16,10 @@ test.use({ exampleKey: "doc_async.html" });
 // Because stepping works differently between gecko and chromium,
 // frame timeline percentages are different in this test.
 test(`stepping-06: Test stepping in async frames and async call stacks`, async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   await warpToMessage(page, "baz 2");

--- a/packages/e2e-tests/tests/stepping-07.test.ts
+++ b/packages/e2e-tests/tests/stepping-07.test.ts
@@ -11,10 +11,10 @@ import test from "../testFixture";
 test.use({ exampleKey: "doc_rr_objects.html" });
 
 test("stepping-07: Test quick stepping using the keyboard", async ({
-  pageWithMeta: { page, recordingId },
+  pageWithMeta: { page, recordingId, testScope },
   exampleKey,
 }) => {
-  await startTest(page, recordingId);
+  await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
   // Open doc_rr_objects.html


### PR DESCRIPTION
* Makes `testScope` required for `startTest`
* Adds `testScope` to all tests