### PR TITLE
Udpate golden recording for doc_rr_objects.html

### DIFF
--- a/packages/e2e-tests/examples.json
+++ b/packages/e2e-tests/examples.json
@@ -108,8 +108,8 @@
     "buildId": "linux-chromium-20240418-4747c93165f9-4699f489a2b6"
   },
   "doc_rr_objects.html": {
-    "recording": "b30bbb21-6910-4080-8fd8-4fb298bc5e70",
-    "buildId": "linux-chromium-20240418-4747c93165f9-4699f489a2b6"
+    "recording": "7ab5a9cf-c1e7-4854-ae3b-a9736af16e9c",
+    "buildId": "macOS-chromium-20240425-b056bd66bbef-c0f8c1a0fc19"
   },
   "doc_rr_preview.html": {
     "recording": "7b91b521-2df6-4452-a2f1-6f597b323861",

--- a/packages/e2e-tests/tests/stepping-07.test.ts
+++ b/packages/e2e-tests/tests/stepping-07.test.ts
@@ -24,9 +24,9 @@ test("stepping-07: Test quick stepping using the keyboard", async ({
 
   await openPauseInformationPanel(page);
 
-  // Pause on line 50
-  await addBreakpoint(page, { lineNumber: 50, url: exampleKey });
-  await rewindToLine(page, 50);
+  // Pause on line 54
+  await addBreakpoint(page, { lineNumber: 54, url: exampleKey });
+  await rewindToLine(page, 54);
 
   // "Step over" ten times *without* waiting for each step to complete
   // TODO [RUN-3271] Chromium currently requires 2 steps per line,
@@ -35,6 +35,6 @@ test("stepping-07: Test quick stepping using the keyboard", async ({
     await page.keyboard.press("F10");
   }
 
-  // after all steps have been executed we should be paused on line 60
-  await waitForPaused(page, 67);
+  // after all steps have been executed we should be paused on line 71
+  await waitForPaused(page, 71);
 });


### PR DESCRIPTION
PR #10504 updated the underlying example/source for this test, but did not update the "golden recording" that FE e2e tests run against, so FE e2e tests continued passing and RUN tests began failing because of different line numbers in the source code.