### PR TITLE
Fix accordion border color

### DIFF
--- a/packages/accordion/index.tsx
+++ b/packages/accordion/index.tsx
@@ -53,12 +53,13 @@ function ResizeHandle({
   return (
     <div
       className={classNames(
-        "absolute w-full border-chrome hover:border-blue-400",
+        "absolute w-full hover:border-blue-400",
         isResizing ? "border-blue-400" : ""
       )}
       style={{
         cursor: "ns-resize",
         borderBottomWidth: `${HANDLE_HEIGHT}px`,
+        borderColor: "var(--chrome)",
         top: `${BORDER_HEIGHT - HANDLE_HEIGHT}px`,
       }}
       onMouseDown={onResizeStart}


### PR DESCRIPTION
I noticed that our border colors in the accordion component had sometime recently gotten broken:
![image](https://github.com/replayio/devtools/assets/29597/969c7b2f-464e-40e5-b444-6506a29e3a11)

This PR fixes them.
![Screenshot 2024-04-26 at 9 26 02 AM](https://github.com/replayio/devtools/assets/29597/1c3a11cd-808d-4ae2-96d3-22a2cccd3eca)