### PR TITLE
Log the url of the session that failed

### DIFF
--- a/packages/e2e-tests/helpers/utils.ts
+++ b/packages/e2e-tests/helpers/utils.ts
@@ -131,12 +131,16 @@ export async function waitForRecordingToFinishIndexing(page: Page): Promise<void
     async () => {
       const supportFormErrorDetails = await getSupportFormErrorDetails(page);
       if (supportFormErrorDetails) {
-        throw new UnrecoverableError(`Session failed: ${supportFormErrorDetails}`);
+        throw new UnrecoverableError(
+          `Session failed (visiting ${page.url()}): ${supportFormErrorDetails}`
+        );
       }
 
       const expectedErrorDetails = await getExpectedErrorDetails(page);
       if (expectedErrorDetails) {
-        throw new UnrecoverableError(`Session failed: ${expectedErrorDetails}`);
+        throw new UnrecoverableError(
+          `Session failed (visiting ${page.url()}): ${expectedErrorDetails}`
+        );
       }
 
       if (await timelineCapsuleLocator.isVisible()) {

--- a/packages/e2e-tests/helpers/utils.ts
+++ b/packages/e2e-tests/helpers/utils.ts
@@ -132,14 +132,14 @@ export async function waitForRecordingToFinishIndexing(page: Page): Promise<void
       const supportFormErrorDetails = await getSupportFormErrorDetails(page);
       if (supportFormErrorDetails) {
         throw new UnrecoverableError(
-          `Session failed (visiting ${page.url()}): ${supportFormErrorDetails}`
+          `Session failed "${supportFormErrorDetails}" (visiting ${page.url()})`
         );
       }
 
       const expectedErrorDetails = await getExpectedErrorDetails(page);
       if (expectedErrorDetails) {
         throw new UnrecoverableError(
-          `Session failed (visiting ${page.url()}): ${expectedErrorDetails}`
+          `Session failed: "${expectedErrorDetails}" (visiting ${page.url()})`
         );
       }
 


### PR DESCRIPTION
* This is a CI/test change only.
* [This test run](https://buildkite.com/replay/runtime-fe-end-to-end-tests/builds/1383#018fbf4e-09d4-4d03-9671-c8786cfd16e2) is an example of where it matters.
* Implementation: When we report `Session failed`, make sure to also give us the info we need to debug it, i.e. the Url of the recording whose session is failing. We need that to look up the relevant crash.

Sidenote: This message is usually encountered when the "golden recording" RTP crashed. The Runtime E2E test pipeline is more likely to encounter this problem, as we re-record golden recordings all the time, possibly on broken builds.