### PR TITLE
fix e2e script after @replayio/playwright upgrade

### DIFF
--- a/packages/e2e-tests/scripts/record-playwright.ts
+++ b/packages/e2e-tests/scripts/record-playwright.ts
@@ -13,7 +13,7 @@ export async function recordPlaywright(
 ) {
   let executablePath: string | undefined = undefined;
   if (config.shouldRecordTest) {
-    executablePath = config.browserPath || getExecutablePath("chromium");
+    executablePath = config.browserPath || getExecutablePath();
   }
 
   const browserServer = await chromium.launchServer({


### PR DESCRIPTION
`getExecutablePath` lost its parameter