### PR TITLE
Fix preprod port

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "npm run dev:prod",
     "dev:local": "DASHBOARD_URL=http://localhost:8080 npm exec next dev -- -p 8081",
     "dev:prod": "next dev -p 8080",
-    "preprod": "NEXT_PUBLIC_API_URL=http://graphql-api.pre-prod.replay.prod/v1/graphql NEXT_PUBLIC_DISPATCH_URL=ws://agent.pre-prod.replay.prod next dev -p 8080",
+    "preprod": "NEXT_PUBLIC_API_URL=http://graphql-api.pre-prod.replay.prod/v1/graphql NEXT_PUBLIC_DISPATCH_URL=ws://agent.pre-prod.replay.prod DASHBOARD_URL=http://localhost:8080 next dev -- -p 8081",
     "export": "next build && next export -o dist",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
When running preprod, it's important that devtools and dashboard are not on the same port.