### PR TITLE
Fix the retry logic in the editLogPoint test helper

### DIFF
--- a/packages/e2e-tests/helpers/source-panel.ts
+++ b/packages/e2e-tests/helpers/source-panel.ts
@@ -337,24 +337,21 @@ export async function editLogPoint(
     // The typeahead popup sometimes sticks around and overlaps the save button.
     // Sometimes, it will show up after we check the first time (PRO-238) so we
     // retry a couple times to ensure that we can clear it and move forward.
-    await waitFor(
-      async () => {
-        await hideTypeAheadSuggestions(page, {
-          sourceLineNumber: lineNumber,
-          type: "log-point-condition",
-        });
-        await hideTypeAheadSuggestions(page, {
-          sourceLineNumber: lineNumber,
-          type: "log-point-content",
-        });
+    await waitFor(async () => {
+      await hideTypeAheadSuggestions(page, {
+        sourceLineNumber: lineNumber,
+        type: "log-point-condition",
+      });
+      await hideTypeAheadSuggestions(page, {
+        sourceLineNumber: lineNumber,
+        type: "log-point-content",
+      });
 
-        const saveButton = line.locator('[data-test-name="PointPanel-SaveButton"]');
-        await expect(saveButton).toBeEnabled();
-        await saveButton.click();
-        await saveButton.waitFor({ state: "detached" });
-      },
-      { timeout: 2_000 }
-    );
+      const saveButton = line.locator('[data-test-name="PointPanel-SaveButton"]');
+      await expect(saveButton).toBeEnabled();
+      await saveButton.click({ timeout: 1_000 });
+      await saveButton.waitFor({ state: "detached" });
+    });
   }
 }
 


### PR DESCRIPTION
The `logpoints-02` e2e test flaked again for the same reason we had tried to fix in the past: a logpoint couldn't be saved because the type-ahead box hides the logpoint's save button ([PRO-444](https://linear.app/replay/issue/PRO-444/e2e-test-failure-logpoints-02-at-pointpanel-savebutton) and [PRO-238](https://linear.app/replay/issue/PRO-238/locatorclick-timeout-60000ms-exceeded-waiting-for-locator[data-test)).
In #10491 we added retry logic so that the type-ahead box is cleared if it showed up after we tried to clear it for the first time but before the save button is clicked. However, that logic didn't work: the click action had a default timeout of 60 seconds but the surrounding retry logic had a timeout of 2 seconds, so if the click action failed it was never retried.