### PR TITLE
Improve message shown when async stack can't be loaded

### DIFF
--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/NewFrames.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/NewFrames.tsx
@@ -10,9 +10,11 @@ import {
   getSelectedFrameId,
   getThreadContext,
 } from "devtools/client/debugger/src/selectors";
+import { isFocusWindowApplied } from "devtools/client/debugger/src/utils/focus";
 import { InlineErrorBoundary } from "replay-next/components/errors/InlineErrorBoundary";
 import { copyToClipboard } from "replay-next/components/sources/utils/clipboard";
 import { FocusContext } from "replay-next/src/contexts/FocusContext";
+import { SessionContext } from "replay-next/src/contexts/SessionContext";
 import { useCurrentFocusWindow } from "replay-next/src/hooks/useCurrentFocusWindow";
 import { useIsPointWithinFocusWindow } from "replay-next/src/hooks/useIsPointWithinFocusWindow";
 import { getPointAndTimeForPauseId, pauseIdCache } from "replay-next/src/suspense/PauseCache";
@@ -44,11 +46,8 @@ function FramesRenderer({
   const replayClient = useContext(ReplayClientContext);
   const sourcesState = useAppSelector(state => state.sources);
   const { rangeForSuspense: focusWindow } = useContext(FocusContext);
+  const { endpoint } = useContext(SessionContext);
   const dispatch = useAppDispatch();
-
-  if (focusWindow === null) {
-    return null;
-  }
 
   const asyncSeparator =
     asyncIndex > 0 ? (
@@ -70,11 +69,17 @@ function FramesRenderer({
       <>
         {asyncSeparator}
         <div className="pane-info empty">
-          This part of the call stack is unavailable because it is outside{" "}
-          <span className="cursor-pointer underline" onClick={() => dispatch(enterFocusMode())}>
-            your debugging window
-          </span>
-          .
+          This part of the call stack is unavailable.
+          {isFocusWindowApplied(focusWindow, endpoint) && (
+            <>
+              {" "}
+              Perhaps it is outside of{" "}
+              <span className="cursor-pointer underline" onClick={() => dispatch(enterFocusMode())}>
+                your debugging window
+              </span>
+              .
+            </>
+          )}
         </div>
       </>
     );

--- a/src/devtools/client/debugger/src/utils/focus.ts
+++ b/src/devtools/client/debugger/src/utils/focus.ts
@@ -1,0 +1,10 @@
+import { TimeStampedPointRange } from "@replayio/protocol";
+
+export function isFocusWindowApplied(
+  focusWindow: TimeStampedPointRange | null,
+  endpoint: string
+): focusWindow is TimeStampedPointRange {
+  return (
+    focusWindow !== null && (focusWindow.begin.point !== "0" || focusWindow.end.point !== endpoint)
+  );
+}

--- a/src/ui/suspense/util.ts
+++ b/src/ui/suspense/util.ts
@@ -12,7 +12,7 @@ export function getAsyncParentPauseIdSuspense(
   replayClient: ReplayClientInterface,
   pauseId: PauseId,
   asyncIndex: number,
-  focusWindow: TimeStampedPointRange
+  focusWindow: TimeStampedPointRange | null
 ): PauseId | null {
   while (asyncIndex > 0) {
     const frames = framesCache.read(replayClient, pauseId)!;


### PR DESCRIPTION
This message is shown all the time when it shouldn't be (because there's no focus window):
![Screenshot 2024-06-12 at 8 35 22 AM](https://github.com/replayio/devtools/assets/29597/40eade9e-8d8e-4cbd-87af-beb9c19ea836)

This PR changes it to (a) not show it when there's no focus window
![Screenshot 2024-06-12 at 8 35 14 AM](https://github.com/replayio/devtools/assets/29597/bd8782f3-3d02-46a7-8581-8e802ab0246c)

and (b) if we do show it, make the wording less certain (since it's often wrong)
![Screenshot 2024-06-12 at 8 35 00 AM](https://github.com/replayio/devtools/assets/29597/939dcdc2-b64b-4c40-9207-6bb842b43f81)
