### PR TITLE
Jump-to-source falls back to parent user event if marker frame cannot be found

### DIFF
--- a/src/ui/components/TestSuite/hooks/useJumpToSource.ts
+++ b/src/ui/components/TestSuite/hooks/useJumpToSource.ts
@@ -19,11 +19,13 @@ import { AwaitTimeout, awaitWithTimeout } from "ui/utils/awaitWithTimeout";
 export function useJumpToSource({
   groupedTestCases,
   testEvent,
+  testEvents,
   testRecording,
   openSourceAutomatically = false,
 }: {
   groupedTestCases: GroupedTestCases;
   testEvent: TestEvent;
+  testEvents: TestEvent[];
   testRecording: TestRecording;
   openSourceAutomatically: boolean;
 }) {
@@ -57,7 +59,8 @@ export function useJumpToSource({
       const locationPromise = TestStepSourceLocationCache.readAsync(
         replayClient,
         groupedTestCases,
-        testEvent
+        testEvent,
+        testEvents
       );
 
       let location;

--- a/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestRecordingEvents/UserActionEventRow.tsx
@@ -10,6 +10,7 @@ import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import {
   GroupedTestCases,
   RecordingTestMetadataV3,
+  TestEvent,
   TestSectionName,
   UserActionEvent,
   isUserActionTestEvent,
@@ -44,18 +45,20 @@ const cypressStepTypesToEventTypes = {
 export default memo(function UserActionEventRow({
   groupedTestCases,
   isSelected,
+  testEvents,
   testSectionName,
   userActionEvent,
 }: {
   groupedTestCases: RecordingTestMetadataV3.GroupedTestCases;
   isSelected: boolean;
+  testEvents: TestEvent[];
   testSectionName: TestSectionName;
   userActionEvent: UserActionEvent;
 }) {
   const { data } = userActionEvent;
-  const testRunnerName = groupedTestCases.environment.testRunner.name;
-  const { command, error, parentId } = data;
-  const resultPoint = userActionEvent.data.timeStampedPoints.result;
+  const { command, error, parentId, timeStampedPoints } = data;
+
+  const resultPoint = timeStampedPoints.result;
 
   const replayClient = useContext(ReplayClientContext);
 
@@ -82,6 +85,7 @@ export default memo(function UserActionEventRow({
   const { disabled: jumpToTestSourceDisabled, onClick: onClickJumpToTestSource } = useJumpToSource({
     groupedTestCases,
     testEvent: userActionEvent,
+    testEvents,
     testRecording,
     openSourceAutomatically: viewMode === "dev",
   });

--- a/src/ui/components/TestSuite/views/TestRecording/TestSection.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestSection.tsx
@@ -31,6 +31,7 @@ export default function TestSection({
         <TestSectionRow
           key={index}
           testEvent={testEvent}
+          testEvents={testEvents}
           testRunnerName={testRunnerName}
           testSectionName={testSectionName}
         />

--- a/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
@@ -4,7 +4,6 @@ import { ReactNode, useContext, useMemo } from "react";
 
 import { highlightNodes, unhighlightNode } from "devtools/client/inspector/markup/actions/markup";
 import Icon from "replay-next/components/Icon";
-import { FocusContext } from "replay-next/src/contexts/FocusContext";
 import { SessionContext } from "replay-next/src/contexts/SessionContext";
 import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
 import { isExecutionPointsGreaterThan } from "replay-next/src/utils/time";
@@ -33,10 +32,12 @@ import styles from "./TestSectionRow.module.css";
 
 export function TestSectionRow({
   testEvent,
+  testEvents,
   testRunnerName,
   testSectionName,
 }: {
   testEvent: TestEvent;
+  testEvents: TestEvent[];
   testRunnerName: TestRunnerName | null;
   testSectionName: TestSectionName;
 }) {
@@ -54,7 +55,7 @@ export function TestSectionRow({
 
   const dispatch = useAppDispatch();
 
-  const { contextMenu, onContextMenu } = useTestEventContextMenu(testEvent);
+  const { contextMenu, onContextMenu } = useTestEventContextMenu(testEvent, testEvents);
 
   const position = useMemo(() => {
     let position: Position = "after";
@@ -109,6 +110,7 @@ export function TestSectionRow({
         <UserActionEventRow
           groupedTestCases={groupedTestCases}
           isSelected={isSelected}
+          testEvents={testEvents}
           testSectionName={testSectionName}
           userActionEvent={testEvent}
         />

--- a/src/ui/components/TestSuite/views/TestRecording/useTestEventContextMenu.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/useTestEventContextMenu.tsx
@@ -19,10 +19,12 @@ import { TestSuiteCache } from "ui/components/TestSuite/suspense/TestSuiteCache"
 import { TestSuiteContext } from "ui/components/TestSuite/views/TestSuiteContext";
 import { useAppDispatch } from "ui/setup/hooks";
 
-export function useTestEventContextMenu(testEvent: TestEvent) {
+export function useTestEventContextMenu(testEvent: TestEvent, testEvents: TestEvent[]) {
   const { contextMenu, onContextMenu } = useContextMenu(
     <>
-      {isUserActionTestEvent(testEvent) && <JumpToSourceMenuItem userActionEvent={testEvent} />}
+      {isUserActionTestEvent(testEvent) && (
+        <JumpToSourceMenuItem testEvents={testEvents} userActionEvent={testEvent} />
+      )}
       <PlayToHereMenuItem testEvent={testEvent} />
       <PlayFromHereMenuItem testEvent={testEvent} />
       {isUserActionTestEvent(testEvent) && <ShowBeforeMenuItem userActionEvent={testEvent} />}
@@ -33,7 +35,13 @@ export function useTestEventContextMenu(testEvent: TestEvent) {
   return { contextMenu, onContextMenu };
 }
 
-function JumpToSourceMenuItem({ userActionEvent }: { userActionEvent: UserActionEvent }) {
+function JumpToSourceMenuItem({
+  testEvents,
+  userActionEvent,
+}: {
+  testEvents: TestEvent[];
+  userActionEvent: UserActionEvent;
+}) {
   const replayClient = useContext(ReplayClientContext);
   const { recordingId } = useContext(SessionContext);
   const { setTestEvent, testRecording } = useContext(TestSuiteContext);
@@ -45,6 +53,7 @@ function JumpToSourceMenuItem({ userActionEvent }: { userActionEvent: UserAction
   const { disabled, onClick } = useJumpToSource({
     groupedTestCases,
     testEvent: userActionEvent,
+    testEvents,
     testRecording,
     openSourceAutomatically: true,
   });


### PR DESCRIPTION
### [Loom overview](https://www.loom.com/share/6d697c9136274fb8892325d39283fdac)

I don't know if this is a good idea or a bad one because I'm not super familiar with the Cypress code or constraints.

Looking at [go/r/bb82f5c3-af5c-4e20-9f1c-5efa4ee6bd29](https://app.replay.io/recording/appreplayio--bb82f5c3-af5c-4e20-9f1c-5efa4ee6bd29), I observed that the `getCypressMarkerFrame` lookup fails to find a "marker frame" because there are only two sources in the call stack– the Replay plugin itself and Cypress. That method expects to find user code in between for some reason, so this breaks the jump-to-source behavior.

In this case, the source is:
```js
cy.contains('Product added to cart!').should('be.visible');
```

That gets rendered in the UI as this:

![Screenshot 2024-06-13 at 10 46 16 PM](https://github.com/replayio/devtools/assets/29597/63920c23-82c8-45b4-9bb9-29443984b3b9)

Clicking on the failed _assert_ (or trying to "jump to source") would ideally jump to the `should('be.visible')` but it fails because of the "marker frame" issue I mentioned above. The idea occurred to me that in this case, jumping to the parent command (`contains('Product added to cart!')`) is probably better than nothing. (In this case, they're even on the same line, but that won't always be true.)

I wish the architecture for this stuff was different. I wish we did this kind of processing in a routine so we could detect cases like this ahead of time and not show "jump to source" buttons that aren't going to work, but I don't even really have an idea of the effort that would be required to rearchitect some of this stuff at the moment.)