### PR TITLE
Don't show processing estimation for recordings with a duration of 0

### DIFF
--- a/src/ui/components/DevToolsProcessingScreen.tsx
+++ b/src/ui/components/DevToolsProcessingScreen.tsx
@@ -36,7 +36,7 @@ export function DevToolsProcessingScreen() {
 
   if (showStalledMessage) {
     secondaryMessage = "There may be a problem. This is taking much longer than expected.";
-  } else if (recording?.duration != null) {
+  } else if (recording?.duration) {
     const durationLabel = formatEstimatedProcessingDuration(recording?.duration);
     secondaryMessage = `Based on the length of this Replay, we expect processing will take about ${durationLabel}`;
   }


### PR DESCRIPTION
Looking at other recordings, I thought this would be null/undefined or a valid value. Seems like it could also be 0 in which case, we shouldn't show an estimated processing duration.

cc @miriambudayr 

| before | after |
| :---: | :---: |
| ![Screenshot 2024-05-13 at 1 38 02 PM](https://github.com/replayio/devtools/assets/29597/e39f4861-4d16-429f-8b6a-4560b1b6c24b) | ![Screenshot 2024-05-13 at 1 37 43 PM](https://github.com/replayio/devtools/assets/29597/1f0f1e34-3214-4e3d-a9e1-a67135f483a0) |