### PR TITLE
Make object_preview-08 e2e test assertion less brittle

### DIFF
--- a/packages/e2e-tests/tests/object_preview-08.test.ts
+++ b/packages/e2e-tests/tests/object_preview-08.test.ts
@@ -26,7 +26,7 @@ test(`object_preview-08: should render ellipsis for collapsed objects with trunc
 
   {
     // Properties truncated by the client (no overflow)
-    const message = await findConsoleMessage(page, "76objectWithSixProperties", "console-log");
+    const message = await findConsoleMessage(page, "objectWithSixProperties", "console-log");
     const textContent = await message.textContent();
     expect(textContent).toContain("{a: 1, b: 2, c: 3, d: 4, e: 5, …}");
   }


### PR DESCRIPTION
I noticed this test failing in the recent RUN e2e tests. I don't think the line number that was attached to the console message was the important part of this test, so I'm removing it. That should make the test more resilient to changes in the example source code.