### PR TITLE
Update the Cypress steps test to check for hover cursor position

### DIFF
--- a/packages/e2e-tests/examples.json
+++ b/packages/e2e-tests/examples.json
@@ -22,8 +22,8 @@
     "buildId": "linux-chromium-20240418-4747c93165f9-4699f489a2b6"
   },
   "cypress-realworld/bankaccounts.spec.js": {
-    "recording": "adbd6030-7338-4768-a4a8-4286cacacf12",
-    "buildId": "linux-chromium-20240123-609ec6caa105-50d01be708a2",
+    "recording": "d6245b53-b3fe-4e8c-9044-4d518d92805a",
+    "buildId": "linux-chromium-20240627-ae45befcc072-6c7e9991dcf5",
     "requiresManualUpdate": true
   },
   "deleted-replay": {

--- a/packages/e2e-tests/tests/cypress-05_hover-dom-previews.test.ts
+++ b/packages/e2e-tests/tests/cypress-05_hover-dom-previews.test.ts
@@ -85,20 +85,20 @@ test("cypress-05: Test DOM node preview on user action step hover", async ({
 
   function getCursorAttributes(node: HTMLElement) {
     return {
-      cursordisplay: node.dataset.cursordisplay,
-      clickdisplay: node.dataset.clickdisplay,
-      clientX: node.dataset.clientx,
-      clientYX: node.dataset.clienty,
+      cursorDisplay: node.dataset.cursorDisplay,
+      clickDisplay: node.dataset.clickDisplay,
+      clientX: node.dataset.clientX,
+      clientY: node.dataset.clientY,
     };
   }
   const clickCursorAttributes = await recordedCursor.evaluate(getCursorAttributes);
 
   expect(clickCursorAttributes).toEqual({
-    cursordisplay: "true",
-    clickdisplay: "true",
+    cursorDisplay: "true",
+    clickDisplay: "true",
     // Read directly from the mouse event in this test
     clientX: "323",
-    clientYX: "245",
+    clientY: "245",
   });
 
   // Make the highlighter go away
@@ -120,12 +120,12 @@ test("cypress-05: Test DOM node preview on user action step hover", async ({
   const afterClickCursorAttributes = await recordedCursor.evaluate(getCursorAttributes);
 
   expect(afterClickCursorAttributes).toEqual({
-    cursordisplay: "true",
+    cursorDisplay: "true",
     // No click display after the click has finished
-    clickdisplay: "false",
+    clickDisplay: "false",
     // Read directly from the mouse event in this test
     clientX: "323",
-    clientYX: "245",
+    clientY: "245",
   });
 
   debugPrint(page, "Checking highlighting for multiple nodes");

--- a/src/ui/components/Video/RecordedCursor.tsx
+++ b/src/ui/components/Video/RecordedCursor.tsx
@@ -39,18 +39,20 @@ export function RecordedCursor() {
           element.style.top = `${mouseY}%`;
           element.style.transform = `scale(${cursorScale})`;
           element.style.setProperty("--click-display", shouldDrawClick ? "block" : "none");
-          // Testing support
 
-          element.dataset.cursordisplay = "true";
-          element.dataset.clickdisplay = shouldDrawClick ? "true" : "false";
-          element.dataset.clientx = `${mouseEvent.clientX}`;
-          element.dataset.clienty = `${mouseEvent.clientY}`;
+          // Set data attributes describing the cursor state for use in our E2E tests
+          element.dataset.cursorDisplay = "true";
+          element.dataset.clickDisplay = shouldDrawClick ? "true" : "false";
+          element.dataset.clientX = `${mouseEvent.clientX}`;
+          element.dataset.clientY = `${mouseEvent.clientY}`;
         } else {
           element.style.display = "none";
           element.style.setProperty("--click-display", "none");
 
-          element.dataset.cursordisplay = "false";
-          element.dataset.clickdisplay = "false";
+          element.dataset.cursorDisplay = "false";
+          element.dataset.clickDisplay = "false";
+          element.dataset.clientX = "0";
+          element.dataset.clientY = "0";
         }
       }
     );
@@ -68,10 +70,10 @@ export function RecordedCursor() {
         position: "absolute",
       }}
       data-test-name="recorded-cursor"
-      data-cursordisplay="false"
-      data-clickdisplay="false"
-      data-clientx="0"
-      data-clienty="0"
+      data-cursor-display="false"
+      data-click-display="false"
+      data-client-x="0"
+      data-client-y="0"
     >
       <div
         style={{

--- a/src/ui/components/Video/RecordedCursor.tsx
+++ b/src/ui/components/Video/RecordedCursor.tsx
@@ -39,9 +39,18 @@ export function RecordedCursor() {
           element.style.top = `${mouseY}%`;
           element.style.transform = `scale(${cursorScale})`;
           element.style.setProperty("--click-display", shouldDrawClick ? "block" : "none");
+          // Testing support
+
+          element.dataset.cursordisplay = "true";
+          element.dataset.clickdisplay = shouldDrawClick ? "true" : "false";
+          element.dataset.clientx = `${mouseEvent.clientX}`;
+          element.dataset.clienty = `${mouseEvent.clientY}`;
         } else {
           element.style.display = "none";
           element.style.setProperty("--click-display", "none");
+
+          element.dataset.cursordisplay = "false";
+          element.dataset.clickdisplay = "false";
         }
       }
     );
@@ -58,6 +67,11 @@ export function RecordedCursor() {
         display: "none",
         position: "absolute",
       }}
+      data-test-name="recorded-cursor"
+      data-cursordisplay="false"
+      data-clickdisplay="false"
+      data-clientx="0"
+      data-clienty="0"
     >
       <div
         style={{


### PR DESCRIPTION
This PR:

- Updates the `cypress/bankaccounts.spec.js` test recording to a fresh run (which I've set to "Never Delete" in admin)
- Updates `RecordedCursor.ts` to have data attributes for cursor details that we can check in the test
- Updates the `cypress-05` test to check the cursor location for a click and after-click step and assert its coords and click display are correct