### PR TITLE
Improve heuristics for finding the user frame that dispatched a Redux…

### DIFF
--- a/packages/e2e-tests/examples.json
+++ b/packages/e2e-tests/examples.json
@@ -13,8 +13,8 @@
     "buildId": "linux-chromium-20240418-4747c93165f9-4699f489a2b6"
   },
   "breakpoints-01": {
-    "recording": "0dc24b18-85c1-44d0-97bc-5025e80b9250",
-    "buildId": "linux-chromium-20240208-e6ff39de2177-11bb013e140b",
+    "recording": "c44d99c0-6eeb-4dda-bf00-bfed2a4710ea",
+    "buildId": "linux-chromium-20240614-d742f2be668d-7ad782ed38d0",
     "requiresManualUpdate": true
   },
   "cra/dist/index.html": {

--- a/packages/e2e-tests/tests/jump-to-code-01_basic.test.ts
+++ b/packages/e2e-tests/tests/jump-to-code-01_basic.test.ts
@@ -10,6 +10,7 @@ import { openSourceExplorerPanel } from "../helpers/source-explorer-panel";
 import {
   addLogpoint,
   getSelectedLineNumber,
+  verifyJumpToCodeResults,
   verifyLogpointStep,
   waitForSelectedSource,
 } from "../helpers/source-panel";
@@ -140,22 +141,11 @@ test(`jump-to-code-01: Test basic jumping functionality`, async ({
 
   debugPrint(page, "Checking that the first keypress J2C jumps to the correct line");
   await firstValidKeypressJumpButton.click();
-  await waitForSelectedSource(page, "Header.tsx");
-  // Should highlight the line that ran
-  await waitFor(async () => {
-    const lineNumber = await getSelectedLineNumber(page, true);
-    expect(lineNumber).toBe(12);
-  });
 
+  // Should have paused on the handler for the first valid keystroke.
   // Should also have jumped in time. Since this can vary (slightly different progress %
   // based on timing differences), we'll add a log statement and verify _which_ hit we're at.
-  await addLogpoint(page, {
-    url: "Header.tsx",
-    lineNumber: 12,
-  });
-
-  // Should have paused on the handler for the first valid keystroke
-  await verifyLogpointStep(page, "1/22", { url: "Header.tsx", lineNumber: 12 });
+  await verifyJumpToCodeResults(page, "Header.tsx", 12, { current: 1, total: 22 });
 
   // the next clicks were on real buttons, so there is a handler
   debugPrint(page, "Checking for an enabled click 'Jump' button");
@@ -164,24 +154,6 @@ test(`jump-to-code-01: Test basic jumping functionality`, async ({
 
   debugPrint(page, "Checking that the first click J2C jumps to the correct line");
   await firstValidClickJumpButton.click();
-  await waitForSelectedSource(page, "TodoListItem.tsx");
-  // Should highlight the line that ran
-  await waitFor(async () => {
-    const lineNumber = await getSelectedLineNumber(page, true);
-    expect(lineNumber).toBe(22);
-  });
 
-  // Should also have jumped in time
-  // Should also have jumped in time. Since this can vary (slightly different progress %
-  // based on timing differences), we'll add a log statement and verify _which_ hit we're at.
-  await addLogpoint(page, {
-    url: "TodoListItem.tsx",
-    lineNumber: 22,
-  });
-
-  // Should have paused on the handler for the first valid click
-  await verifyLogpointStep(page, "1/2", {
-    url: "TodoListItem.tsx",
-    lineNumber: 22,
-  });
+  await verifyJumpToCodeResults(page, "TodoListItem.tsx", 22, { current: 1, total: 2 });
 });

--- a/packages/e2e-tests/tests/jump-to-code-01_basic.test.ts
+++ b/packages/e2e-tests/tests/jump-to-code-01_basic.test.ts
@@ -71,7 +71,7 @@ test(`jump-to-code-01: Test basic jumping functionality`, async ({
   const queryParams = new URLSearchParams();
   // Force this test to always re-run the Event Listeners (and other) routines
   // See pref names in packages/shared/user-data/GraphQL/config.ts
-  // queryParams.set("features", "backend_rerunRoutines");
+  queryParams.set("features", "backend_rerunRoutines");
 
   await startTest(page, recordingId, testScope, undefined, queryParams);
   await openDevToolsTab(page);

--- a/packages/e2e-tests/tests/jump-to-code-02_redux-j2c.test.ts
+++ b/packages/e2e-tests/tests/jump-to-code-02_redux-j2c.test.ts
@@ -1,0 +1,96 @@
+import { Locator, Page, expect } from "@playwright/test";
+
+import { openDevToolsTab, startTest } from "../helpers";
+import { getEventJumpButton } from "../helpers/info-event-panel";
+import { getReduxActions, openReduxDevtoolsPanel } from "../helpers/redux-devtools-panel";
+import { closeSource, verifyJumpToCodeResults } from "../helpers/source-panel";
+import { getByTestName, waitFor } from "../helpers/utils";
+import test from "../testFixture";
+
+test.use({ exampleKey: "breakpoints-01" });
+
+async function checkForJumpButton(actionListItem: Locator, shouldBeEnabled: boolean) {
+  const jumpButton = getEventJumpButton(actionListItem);
+  expect(await jumpButton.isVisible()).toBe(true);
+  await jumpButton.hover();
+
+  await waitFor(async () => {
+    const buttonText = await getByTestName(jumpButton, "JumpToCodeButtonLabel").innerText();
+    const expectedText = shouldBeEnabled ? "Jump to code" : "No results";
+    expect(buttonText).toBe(expectedText);
+  });
+
+  return jumpButton;
+}
+
+async function clickReduxActionJumpButton(page: Page, actionListItem: Locator) {
+  await actionListItem.scrollIntoViewIfNeeded();
+  await actionListItem.hover();
+  const jumpButton = await checkForJumpButton(actionListItem, true);
+  await jumpButton.click();
+}
+
+async function jumpToReduxDispatch(page: Page, actionType: string, index = 0) {
+  const reduxListItemsLocator = getReduxActions(page);
+  const reduxSearchInput = page.locator("#redux-searchbox");
+
+  await reduxSearchInput.fill(actionType);
+  const actionListItem = reduxListItemsLocator.filter({ hasText: actionType }).nth(index);
+  await clickReduxActionJumpButton(page, actionListItem);
+}
+
+test(`jump-to-code-02: Redux J2C functionality`, async ({
+  pageWithMeta: { page, recordingId, testScope },
+  exampleKey,
+}) => {
+  await startTest(page, recordingId, testScope);
+  await openDevToolsTab(page);
+
+  await openReduxDevtoolsPanel(page);
+
+  const reduxListItemsLocator = getReduxActions(page);
+
+  await waitFor(async () => {
+    const numListItems = await reduxListItemsLocator.count();
+    expect(numListItems).toBeGreaterThan(0);
+  });
+
+  // Inside of a thunk
+  await jumpToReduxDispatch(page, "app/setRecordingId");
+  await verifyJumpToCodeResults(page, "session.ts", 170, { current: 1, total: 1 });
+  await closeSource(page, "session.ts");
+
+  // Inside of the same thunk, after several awaits
+  await jumpToReduxDispatch(page, "app/setRecordingTarget");
+  await verifyJumpToCodeResults(page, "session.ts", 363, { current: 1, total: 1 });
+  await closeSource(page, "session.ts");
+
+  // Inside of one of the bootstrapping functions that receives the store
+  // should be "debugger/src/client/index.ts"
+  await jumpToReduxDispatch(page, "sources/allSourcesReceived");
+  await verifyJumpToCodeResults(page, "index.ts", 13, { current: 1, total: 1 });
+  await closeSource(page, "index.ts");
+
+  // Inside of an RTK listener middleware effect
+  jumpToReduxDispatch(page, "tabs/tabsRestored");
+  await verifyJumpToCodeResults(page, "newSources.ts", 43, { current: 1, total: 1 });
+  await closeSource(page, "newSources.ts");
+
+  // Inside of a `useEffect`
+  jumpToReduxDispatch(page, "set_selected_primary_panel");
+  await verifyJumpToCodeResults(page, "SidePanel.tsx", 57, { current: 1, total: 1 });
+  await closeSource(page, "SidePanel.tsx");
+
+  // Inside of a `connect()`ed class component, with `this.props.setExpandedState()`.
+  // Note that this appears to be one or two execution ticks off, so the line hit won't
+  // line up perfectly, but it should still _display_ as "1/4"
+  jumpToReduxDispatch(page, "SET_EXPANDED_STATE");
+  await verifyJumpToCodeResults(page, "SourcesTree.tsx", 196, { current: 1, total: 4 });
+  await closeSource(page, "SourcesTree.tsx");
+
+  // Inside of an adapter that passes dispatch-wrapped actions to <QuickOpenModal>
+  // This is also one tick off, but should still _display_ as "1/3"
+  jumpToReduxDispatch(page, "quickOpen/setQuickOpenQuery");
+  await verifyJumpToCodeResults(page, "QuickOpenModal.tsx", 551, { current: 1, total: 3 });
+  await closeSource(page, "QuickOpenModal.tsx");
+});

--- a/packages/e2e-tests/tests/jump-to-code-02_redux-j2c.test.ts
+++ b/packages/e2e-tests/tests/jump-to-code-02_redux-j2c.test.ts
@@ -7,6 +7,7 @@ import { closeSource, verifyJumpToCodeResults } from "../helpers/source-panel";
 import { getByTestName, waitFor } from "../helpers/utils";
 import test from "../testFixture";
 
+// trunk-ignore(gitleaks/generic-api-key)
 test.use({ exampleKey: "breakpoints-01" });
 
 async function checkForJumpButton(actionListItem: Locator, shouldBeEnabled: boolean) {

--- a/packages/e2e-tests/tests/react_devtools-02-integrations.test.ts
+++ b/packages/e2e-tests/tests/react_devtools-02-integrations.test.ts
@@ -32,10 +32,7 @@ test("react_devtools-02: RDT integrations (Chromium)", async ({
 
   await openDevToolsTab(page);
 
-  await warpToMessage(
-    page,
-    "Waiting for breakpoint at doc_rr_basic_chromium.html:21 (waitForBreakpoint)"
-  );
+  await warpToMessage(page, "Waiting for breakpoint at doc_rr_basic.html:21 (waitForBreakpoint)");
 
   // If the "React" tab shows up, we know that the routine ran
   await openReactDevtoolsPanel(page);
@@ -79,14 +76,14 @@ test("react_devtools-02: RDT integrations (Chromium)", async ({
     "SystemProvider",
     "Head",
     "SideEffect",
-    "Auth0Provider",
-    "Auth0Provider",
+    // Tough transpiled variable, apparently: `export var ApolloProvider = function (_a) {`
+    "c",
+    "ApolloContext.Consumer",
+    "ApolloContext.Provider",
+    "ConfirmProvider",
     "Context.Provider",
-    "Context.Consumer",
-    "SSRRecordingPage",
-    "RecordingHead",
-    "Head",
-    "SideEffect",
+    "Routing",
+    "Provider",
   ];
 
   debugPrint(page, "Checking list of rewritten component names");
@@ -143,7 +140,7 @@ test("react_devtools-02: RDT integrations (Chromium)", async ({
   await searchComponents(page, "Anonymous"); // Search and select 1st result
   await verifySearchResults(page, {
     currentNumber: 1,
-    totalNumber: 15,
+    totalNumber: 16,
   });
 
   await componentSearchInput.focus();
@@ -152,7 +149,7 @@ test("react_devtools-02: RDT integrations (Chromium)", async ({
   await componentSearchInput.press("Enter");
   await verifySearchResults(page, {
     currentNumber: 4,
-    totalNumber: 15,
+    totalNumber: 16,
   });
 
   await viewSourceButton.click();
@@ -161,7 +158,7 @@ test("react_devtools-02: RDT integrations (Chromium)", async ({
   await waitForSelectedSource(page, "SourcesTreeItem.tsx");
   await waitFor(async () => {
     const lineNumber = await getSelectedLineNumber(page, false);
-    expect(lineNumber).toBe(133);
+    expect(lineNumber).toBe(132);
   });
 
   list.evaluate(el => (el.scrollTop = 0));

--- a/src/ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsPanel.tsx
+++ b/src/ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsPanel.tsx
@@ -15,7 +15,7 @@ import { ReduxDevToolsContents } from "ui/components/SecondaryToolbox/redux-devt
 import { ReduxDevToolsList } from "ui/components/SecondaryToolbox/redux-devtools/ReduxDevToolsList";
 import { useAppSelector } from "ui/setup/hooks";
 import { reduxDevToolsAnnotationsCache } from "ui/suspense/annotationsCaches";
-import { applyMiddlewareDeclCache } from "ui/suspense/jumpToLocationCache";
+import { reduxStoreDetailsCache } from "ui/suspense/jumpToLocationCache";
 
 import styles from "./ReduxDevToolsPanel.module.css";
 
@@ -84,7 +84,7 @@ export default function ReduxDevToolsPanel() {
   useEffect(() => {
     // Preload the cache for where `applyMiddleware` is defined
     // This will speed up the first click on a Redux "J2C" button
-    applyMiddlewareDeclCache.prefetch(client);
+    reduxStoreDetailsCache.prefetch(client);
   }, [client]);
 
   return (

--- a/src/ui/suspense/jumpToLocationCache.ts
+++ b/src/ui/suspense/jumpToLocationCache.ts
@@ -116,7 +116,6 @@ async function findLikelyAppDispatchFrame(
   const framesWithoutReplayStub = pauseFrames.slice(2);
 
   for (const frame of framesWithoutReplayStub) {
-    // console.log("Checking middleware status: ", frame);
     const isMiddleware = await isReduxMiddleware(replayClient, frame.executionLocation);
     if (isMiddleware) {
       continue;


### PR DESCRIPTION
This PR:

- Reworks the Redux Jump-to-Code feature to improve the heuristics we use to find the right userland stack frame to jump to.
- Updates to a new `breakpoints-01` recording just so we've got a more recent example
  - Updates the expectations in the `react_devtools-02` test to match the new `breakpoints-01` recording
- Extracts a reusable test util for verifying that a given J2C button click jumped to the right file and time
- Adds a new E2E test that exercises the Redux J2C behavior by checking that several different dispatched actions end up on the right lines / stack frames

The original logic was iterating backwards across the point stack frames looking for an applyMiddleware frame, and going backwards one more frame from there. This is problematic because I'm seeing variance in whether or not applyMiddleware actually shows up in stack frames. For some reason it shows up in Metabase recording stack traces, but not in our own E2E tests (and we're both using RTK).  That meant that the existing logic could keep right on walking backwards long past the frame it "should" have found.

What I've settled on is using the logic we had that tries to identify "is this function in a Redux middleware" based on source outlines (looking for the triply-nested function signature of a middleware definition), and stopping at the first frame that appears to be not a middleware and not applyMiddleware.  This seems to be producing pretty reasonable results.

As an example, try opening https://app.replay.io/recording/breakpoints-01-test-basic-breakpoint-functionality--4f74bac8-d3f5-4e17-aeca-d670e002eabf and then the same recording in this preview, and see how the PR version more consistently lands on the `dispatch()` call in app code rather than inside of `applyMiddleware`. Same for a Metabase recording.