### PR TITLE
Use new React-specific DepGraph queries to improve React Component Stack display

### DIFF
--- a/packages/e2e-tests/tests/react_devtools-02-integrations.test.ts
+++ b/packages/e2e-tests/tests/react_devtools-02-integrations.test.ts
@@ -140,7 +140,7 @@ test("react_devtools-02: RDT integrations (Chromium)", async ({
   await searchComponents(page, "Anonymous"); // Search and select 1st result
   await verifySearchResults(page, {
     currentNumber: 1,
-    totalNumber: 16,
+    totalNumber: 17,
   });
 
   await componentSearchInput.focus();
@@ -149,7 +149,7 @@ test("react_devtools-02: RDT integrations (Chromium)", async ({
   await componentSearchInput.press("Enter");
   await verifySearchResults(page, {
     currentNumber: 4,
-    totalNumber: 16,
+    totalNumber: 17,
   });
 
   await viewSourceButton.click();

--- a/packages/shared/client/ReplayClient.ts
+++ b/packages/shared/client/ReplayClient.ts
@@ -78,7 +78,13 @@ import throttle from "lodash/throttle";
 import uniqueId from "lodash/uniqueId";
 
 // eslint-disable-next-line no-restricted-imports
-import { addEventListener, client, initSocket, removeEventListener, sendMessage } from "protocol/socket";
+import {
+  addEventListener,
+  client,
+  initSocket,
+  removeEventListener,
+  sendMessage,
+} from "protocol/socket";
 import { assert, compareNumericStrings, defer, waitForTime } from "protocol/utils";
 import { initProtocolMessagesStore } from "replay-next/components/protocol/ProtocolMessagesStore";
 import { insert } from "replay-next/src/utils/array";
@@ -88,11 +94,12 @@ import { isPointInRegion, isRangeInRegions } from "shared/utils/time";
 
 import {
   AnnotationListener,
+  DependencyChainStep,
+  DependencyGraphMode,
   ReplayClientEvents,
   ReplayClientInterface,
   SourceLocationRange,
   TimeStampedPointWithPaintHash,
-  DependencyChainStep,
 } from "./types";
 
 export const MAX_POINTS_TO_FIND = 10_000;
@@ -1208,9 +1215,16 @@ export class ReplayClient implements ReplayClientInterface {
     return this.focusWindow;
   }
 
-  async getDependencies(point: ExecutionPoint): Promise<DependencyChainStep[]> {
+  async getDependencies(
+    point: ExecutionPoint,
+    mode?: DependencyGraphMode
+  ): Promise<DependencyChainStep[]> {
     const sessionId = await this.waitForSession();
-    const result = await sendMessage("Session.experimentalCommand", { name: "analyzeDependencies", params: { point } }, sessionId);
+    const result = await sendMessage(
+      "Session.experimentalCommand",
+      { name: "analyzeDependencies", params: { point, mode } },
+      sessionId
+    );
     return result.rval.dependencies;
   }
 

--- a/packages/shared/client/types.ts
+++ b/packages/shared/client/types.ts
@@ -268,6 +268,10 @@ export type DependencyChainStepInfo =
       code: "ReactCallSetState";
     }
   | {
+      // A React external store triggered a rerender.
+      code: "ReactExternalStoreRerender";
+    }
+  | {
       // An application render function called useEffect().
       code: "ReactCallUseEffect";
     }
@@ -289,6 +293,12 @@ export type DependencyChainStep = DependencyChainStepInfo & {
   time?: number;
   point?: ExecutionPoint;
 };
+
+export enum DependencyGraphMode {
+  // Renders of a fiber depend on the last time the parent of that fiber was
+  // rendered, instead of whatever triggered the fiber's render.
+  ReactParentRenders = "ReactParentRenders",
+}
 
 export interface ReplayClientInterface {
   get loadedRegions(): LoadedRegions | null;
@@ -437,6 +447,9 @@ export interface ReplayClientInterface {
     }) => void,
     onSourceContentsChunk: ({ chunk, sourceId }: { chunk: string; sourceId: SourceId }) => void
   ): Promise<void>;
-  getDependencies(point: ExecutionPoint): Promise<DependencyChainStep[]>;
+  getDependencies(
+    point: ExecutionPoint,
+    mode?: DependencyGraphMode
+  ): Promise<DependencyChainStep[]>;
   waitForSession(): Promise<string>;
 }

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/ReactComponentStack.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/ReactComponentStack.tsx
@@ -3,11 +3,13 @@ import React, { useContext, useState } from "react";
 import { useImperativeCacheValue } from "suspense";
 
 import { Button } from "replay-next/components/Button";
+import Expandable from "replay-next/components/Expandable";
 import Icon from "replay-next/components/Icon";
 import Loader from "replay-next/components/Loader";
 import { JsonViewer } from "replay-next/components/SyntaxHighlighter/JsonViewer";
 import { useMostRecentLoadedPause } from "replay-next/src/hooks/useMostRecentLoadedPause";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
+import { DependencyGraphMode } from "shared/client/types";
 import { seek } from "ui/actions/timeline";
 import { useAppDispatch } from "ui/setup/hooks";
 import { depGraphCache, reactComponentStackCache } from "ui/suspense/depGraphCache";
@@ -33,48 +35,82 @@ function JumpToDefinitionButton({ point }: { point?: TimeStampedPoint }) {
   );
 }
 
-export function ReactComponentStack() {
-  const { point, time, pauseId } = useMostRecentLoadedPause() ?? {};
+function ReactComponentStack({ point }: { point?: TimeStampedPoint }) {
   const replayClient = useContext(ReplayClientContext);
-  const [currentPoint, setCurrentPoint] = useState<ExecutionPoint | null>(null);
+  const { status: reactStackStatus, value: reactStackValue } = useImperativeCacheValue(
+    reactComponentStackCache,
+    replayClient,
+    point ?? null
+  );
+
+  let reactStackContent: React.ReactNode = undefined;
+
+  if (reactStackStatus === "rejected") {
+    reactStackContent = <div>Error loading dependencies</div>;
+  } else if (reactStackStatus === "pending") {
+    reactStackContent = <Loader />;
+  } else {
+    reactStackContent = (
+      <div className="m-1 flex grow flex-col border">
+        <h3 className="text-base font-bold">React Component Stack</h3>
+        {reactStackValue?.map((entry, index) => {
+          const jumpButton = entry.point ? <JumpToDefinitionButton point={entry} /> : null;
+          return (
+            <div key={index} className="m-1 flex flex-col">
+              <div title={entry.parentLocation.url}>
+                &lt;{entry.componentName}&gt; {jumpButton}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  return <div className="react-component-stack flex flex-col">{reactStackContent}</div>;
+}
+
+function DepGraphDisplay({
+  point,
+  mode,
+  title,
+}: {
+  point: ExecutionPoint;
+  mode?: DependencyGraphMode;
+  title: string;
+}) {
+  const replayClient = useContext(ReplayClientContext);
 
   const { status: depGraphStatus, value: depGraphValue } = useImperativeCacheValue(
     depGraphCache,
     replayClient,
-    currentPoint
+    point,
+    mode ?? null
   );
-
-  const { status: reactStackStatus, value: reactStackValue } = useImperativeCacheValue(
-    reactComponentStackCache,
-    replayClient,
-    currentPoint
-  );
-
-  if (!pauseId || !point) {
-    return <div>Not paused at a point</div>;
-  }
 
   let depGraphContent: React.ReactNode = undefined;
   let formattedDepGraphContent: React.ReactNode = undefined;
-  let reactStackContent: React.ReactNode = undefined;
 
   if (depGraphStatus === "rejected") {
     depGraphContent = <div>Error loading dependencies</div>;
   } else if (depGraphStatus === "pending") {
     depGraphContent = <Loader />;
   } else {
+    const valueDescending = depGraphValue?.slice().reverse();
+
     depGraphContent = (
       <div className="m-1 grow border ">
-        <h3 className="text-sm font-bold">Dependency Graph JSON</h3>
-        <JsonViewer jsonText={JSON.stringify(depGraphValue, null, 2)} />
+        <Expandable header={<h4 className="inline text-sm font-bold">Dependency Graph JSON</h4>}>
+          <JsonViewer jsonText={JSON.stringify(valueDescending, null, 2)} />
+        </Expandable>
       </div>
     );
 
     formattedDepGraphContent = (
       <div className="m-1 grow border ">
-        <h3 className="text-sm font-bold">Dependency Graph Formatted</h3>
+        <h4 className="text-sm font-bold">Dependency Graph Formatted</h4>
         <div className="m-1 flex flex-col">
-          {depGraphValue?.map((entry, index) => {
+          {valueDescending?.map((entry, index) => {
             let jumpButton: React.ReactNode = undefined;
 
             if (entry.point && entry.time) {
@@ -94,36 +130,38 @@ export function ReactComponentStack() {
     );
   }
 
-  if (reactStackStatus === "rejected") {
-    reactStackContent = <div>Error loading dependencies</div>;
-  } else if (reactStackStatus === "pending") {
-    reactStackContent = <Loader />;
-  } else {
-    reactStackContent = (
-      <div className="m-1 flex grow flex-col border">
-        <h3 className="text-sm font-bold">React Component Stack</h3>
-        {reactStackValue?.map((entry, index) => {
-          const jumpButton = entry.point ? <JumpToDefinitionButton point={entry} /> : null;
-          return (
-            <div key={index} className="m-1 flex flex-col">
-              <div title={entry.parentLocation.url}>
-                &lt;{entry.componentName}&gt; {jumpButton}
-              </div>
-            </div>
-          );
-        })}
-      </div>
-    );
+  return (
+    <div className="react-component-stack m-1 flex flex-col">
+      <h3 className="text-base font-bold">{title}</h3>
+      {formattedDepGraphContent}
+      {depGraphContent}
+    </div>
+  );
+}
+
+export function DepGraphPrototypePanel() {
+  const { point, time, pauseId } = useMostRecentLoadedPause() ?? {};
+  const replayClient = useContext(ReplayClientContext);
+  const [currentPoint, setCurrentPoint] = useState<ExecutionPoint | null>(null);
+
+  if (!pauseId || !point || !time) {
+    return <div>Not paused at a point</div>;
   }
+
+  let timeStampedPoint: TimeStampedPoint = { point, time };
 
   return (
     <div className="react-component-stack flex flex-col">
       <Button className="self-start" onClick={() => setCurrentPoint(point)}>
         Load dependencies
       </Button>
-      {reactStackContent}
-      {formattedDepGraphContent}
-      {depGraphContent}
+      <ReactComponentStack point={timeStampedPoint} />
+      <DepGraphDisplay point={point} title="Dep Graph (Regular)" />
+      <DepGraphDisplay
+        point={point}
+        mode={DependencyGraphMode.ReactParentRenders}
+        title="Dep Graph (React)"
+      />
     </div>
   );
 }

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/index.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/index.tsx
@@ -10,7 +10,7 @@ import NewFrames from "./Frames/NewFrames";
 import FrameTimeline from "./FrameTimeline";
 import LogpointsPane from "./LogpointsPane";
 import NewScopes from "./NewScopes";
-import { ReactComponentStack } from "./ReactComponentStack";
+import { DepGraphPrototypePanel } from "./ReactComponentStack";
 
 import { Accordion, AccordionPane } from "@recordreplay/accordion";
 
@@ -65,7 +65,7 @@ export default function SecondaryPanes() {
           expanded={reactStackVisible}
           onToggle={() => setReactStackVisible(!reactStackVisible)}
         >
-          {currentPoint && <ReactComponentStack />}
+          {currentPoint && <DepGraphPrototypePanel />}
         </AccordionPane>
         <AccordionPane
           header="Scopes"

--- a/src/ui/suspense/depGraphCache.ts
+++ b/src/ui/suspense/depGraphCache.ts
@@ -1,32 +1,15 @@
-import {
-  ExecutionPoint,
-  Frame,
-  FunctionMatch,
-  FunctionOutline,
-  Location,
-  PauseDescription,
-  PauseId,
-  PointDescription,
-  PointStackFrame,
-  RunEvaluationResult,
-  TimeStampedPoint,
-  TimeStampedPointRange,
-} from "@replayio/protocol";
+import { ExecutionPoint, Location, TimeStampedPoint } from "@replayio/protocol";
 import { Cache, createCache } from "suspense";
 
-import { sourceOutlineCache } from "replay-next/src/suspense/SourceOutlineCache";
-import { sourcesByIdCache, sourcesByUrlCache } from "replay-next/src/suspense/SourcesCache";
-import {
-  getSourceIdToDisplayForUrl,
-  getSourceToDisplayForUrl,
-} from "replay-next/src/utils/sources";
+import { Source, sourcesByIdCache, sourcesByUrlCache } from "replay-next/src/suspense/SourcesCache";
+import { getSourceToDisplayForUrl } from "replay-next/src/utils/sources";
 import {
   DependencyChainStep,
   DependencyGraphMode,
   ReplayClientInterface,
+  URLLocation,
 } from "shared/client/types";
 import { formatFunctionDetailsFromLocation } from "ui/actions/eventListeners/eventListenerUtils";
-import { findFunctionOutlineForLocation } from "ui/actions/eventListeners/jumpToCode";
 
 import { formattedPointStackCache } from "./frameCache";
 
@@ -47,14 +30,19 @@ export const depGraphCache: Cache<
     }
     const dependencies = await replayClient.getDependencies(point, mode ?? undefined);
 
-    console.log("Deps for point: ", point, dependencies);
     return dependencies;
   },
 });
 
+interface LocationWithUrl extends Location {
+  url: string;
+}
+
 interface ReactComponentStackEntry extends TimeStampedPoint {
-  parentLocation: Location & { url: string };
+  parentLocation: LocationWithUrl | null;
+  componentLocation: LocationWithUrl | null;
   componentName: string;
+  parentComponentName: string;
 }
 
 export const REACT_DOM_SOURCE_URLS = [
@@ -66,6 +54,115 @@ export const REACT_DOM_SOURCE_URLS = [
 
 export const isReactUrl = (url?: string) =>
   REACT_DOM_SOURCE_URLS.some(partial => url?.includes(partial));
+
+const pairwise = <T>(arr: T[]): [T, T][] => {
+  const pairs: [T, T][] = [];
+  for (let i = 0; i < arr.length - 1; i++) {
+    pairs.push([arr[i], arr[i + 1]]);
+  }
+  return pairs;
+};
+
+interface RenderCreateElementPair {
+  render: {
+    // React has rendered a component.
+    code: "ReactRender";
+    calleeLocation?: URLLocation;
+  } & TimeStampedPoint;
+  createElement: {
+    // An application render function created an element object for converting
+    // into a component.
+    code: "ReactCreateElement";
+  } & TimeStampedPoint;
+}
+
+async function getComponentDetails(
+  replayClient: ReplayClientInterface,
+  location: URLLocation | undefined,
+  sourcesById: Map<string, Source>
+): Promise<{ componentName: string; location: LocationWithUrl | null }> {
+  let componentName = "Unknown";
+  let finalLocation: LocationWithUrl | null = null;
+
+  if (location) {
+    const sourcesByUrl = await sourcesByUrlCache.readAsync(replayClient);
+
+    const bestSource = getSourceToDisplayForUrl(sourcesById, sourcesByUrl, location.url);
+
+    if (bestSource) {
+      const locationInFunction: Location = {
+        sourceId: bestSource.sourceId,
+        line: location.line,
+        column: location.column,
+      };
+      finalLocation = {
+        ...locationInFunction,
+        url: location.url,
+      };
+
+      const formattedFunctionDescription = await formatFunctionDetailsFromLocation(
+        replayClient,
+        "component",
+        locationInFunction,
+        undefined,
+        true
+      );
+
+      componentName =
+        formattedFunctionDescription?.classComponentName ??
+        formattedFunctionDescription?.functionName ??
+        "Unknown";
+    }
+  }
+
+  return {
+    componentName,
+    location: finalLocation,
+  };
+}
+
+async function formatComponentStackEntry(
+  replayClient: ReplayClientInterface,
+  sourcesById: Map<string, Source>,
+  currentComponent: RenderCreateElementPair,
+  parentComponent: RenderCreateElementPair
+): Promise<ReactComponentStackEntry | null> {
+  const elementCreationPoint = currentComponent.createElement;
+  const componentLocation = currentComponent.render.calleeLocation;
+  const parentLocation = parentComponent.render.calleeLocation;
+
+  if (!componentLocation || !parentLocation) {
+    return null;
+  }
+
+  const [componentDetails, parentComponentDetails] = await Promise.all([
+    getComponentDetails(replayClient, componentLocation, sourcesById),
+    getComponentDetails(replayClient, parentLocation, sourcesById),
+  ]);
+
+  const pointStack = await formattedPointStackCache.readAsync(replayClient, {
+    ...elementCreationPoint,
+    frameDepth: 2,
+  });
+
+  let finalJumpPoint: TimeStampedPoint = elementCreationPoint;
+
+  if (pointStack.allFrames.length > 1) {
+    // Element creation happens up one frame
+    const elementCreationFrame = pointStack.allFrames[1];
+    finalJumpPoint = elementCreationFrame.point!;
+  }
+
+  const stackEntry: ReactComponentStackEntry = {
+    ...finalJumpPoint,
+    parentLocation: parentComponentDetails.location,
+    componentLocation: componentDetails.location,
+    componentName: componentDetails.componentName,
+    parentComponentName: parentComponentDetails.componentName,
+  };
+
+  return stackEntry;
+}
 
 export const reactComponentStackCache: Cache<
   [replayClient: ReplayClientInterface, point: TimeStampedPoint | null],
@@ -85,13 +182,17 @@ export const reactComponentStackCache: Cache<
         ...point,
         frameDepth: 2,
       },
+      // don't ignore any files, we _want_ `node_modules` here
       []
     );
 
-    console.log("Point stack for point: ", point, currentPointStack);
-
     const precedingFrame = currentPointStack.allFrames[1];
 
+    // We expect that if we're currently rendering a React component,
+    // the parent frame is either `renderWithHooks()` or
+    // `finishClassComponent()`. For now we'll just check if the
+    // preceding frame is at least in a React build artifact.
+    // If not, there's no point in trying to build a component stack.
     if (!isReactUrl(precedingFrame?.url)) {
       return null;
     }
@@ -103,8 +204,6 @@ export const reactComponentStackCache: Cache<
       DependencyGraphMode.ReactParentRenders
     );
 
-    console.log("Deps: ", { originalDependencies, reactDependencies });
-
     if (!originalDependencies || !reactDependencies) {
       return null;
     }
@@ -114,6 +213,9 @@ export const reactComponentStackCache: Cache<
     const sourcesById = await sourcesByIdCache.readAsync(replayClient);
 
     const remainingDepEntries = reactDependencies.slice().reverse();
+
+    const renderPairs: RenderCreateElementPair[] = [];
+
     while (remainingDepEntries.length) {
       const depEntry = remainingDepEntries.shift()!;
 
@@ -134,71 +236,29 @@ export const reactComponentStackCache: Cache<
           console.error("Expected point in previous entry: ", previousEntry);
         }
 
-        const elementCreationPoint: TimeStampedPoint = {
-          point: previousEntry.point!,
-          time: previousEntry.time!,
-        };
-        const parentLocation = depEntry.calleeLocation;
+        const renderPair = {
+          render: depEntry,
+          createElement: previousEntry as {
+            code: "ReactCreateElement";
+          },
+        } as RenderCreateElementPair;
 
-        let componentName = "Unknown";
+        renderPairs.push(renderPair);
+      }
+    }
 
-        if (parentLocation) {
-          const sourcesByUrl = await sourcesByUrlCache.readAsync(replayClient);
-          const sourcesForUrl = sourcesByUrl.get(parentLocation.url);
+    const renderPairsWithParents = pairwise(renderPairs);
 
-          const bestSource = getSourceToDisplayForUrl(
-            sourcesById,
-            sourcesByUrl,
-            parentLocation.url
-          );
+    for (const [current, parent] of renderPairsWithParents) {
+      const stackEntry = await formatComponentStackEntry(
+        replayClient,
+        sourcesById,
+        current,
+        parent
+      );
 
-          if (!bestSource) {
-            continue;
-          }
-
-          const locationInFunction: Location = {
-            sourceId: bestSource.sourceId,
-            line: parentLocation.line,
-            column: parentLocation.column,
-          };
-
-          const formattedFunctionDescription = await formatFunctionDetailsFromLocation(
-            replayClient,
-            "component",
-            locationInFunction,
-            undefined,
-            true
-          );
-
-          componentName =
-            formattedFunctionDescription?.classComponentName ??
-            formattedFunctionDescription?.functionName ??
-            "Unknown";
-
-          const pointStack = await formattedPointStackCache.readAsync(replayClient, {
-            ...elementCreationPoint,
-            frameDepth: 2,
-          });
-
-          let finalJumpPoint = elementCreationPoint;
-
-          if (pointStack.allFrames.length > 1) {
-            // Element creation happens up one frame
-            const elementCreationFrame = pointStack.allFrames[1];
-            finalJumpPoint = elementCreationFrame.point!;
-          }
-
-          const stackEntry: ReactComponentStackEntry = {
-            ...finalJumpPoint,
-            parentLocation: {
-              ...locationInFunction,
-              url: parentLocation.url,
-            },
-            componentName,
-          };
-
-          componentStack.push(stackEntry);
-        }
+      if (stackEntry) {
+        componentStack.push(stackEntry);
       }
     }
 


### PR DESCRIPTION
This PR:

- Updates `ReplayClient.getDependences()` to accept the new `mode` option from the backend protocol method
- Reworks the DepGraph Panel component to extract the UI for formatting a DG response into its own component
- Makes two separate DG queries when you click "Load Deps", one normal and one with the new `"react"` mode option, and displays both of those formatted
  - Reverses the item orders so that the timestamps are descending, call-stack style
- Reworks the React Component Stack logic:
  - determines both the parent and the child component details
  - uses the React-specific DG result to determine the real ancestor chain, even if the parent component didn't render in _this_ render pass (ie, "jump me back to when my parent last rendered me")
- Updates the RCS display:
  - shows `ParentComponent -> <ChildComponent>` in the list, to be clear where we're jumping to (the parent, in the process of rendering the child)
  - shows the _current_ component we're paused in so that we know where we are can get back to that point

![image](https://github.com/replayio/devtools/assets/1128784/973795a0-336d-40d0-864f-abe1c8dfe5a9)
