### PR TITLE
Fix the scaling logic for cursor and highlighter

### DIFF
--- a/src/ui/components/Video/imperative/MutableGraphicsState.tsx
+++ b/src/ui/components/Video/imperative/MutableGraphicsState.tsx
@@ -57,7 +57,7 @@ export const state = createState<State>({
 let lock: Object | null = null;
 
 export async function updateState(
-  containerElement: HTMLElement,
+  graphicsElement: HTMLElement,
   options: Partial<{
     didResize?: boolean;
     executionPoint: ExecutionPoint | null;
@@ -101,7 +101,7 @@ export async function updateState(
     const naturalHeight = naturalDimensions.height;
     const naturalWidth = naturalDimensions.width;
 
-    const containerRect = containerElement.getBoundingClientRect();
+    const containerRect = graphicsElement.getBoundingClientRect();
     const scaledDimensions = fitImageToContainer({
       containerHeight: containerRect.height,
       containerWidth: containerRect.width,

--- a/src/ui/components/Video/imperative/runVideoPlayback.ts
+++ b/src/ui/components/Video/imperative/runVideoPlayback.ts
@@ -10,7 +10,7 @@ export async function runVideoPlayback({
   abortSignal,
   beginPoint,
   beginTime,
-  containerElement,
+  graphicsElement,
   endPoint,
   endTime,
   reduxStore,
@@ -19,7 +19,7 @@ export async function runVideoPlayback({
   abortSignal: AbortSignal;
   beginPoint: ExecutionPoint | null;
   beginTime: number;
-  containerElement: HTMLElement;
+  graphicsElement: HTMLElement;
   endPoint: ExecutionPoint | null;
   endTime: number;
   reduxStore: AppStore;
@@ -59,7 +59,7 @@ export async function runVideoPlayback({
     } else {
       const updateGraphicsPromise = updateGraphics({
         abortSignal,
-        containerElement,
+        graphicsElement,
         executionPoint: null,
         replayClient,
         time: nextTimelineTime,

--- a/src/ui/components/Video/imperative/subscribeToMutableSources.ts
+++ b/src/ui/components/Video/imperative/subscribeToMutableSources.ts
@@ -6,7 +6,7 @@ import { updateState } from "ui/components/Video/imperative/MutableGraphicsState
 import { repositionGraphicsOverlayElements } from "ui/components/Video/imperative/repositionGraphicsOverlayElements";
 import { runVideoPlayback } from "ui/components/Video/imperative/runVideoPlayback";
 import { updateGraphics } from "ui/components/Video/imperative/updateGraphics";
-import { getPlayback, isPlaying } from "ui/reducers/timeline";
+import { getPlayback } from "ui/reducers/timeline";
 import { AppStore } from "ui/setup/store";
 
 export function subscribeToMutableSources({
@@ -59,7 +59,6 @@ export function subscribeToMutableSources({
     }
 
     const didStartPlaying = isPlaying && !prevIsPlaying;
-    const didStopPlaying = !isPlaying && prevIsPlaying;
 
     prevTime = time;
     prevExecutionPoint = executionPoint;
@@ -78,7 +77,7 @@ export function subscribeToMutableSources({
           abortSignal: abortController.signal,
           beginPoint: playbackState.beginPoint,
           beginTime: playbackState.beginTime,
-          containerElement,
+          graphicsElement,
           endPoint: playbackState.endPoint,
           endTime: playbackState.endTime,
           reduxStore,
@@ -95,7 +94,7 @@ export function subscribeToMutableSources({
 
       updateGraphics({
         abortSignal: abortController.signal,
-        containerElement,
+        graphicsElement,
         executionPoint,
         replayClient,
         time,

--- a/src/ui/components/Video/imperative/updateGraphics.ts
+++ b/src/ui/components/Video/imperative/updateGraphics.ts
@@ -9,18 +9,18 @@ import { updateState } from "ui/components/Video/imperative/MutableGraphicsState
 
 export async function updateGraphics({
   abortSignal,
-  containerElement,
+  graphicsElement,
   executionPoint,
   replayClient,
   time,
 }: {
   abortSignal: AbortSignal;
-  containerElement: HTMLElement;
+  graphicsElement: HTMLElement;
   executionPoint: ExecutionPoint | null;
   time: number;
   replayClient: ReplayClientInterface;
 }) {
-  updateState(containerElement, {
+  updateState(graphicsElement, {
     executionPoint,
     status: "loading",
     time,
@@ -37,7 +37,7 @@ export async function updateGraphics({
   const paintPoint = findMostRecentPaint(time);
   const isBeforeFirstCachedPaint = !paintPoint || !paintPoint.paintHash;
   if (isBeforeFirstCachedPaint) {
-    updateState(containerElement, {
+    updateState(graphicsElement, {
       executionPoint,
       screenShot: null,
       screenShotType: null,
@@ -54,7 +54,7 @@ export async function updateGraphics({
       promises.push(
         fetchPaintContents({
           abortSignal,
-          containerElement,
+          graphicsElement,
           replayClient,
           time,
         })
@@ -91,7 +91,7 @@ export async function updateGraphics({
 
   // Show the first screenshot we get back (if we've found one)
   if (screenShot != null) {
-    updateState(containerElement, {
+    updateState(graphicsElement, {
       executionPoint,
       screenShot,
       screenShotType: repaintGraphicsScreenShot != null ? "repaint" : "cached-paint",
@@ -115,7 +115,7 @@ export async function updateGraphics({
 
     if (repaintGraphicsScreenShot != null) {
       // The repaint graphics API fails a lot; it should fail quietly here
-      updateState(containerElement, {
+      updateState(graphicsElement, {
         executionPoint,
         screenShot: repaintGraphicsScreenShot,
         screenShotType: "repaint",
@@ -129,7 +129,7 @@ export async function updateGraphics({
 
   if (screenShot == null) {
     // If we couldn't load either a cached screenshot or a repaint, update the DOM to reflect that
-    updateState(containerElement, {
+    updateState(graphicsElement, {
       executionPoint,
       screenShotType: null,
       status: isBeforeFirstCachedPaint ? "loaded" : "failed",
@@ -140,12 +140,12 @@ export async function updateGraphics({
 
 async function fetchPaintContents({
   abortSignal,
-  containerElement,
+  graphicsElement,
   replayClient,
   time,
 }: {
   abortSignal: AbortSignal;
-  containerElement: HTMLElement;
+  graphicsElement: HTMLElement;
   time: number;
   replayClient: ReplayClientInterface;
 }): Promise<ScreenShot | undefined> {
@@ -162,7 +162,7 @@ async function fetchPaintContents({
       return;
     }
 
-    updateState(containerElement, {
+    updateState(graphicsElement, {
       status: "failed",
     });
   }


### PR DESCRIPTION
In #10554 we fixed the scaling logic for cursor and highlighter in our screenshot panel by passing `graphicsElement` instead of `containerElement` to the `updateState()` function of `MutableGraphicsState`. But the PR only fixed one of the callers to `updateState()`, this PR fixes the others.