### PR TITLE
Fix default Primary Panel logic

### DIFF
--- a/src/ui/setup/dynamic/url.ts
+++ b/src/ui/setup/dynamic/url.ts
@@ -20,7 +20,7 @@ export type MutableURLParams = {
   viewMode: ViewMode | null;
 };
 
-// This method returns a subset of URL parameters, onces that change to mirror Redux state;
+// This method returns a subset of URL parameters, ones that change to mirror Redux state;
 // Read-only parameters are managed by shared/utils/environment
 export function getMutableParamsFromURL(): MutableURLParams {
   const { searchParams } = getURL();

--- a/src/ui/setup/index.ts
+++ b/src/ui/setup/index.ts
@@ -17,6 +17,7 @@ import { getUserInfo } from "ui/hooks/users";
 import { initialAppState } from "ui/reducers/app";
 import { syncInitialLayoutState } from "ui/reducers/layout";
 import { SourcesState, initialState as initialSourcesState } from "ui/reducers/sources";
+import { getMutableParamsFromURL } from "ui/setup/dynamic/url";
 import { ReplaySession, getReplaySession } from "ui/setup/prefs";
 import type { LayoutState } from "ui/state/layout";
 import { setUserInBrowserPrefs } from "ui/utils/browser";
@@ -44,6 +45,11 @@ const getDefaultSelectedPrimaryPanel = (
   session: ReplaySession | undefined,
   recording?: Recording
 ) => {
+  const { primaryPanel } = getMutableParamsFromURL();
+  if (primaryPanel) {
+    return primaryPanel;
+  }
+
   if (session) {
     return session.selectedPrimaryPanel;
   }


### PR DESCRIPTION
- [x] If a URL parameter caused the protocol panel to be shown to someone who didn't have that feature enabled, we should gracefully fall back to a different default panel
- [x] If a URL parameter specifies a default primary panel, we should not override with the user's most recent panel because that could be confusing

I don't really like the logic that's built on the old "async storage" stuff, but this seems like the smallest change that fixes the problems.