### PR TITLE
Fixing border on UnexpectedError screen

### DIFF
--- a/packages/replay-next/components/errors/ModalFrame.module.css
+++ b/packages/replay-next/components/errors/ModalFrame.module.css
@@ -24,7 +24,6 @@
   font-family: var(--font-family-default);
   background-color: var(--support-form-modal-background-color);
   color: var(--support-form-color);
-  border: 1px solid var(--support-form-modal-border-color);
   border-radius: 0.75rem;
   filter: var(--context-menu-filter);
 }

--- a/packages/replay-next/variables.css
+++ b/packages/replay-next/variables.css
@@ -124,7 +124,6 @@
   --support-form-color: var(--grey-90);
   --support-form-close-icon-color: #ffffff;
   --support-form-modal-background-color: #ffffff;
-  --support-form-modal-border-color: var(--grey-90);
   --support-form-link-background-color: var(--grey-20);
   --support-form-link-background-color-hover: var(--grey-30);
   --support-form-text-area-background-color: var(--grey-20);


### PR DESCRIPTION
**Old vs new**
![image](https://github.com/replayio/devtools/assets/9154902/33d8503e-57ff-4fa8-b4ef-354e5f183054)

Fixes [DES-1198](https://linear.app/replay/issue/DES-1198/the-border-is-too-dark) 