### PR TITLE
Make sure that Scopes display loading state when seek happens

### DIFF
--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/NewFrames.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/NewFrames.tsx
@@ -233,7 +233,7 @@ function Frames({ panel, point, time }: FramesProps) {
   );
 }
 
-export default function FramesSuspenseWrapper(props: FramesProps) {
+export default function NewFrames(props: FramesProps) {
   return (
     <Suspense
       fallback={

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/NewScopes.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/NewScopes.tsx
@@ -17,15 +17,25 @@ import { getPreferredGeneratedSources } from "ui/reducers/sources";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { pickScopes } from "ui/suspense/scopeCache";
 
-import { getSelectedFrameId } from "../../selectors";
+import { getSeekLock, getSelectedFrameId } from "../../selectors";
 import { ConvertedScope, convertScopes } from "../../utils/pause/scopes/convertScopes";
 import styles from "./NewObjectInspector.module.css";
+
+function LoadingInfo() {
+  return <div className="pane-info">Loading…</div>;
+}
 
 function ScopesRenderer() {
   const replayClient = useContext(ReplayClientContext);
   const sourcesById = sourcesByIdCache.read(replayClient);
   const preferredGeneratedSources = useAppSelector(getPreferredGeneratedSources);
   const selectedFrameId = useAppSelector(getSelectedFrameId);
+  const seekLock = useAppSelector(getSeekLock);
+
+  if (seekLock) {
+    return <LoadingInfo />;
+  }
+
   if (!selectedFrameId) {
     return (
       <div className="pane pane-info">
@@ -117,7 +127,7 @@ function Scope({
   return null;
 }
 
-export default function Scopes() {
+export default function NewScopes() {
   const selectedFrameId = useAppSelector(getSelectedFrameId);
   const dispatch = useAppDispatch();
 
@@ -146,7 +156,7 @@ export default function Scopes() {
           key={`${selectedFrameId?.pauseId}:${selectedFrameId?.frameId}`}
           fallback={<div className="pane-info">Error loading scopes</div>}
         >
-          <Suspense fallback={<div className="pane-info">Loading…</div>}>
+          <Suspense fallback={<LoadingInfo />}>
             <ScopesRenderer />
           </Suspense>
         </InlineErrorBoundary>


### PR DESCRIPTION
While investigating a test failure I noticed that it's possible to see such a state
<img width="226" alt="Frames panel displays a loading state while Scopes display that we are not paused on a point with scopes" src="https://github.com/replayio/devtools/assets/9800850/42fda361-b597-40dc-b014-d95ae7970d7b">

This PR improves this by making sure that Scopes also display a loading state - just like Frames - in this situation