### PR TITLE
Source viewer font-size fixes

### DIFF
--- a/packages/replay-next/components/sources/hooks/useGetItemSize.ts
+++ b/packages/replay-next/components/sources/hooks/useGetItemSize.ts
@@ -49,7 +49,7 @@ export default function useGetItemSize({
     });
 
     setMeasurements(newMap);
-  }, [availableWidth, pointsWithPendingEdits, sourceId]);
+  }, [availableWidth, lineHeight, pointsWithPendingEdits, sourceId]);
 
   const getItemSize = useCallback(
     (index: number) => {

--- a/packages/replay-next/components/sources/hooks/useGetItemSize.ts
+++ b/packages/replay-next/components/sources/hooks/useGetItemSize.ts
@@ -98,11 +98,21 @@ function measurePanelSize(sourceId: string, content: string, condition: string |
     '[data-test-name="PointPanel-Condition"]'
   ) as HTMLElement;
   assert(conditionElement, "Syntax highlighted condition element not found");
-  conditionElement.textContent = condition ?? "";
+  conditionElement.textContent = processTextForMeasuring(condition ?? "");
 
   const contentElement = root.querySelector('[data-test-name="PointPanel-Content"]') as HTMLElement;
   assert(contentElement, "Syntax highlighted content element not found");
-  contentElement.textContent = content;
+  contentElement.textContent = processTextForMeasuring(content);
 
   return root.clientHeight;
+}
+
+function processTextForMeasuring(text: string): string {
+  const lines = text.split(/[\r\n]/);
+  if (lines[lines.length - 1].length === 0) {
+    // If the last line is empty (e.g. Shift+Enter) then we don't always measure the size correctly
+    // Adding a space to the last line fixes this
+    return text + " ";
+  }
+  return text;
 }

--- a/packages/replay-next/components/sources/hooks/useSourceListCssVariables.ts
+++ b/packages/replay-next/components/sources/hooks/useSourceListCssVariables.ts
@@ -48,7 +48,7 @@ export function useSourceListCssVariables({
     return () => {
       observer.disconnect();
     };
-  }, []);
+  }, [elementRef]);
 
   useLayoutEffect(() => {
     const element = elementRef.current;

--- a/packages/replay-next/components/sources/hooks/useSourceListCssVariables.ts
+++ b/packages/replay-next/components/sources/hooks/useSourceListCssVariables.ts
@@ -1,4 +1,10 @@
-import { RefObject, useCallback, useLayoutEffect, useRef } from "react";
+import { MutableRefObject, RefObject, useCallback, useLayoutEffect, useRef } from "react";
+
+type CSSVariables = {
+  "--longest-line-width": string;
+  "--source-hit-count-offset": string;
+  "--source-line-number-offset": string;
+};
 
 // In order to render the source list as efficiently as possible, it uses a flat DOM structure
 // This complicates positioning of items like the log point panel or inline search highlights
@@ -16,37 +22,38 @@ export function useSourceListCssVariables({
   maxLineIndexStringLength: number;
 }) {
   const longestLineWidthRef = useRef<number>(0);
-  const cssVariablesRef = useRef<{
-    "--longest-line-width": string;
-    "--source-hit-count-offset": string;
-    "--source-line-number-offset": string;
-  }>({
+  const cssVariablesRef = useRef<CSSVariables>({
     "--longest-line-width": "0px",
     "--source-hit-count-offset": "0px",
     "--source-line-number-offset": "0px",
   });
 
   useLayoutEffect(() => {
+    const observer = new MutationObserver(mutations => {
+      mutations.forEach(mutation => {
+        if (mutation.type === "attributes" && mutation.attributeName === "class") {
+          const element = elementRef.current;
+          if (element) {
+            updateCssVariables(element, cssVariablesRef);
+          }
+        }
+      });
+    });
+
+    const root = document.body.parentElement;
+    if (root) {
+      observer.observe(root, { attributes: true });
+    }
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  useLayoutEffect(() => {
     const element = elementRef.current;
     if (element) {
-      const hitCountElement = element.querySelector('[data-test-name="SourceLine-HitCount"]');
-      if (hitCountElement) {
-        const value = `${
-          (hitCountElement as HTMLElement).offsetWidth +
-          parseFloat(getComputedStyle(hitCountElement).marginRight)
-        }px`;
-
-        cssVariablesRef.current["--source-hit-count-offset"] = value;
-        element.style.setProperty("--source-hit-count-offset", value);
-      }
-
-      const lineNumberElement = element.querySelector('[data-test-name="SourceLine-LineNumber"]');
-      if (lineNumberElement) {
-        const value = `${(lineNumberElement as HTMLElement).offsetWidth}px`;
-
-        cssVariablesRef.current["--source-line-number-offset"] = value;
-        element.style.setProperty("--source-line-number-offset", value);
-      }
+      updateCssVariables(element, cssVariablesRef);
     }
   }, [elementRef, maxHitCountStringLength, maxLineIndexStringLength]);
 
@@ -79,4 +86,25 @@ export function useSourceListCssVariables({
     cssVariablesRef,
     itemsRenderedCallback,
   };
+}
+
+function updateCssVariables(element: HTMLElement, cssVariablesRef: MutableRefObject<CSSVariables>) {
+  const hitCountElement = element.querySelector('[data-test-name="SourceLine-HitCount"]');
+  if (hitCountElement) {
+    const value = `${
+      (hitCountElement as HTMLElement).offsetWidth +
+      parseFloat(getComputedStyle(hitCountElement).marginRight)
+    }px`;
+
+    cssVariablesRef.current["--source-hit-count-offset"] = value;
+    element.style.setProperty("--source-hit-count-offset", value);
+  }
+
+  const lineNumberElement = element.querySelector('[data-test-name="SourceLine-LineNumber"]');
+  if (lineNumberElement) {
+    const value = `${(lineNumberElement as HTMLElement).offsetWidth}px`;
+
+    cssVariablesRef.current["--source-line-number-offset"] = value;
+    element.style.setProperty("--source-line-number-offset", value);
+  }
 }

--- a/packages/replay-next/components/sources/log-point-panel/LogPointPanel.module.css
+++ b/packages/replay-next/components/sources/log-point-panel/LogPointPanel.module.css
@@ -3,7 +3,6 @@
 .ErrorFallback {
   width: calc(var(--list-width) - var(--source-line-number-offset));
   border-left: var(--hit-count-bar-size) solid var(--color-hit-counts-bar-0);
-  font-size: var(--font-size-small);
   user-select: none;
 
   display: flex;
@@ -11,6 +10,9 @@
   padding: 0.5rem;
   gap: 0.25rem;
   background-color: var(--point-panel-background-color);
+
+  font-size: var(--font-size-regular);
+  line-height: var(--line-height);
 
   --badge-picker-button-size: 1.25rem;
   --badge-picker-icon-size: 1rem;


### PR DESCRIPTION
Print statement panel dynamic sizing bug fixes:
- Fixed minor font-size and line-height inconsistencies for print statement panel
- Handle edge case with empty last line (aka Shift+Enter)

![Screenshot 2024-06-21 at 10 58 36 AM](https://github.com/replayio/devtools/assets/29597/1a8e9514-1c56-4998-84e0-7b71a1d022b7)

Also updated the `useSourceListCssVariables` hook to reevaluate CSS variables (width of line numbers and hit counts) when the font size preference changes.