### PR TITLE
Show test panel regardless of what workspace it is in

### DIFF
--- a/src/ui/components/TestSuite/utils/isTestSuiteReplay.ts
+++ b/src/ui/components/TestSuite/utils/isTestSuiteReplay.ts
@@ -7,7 +7,6 @@ import {
 export function isTestSuiteReplay(recording: Recording): boolean {
   const testMetadata = recording?.metadata?.test;
   return (
-    !!recording.isInTestWorkspace &&
     testMetadata != null &&
     (isGroupedTestCasesV2(testMetadata) || isGroupedTestCasesV3(testMetadata))
   );


### PR DESCRIPTION
We should always show the test panel regardless of whether you upload it to your workspace or not.