### PR TITLE
Force earlier CLI version for replay upload in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,6 +125,7 @@ jobs:
       - uses: replayio/action-upload@v0.5.1
         if: always()
         with:
+          cli-version: 0.21.4
           api-key: ${{ env.RECORD_REPLAY_API_KEY }}
           public: true
   authenticated-e2etest:
@@ -187,6 +188,7 @@ jobs:
       - uses: replayio/action-upload@v0.5.1
         if: always()
         with:
+          cli-version: 0.21.4
           api-key: ${{ env.RECORD_REPLAY_API_KEY }}
           public: true
   unit-test:


### PR DESCRIPTION
The latest CLI is working but causing GH to hang when used with
action-upload. Rolling back to an earlier version resolves the
issue for this repo until we figure out the root cause and fix it.