### PR TITLE
Improve video cursor display, especially for Cypress tests

### DIFF
--- a/packages/protocol/RecordedEventsCache.ts
+++ b/packages/protocol/RecordedEventsCache.ts
@@ -83,14 +83,25 @@ export const RecordedNavigationEventsCache = createSingleEntryCache<[], Navigati
   },
 });
 
-export function findMostRecentClickEvent(time: number) {
+export function findMostRecentClickEvent(time: number, startTime: number = 0) {
   const events = RecordedClickEventsCache.getValueIfCached() ?? [];
   const index = findIndexLTE(events, { time } as MouseEvent, (a, b) => a.time - b.time);
-  return index >= 0 ? events[index] : null;
+  if (index < 0) {
+    return null;
+  }
+  const event = events[index];
+  return event.time >= startTime ? event : null;
 }
 
-export function findMostRecentMouseEvent(time: number) {
+export function findMostRecentMouseEvent(time: number, startTime: number = 0) {
   const events = RecordedMouseEventsCache.getValueIfCached() ?? [];
   const index = findIndexLTE(events, { time } as MouseEvent, (a, b) => a.time - b.time);
-  return index >= 0 ? events[index] : null;
+  if (index < 0) {
+    return null;
+  }
+  if (index < 0) {
+    return null;
+  }
+  const event = events[index];
+  return event.time >= startTime ? event : null;
 }

--- a/packages/protocol/RecordedEventsCache.ts
+++ b/packages/protocol/RecordedEventsCache.ts
@@ -83,25 +83,14 @@ export const RecordedNavigationEventsCache = createSingleEntryCache<[], Navigati
   },
 });
 
