### PR TITLE
Enable dependency graph collection in e2e tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ on:
 env:
   RECORD_REPLAY_API_KEY: rwk_yaEG8jo6gcisGHHoMj8SNoOMIHSbT7REuU5E1QnKCiL
   RECORD_REPLAY_METADATA_TEST_RUN_TITLE: E2E Tests
+  RECORD_REPLAY_DISABLE_FEATURES: ["no-dependency-graph"]
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ on:
 env:
   RECORD_REPLAY_API_KEY: rwk_yaEG8jo6gcisGHHoMj8SNoOMIHSbT7REuU5E1QnKCiL
   RECORD_REPLAY_METADATA_TEST_RUN_TITLE: E2E Tests
-  RECORD_REPLAY_DISABLE_FEATURES: ["no-dependency-graph"]
+  RECORD_REPLAY_DISABLE_FEATURES: '["no-dependency-graph"]'
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}


### PR DESCRIPTION
See https://linear.app/replay/issue/PRO-513/enable-dependency-graph-collection-in-e2e-tests