### PR TITLE
Display matched selector priority

### DIFF
--- a/src/devtools/client/inspector/computed/actions/index.ts
+++ b/src/devtools/client/inspector/computed/actions/index.ts
@@ -98,15 +98,16 @@ export async function createComputedProperties(
       for (const declaration of rule.declarations) {
         for (const property of declaration.computed || NO_COMPUTEDS) {
           if (property.name === name) {
-            const combinedNameValue = `${name}:${property.value}`;
+            const value = property.value + (property.priority ? ` !${property.priority}` : "");
+            const combinedNameValue = `${name}:${value}`;
             let parsedValue = cachedParsedProperties.get(combinedNameValue)!;
             if (!parsedValue) {
-              parsedValue = outputParser.parseCssProperty(name, property.value);
+              parsedValue = outputParser.parseCssProperty(name, value);
               cachedParsedProperties.set(combinedNameValue, parsedValue);
             }
 
             selectors.push({
-              value: property.value,
+              value,
               parsedValue,
               selector,
               stylesheet,

--- a/src/devtools/client/inspector/computed/actions/index.ts
+++ b/src/devtools/client/inspector/computed/actions/index.ts
@@ -101,7 +101,7 @@ export async function createComputedProperties(
             const combinedNameValue = `${name}:${property.value}`;
             let parsedValue = cachedParsedProperties.get(combinedNameValue)!;
             if (!parsedValue) {
-              parsedValue = outputParser.parseCssProperty(name, value);
+              parsedValue = outputParser.parseCssProperty(name, property.value);
               cachedParsedProperties.set(combinedNameValue, parsedValue);
             }
 

--- a/src/devtools/client/inspector/computed/actions/index.ts
+++ b/src/devtools/client/inspector/computed/actions/index.ts
@@ -98,8 +98,7 @@ export async function createComputedProperties(
       for (const declaration of rule.declarations) {
         for (const property of declaration.computed || NO_COMPUTEDS) {
           if (property.name === name) {
-            const value = property.value + (property.priority ? ` !${property.priority}` : "");
-            const combinedNameValue = `${name}:${value}`;
+            const combinedNameValue = `${name}:${property.value}`;
             let parsedValue = cachedParsedProperties.get(combinedNameValue)!;
             if (!parsedValue) {
               parsedValue = outputParser.parseCssProperty(name, value);
@@ -107,8 +106,9 @@ export async function createComputedProperties(
             }
 
             selectors.push({
-              value,
+              value: property.value,
               parsedValue,
+              priority: property.priority,
               selector,
               stylesheet,
               stylesheetURL,

--- a/src/devtools/client/inspector/computed/components/MatchedSelector.tsx
+++ b/src/devtools/client/inspector/computed/components/MatchedSelector.tsx
@@ -30,6 +30,7 @@ export default function MatchedSelector(props: MatchedSelectorProps) {
             colorSpanClassName="computed-color"
             colorSwatchClassName="computed-colorswatch"
             fontFamilySpanClassName="computed-font-family"
+            priority={selector.priority}
             values={selector.parsedValue}
           />
         </div>

--- a/src/devtools/client/inspector/computed/state/index.ts
+++ b/src/devtools/client/inspector/computed/state/index.ts
@@ -1,3 +1,5 @@
+import { Priority } from "../../rules/models/text-property";
+
 export interface ComputedPropertyState {
   name: string;
   value: string;
@@ -9,7 +11,7 @@ export interface MatchedSelectorState {
   selector: string;
   value: string;
   parsedValue: any[];
-  priority: string;
+  priority: Priority;
   overridden: boolean;
   stylesheet: string;
   stylesheetURL: string;

--- a/src/devtools/client/inspector/computed/state/index.ts
+++ b/src/devtools/client/inspector/computed/state/index.ts
@@ -9,6 +9,7 @@ export interface MatchedSelectorState {
   selector: string;
   value: string;
   parsedValue: any[];
+  priority: string;
   overridden: boolean;
   stylesheet: string;
   stylesheetURL: string;

--- a/src/devtools/client/inspector/rules/components/DeclarationValue.tsx
+++ b/src/devtools/client/inspector/rules/components/DeclarationValue.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import { COLOR, FONT_FAMILY, URI } from "third-party/css/output-parser";
 
+import { Priority } from "../models/text-property";
 import Color from "./value/Color";
 import FontFamily from "./value/FontFamily";
 import Url from "./value/Url";
@@ -10,7 +11,7 @@ interface DeclarationValueProps {
   colorSpanClassName: string;
   colorSwatchClassName: string;
   fontFamilySpanClassName: string;
-  priority?: string;
+  priority?: Priority;
   values: (string | Record<string, string>)[];
 }
 

--- a/src/devtools/client/inspector/rules/components/DeclarationValue.tsx
+++ b/src/devtools/client/inspector/rules/components/DeclarationValue.tsx
@@ -10,12 +10,13 @@ interface DeclarationValueProps {
   colorSpanClassName: string;
   colorSwatchClassName: string;
   fontFamilySpanClassName: string;
+  priority?: string;
   values: (string | Record<string, string>)[];
 }
 
 class DeclarationValue extends React.PureComponent<DeclarationValueProps> {
   render() {
-    return this.props.values.map(v => {
+    const values = this.props.values.map(v => {
       if (typeof v === "string") {
         return v;
       }
@@ -46,6 +47,13 @@ class DeclarationValue extends React.PureComponent<DeclarationValueProps> {
 
       return value;
     });
+
+    return (
+      <>
+        {values}
+        {this.props.priority ? ` !${this.props.priority}` : null}
+      </>
+    );
   }
 }
 


### PR DESCRIPTION
This is a follow-up to the investigation that led to https://github.com/replayio/devtools/pull/10608 . We can see there that the non-top rule was originally left as the "matching one". 

While it shouldn't even be displayed there in the first place (which got fixed by https://github.com/replayio/devtools/pull/10608 ), it wasn't apparent *why* it got matched. The specificity wasn't higher. It turns out that it was an `!important` rule but we never surfaced that in the UI.