### PR TITLE
Slightly decrease line-height in Support form

### DIFF
--- a/packages/replay-next/components/errors/SupportForm.module.css
+++ b/packages/replay-next/components/errors/SupportForm.module.css
@@ -5,6 +5,7 @@
   border-radius: 0.25rem;
   padding: 0.25rem 0.5rem;
   border: none;
+  line-height: 1.25rem;
   font-family: var(--font-family-default);
   font-size: var(--font-size-regular);
   background-color: var(--support-form-text-area-background-color);


### PR DESCRIPTION
Noticed this while looking into PRO-412

| Before | After |
| :---: | :---: |
| ![Screenshot 2024-05-10 at 3 43 20 PM](https://github.com/replayio/devtools/assets/29597/e7aaa416-e096-4b7f-9073-124fdba9a376) |  ![Screenshot 2024-05-10 at 3 43 26 PM](https://github.com/replayio/devtools/assets/29597/2972beec-0c3a-4aca-bcf0-bdbdeaa48baa) |