### PR TITLE
Disable `repaint-06`

### DIFF
--- a/packages/e2e-tests/scripts/buildkite_run_fe_tests.ts
+++ b/packages/e2e-tests/scripts/buildkite_run_fe_tests.ts
@@ -21,8 +21,12 @@ let TestFileOverrideList = [];
 
 // Disable some tests that we know to be problematic.
 const TestFileBlackList = new Set([
-  // https://linear.app/replay/issue/RUN-3274/
+  // Disable some paint expectations. Things have improved but are not perfect
+  // with paints. Let's revisit it once we see it have a real impact on the
+  // user, or else, post GA.
+  // https://linear.app/replay/issue/TT-189/re-enable-repaint-01-repaint-06
   "tests/repaint-01.test.ts",
+  "tests/repaint-06.test.ts",
 ]);
 
 // Enable some tests that we have recently fixed but not yet enabled everywhere.

--- a/packages/e2e-tests/scripts/buildkite_run_fe_tests.ts
+++ b/packages/e2e-tests/scripts/buildkite_run_fe_tests.ts
@@ -21,9 +21,9 @@ let TestFileOverrideList = [];
 
 // Disable some tests that we know to be problematic.
 const TestFileBlackList = new Set([
-  // Disable some paint expectations. Things have improved but are not perfect
-  // with paints. Let's revisit it once we see it have a real impact on the
-  // user, or else, post GA.
+  // Disable some paint expectations. Paints and repaintGraphics have improved
+  // but are not perfect. Let's revisit it once we see it have a real impact
+  // on the user, or else, post GA.
   // https://linear.app/replay/issue/TT-189/re-enable-repaint-01-repaint-06
   "tests/repaint-01.test.ts",
   "tests/repaint-06.test.ts",


### PR DESCRIPTION
Things have improved but are not perfect with paints. Let's revisit it once we see it have a real impact on the user, or else, post GA.
There are still several related hangs and correctness issues, but we have downgraded them, because Recorder correctness, Recorder crashes and RTP crashes seem to be in much worse shape.


* `->` Re-open via https://linear.app/replay/issue/TT-189/re-enable-repaint-01-repaint-06