### PR TITLE
Update passport docs links to new site

### DIFF
--- a/src/ui/components/Passport/Passport.tsx
+++ b/src/ui/components/Passport/Passport.tsx
@@ -88,8 +88,7 @@ const Passport = (props: PropsFromRedux) => {
       completed: !showConsoleNavigate,
       videoUrl: "https://vercel.replay.io/passport/time_travel_in_console.gif",
       imageBaseName: "time_travel_in_the_console",
-      docsLink:
-        "https://replayio.notion.site/Navigate-in-the-console-3b732260a9254c20b43d213c4a93c9de?pvs=4",
+      docsLink: "https://docs.replay.io/basics/replay-devtools/browser-devtools/console",
       blurb: "Look for the blue button in the console.",
     },
     {
@@ -97,8 +96,7 @@ const Passport = (props: PropsFromRedux) => {
       completed: !showBreakpointEdit,
       videoUrl: "https://vercel.replay.io/passport/set_print_statement.gif",
       imageBaseName: "set_a_print_statement",
-      docsLink:
-        "https://replayio.notion.site/Adding-print-statements-18a7d1f85b434706b46af0a8d5d298fe?pvs=4",
+      docsLink: "https://docs.replay.io/learn/replay-course#console-logs-overview",
       blurb: "When looking at a source, click the plus sign.",
     },
   ];
