### PR TITLE
Stop mousedown event propagation in the Focuser

### DIFF
--- a/src/ui/components/Timeline/Focuser.tsx
+++ b/src/ui/components/Timeline/Focuser.tsx
@@ -14,7 +14,7 @@ import { getPositionFromTime, getTimeFromPosition } from "ui/utils/timeline";
 
 import { EditMode } from "./Timeline";
 
-function stopEvent(event: MouseEvent) {
+function stopEvent(event: MouseEvent | React.MouseEvent) {
   event.preventDefault();
   event.stopPropagation();
 }
@@ -206,7 +206,7 @@ function Focuser({ editMode, setEditMode }: Props) {
   const right = getPositionFromTime(focusWindow.end, zoomRegion);
 
   return (
-    <div className="relative top-0 left-0 h-full w-full" ref={containerRef}>
+    <div className="relative top-0 left-0 h-full w-full" onMouseDown={stopEvent} ref={containerRef}>
       <div
         className="group absolute h-full"
         ref={draggableAreaRef}


### PR DESCRIPTION
The `Focuser` is overlaid over the `Timeline` and stops all mouse events from propagating to it except mousedown events, those confused the `Timeline` so that it thought that a click on the "Save" or "Cancel" buttons of the `FocusModePopout` was a click on the timeline and so it jumped to the end of the recording.