### PR TITLE
HACK DO NOT SUBMIT.  Integration example for replay videos.

### DIFF
--- a/packages/replay-next/src/suspense/ScreenshotCache.ts
+++ b/packages/replay-next/src/suspense/ScreenshotCache.ts
@@ -1,4 +1,4 @@
-import { ExecutionPoint, ScreenShot } from "@replayio/protocol";
+import { ExecutionPoint, ScreenShot, Video } from "@replayio/protocol";
 import { createCache } from "suspense";
 
 import { paintHashCache } from "replay-next/src/suspense/PaintHashCache";
@@ -17,5 +17,18 @@ export const screenshotCache = createCache<
     paintHashCache.cacheValue(screenShot, screenShot.hash);
 
     return screenShot;
+  },
+});
+
+export const videoCache = createCache<
+  [replayClient: ReplayClientInterface],
+  Video[]
+>({
+  config: { immutable: true },
+  debugLabel: "ScreenshotCache",
+  getKey: ([client]) => client.getRecordingId() || "",
+  load: async ([client]) => {
+    const videos = await client.getVideos();
+    return videos;
   },
 });

--- a/packages/shared/client/ReplayClient.ts
+++ b/packages/shared/client/ReplayClient.ts
@@ -45,6 +45,7 @@ import {
   TimeStampedPoint,
   TimeStampedPointRange,
   VariableMapping,
+  Video,
   annotations,
   createPauseResult,
   findPointsResults,
@@ -808,6 +809,15 @@ export class ReplayClient implements ReplayClientInterface {
       sessionId
     );
     return screen;
+  }
+
+  async getVideos(): Promise<Video[]> {
+    const sessionId = await this.waitForSession();
+    const { videos } = await client.Graphics.getVideos(
+      { mimeType: "video/webm" },
+      sessionId
+    );
+    return videos;
   }
 
   async mapExpressionToGeneratedScope(expression: string, location: Location): Promise<string> {

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -48,6 +48,8 @@ const csp = (props: any) => {
     // Required to inline images from the database and from external avaters
     `img-src 'self' data: https:`,
 
+    `media-src 'self' data: https:`,
+
     // Required for our logpoint analysis cache (which uses a Web worker)
     `worker-src 'self' blob:`,
   ]


### PR DESCRIPTION
A (possible/plausible?) integration of the new getVideos functionality.  Missing is needing to account for multiple videos (due to resolution changes), and probably some new logic to fall back to the old .pngs if no videos are present.