### PR TITLE
Re-enable full repaint-06 e2e test

### DIFF
--- a/packages/e2e-tests/tests/repaint-06.test.ts
+++ b/packages/e2e-tests/tests/repaint-06.test.ts
@@ -14,12 +14,11 @@ test("repaint-06: repaints the screen screen when stepping over code that modifi
   await startTest(page, recordingId, testScope);
   await openDevToolsTab(page);
 
-  // TODO [FE-2363] Some of these points fail repaint, so they're disabled until RUN-3397 has been fixed
   const printedStrings = [
-    // "catch",
-    // "afterCatch",
+    "catch",
+    "afterCatch",
     "finally",
-    // "yield 1",
+    "yield 1",
     "generated 1",
     "yield 2",
     "generated 2",


### PR DESCRIPTION
Paint fixes (TT-185) shipped a few weeks ago, so let's re-enable the full repaint-06 e2e test. Based on my local testing, it seems ready to go.