### PR TITLE
[TT-189] Add platform-specific block lists and a bit more  logic

### DIFF
--- a/packages/e2e-tests/scripts/buildkite_run_fe_tests.ts
+++ b/packages/e2e-tests/scripts/buildkite_run_fe_tests.ts
@@ -21,21 +21,21 @@ let TestFileOverrideList = [];
 
 // Disable some tests that we know to be problematic.
 const TestFileBlockLists = {
-  "linux": [],
-  "darwin": [
+  linux: [],
+  darwin: [
     // This test has been failing for a long, long time.  disable it for now so
     // we can get back to green builds.
     // https://linear.app/replay/issue/TT-189/re-enable-failing-fe-tests
     "tests/inspector-elements-02_node-picker.test.ts",
   ],
-  "ALL": [
+  ALL: [
     // Disable some paint expectations. Paints and repaintGraphics have improved
     // but are not perfect. Let's revisit it once we see it have a real impact
     // on the user, or else, post GA.
     // https://linear.app/replay/issue/TT-189/re-enable-failing-fe-tests
     "tests/repaint-01.test.ts",
     "tests/repaint-06.test.ts",
-  ]
+  ],
 };
 
 const TestFileBlockList = new Set([
@@ -45,9 +45,9 @@ const TestFileBlockList = new Set([
 
 // Force some tests to run that we have recently fixed but not yet enabled everywhere.
 const TestFileForceLists = {
-  "linux": [],
-  "darwin": [],
-  "ALL": [],
+  linux: [],
+  darwin: [],
+  ALL: [],
 };
 
 const TestFileForceList = new Set([
@@ -60,7 +60,8 @@ const TestFileForceList = new Set([
  * "recent Chromium".
  */
 function checkReRecord(testFile, exampleFileInfo: ExampleInfo) {
-  const wouldNormallyTest = exampleFileInfo.runtime === "chromium" &&
+  const wouldNormallyTest =
+    exampleFileInfo.runtime === "chromium" &&
     exampleFileInfo.runtimeReleaseDate.getUTCFullYear() === 2024 &&
     !exampleFileInfo.requiresManualUpdate;
 
@@ -73,7 +74,9 @@ function checkReRecord(testFile, exampleFileInfo: ExampleInfo) {
 
   if (shouldForceTest) {
     if (wouldNormallyTest) {
-      console.warn(chalk.yellow(`🟡 FORCED: ${testFile} (would normally test.  remove it from force list?)`));
+      console.warn(
+        chalk.yellow(`🟡 FORCED: ${testFile} (would normally test.  remove it from force list?)`)
+      );
     } else {
       console.warn(chalk.yellow(`✅ FORCED: ${testFile}`));
     }
@@ -82,7 +85,11 @@ function checkReRecord(testFile, exampleFileInfo: ExampleInfo) {
 
   if (shouldBlockTest) {
     if (!wouldNormallyTest) {
-      console.warn(chalk.yellow(`🟡 BLOCKED: ${testFile} (would not normally test.  remove it from block list?)`));
+      console.warn(
+        chalk.yellow(
+          `🟡 BLOCKED: ${testFile} (would not normally test.  remove it from block list?)`
+        )
+      );
     } else {
       console.warn(chalk.yellow(`❌ BLOCKED: ${testFile}`));
     }

--- a/packages/e2e-tests/scripts/buildkite_run_fe_tests.ts
+++ b/packages/e2e-tests/scripts/buildkite_run_fe_tests.ts
@@ -64,10 +64,10 @@ function checkReRecord(testFile, exampleFileInfo: ExampleInfo) {
     exampleFileInfo.runtimeReleaseDate.getUTCFullYear() === 2024 &&
     !exampleFileInfo.requiresManualUpdate;
 
-  const shouldNeverTest = TestFileBlockList.has(testFile);
+  const shouldBlockTest = TestFileBlockList.has(testFile);
   const shouldForceTest = TestFileForceList.has(testFile);
 
-  if (shouldNeverTest && shouldForceTest) {
+  if (shouldBlockTest && shouldForceTest) {
     throw new Error(`Test is both in Blocked and Forced: ${testFile}`);
   }
 
@@ -80,7 +80,7 @@ function checkReRecord(testFile, exampleFileInfo: ExampleInfo) {
     return true;
   }
 
-  if (shouldNeverTest) {
+  if (shouldBlockTest) {
     if (!wouldNormallyTest) {
       console.warn(chalk.yellow(`🟡 BLOCKED: ${testFile} (would not normally test.  remove it from block list?)`));
     } else {


### PR DESCRIPTION
* switch from black/white to block/force since it's a little clearer what they do.
* add output for when a test is blocked but wouldn't be run anyway, or forced when it would be run anyway.
* add platform specific block/force lists (so I can block the long-time macos failing `tests/inspector-elements-02_node-picker.test.ts` - added this to TT-189.)

Honestly I think we should probably move away from a block list and more to an expected-failure/XFAIL list.   Then we can see when it starts passing in CI.  for sometime soon.
