### PR TITLE
Wait for the logpoint to be saved in e2e tests

### DIFF
--- a/packages/e2e-tests/helpers/source-panel.ts
+++ b/packages/e2e-tests/helpers/source-panel.ts
@@ -337,7 +337,7 @@ export async function editLogPoint(
     // The typeahead popup sometimes sticks around and overlaps the save button.
     // Sometimes, it will show up after we check the first time (PRO-238) so we
     // retry a couple times to ensure that we can clear it and move forward.
-    waitFor(
+    await waitFor(
       async () => {
         await hideTypeAheadSuggestions(page, {
           sourceLineNumber: lineNumber,


### PR DESCRIPTION
I think this may have been the cause of some recent `logpoints-02` test failures.