@@ -109,7 +107,7 @@ const Passport = (props: PropsFromRedux) => {
       completed: !showJumpToCode,
       videoUrl: "https://vercel.replay.io/passport/jump_to_code.gif",
       imageBaseName: "jump_to_code",
-      docsLink: "https://replayio.notion.site/Jump-to-code-45026e5087014475a52dc4a8024dc850?pvs=4",
+      docsLink: "https://docs.replay.io/basics/getting-started/inspect-replay#jump-to-an-event",
       blurb: "Click the info icon on the left nav, then look for the blue button.",
     },
     {
@@ -117,7 +115,7 @@ const Passport = (props: PropsFromRedux) => {
       completed: !showJumpToEvent,
       videoUrl: "https://vercel.replay.io/passport/jump_to_an_event.gif",
       imageBaseName: "jump_to_event",
-      docsLink: "https://replayio.notion.site/Jump-to-event-199d592b0ff1458bac0f27a7c2a9f78d?pvs=4",
+      docsLink: "https://docs.replay.io/basics/getting-started/inspect-replay#jump-to-an-event",
       blurb: "Click the info icon on the left nav to see all events in your replay.",
     },
     {
@@ -126,7 +124,7 @@ const Passport = (props: PropsFromRedux) => {
       videoUrl: "https://vercel.replay.io/passport/jump_to_network_request.gif",
       imageBaseName: "jump_to_network_request",
       docsLink:
-        "https://www.notion.so/replayio/Jump-to-network-request-8fc5dadc78274ca68a91714226ca165d?pvs=4",
+        "https://docs.replay.io/basics/getting-started/inspect-replay#inspect-network-calls",
       blurb: "In the network pane, you can jump to some requests.",
     },
   ];
@@ -137,8 +135,7 @@ const Passport = (props: PropsFromRedux) => {
       completed: !showInspectElement,
       videoUrl: "https://vercel.replay.io/passport/inspect_an_element.gif",
       imageBaseName: "inspect_element",
-      docsLink:
-        "https://replayio.notion.site/Inspect-UI-elements-5dcab655fe7343a798f3adacbaf937fc?pvs=4",
+      docsLink: "https://docs.replay.io/learn/replay-course#elements-panel",
       blurb: "Look for the elements tab to the right of the console.",
     },
     {
@@ -147,7 +144,7 @@ const Passport = (props: PropsFromRedux) => {
       videoUrl: "https://vercel.replay.io/passport/inspect_a_network_request.gif",
       imageBaseName: "inspect_network_request",
       docsLink:
-        "https://replayio.notion.site/Inspect-network-elements-f3e47ee936324fef92fe555c9de6567d?pvs=4",
+        "https://docs.replay.io/basics/getting-started/inspect-replay#inspect-network-calls",
       blurb: "Network requests is to the right of the console and elements tabs.",
     },
     {
@@ -155,8 +152,7 @@ const Passport = (props: PropsFromRedux) => {
       completed: !showInspectReactComponent,
       videoUrl: "https://vercel.replay.io/passport/inspect_a_react_component.gif",
       imageBaseName: "inspect_react_component",
-      docsLink:
-        "https://replayio.notion.site/Inspect-React-elements-5e4ae5b2a8fb4b6bba8ca5167ce94eb0?pvs=4",
+      docsLink: "https://docs.replay.io/learn/replay-course#react-panel",
       blurb: "The React tab is in the same area as console, elements, and network events.",
     },
   ];
@@ -167,7 +163,7 @@ const Passport = (props: PropsFromRedux) => {
       completed: !showAddComment,
       videoUrl: "https://vercel.replay.io/passport/add_a_comment.gif",
       imageBaseName: "add_a_comment",
-      docsLink: "https://replayio.notion.site/Add-a-comment-1b042007d9874ad6880af1dea7dd1e42?pvs=4",
+      docsLink: "https://docs.replay.io/learn/replay-course#commenting-and-sharing",
       blurb:
         "Click in the video region to set a comment. It's also possible to add comments to console logs, print statements, and network monitor requests.",
     },
@@ -176,7 +172,8 @@ const Passport = (props: PropsFromRedux) => {
       completed: !showAddUnicornBadge,
       videoUrl: "https://vercel.replay.io/passport/unicorn_badge.gif",
       imageBaseName: "add_a_unicorn_badge",
-      docsLink: "https://replayio.notion.site/Add-a-badge-c50800e3065c4c2d9ad7b16449d0a8a1?pvs=4",
+      docsLink:
+        "https://docs.replay.io/basics/replay-devtools/time-travel-devtools/live-console-logs#prefix-messages-with-badges",
       blurb: "When setting a print statement, click the gray circle to the left.",
     },
     {
@@ -184,8 +181,7 @@ const Passport = (props: PropsFromRedux) => {
       completed: !showSearchSourceText,
       videoUrl: "https://vercel.replay.io/passport/search_source_text.gif",
       imageBaseName: "search_source_text",
-      docsLink:
-        "https://replayio.notion.site/Search-source-text-869e0205b8b14f94b3f15020fc4bf0f9?pvs=4",
+      docsLink: "https://docs.replay.io/learn/replay-course#source-explorer",
       blurb: "Click the magnifying glass icon in the left nav.",
     },
     {
@@ -194,7 +190,7 @@ const Passport = (props: PropsFromRedux) => {
       videoUrl: "https://vercel.replay.io/passport/use_focus_mode.gif",
       imageBaseName: "use_focus_mode",
       docsLink:
-        "https://replayio.notion.site/Set-a-focus-window-2409a0207b2449e6baf162f27ce37b35?pvs=4",
+        "https://docs.replay.io/basics/replay-devtools/time-travel-devtools/focus-window#features",
       blurb: "Look for the focus icon in the bottom right corner.",
     },
     {
@@ -202,7 +198,8 @@ const Passport = (props: PropsFromRedux) => {
       completed: !showFindFile,
       videoUrl: "https://vercel.replay.io/passport/find_file.gif",
       imageBaseName: "find_file",
-      docsLink: "https://replayio.notion.site/Go-to-file-4e867dc10f7d4db3be78e9bfc53c97f9?pvs=4",
+      docsLink:
+        "https://docs.replay.io/basics/replay-devtools/browser-devtools/source-viewer#basics",
       blurb: "Press command-P on your keyboard.",
     },
   ];
@@ -214,7 +211,7 @@ const Passport = (props: PropsFromRedux) => {
       completed: !showShareNag,
       videoUrl: "https://vercel.replay.io/passport/share.gif",
       imageBaseName: "share",
-      docsLink: "https://replayio.notion.site/Share-7ecdd5ce6c36456bb1354540656f6799?pvs=4",
+      docsLink: "https://docs.replay.io/basics/replay-teams/managing-replays#sharing-a-replay",
       blurb: "Click the blue share button at the top of the app.",
     });
   }


### PR DESCRIPTION
This just updates all of the links to point to the new documentation site. I did my best to find an analogous page in each case, but even in cases where the fit is not perfect, I think it's better to consistently land people on the new docs so they can at least look around for what they are looking for using the new site.