-export function findMostRecentClickEvent(time: number, startTime: number = 0) {
+export function findMostRecentClickEvent(time: number) {
   const events = RecordedClickEventsCache.getValueIfCached() ?? [];
   const index = findIndexLTE(events, { time } as MouseEvent, (a, b) => a.time - b.time);
-  if (index < 0) {
-    return null;
-  }
-  const event = events[index];
-  return event.time >= startTime ? event : null;
+  return index >= 0 ? events[index] : null;
 }
 
-export function findMostRecentMouseEvent(time: number, startTime: number = 0) {
+export function findMostRecentMouseEvent(time: number) {
   const events = RecordedMouseEventsCache.getValueIfCached() ?? [];
   const index = findIndexLTE(events, { time } as MouseEvent, (a, b) => a.time - b.time);
-  if (index < 0) {
-    return null;
-  }
-  if (index < 0) {
-    return null;
-  }
-  const event = events[index];
-  return event.time >= startTime ? event : null;
+  return index >= 0 ? events[index] : null;
 }

--- a/packages/shared/test-suites/RecordingTestMetadata.ts
+++ b/packages/shared/test-suites/RecordingTestMetadata.ts
@@ -1173,6 +1173,50 @@ export function isUserActionTestEvent(
   return value.type === "user-action";
 }
 
+export function isUserClickEvent(event: TestEvent) {
+  if (isUserActionTestEvent(event)) {
+    const { category, command, testRunnerName } = event.data;
+    if (category !== "command") {
+      return false;
+    }
+
+    switch (testRunnerName) {
+      case "cypress": {
+        return ["click", "check", "uncheck"].includes(command.name);
+      }
+      case "playwright": {
+        return ["locator.click", "locator.check", "locator.uncheck"].some(name =>
+          command.name.startsWith(name)
+        );
+      }
+    }
+  }
+
+  return false;
+}
+
+export function isUserKeyboardEvent(event: TestEvent) {
+  if (isUserActionTestEvent(event)) {
+    const { category, command, testRunnerName } = event.data;
+    if (category !== "command") {
+      return false;
+    }
+
+    switch (testRunnerName) {
+      case "cypress": {
+        return ["type"].includes(command.name);
+      }
+      case "playwright": {
+        return ["locator.type", "keyboard.down", "keyboard.press", "keyboard.type"].some(name =>
+          command.name.startsWith(name)
+        );
+      }
+    }
+  }
+
+  return false;
+}
+
 export function compareTestEventExecutionPoints(
   a: RecordingTestMetadataV3.TestEvent,
   b: RecordingTestMetadataV3.TestEvent

--- a/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
+++ b/src/ui/components/TestSuite/views/TestRecording/TestSectionRow.tsx
@@ -3,10 +3,14 @@ import { TimeStampedPoint, TimeStampedPointRange } from "@replayio/protocol";
 import { ReactNode, useContext, useMemo } from "react";
 
 import { highlightNodes, unhighlightNode } from "devtools/client/inspector/markup/actions/markup";
+import { RecordedMouseEventsCache } from "protocol/RecordedEventsCache";
 import Icon from "replay-next/components/Icon";
 import { SessionContext } from "replay-next/src/contexts/SessionContext";
 import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
-import { isExecutionPointsGreaterThan } from "replay-next/src/utils/time";
+import {
+  isExecutionPointsGreaterThan,
+  isExecutionPointsWithinRange,
+} from "replay-next/src/utils/time";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import {
   TestEvent,
@@ -16,6 +20,7 @@ import {
   getTestEventTimeStampedPoint,
   getUserActionEventRange,
   isUserActionTestEvent,
+  isUserClickEvent,
 } from "shared/test-suites/RecordingTestMetadata";
 import { extendFocusWindowIfNecessary, seek, setHoverTime } from "ui/actions/timeline";
 import { TestSuiteCache } from "ui/components/TestSuite/suspense/TestSuiteCache";
@@ -148,7 +153,41 @@ export function TestSectionRow({
   };
 
   const onMouseEnter = async () => {
-    dispatch(setHoverTime(getTestEventTime(testEvent)));
+    let hoverTime: number | null = null;
+    if (isUserActionTestEvent(testEvent) && isUserClickEvent(testEvent)) {
+      // Find the actual mouse event that _should_ have occurred
+      // inside of this test step. We want to use that as the hover
+      // time, so that the `RecordedCursor` logic will show the mouse
+      // event correctly instead of finding an _earlier_ mouse event
+      // that happened _before_ this test step.
+      const { data } = testEvent;
+      const { timeStampedPoints } = data;
+      const mouseEvents = RecordedMouseEventsCache.getValueIfCached();
+
+      if (timeStampedPoints.beforeStep !== null && timeStampedPoints.afterStep !== null) {
+        const mouseEvent = mouseEvents?.find(e => {
+          return (
+            e.kind === "mousedown" &&
+            isExecutionPointsWithinRange(
+              e.point,
+              timeStampedPoints.beforeStep!.point,
+              timeStampedPoints.afterStep!.point
+            )
+          );
+        });
+
+        hoverTime = mouseEvent?.time ?? null;
+      }
+    }
+
+    if (!hoverTime) {
+      // Otherwise, default the hover time to whatever is most
+      // appropriate for this test step based on its type.
+      hoverTime = getTestEventTime(testEvent);
+    }
+
+    dispatch(setHoverTime(hoverTime));
+
     if (!isUserActionTestEvent(testEvent)) {
       return;
     }

--- a/src/ui/components/Video/RecordedCursor.tsx
+++ b/src/ui/components/Video/RecordedCursor.tsx
@@ -2,7 +2,6 @@ import assert from "assert";
 import { useLayoutEffect, useRef } from "react";
 
 import { findMostRecentClickEvent, findMostRecentMouseEvent } from "protocol/RecordedEventsCache";
-import { useCurrentFocusWindow } from "replay-next/src/hooks/useCurrentFocusWindow";
 import { state } from "ui/components/Video/imperative/MutableGraphicsState";
 
 // One frame seems reasonable for a click to be considered
@@ -11,7 +10,6 @@ const CLICK_TIMING_THRESHOLD_MS = 16.67;
 
 export function RecordedCursor() {
   const elementRef = useRef<HTMLDivElement>(null);
-  const focusWindow = useCurrentFocusWindow();
 
   useLayoutEffect(() => {
     const element = elementRef.current;
@@ -22,8 +20,8 @@ export function RecordedCursor() {
       ({ currentTime, graphicsRect, localScale, recordingScale }) => {
         const { height, width } = graphicsRect;
 
-        const mouseEvent = findMostRecentMouseEvent(currentTime, focusWindow?.begin.time);
-        const clickEvent = findMostRecentClickEvent(currentTime, focusWindow?.begin.time);
+        const mouseEvent = findMostRecentMouseEvent(currentTime);
+        const clickEvent = findMostRecentClickEvent(currentTime);
         const shouldDrawClick =
           clickEvent && clickEvent.time + CLICK_TIMING_THRESHOLD_MS >= currentTime;
 
@@ -51,7 +49,7 @@ export function RecordedCursor() {
     return () => {
       unsubscribe();
     };
-  }, [focusWindow]);
+  }, []);
 
   return (
     <div

--- a/src/ui/components/Video/RecordedCursor.tsx
+++ b/src/ui/components/Video/RecordedCursor.tsx
@@ -2,6 +2,7 @@ import assert from "assert";
 import { useLayoutEffect, useRef } from "react";
 
 import { findMostRecentClickEvent, findMostRecentMouseEvent } from "protocol/RecordedEventsCache";
+import { useCurrentFocusWindow } from "replay-next/src/hooks/useCurrentFocusWindow";
 import { state } from "ui/components/Video/imperative/MutableGraphicsState";
 
 // One frame seems reasonable for a click to be considered
@@ -10,6 +11,7 @@ const CLICK_TIMING_THRESHOLD_MS = 16.67;
 
 export function RecordedCursor() {
   const elementRef = useRef<HTMLDivElement>(null);
+  const focusWindow = useCurrentFocusWindow();
 
   useLayoutEffect(() => {
     const element = elementRef.current;
@@ -20,8 +22,8 @@ export function RecordedCursor() {
       ({ currentTime, graphicsRect, localScale, recordingScale }) => {
         const { height, width } = graphicsRect;
 
-        const mouseEvent = findMostRecentMouseEvent(currentTime);
-        const clickEvent = findMostRecentClickEvent(currentTime);
+        const mouseEvent = findMostRecentMouseEvent(currentTime, focusWindow?.begin.time);
+        const clickEvent = findMostRecentClickEvent(currentTime, focusWindow?.begin.time);
         const shouldDrawClick =
           clickEvent && clickEvent.time + CLICK_TIMING_THRESHOLD_MS >= currentTime;
 
@@ -49,7 +51,7 @@ export function RecordedCursor() {
     return () => {
       unsubscribe();
     };
-  }, []);
+  }, [focusWindow]);
 
   return (
     <div

--- a/src/ui/components/Video/RecordedCursor.tsx
+++ b/src/ui/components/Video/RecordedCursor.tsx
@@ -4,7 +4,9 @@ import { useLayoutEffect, useRef } from "react";
 import { findMostRecentClickEvent, findMostRecentMouseEvent } from "protocol/RecordedEventsCache";
 import { state } from "ui/components/Video/imperative/MutableGraphicsState";
 
-const CLICK_TIMING_THRESHOLD_MS = 200;
+// One frame seems reasonable for a click to be considered
+// recent enough to be drawn on the screen
+const CLICK_TIMING_THRESHOLD_MS = 16.67;
 
 export function RecordedCursor() {
   const elementRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
This PR:

- Extracts the current logic that determines "is this a click or keyboard test step?" out of `UserActionEventRow.ts` (where it's currently used to determine "_can_ we have a Jump-to-Code result?") and turns it into standalone utils in `RecordedTestMetadata.ts`
- Updates `TestSectionRow.ts` to use the current mouse event (if available) as the hover time for click steps
  - Previously, we were always using the `beforeStep` time as the hover time for user interaction test steps.  However, for a click step, the mouse event occurs in the _middle_ of the step (ie, `mouseEvent.time >= beforeStep.time && mouseEvent.time <= afterStep.time`).  The `RecordedCursor` logic tries to find "the most recent mouse event <= the current display time".  That meant we were finding a mouse event from _before_ this test step, which resulted in an off-by-one style display as you'd hover or click on test steps.
  - Now, if the current test step is a click, we do a search for a mouse click event that occurred _during_ the test step, and use that event's timestamp as the hover time. This should give more consistent results and ensure that the "correct" event is displayed for the click step.
- Updates the `RecordedCursor.ts` logic to be more narrow in what it displays:
  - Limits the possible search range for "most recent mouse event" to use the focus window. Previously, if you selected a Cypress test halfway through a recording, we would find and show the last mouse click in the previous test because that was "the most recent", even though it was conceptually irrelevant for _this_ test. Since we always zoom in focus on the current test, limiting "most recent mouse event" to the current focus window prevents that.
  - Updates the time that we still show the "click" mouse cursor circle to be one frame (16.67ms), instead of 200ms, to narrow down the appearance of when a click happened.

Note that this is just about mouse event _timing_. We've also found that there are bad synthetic `clientX/Y` values ( see [this summary comment from PRO-598](https://linear.app/replay/issue/PRO-598/cypress-fake-mouse-events-are-not-displayed-in-the-video-panel#comment-52439c6e) and the actual issue in [TT-1474](https://linear.app/replay/issue/TT-1474/fix-x-y-coordinates-of-synthetic-mouse-events).  That means that even though this PR _improves_ the behavior significantly, we also need the runtime fix to make the locations be correct.

Some examples from recording https://app.replay.io/recording/cypresstestsuiauthspects--8ebc83cd-ea98-49d4-bbf6-643708ff9482 , and Clicked on test "Should allow a visitor to sign up":

### Jumping to a later test in the recording

Before this PR, an incorrect cursor left over from the previous test in the recording:

![image](https://github.com/replayio/devtools/assets/1128784/e64ec0df-4423-4692-8906-ee2340b789d0)

After, no cursor at the start of the test:

![image](https://github.com/replayio/devtools/assets/1128784/25219be8-33c9-43c0-8804-da7e30b881bc)


### Hovering over clicks

#### Step 04, clicking "signup"

Before, still showing the really old cursor prior to this test:

![image](https://github.com/replayio/devtools/assets/1128784/a728efb3-7daf-4d29-8034-5982e45b527b)

After, showing a cursor that is at least at the right timestamp and in the vicinity, although the X/Y values are still wrong:

![image](https://github.com/replayio/devtools/assets/1128784/27106f96-f3d2-4699-8fa7-ad599f900fad)

#### Step 30, clicking "Submit"

Before, no click indicator, and it's still an old cursor. It's actually _closer_ to the button, but it's the wrong event:

![image](https://github.com/replayio/devtools/assets/1128784/59c6a740-358c-442c-b6a9-4f04515551d4)

After, showing a click indicator, and it's the _right_ event even if the coords are still off:

![image](https://github.com/replayio/devtools/assets/1128784/5d5b7bc9-31c0-4a6b-8e8e-1c423cf38c3e)


### Cursor Click Indicator

#### Step 45, hovering `wait @loginuser`

Before, we're showing the "right" event because it's well past the click step, but we keep showing a click indicator for an extended time even though the page is now blank:

![image](https://github.com/replayio/devtools/assets/1128784/e09ec47b-61e7-45b7-9d23-4092be3c33f2)

After, we're also showing the same correct event, but we're no longer showing the click indicator because we're more than 1 frame past the click:

![image](https://github.com/replayio/devtools/assets/1128784/04954586-93b9-4ede-a24d-8d2e8ea431fc)


