### PR TITLE
Increase contrast on details pane

### DIFF
--- a/packages/replay-next/variables.css
+++ b/packages/replay-next/variables.css
@@ -198,6 +198,9 @@
 
   --background-color-current-execution-point: #25364e;
   --background-color-current-execution-point-column: #2663c080;
+  --background-color-current-execution-point-test-code: var(
+    --background-color-current-execution-point-column
+  );
   --background-color-current-search-result: #25364e;
   --background-color-default: var(--chrome);
   --background-color-disabled-button: #454950;
@@ -755,6 +758,9 @@
 
   --background-color-current-execution-point: #eaf3ff;
   --background-color-current-execution-point-column: #b8d7ff;
+  --background-color-current-execution-point-test-code: var(
+    --background-color-current-execution-point-column
+  );
   --background-color-current-search-result: #eaf3ff;
   --background-color-inputs: var(--theme-text-field-bgcolor);
   --background-color-resize-handle: #cfcfcf;

--- a/src/ui/components/TestSuite/views/TestRecording/TestEventStepDetails/TestEventDetails.module.css
+++ b/src/ui/components/TestSuite/views/TestRecording/TestEventStepDetails/TestEventDetails.module.css
@@ -99,7 +99,7 @@
   padding: 0 0.5rem;
 }
 .SourceCodeLineSelected {
-  background-color: var(--background-color-current-execution-point);
+  background-color: var(--background-color-current-execution-point-test-code);
 }
 
 .TabsContainer {


### PR DESCRIPTION
**Old/new light theme**
![image](https://github.com/replayio/devtools/assets/9154902/6636d809-5287-400c-a038-c976dbf63f44)

**Old/new dark theme**
![image](https://github.com/replayio/devtools/assets/9154902/bc033d99-1c74-4085-8806-2ae6e8c92407)

Color note:
Fortunately we already had a slightly darker version of blue to use, so I could use that. Philosophically I think it's important to name things (so I added a new variable) and point variables to one place instead of repeating variables (so I referred the new variable to another variable).
