### PR TITLE
Fixed non-DOM props being spread onto HTML element in Popup

### DIFF
--- a/packages/replay-next/components/sources/PreviewPopup.tsx
+++ b/packages/replay-next/components/sources/PreviewPopup.tsx
@@ -27,7 +27,7 @@ type Props = {
   target: HTMLElement;
 };
 
-export default function PreviewPopup(props: Props) {
+export default function PreviewPopup({ expression, sourceId, ...props }: Props) {
   return (
     <InlineErrorBoundary name="PreviewPopup">
       <Suspense
@@ -39,7 +39,7 @@ export default function PreviewPopup(props: Props) {
           </Popup>
         }
       >
-        <SuspendingPreviewPopup {...props} />
+        <SuspendingPreviewPopup expression={expression} sourceId={sourceId} {...props} />
       </Suspense>
     </InlineErrorBoundary>
   );


### PR DESCRIPTION
This avoid React warning from appearing in the console