### PR TITLE
Retry saving breakpoints in tests when type ahead hides the button

### DIFF
--- a/packages/e2e-tests/helpers/source-panel.ts
+++ b/packages/e2e-tests/helpers/source-panel.ts
@@ -335,20 +335,26 @@ export async function editLogPoint(
 
   if (saveAfterEdit) {
     // The typeahead popup sometimes sticks around and overlaps the save button.
-    // Ensure it goes away.
-    await hideTypeAheadSuggestions(page, {
-      sourceLineNumber: lineNumber,
-      type: "log-point-condition",
-    });
-    await hideTypeAheadSuggestions(page, {
-      sourceLineNumber: lineNumber,
-      type: "log-point-content",
-    });
+    // Sometimes, it will show up after we check the first time (PRO-238) so we
+    // retry a couple times to ensure that we can clear it and move forward.
+    waitFor(
+      async () => {
+        await hideTypeAheadSuggestions(page, {
+          sourceLineNumber: lineNumber,
+          type: "log-point-condition",
+        });
+        await hideTypeAheadSuggestions(page, {
+          sourceLineNumber: lineNumber,
+          type: "log-point-content",
+        });
 
-    const saveButton = line.locator('[data-test-name="PointPanel-SaveButton"]');
-    await expect(saveButton).toBeEnabled();
-    await saveButton.click();
-    await saveButton.waitFor({ state: "detached" });
+        const saveButton = line.locator('[data-test-name="PointPanel-SaveButton"]');
+        await expect(saveButton).toBeEnabled();
+        await saveButton.click();
+        await saveButton.waitFor({ state: "detached" });
+      },
+      { timeout: 2_000 }
+    );
   }
 }
 


### PR DESCRIPTION
Added comments to https://app.replay.io/recording/logpoints-02-conditional-log-points--48d35edf-4c2c-4763-a91c-2454e47a399d. The cause is a race condition in which the type-ahead box will sometime show up after we try to clear it but before we click the save button.

If the logic for managing the save button were specific to this test, we could wait on the dialog and then clear it. Instead, the logic is shared for any add or edit logpoint so i'm adding retries to ensure we handle this more cleanly.