### PR TITLE
Avoid spamming telemetry with repeated `reactdevtools.node_not_found` events

### DIFF
--- a/src/ui/components/SecondaryToolbox/react-devtools/ReplayWall.ts
+++ b/src/ui/components/SecondaryToolbox/react-devtools/ReplayWall.ts
@@ -168,7 +168,10 @@ export class ReplayWall implements Wall {
           // Get the first node ID we found for this fiber ID, if available.
           const [nodeId] = fiberIdsToNodeIds.get(fiberId) ?? [];
           if (!nodeId) {
-            sendTelemetryEvent("reactdevtools.node_not_found", payload);
+            // skip on hitting this again for the same fiberId (maybe combo it with pauseId?)
+            sendTelemetryEvent("reactdevtools.node_not_found", payload, {
+              id: fiberId,
+            });
             return;
           }
 

--- a/src/ui/components/SecondaryToolbox/react-devtools/ReplayWall.ts
+++ b/src/ui/components/SecondaryToolbox/react-devtools/ReplayWall.ts
@@ -168,9 +168,8 @@ export class ReplayWall implements Wall {
           // Get the first node ID we found for this fiber ID, if available.
           const [nodeId] = fiberIdsToNodeIds.get(fiberId) ?? [];
           if (!nodeId) {
-            // skip on hitting this again for the same fiberId (maybe combo it with pauseId?)
             sendTelemetryEvent("reactdevtools.node_not_found", payload, {
-              id: fiberId,
+              distinctOn: fiberId,
             });
             return;
           }

--- a/src/ui/utils/telemetry.ts
+++ b/src/ui/utils/telemetry.ts
@@ -116,16 +116,20 @@ const sentEvents = new Set<string>();
 
 type TelemetryOptions = {
   /** It can be used to avoid sending repeated events. It's always combined with `event` for that purpose */
-  id?: string;
+  distinctOn?: string;
 };
 
-export function sendTelemetryEvent(event: string, tags: any = {}, { id }: TelemetryOptions = {}) {
+export function sendTelemetryEvent(
+  event: string,
+  tags: any = {},
+  { distinctOn }: TelemetryOptions = {}
+) {
   if (userData.get("global_logTelemetryEvent")) {
     console.log("telemetry event", { event, tags });
   }
 
-  if (id) {
-    const key = `${event}:${id}`;
+  if (distinctOn) {
+    const key = `${event}:${distinctOn}`;
     if (sentEvents.has(key)) {
       return;
     }

--- a/src/ui/utils/telemetry.ts
+++ b/src/ui/utils/telemetry.ts
@@ -112,9 +112,24 @@ export function setTelemetryContext({ id, email, internal }: TelemetryUser) {
   }
 }
 
-export function sendTelemetryEvent(event: string, tags: any = {}) {
+const sentEvents = new Set<string>();
+
+type TelemetryOptions = {
+  /** It can be used to avoid sending repeated events. It's always combined with `event` for that purpose */
+  id?: string;
+};
+
+export function sendTelemetryEvent(event: string, tags: any = {}, { id }: TelemetryOptions = {}) {
   if (userData.get("global_logTelemetryEvent")) {
     console.log("telemetry event", { event, tags });
+  }
+
+  if (id) {
+    const key = `${event}:${id}`;
+    if (sentEvents.has(key)) {
+      return;
+    }
+    sentEvents.add(key);
   }
 
   if (skipTelemetry()) {


### PR DESCRIPTION
I noticed a lot of repeated network requests going out when scrolling through the Network/Elements panels and I linked them them to this call site.