### PR TITLE
Look up DOM nodes for Cypress "click" steps at the before point

### DIFF
--- a/src/ui/components/TestSuite/utils/cypressStepDomNodes.ts
+++ b/src/ui/components/TestSuite/utils/cypressStepDomNodes.ts
@@ -1,0 +1,119 @@
+declare var __RECORD_REPLAY_ARGUMENTS__: {
+  getPersistentId?: (value: any) => number | null | void;
+
+  internal?: {
+    registerPlainObject?: (value: any) => string | null | void;
+  };
+};
+
+declare var __RECORD_REPLAY__: {
+  getObjectFromProtocolId?: (id: string | number) => any;
+  getProtocolIdForObject?: (object: any) => string | number | null;
+};
+
+export function findDOMNodeObjectIdForPersistentId(persistentId: number): string | null {
+  if (
+    typeof __RECORD_REPLAY__ === "undefined" ||
+    __RECORD_REPLAY__ == null ||
+    __RECORD_REPLAY__.getProtocolIdForObject == null
+  ) {
+    return null;
+  }
+
+  if (
+    typeof __RECORD_REPLAY_ARGUMENTS__ === "undefined" ||
+    __RECORD_REPLAY_ARGUMENTS__ == null ||
+    __RECORD_REPLAY_ARGUMENTS__.getPersistentId == null
+  ) {
+    return null;
+  }
+
+  const { getPersistentId } = __RECORD_REPLAY_ARGUMENTS__;
+
+  let domNodeId: string | null = null;
+
+  function getObjectId(value: any) {
+    if (typeof __RECORD_REPLAY_ARGUMENTS__ !== "undefined" && __RECORD_REPLAY_ARGUMENTS__ != null) {
+      // TODO [FE-2005][FE-2067] With persistent DOM ids, presumably we should switch to using this API?
+      // if (__RECORD_REPLAY_ARGUMENTS__.getPersistentId) {
+      //   const id = __RECORD_REPLAY_ARGUMENTS__.getPersistentId(value);
+      //   if (id) {
+      //     return id;
+      //   }
+      // }
+
+      if (
+        __RECORD_REPLAY_ARGUMENTS__.internal &&
+        __RECORD_REPLAY_ARGUMENTS__.internal.registerPlainObject
+      ) {
+        const id = __RECORD_REPLAY_ARGUMENTS__.internal.registerPlainObject(value);
+        if (id) {
+          return parseInt(id);
+        }
+      }
+    }
+
+    throw Error("Could not find object id");
+  }
+
+  const rootNode = document;
+  let queue: (number | ChildNode | Document | Element)[] = [0, rootNode];
+
+  // This loop modified from the version in `serialization.ts`,
+  // which is used to serialize the entire DOM tree.
+  // In our case, we want to _loop_ over the entire DOM tree,
+  // but we're only looking to find a single DOM node by persistent ID.
+  // It's important that we be able to drill down through iframes,
+  // especially since Cypress tests always run in an iframe.
+  while (queue.length > 0) {
+    const _parentObjectId = queue.shift() as number;
+    const domNodeOrText = queue.shift() as Element;
+
+    const objectId = getObjectId(domNodeOrText);
+    const nodePersistentId = getPersistentId(domNodeOrText);
+
+    if (persistentId === nodePersistentId) {
+      // Turn this back into a string
+      domNodeId = `${objectId}`;
+      break;
+    }
+
+    let { childNodes, nodeType } = domNodeOrText;
+
+    if (childNodes) {
+      for (let child of childNodes) {
+        switch (child.nodeType) {
+          case Node.COMMENT_NODE: {
+            break;
+          }
+          case Node.TEXT_NODE: {
+            if (child.textContent?.trim()) {
+              queue.push(objectId);
+              queue.push(child);
+            }
+            break;
+          }
+          default: {
+            queue.push(objectId);
+            queue.push(child);
+            break;
+          }
+        }
+      }
+    }
+
+    switch (nodeType) {
+      case Node.ELEMENT_NODE: {
+        if (domNodeOrText instanceof HTMLIFrameElement) {
+          if (domNodeOrText.contentDocument != null) {
+            queue.push(objectId);
+            queue.push(domNodeOrText.contentDocument);
+          }
+        }
+        break;
+      }
+    }
+  }
+
+  return domNodeId;
+}


### PR DESCRIPTION
This PR:

- Updates the Cypress-specific logic in `TestEventDetailsCache.ts` to do additional lookups when the test step is a `"click"` event, by looking for the corresponding DOM node at the `beforeStep`.  This ensures the DOM node _should_ still be in the DOM and we have something to highlight.

The logic is ugly, but in general;

- We have DOM node previews from the `result` step. These include a persistent ID
- We do an eval at the `beforeStep` point, and pass in all of the target node persistent IDs
- We use a modified version of the DOM tree walking logic used by the Elements panel, and loop over the whole tree looking for a DOM node with the same persistent ID. When we find it, we return the _per-pause_ object ID.
- We look up the actual DOM node previews from that pause now that we know the object IDs
- We cache the "before" versions using the "_result_" point as the key, which is fine - that's what the row component uses as the lookup, but what really matters is that we've saved a pause ID and DOM node IDs, and the pause we saved for highlighting doesn't have to be a pause for the result point.