### PR TITLE
Support loading additional supplemental recordings

### DIFF
--- a/packages/protocol/RecordedEventsCache.ts
+++ b/packages/protocol/RecordedEventsCache.ts
@@ -5,7 +5,7 @@ import {
 } from "@replayio/protocol";
 import { createSingleEntryCache } from "suspense";
 
-import { compareExecutionPoints } from "protocol/utils";
+import { compareNumericStrings } from "protocol/utils";
 import { findIndexLTE } from "replay-next/src/utils/array";
 import { replayClient } from "shared/client/ReplayClientContext";
 
@@ -39,7 +39,7 @@ export const RecordedEventsCache = createSingleEntryCache<[], RecordedEvent[]>({
 
     const events = [...keyboardEvents, ...mouseEvents, ...navigationEvents];
 
-    return events.sort((a, b) => compareExecutionPoints(a.point, b.point));
+    return events.sort((a, b) => compareNumericStrings(a.point, b.point));
   },
 });
 

--- a/packages/protocol/RecordedEventsCache.ts
+++ b/packages/protocol/RecordedEventsCache.ts
@@ -5,7 +5,7 @@ import {
 } from "@replayio/protocol";
 import { createSingleEntryCache } from "suspense";
 
-import { compareNumericStrings } from "protocol/utils";
+import { compareExecutionPoints } from "protocol/utils";
 import { findIndexLTE } from "replay-next/src/utils/array";
 import { replayClient } from "shared/client/ReplayClientContext";
 
@@ -39,7 +39,7 @@ export const RecordedEventsCache = createSingleEntryCache<[], RecordedEvent[]>({
 
     const events = [...keyboardEvents, ...mouseEvents, ...navigationEvents];
 
-    return events.sort((a, b) => compareNumericStrings(a.point, b.point));
+    return events.sort((a, b) => compareExecutionPoints(a.point, b.point));
   },
 });
 

--- a/packages/protocol/execution-point-utils.ts
+++ b/packages/protocol/execution-point-utils.ts
@@ -1,15 +1,15 @@
 import { ExecutionPoint } from "@replayio/protocol";
 
-import { compareExecutionPoints } from "protocol/utils";
+import { compareNumericStrings } from "protocol/utils";
 
 export function pointEquals(p1: ExecutionPoint, p2: ExecutionPoint) {
   p1 == p2;
 }
 
 export function pointPrecedes(p1: ExecutionPoint, p2: ExecutionPoint) {
-  return compareExecutionPoints(p1, p2) < 0;
+  return compareNumericStrings(p1, p2) < 0;
 }
 
 export function comparePoints(p1: ExecutionPoint, p2: ExecutionPoint) {
-  return compareExecutionPoints(p1, p2);
+  return compareNumericStrings(p1, p2);
 }

--- a/packages/protocol/execution-point-utils.ts
+++ b/packages/protocol/execution-point-utils.ts
@@ -1,15 +1,15 @@
 import { ExecutionPoint } from "@replayio/protocol";
 
-import { compareNumericStrings } from "protocol/utils";
+import { compareExecutionPoints } from "protocol/utils";
 
 export function pointEquals(p1: ExecutionPoint, p2: ExecutionPoint) {
   p1 == p2;
 }
 
 export function pointPrecedes(p1: ExecutionPoint, p2: ExecutionPoint) {
-  return compareNumericStrings(p1, p2) < 0;
+  return compareExecutionPoints(p1, p2) < 0;
 }
 
 export function comparePoints(p1: ExecutionPoint, p2: ExecutionPoint) {
-  return compareNumericStrings(p1, p2);
+  return compareExecutionPoints(p1, p2);
 }

--- a/packages/protocol/socket.ts
+++ b/packages/protocol/socket.ts
@@ -128,7 +128,6 @@ let gSessionCallbacks: SessionCallbacks | undefined;
 
 export function setSessionCallbacks(sessionCallbacks: SessionCallbacks) {
   if (gSessionCallbacks !== undefined) {
-    console.error("Session callbacks can only be set once");
     return;
   }
 

--- a/packages/protocol/utils.ts
+++ b/packages/protocol/utils.ts
@@ -154,23 +154,16 @@ export function breakdownSupplementalId(id: string): { id: string, supplementalI
   return { id: match[2], supplementalIndex };
 }
 
-const SupplementalNumericStringShift = 200;
-
-export function transformSupplementalNumericString(v: string, supplementalIndex: number): string {
-  assert(BigInt(v) < BigInt(1) << BigInt(SupplementalNumericStringShift));
-  if (!supplementalIndex) {
-    return v;
-  }
-  return (BigInt(v) | (BigInt(1) << BigInt(SupplementalNumericStringShift))).toString();
-}
-
 /**
  * Compare 2 integers encoded as numeric strings, because we want to avoid using BigInt (for now).
  * This will only work correctly if both strings encode positive integers (without decimal places),
  * using the same base (usually 10) and don't use "fancy stuff" like leading "+", "0" or scientific
  * notation.
  */
-export function compareNumericStrings(a: string, b: string) {
+export function compareExecutionPoints(transformedA: string, transformedB: string) {
+  const { id: a, supplementalIndex: indexA } = breakdownSupplementalId(transformedA);
+  const { id: b, supplementalIndex: indexB } = breakdownSupplementalId(transformedB);
+  assert(indexA == indexB);
   return a.length < b.length ? -1 : a.length > b.length ? 1 : a < b ? -1 : a > b ? 1 : 0;
 }
 

--- a/packages/protocol/utils.ts
+++ b/packages/protocol/utils.ts
@@ -154,16 +154,23 @@ export function breakdownSupplementalId(id: string): { id: string, supplementalI
   return { id: match[2], supplementalIndex };
 }
 
+const SupplementalNumericStringShift = 200;
+
+export function transformSupplementalNumericString(v: string, supplementalIndex: number): string {
+  assert(BigInt(v) < BigInt(1) << BigInt(SupplementalNumericStringShift));
+  if (!supplementalIndex) {
+    return v;
+  }
+  return (BigInt(v) | (BigInt(1) << BigInt(SupplementalNumericStringShift))).toString();
+}
+
 /**
  * Compare 2 integers encoded as numeric strings, because we want to avoid using BigInt (for now).
  * This will only work correctly if both strings encode positive integers (without decimal places),
  * using the same base (usually 10) and don't use "fancy stuff" like leading "+", "0" or scientific
  * notation.
  */
-export function compareExecutionPoints(transformedA: string, transformedB: string) {
-  const { id: a, supplementalIndex: indexA } = breakdownSupplementalId(transformedA);
-  const { id: b, supplementalIndex: indexB } = breakdownSupplementalId(transformedB);
-  assert(indexA == indexB);
+export function compareNumericStrings(a: string, b: string) {
   return a.length < b.length ? -1 : a.length > b.length ? 1 : a < b ? -1 : a > b ? 1 : 0;
 }
 

--- a/packages/protocol/utils.ts
+++ b/packages/protocol/utils.ts
@@ -140,13 +140,30 @@ export class ArrayMap<K, V> {
   }
 }
 
+export function transformSupplementalId(id: string, supplementalIndex: number) {
+  return `s${supplementalIndex}-${id}`;
+}
+
+export function breakdownSupplementalId(id: string): { id: string, supplementalIndex: number } {
+  const match = /^s(\d+)-(.*)/.exec(id);
+  if (!match) {
+    return { id, supplementalIndex: 0 };
+  }
+  const supplementalIndex = +match[1];
+  assert(supplementalIndex > 0);
+  return { id: match[2], supplementalIndex };
+}
+
 /**
  * Compare 2 integers encoded as numeric strings, because we want to avoid using BigInt (for now).
  * This will only work correctly if both strings encode positive integers (without decimal places),
  * using the same base (usually 10) and don't use "fancy stuff" like leading "+", "0" or scientific
  * notation.
  */
-export function compareNumericStrings(a: string, b: string) {
+export function compareExecutionPoints(transformedA: string, transformedB: string) {
+  const { id: a, supplementalIndex: indexA } = breakdownSupplementalId(transformedA);
+  const { id: b, supplementalIndex: indexB } = breakdownSupplementalId(transformedB);
+  assert(indexA == indexB);
   return a.length < b.length ? -1 : a.length > b.length ? 1 : a < b ? -1 : a > b ? 1 : 0;
 }
 

--- a/packages/protocol/utils.ts
+++ b/packages/protocol/utils.ts
@@ -141,6 +141,9 @@ export class ArrayMap<K, V> {
 }
 
 export function transformSupplementalId(id: string, supplementalIndex: number) {
+  if (!supplementalIndex) {
+    return id;
+  }
   return `s${supplementalIndex}-${id}`;
 }
 

--- a/packages/protocol/utils.ts
+++ b/packages/protocol/utils.ts
@@ -161,16 +161,6 @@ export function sameSupplementalIndex(idA: string, idB: string) {
   return breakdownSupplementalId(idA).supplementalIndex == breakdownSupplementalId(idB).supplementalIndex;
 }
 
-const SupplementalNumericStringShift = 200;
-
-export function transformSupplementalNumericString(v: string, supplementalIndex: number): string {
-  assert(BigInt(v) < BigInt(1) << BigInt(SupplementalNumericStringShift));
-  if (!supplementalIndex) {
-    return v;
-  }
-  return (BigInt(v) | (BigInt(1) << BigInt(SupplementalNumericStringShift))).toString();
-}
-
 /*
  * Compare 2 integers encoded as numeric strings, because we want to avoid using BigInt (for now).
  * This will only work correctly if both strings encode positive integers (without decimal places),

--- a/packages/replay-next/components/console/MessageHoverButton.tsx
+++ b/packages/replay-next/components/console/MessageHoverButton.tsx
@@ -22,10 +22,10 @@ import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
 import { useNag } from "replay-next/src/hooks/useNag";
 import { sourcesByIdCache } from "replay-next/src/suspense/SourcesCache";
 import { getPreferredLocationWorkaround } from "replay-next/src/utils/sources";
-import { isExecutionPointsGreaterThan } from "replay-next/src/utils/time";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import { addComment as addCommentGraphQL } from "shared/graphql/Comments";
 import { Nag } from "shared/graphql/types";
+import { compareTimeStampedPoints } from "protocol/utils";
 
 import styles from "./MessageHoverButton.module.css";
 
@@ -48,7 +48,7 @@ export default function MessageHoverButton({
   const { inspectFunctionDefinition, showCommentsPanel } = useContext(InspectorContext);
   const { accessToken, recordingId, trackEvent } = useContext(SessionContext);
   const graphQLClient = useContext(GraphQLClientContext);
-  const { executionPoint: currentExecutionPoint, update } = useContext(TimelineContext);
+  const { executionPoint: currentExecutionPoint, time: currentTime, update } = useContext(TimelineContext);
   const { canShowConsoleAndSources } = useContext(LayoutContext);
 
   const invalidateCache = useCacheRefresh();
@@ -134,9 +134,11 @@ export default function MessageHoverButton({
       dismissFirstConsoleNavigateNag();
     };
 
+    const pointTS = { point: executionPoint, time };
+
     const label =
       currentExecutionPoint === null ||
-      isExecutionPointsGreaterThan(executionPoint, currentExecutionPoint)
+      compareTimeStampedPoints(pointTS, { point: currentExecutionPoint, time: currentTime }) > 0
         ? "Fast-forward"
         : "Rewind";
 
@@ -153,7 +155,7 @@ export default function MessageHoverButton({
           className={styles.ConsoleMessageHoverButtonIcon}
           type={
             currentExecutionPoint === null ||
-            isExecutionPointsGreaterThan(executionPoint, currentExecutionPoint)
+            compareTimeStampedPoints(pointTS, { point: currentExecutionPoint, time: currentTime }) > 0
               ? "fast-forward"
               : "rewind"
           }

--- a/packages/replay-next/components/sources/SeekHoverButtons.tsx
+++ b/packages/replay-next/components/sources/SeekHoverButtons.tsx
@@ -33,7 +33,7 @@ export function SeekHoverButtons(props: Props) {
 function SuspendingComponent({ lineHitCounts, lineNumber, source }: Props) {
   const { rangeForSuspense: focusRange } = useContext(FocusContext);
   const replayClient = useContext(ReplayClientContext);
-  const { executionPoint, update } = useContext(TimelineContext);
+  const { executionPoint, time, update } = useContext(TimelineContext);
 
   let hitPoints: TimeStampedPoint[] | null = null;
   let hitPointStatus: HitPointStatus | null = null;
@@ -56,7 +56,7 @@ function SuspendingComponent({ lineHitCounts, lineNumber, source }: Props) {
   let goToPrevPoint: undefined | EventHandler = undefined;
   let goToNextPoint: undefined | EventHandler = undefined;
   if (executionPoint && hitPoints !== null && hitPointStatus !== "too-many-points-to-find") {
-    const prevTargetPoint = findLastHitPoint(hitPoints, executionPoint);
+    const prevTargetPoint = findLastHitPoint(hitPoints, { point: executionPoint, time });
     if (prevTargetPoint) {
       goToPrevPoint = () => {
         const location = {
@@ -68,7 +68,7 @@ function SuspendingComponent({ lineHitCounts, lineNumber, source }: Props) {
       };
     }
 
-    const nextTargetPoint = findNextHitPoint(hitPoints, executionPoint);
+    const nextTargetPoint = findNextHitPoint(hitPoints, { point: executionPoint, time });
     if (nextTargetPoint) {
       goToNextPoint = () => {
         const location = {

--- a/packages/replay-next/components/sources/log-point-panel/LogPointPanel.tsx
+++ b/packages/replay-next/components/sources/log-point-panel/LogPointPanel.tsx
@@ -9,7 +9,7 @@ import {
   useTransition,
 } from "react";
 
-import { assert, sameSupplementalIndex } from "protocol/utils";
+import { assert } from "protocol/utils";
 import AvatarImage from "replay-next/components/AvatarImage";
 import { InlineErrorBoundary } from "replay-next/components/errors/InlineErrorBoundary";
 import Icon from "replay-next/components/Icon";
@@ -28,8 +28,8 @@ import { TimelineContext } from "replay-next/src/contexts/TimelineContext";
 import { useNag } from "replay-next/src/hooks/useNag";
 import { hitPointsForLocationCache } from "replay-next/src/suspense/HitPointsCache";
 import { getSourceSuspends } from "replay-next/src/suspense/SourcesCache";
-import { findIndexBigInt } from "replay-next/src/utils/array";
 import { validateCode } from "replay-next/src/utils/code";
+import { findHitPointBefore } from "../utils/points";
 import { MAX_POINTS_TO_RUN_EVALUATION } from "shared/client/ReplayClient";
 import { ReplayClientContext } from "shared/client/ReplayClientContext";
 import {
@@ -214,12 +214,8 @@ export function PointPanelWithHitPoints({
     if (!currentExecutionPoint) {
       return null;
     }
-    if (!sameSupplementalIndex(currentExecutionPoint, location.sourceId)) {
-      return null;
-    }
-    const executionPoints = hitPoints.map(hitPoint => hitPoint.point);
-    const index = findIndexBigInt(executionPoints, currentExecutionPoint, false);
-    return hitPoints[index] || null;
+    const [hitPoint] = findHitPointBefore(hitPoints, { point: currentExecutionPoint, time: currentTime });
+    return hitPoint || null;
   }, [hitPoints, currentExecutionPoint]);
 
   // If we've found a hit point match, use data from its scope.

--- a/packages/replay-next/components/sources/log-point-panel/LogPointPanel.tsx
+++ b/packages/replay-next/components/sources/log-point-panel/LogPointPanel.tsx
@@ -9,7 +9,7 @@ import {
   useTransition,
 } from "react";
 
-import { assert } from "protocol/utils";
+import { assert, sameSupplementalIndex } from "protocol/utils";
 import AvatarImage from "replay-next/components/AvatarImage";
 import { InlineErrorBoundary } from "replay-next/components/errors/InlineErrorBoundary";
 import Icon from "replay-next/components/Icon";
@@ -212,6 +212,9 @@ export function PointPanelWithHitPoints({
   // which may be paused at a different location.
   const closestHitPoint = useMemo(() => {
     if (!currentExecutionPoint) {
+      return null;
+    }
+    if (!sameSupplementalIndex(currentExecutionPoint, location.sourceId)) {
       return null;
     }
     const executionPoints = hitPoints.map(hitPoint => hitPoint.point);

--- a/packages/replay-next/components/sources/useSourceContextMenu.tsx
+++ b/packages/replay-next/components/sources/useSourceContextMenu.tsx
@@ -133,7 +133,7 @@ function FastForwardButton({
   lineNumber: number;
   sourceId: SourceId;
 }) {
-  const { executionPoint: currentExecutionPoint, update } = useContext(TimelineContext);
+  const { executionPoint: currentExecutionPoint, time: currentTime, update } = useContext(TimelineContext);
 
   const [hitPoints, hitPointStatus] = useDeferredHitCounts({
     lineHitCounts,
@@ -143,7 +143,7 @@ function FastForwardButton({
 
   let fastForwardToExecutionPoint: TimeStampedPoint | null = null;
   if (currentExecutionPoint && hitPoints !== null && hitPointStatus !== "too-many-points-to-find") {
-    fastForwardToExecutionPoint = findNextHitPoint(hitPoints, currentExecutionPoint);
+    fastForwardToExecutionPoint = findNextHitPoint(hitPoints, { point: currentExecutionPoint, time: currentTime });
   }
 
   const fastForward = () => {
@@ -172,7 +172,7 @@ function RewindButton({
   lineNumber: number;
   sourceId: SourceId;
 }) {
-  const { executionPoint: currentExecutionPoint, update } = useContext(TimelineContext);
+  const { executionPoint: currentExecutionPoint, time: currentTime, update } = useContext(TimelineContext);
 
   const [hitPoints, hitPointStatus] = useDeferredHitCounts({
     lineHitCounts,
@@ -182,7 +182,7 @@ function RewindButton({
 
   let rewindToExecutionPoint: TimeStampedPoint | null = null;
   if (currentExecutionPoint && hitPoints !== null && hitPointStatus !== "too-many-points-to-find") {
-    rewindToExecutionPoint = findLastHitPoint(hitPoints, currentExecutionPoint);
+    rewindToExecutionPoint = findLastHitPoint(hitPoints, { point: currentExecutionPoint, time: currentTime });
   }
 
   const rewind = () => {

--- a/packages/replay-next/components/sources/utils/findLastHitPoint.ts
+++ b/packages/replay-next/components/sources/utils/findLastHitPoint.ts
@@ -1,15 +1,15 @@
-import { ExecutionPoint, TimeStampedPoint } from "@replayio/protocol";
+import { TimeStampedPoint } from "@replayio/protocol";
 import findLast from "lodash/findLast";
 
-import { compareExecutionPoints, isExecutionPointsLessThan } from "replay-next/src/utils/time";
+import { compareTimeStampedPoints } from "protocol/utils";
 
-export function findLastHitPoint(hitPoints: TimeStampedPoint[], executionPoint: ExecutionPoint) {
+export function findLastHitPoint(hitPoints: TimeStampedPoint[], executionPoint: TimeStampedPoint) {
   const hitPoint = findLast(
     hitPoints,
-    point => compareExecutionPoints(point.point, executionPoint) < 0
+    point => compareTimeStampedPoints(point, executionPoint) < 0
   );
   if (hitPoint != null) {
-    if (isExecutionPointsLessThan(hitPoint.point, executionPoint)) {
+    if (compareTimeStampedPoints(hitPoint, executionPoint) < 0) {
       return hitPoint;
     }
   }

--- a/packages/replay-next/components/sources/utils/findNextHitPoints.ts
+++ b/packages/replay-next/components/sources/utils/findNextHitPoints.ts
@@ -1,11 +1,11 @@
-import { ExecutionPoint, TimeStampedPoint } from "@replayio/protocol";
+import { TimeStampedPoint } from "@replayio/protocol";
 
-import { compareExecutionPoints, isExecutionPointsGreaterThan } from "replay-next/src/utils/time";
+import { compareTimeStampedPoints } from "protocol/utils";
 
-export function findNextHitPoint(hitPoints: TimeStampedPoint[], executionPoint: ExecutionPoint) {
-  const hitPoint = hitPoints.find(point => compareExecutionPoints(point.point, executionPoint) > 0);
+export function findNextHitPoint(hitPoints: TimeStampedPoint[], executionPoint: TimeStampedPoint) {
+  const hitPoint = hitPoints.find(point => compareTimeStampedPoints(point, executionPoint) > 0);
   if (hitPoint != null) {
-    if (isExecutionPointsGreaterThan(hitPoint.point, executionPoint)) {
+    if (compareTimeStampedPoints(hitPoint, executionPoint) > 0) {
       return hitPoint;
     }
   }

--- a/packages/replay-next/components/sources/utils/points.test.ts
+++ b/packages/replay-next/components/sources/utils/points.test.ts
@@ -17,7 +17,7 @@ describe("utils/points", () => {
 
   describe("findClosestHitPoint", () => {
     function verifyIndex(executionPoint: ExecutionPoint, expectedIndex: number) {
-      const match = findClosestHitPoint(hitPoints, executionPoint);
+      const match = findClosestHitPoint(hitPoints, { point: executionPoint, time: 0 });
       expect(match).toHaveLength(2);
       expect(match[1]).toBe(expectedIndex);
     }
@@ -49,7 +49,7 @@ describe("utils/points", () => {
       exactMatch: boolean,
       expectedIndex: number
     ) {
-      const match = findHitPoint(hitPoints, executionPoint, exactMatch);
+      const match = findHitPoint(hitPoints, { point: executionPoint, time: 0 }, exactMatch);
       expect(match).toHaveLength(2);
       expect(match[1]).toBe(expectedIndex);
     }
@@ -92,7 +92,7 @@ describe("utils/points", () => {
 
   describe("findHitPointAfter", () => {
     function verifyIndex(executionPoint: ExecutionPoint, expectedIndex: number) {
-      const match = findHitPointAfter(hitPoints, executionPoint);
+      const match = findHitPointAfter(hitPoints, { point: executionPoint, time: 0 });
       expect(match).toHaveLength(2);
       expect(match[1]).toBe(expectedIndex);
     }
@@ -119,7 +119,7 @@ describe("utils/points", () => {
   // 0:1000, 1:4000, 2:6000
   describe("findHitPointBefore", () => {
     function verifyIndex(executionPoint: ExecutionPoint, expectedIndex: number) {
-      const match = findHitPointBefore(hitPoints, executionPoint);
+      const match = findHitPointBefore(hitPoints, { point: executionPoint, time: 0 });
       expect(match).toHaveLength(2);
       expect(match[1]).toBe(expectedIndex);
     }

--- a/packages/replay-next/components/sources/utils/points.ts
+++ b/packages/replay-next/components/sources/utils/points.ts
@@ -1,6 +1,6 @@
 import { ExecutionPoint, SourceId, TimeStampedPoint } from "@replayio/protocol";
 
-import { binarySearch, compareTimeStampedPoints, sameSupplementalIndex } from "protocol/utils";
+import { binarySearch, compareTimeStampedPoints, breakdownSupplementalId } from "protocol/utils";
 import {
   isExecutionPointsGreaterThan,
   isExecutionPointsLessThan,
@@ -27,7 +27,8 @@ export function findClosestHitPoint(
       return [hitPoint, index];
     }
 
-    if (!sameSupplementalIndex(executionPoint.point, hitPoint.point)) {
+    if (breakdownSupplementalId(executionPoint.point).supplementalIndex ||
+        breakdownSupplementalId(hitPoint.point).supplementalIndex) {
       return [hitPoint, index];
     }
 

--- a/packages/replay-next/src/suspense/FocusIntervalCache.ts
+++ b/packages/replay-next/src/suspense/FocusIntervalCache.ts
@@ -7,6 +7,7 @@ import {
 } from "suspense";
 
 import { ProtocolError, isCommandError } from "shared/utils/error";
+import { breakdownSupplementalId, transformSupplementalNumericString } from "protocol/utils";
 
 type Options<Point extends number | bigint, Params extends Array<any>, Value> = {
   debugLabel?: string;
@@ -35,7 +36,10 @@ export function createFocusIntervalCacheForExecutionPoints<Params extends Array<
   return createFocusIntervalCache<bigint, Params, Value>({
     ...rest,
     getPointForValue: (value: Value): bigint => {
-      return BigInt(getPointForValue(value));
+      const transformedPoint = getPointForValue(value);
+      const { id: point, supplementalIndex } = breakdownSupplementalId(transformedPoint);
+      const newPoint = transformSupplementalNumericString(point, supplementalIndex);
+      return BigInt(newPoint);
     },
     load: (start: bigint, end: bigint, ...params: [...Params, IntervalCacheLoadOptions<Value>]) =>
       load(start.toString(), end.toString(), ...params),

--- a/packages/replay-next/src/suspense/HitPointsCache.ts
+++ b/packages/replay-next/src/suspense/HitPointsCache.ts
@@ -3,7 +3,7 @@ import { createCache } from "suspense";
 
 import { breakpointPositionsIntervalCache } from "replay-next/src/suspense/BreakpointPositionsCache";
 import { bucketBreakpointLines } from "replay-next/src/utils/source";
-import { compareNumericStrings } from "replay-next/src/utils/string";
+import { compareExecutionPoints } from "protocol/utils";
 import { MAX_POINTS_TO_RUN_EVALUATION } from "shared/client/ReplayClient";
 import {
   HitPointStatus,
@@ -69,7 +69,7 @@ export const hitPointsCache = createFocusIntervalCacheForExecutionPoints<
           );
         }
       );
-      hitPoints.sort((a, b) => compareNumericStrings(a.point, b.point));
+      hitPoints.sort((a, b) => compareExecutionPoints(a.point, b.point));
     } else {
       const pointDescriptions = await replayClient.findPoints(
         { kind: "locations", locations },

--- a/packages/replay-next/src/suspense/HitPointsCache.ts
+++ b/packages/replay-next/src/suspense/HitPointsCache.ts
@@ -3,7 +3,7 @@ import { createCache } from "suspense";
 
 import { breakpointPositionsIntervalCache } from "replay-next/src/suspense/BreakpointPositionsCache";
 import { bucketBreakpointLines } from "replay-next/src/utils/source";
-import { compareExecutionPoints } from "protocol/utils";
+import { compareNumericStrings } from "replay-next/src/utils/string";
 import { MAX_POINTS_TO_RUN_EVALUATION } from "shared/client/ReplayClient";
 import {
   HitPointStatus,
@@ -69,7 +69,7 @@ export const hitPointsCache = createFocusIntervalCacheForExecutionPoints<
           );
         }
       );
-      hitPoints.sort((a, b) => compareExecutionPoints(a.point, b.point));
+      hitPoints.sort((a, b) => compareNumericStrings(a.point, b.point));
     } else {
       const pointDescriptions = await replayClient.findPoints(
         { kind: "locations", locations },

--- a/packages/replay-next/src/utils/loggables.ts
+++ b/packages/replay-next/src/utils/loggables.ts
@@ -7,7 +7,7 @@ import { TerminalExpression } from "replay-next/src/contexts/TerminalContext";
 import { EventLog } from "replay-next/src/suspense/EventsCache";
 import { UncaughtException } from "replay-next/src/suspense/ExceptionsCache";
 
-import { compareExecutionPoints } from "./time";
+import { compareTimeStampedPoints } from "protocol/utils";
 
 export function isEventLog(loggable: Loggable): loggable is EventLog {
   return loggable.type === "EventLog";
@@ -80,5 +80,8 @@ export function loggableSort(a: Loggable, b: Loggable): number {
     }
   }
 
-  return compareExecutionPoints(aPoint, bPoint);
+  const aTime = getLoggableTime(a);
+  const bTime = getLoggableTime(b);
+
+  return compareTimeStampedPoints({ point: aPoint, time: aTime }, { point: bPoint, time: bTime });
 }

--- a/packages/replay-next/src/utils/string.ts
+++ b/packages/replay-next/src/utils/string.ts
@@ -1,5 +1,9 @@
 export const NEW_LINE_REGEX = /\r\n?|\n|\u2028|\u2029/;
 
+export function compareNumericStrings(a: string, b: string): number {
+  return a.length < b.length ? -1 : a.length > b.length ? 1 : a < b ? -1 : a > b ? 1 : 0;
+}
+
 // Convenience function to JSON-stringify values that may contain circular references.
 export function stringify(value: any, space?: string | number): string {
   const cache: any[] = [];

--- a/packages/replay-next/src/utils/string.ts
+++ b/packages/replay-next/src/utils/string.ts
@@ -1,9 +1,5 @@
 export const NEW_LINE_REGEX = /\r\n?|\n|\u2028|\u2029/;
 
-export function compareNumericStrings(a: string, b: string): number {
-  return a.length < b.length ? -1 : a.length > b.length ? 1 : a < b ? -1 : a > b ? 1 : 0;
-}
-
 // Convenience function to JSON-stringify values that may contain circular references.
 export function stringify(value: any, space?: string | number): string {
   const cache: any[] = [];

--- a/packages/replay-next/src/utils/time.ts
+++ b/packages/replay-next/src/utils/time.ts
@@ -6,7 +6,7 @@ import differenceInWeeks from "date-fns/differenceInWeeks";
 import differenceInYears from "date-fns/differenceInYears";
 import padStart from "lodash/padStart";
 import prettyMilliseconds from "pretty-ms";
-import { compareExecutionPoints as baseCompareExecutionPoints } from "protocol/utils";
+import { compareExecutionPoints as baseCompareExecutionPoints, sameSupplementalIndex } from "protocol/utils";
 
 export const compareExecutionPoints = baseCompareExecutionPoints;
 
@@ -23,6 +23,9 @@ export function isExecutionPointsWithinRange(
   beginPoint: ExecutionPoint,
   endPoint: ExecutionPoint
 ): boolean {
+  if (!sameSupplementalIndex(point, beginPoint)) {
+    return true;
+  }
   return !(
     isExecutionPointsLessThan(point, beginPoint) || isExecutionPointsGreaterThan(point, endPoint)
   );

--- a/packages/replay-next/src/utils/time.ts
+++ b/packages/replay-next/src/utils/time.ts
@@ -6,10 +6,9 @@ import differenceInWeeks from "date-fns/differenceInWeeks";
 import differenceInYears from "date-fns/differenceInYears";
 import padStart from "lodash/padStart";
 import prettyMilliseconds from "pretty-ms";
+import { compareExecutionPoints as baseCompareExecutionPoints } from "protocol/utils";
 
-export function compareExecutionPoints(a: ExecutionPoint, b: ExecutionPoint): number {
-  return Number(BigInt(a) - BigInt(b));
-}
+export const compareExecutionPoints = baseCompareExecutionPoints;
 
 export function isExecutionPointsGreaterThan(a: ExecutionPoint, b: ExecutionPoint): boolean {
   return compareExecutionPoints(a, b) > 0;

--- a/packages/shared/client/ReplayClient.ts
+++ b/packages/shared/client/ReplayClient.ts
@@ -78,7 +78,7 @@ import uniqueId from "lodash/uniqueId";
 
 // eslint-disable-next-line no-restricted-imports
 import { addEventListener, client, initSocket, removeEventListener } from "protocol/socket";
-import { assert, compareExecutionPoints, defer, waitForTime, transformSupplementalId, breakdownSupplementalId } from "protocol/utils";
+import { assert, compareNumericStrings, defer, waitForTime, transformSupplementalId, breakdownSupplementalId, transformSupplementalNumericString } from "protocol/utils";
 import { initProtocolMessagesStore } from "replay-next/components/protocol/ProtocolMessagesStore";
 import { insert } from "replay-next/src/utils/array";
 import { TOO_MANY_POINTS_TO_FIND } from "shared/constants";
@@ -314,7 +314,7 @@ export class ReplayClient implements ReplayClientInterface {
         let middleIndex = (lowIndex + highIndex) >>> 1;
         const message = sortedMessages[middleIndex];
 
-        if (compareExecutionPoints(message.point.point, newMessagePoint)) {
+        if (compareNumericStrings(message.point.point, newMessagePoint)) {
           lowIndex = middleIndex + 1;
         } else {
           highIndex = middleIndex;
@@ -357,7 +357,7 @@ export class ReplayClient implements ReplayClientInterface {
     const sortedMessages = response.messages.sort((messageA: Message, messageB: Message) => {
       const pointA = messageA.point.point;
       const pointB = messageB.point.point;
-      return compareExecutionPoints(pointA, pointB);
+      return compareNumericStrings(pointA, pointB);
     });
 
     return {
@@ -537,9 +537,9 @@ export class ReplayClient implements ReplayClientInterface {
       throw commandError("Too many points", ProtocolError.TooManyPoints);
     }
 
-    points.sort((a, b) => compareExecutionPoints(a.point, b.point));
+    points.sort((a, b) => compareNumericStrings(a.point, b.point));
     return points.map(desc => {
-      const point = transformSupplementalId(desc.point, supplementalIndex);
+      const point = transformSupplementalNumericString(desc.point, supplementalIndex);
       return { ...desc, point };
     });
   }

--- a/packages/shared/client/ReplayClient.ts
+++ b/packages/shared/client/ReplayClient.ts
@@ -78,7 +78,7 @@ import uniqueId from "lodash/uniqueId";
 
 // eslint-disable-next-line no-restricted-imports
 import { addEventListener, client, initSocket, removeEventListener } from "protocol/socket";
-import { assert, compareNumericStrings, defer, waitForTime, transformSupplementalId, breakdownSupplementalId, transformSupplementalNumericString } from "protocol/utils";
+import { assert, compareExecutionPoints, defer, waitForTime, transformSupplementalId, breakdownSupplementalId } from "protocol/utils";
 import { initProtocolMessagesStore } from "replay-next/components/protocol/ProtocolMessagesStore";
 import { insert } from "replay-next/src/utils/array";
 import { TOO_MANY_POINTS_TO_FIND } from "shared/constants";
@@ -314,7 +314,7 @@ export class ReplayClient implements ReplayClientInterface {
         let middleIndex = (lowIndex + highIndex) >>> 1;
         const message = sortedMessages[middleIndex];
 
-        if (compareNumericStrings(message.point.point, newMessagePoint)) {
+        if (compareExecutionPoints(message.point.point, newMessagePoint)) {
           lowIndex = middleIndex + 1;
         } else {
           highIndex = middleIndex;
@@ -357,7 +357,7 @@ export class ReplayClient implements ReplayClientInterface {
     const sortedMessages = response.messages.sort((messageA: Message, messageB: Message) => {
       const pointA = messageA.point.point;
       const pointB = messageB.point.point;
-      return compareNumericStrings(pointA, pointB);
+      return compareExecutionPoints(pointA, pointB);
     });
 
     return {
@@ -537,9 +537,9 @@ export class ReplayClient implements ReplayClientInterface {
       throw commandError("Too many points", ProtocolError.TooManyPoints);
     }
 
-    points.sort((a, b) => compareNumericStrings(a.point, b.point));
+    points.sort((a, b) => compareExecutionPoints(a.point, b.point));
     return points.map(desc => {
-      const point = transformSupplementalNumericString(desc.point, supplementalIndex);
+      const point = transformSupplementalId(desc.point, supplementalIndex);
       return { ...desc, point };
     });
   }

--- a/packages/shared/client/types.ts
+++ b/packages/shared/client/types.ts
@@ -162,10 +162,18 @@ export interface TimeStampedPointWithPaintHash extends TimeStampedPoint {
 
 export type AnnotationListener = (annotation: Annotation) => void;
 
+export interface SupplementalRecording {
+  recordingId: string;
+}
+
+export interface SupplementalSession extends SupplementalRecording {
+  sessionId: string;
+}
+
 export interface ReplayClientInterface {
   get loadedRegions(): LoadedRegions | null;
   addEventListener(type: ReplayClientEvents, handler: Function): void;
-  configure(sessionId: string): Promise<void>;
+  configure(sessionId: string, supplemental: SupplementalSession[]): Promise<void>;
   createPause(executionPoint: ExecutionPoint): Promise<createPauseResult>;
   evaluateExpression(
     pauseId: PauseId,

--- a/packages/shared/client/types.ts
+++ b/packages/shared/client/types.ts
@@ -323,4 +323,5 @@ export interface ReplayClientInterface {
     onSourceContentsChunk: ({ chunk, sourceId }: { chunk: string; sourceId: SourceId }) => void
   ): Promise<void>;
   waitForSession(): Promise<string>;
+  numSupplementalRecordings(): number;
 }

--- a/packages/shared/client/types.ts
+++ b/packages/shared/client/types.ts
@@ -162,8 +162,16 @@ export interface TimeStampedPointWithPaintHash extends TimeStampedPoint {
 
 export type AnnotationListener = (annotation: Annotation) => void;
 
+export interface SupplementalRecordingConnection {
+  clientFirst: boolean;
+  clientRecordingId: string;
+  clientPoint: TimeStampedPoint;
+  serverPoint: TimeStampedPoint;
+}
+
 export interface SupplementalRecording {
-  recordingId: string;
+  serverRecordingId: string;
+  connections: SupplementalRecordingConnection[];
 }
 
 export interface SupplementalSession extends SupplementalRecording {
@@ -173,7 +181,7 @@ export interface SupplementalSession extends SupplementalRecording {
 export interface ReplayClientInterface {
   get loadedRegions(): LoadedRegions | null;
   addEventListener(type: ReplayClientEvents, handler: Function): void;
-  configure(sessionId: string, supplemental: SupplementalSession[]): Promise<void>;
+  configure(recordingId: string, sessionId: string, supplemental: SupplementalSession[]): Promise<void>;
   createPause(executionPoint: ExecutionPoint): Promise<createPauseResult>;
   evaluateExpression(
     pauseId: PauseId,

--- a/packages/shared/utils/time.ts
+++ b/packages/shared/utils/time.ts
@@ -4,6 +4,7 @@ import {
   TimeStampedPoint,
   TimeStampedPointRange,
 } from "@replayio/protocol";
+import { sameSupplementalIndex } from "protocol/utils";
 
 const supportsPerformanceNow =
   typeof performance !== "undefined" && typeof performance.now === "function";
@@ -74,6 +75,9 @@ export function isRangeInRegions(
 }
 
 export function isPointInRegion(point: ExecutionPoint, range: TimeStampedPointRange): boolean {
+  if (!sameSupplementalIndex(point, range.begin.point)) {
+    return true;
+  }
   const pointNumber = BigInt(point);
   return pointNumber >= BigInt(range.begin.point) && pointNumber <= BigInt(range.end.point);
 }

--- a/src/devtools/client/debugger/src/components/Editor/Footer.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Footer.tsx
@@ -20,7 +20,7 @@ function SourceFooter() {
       <div className="source-footer">
         <InlineErrorBoundary
           name="SourceFooter"
-          fallback={<div className="error">An error occurred while replaying</div>}
+          fallback={<div className="error"></div>}
         >
           <Suspense>
             <SourcemapToggleSuspends cursorPosition={cursorPosition} />

--- a/src/devtools/client/debugger/src/components/PrimaryPanes/index.tsx
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/index.tsx
@@ -1,10 +1,12 @@
 import classnames from "classnames";
 
 import { useGraphQLUserData } from "shared/user-data/GraphQL/useGraphQLUserData";
+import { useContext, useState } from "react";
 
 import Outline from "../SourceOutline/SourceOutline";
 import QuickOpenButton from "./QuickOpenButton";
 import SourcesTree from "./SourcesTree";
+import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
 import { Accordion, AccordionPane } from "@recordreplay/accordion";
 
@@ -15,19 +17,44 @@ export default function PrimaryPanes() {
   const [sourcesCollapsed, setSourcesCollapsed] = useGraphQLUserData("layout_sourcesCollapsed");
   const [enableLargeText] = useGraphQLUserData("global_enableLargeText");
 
+  const [supplementalSourcesCollapsed, setSupplementalSourcesCollapsed] = useState(sourcesCollapsed);
+  const replayClient = useContext(ReplayClientContext);
+
+  const sourcePanes = [];
+
+  sourcePanes.push(
+    <AccordionPane
+      header="Sources"
+      // ExperimentFeature: LargeText Logic
+      className={classnames("sources-pane", enableLargeText ? "text-base" : "text-xs")}
+      expanded={!sourcesCollapsed}
+      onToggle={() => setSourcesCollapsed(!sourcesCollapsed)}
+      initialHeight={400}
+      button={<QuickOpenButton />}
+    >
+      <SourcesTree supplementalIndex={0}/>
+    </AccordionPane>
+  );
+
+  for (let i = 0; i < replayClient.numSupplementalRecordings(); i++) {
+      sourcePanes.push(
+        <AccordionPane
+          header="Backend Sources"
+          // ExperimentFeature: LargeText Logic
+          className={classnames("sources-pane", enableLargeText ? "text-base" : "text-xs")}
+          expanded={!supplementalSourcesCollapsed}
+          onToggle={() => setSupplementalSourcesCollapsed(!supplementalSourcesCollapsed)}
+          initialHeight={200}
+          button={<QuickOpenButton />}
+        >
+          <SourcesTree supplementalIndex={i + 1}/>
+        </AccordionPane>
+      );
+    }
+
   return (
     <Accordion>
-      <AccordionPane
-        header="Sources"
-        // ExperimentFeature: LargeText Logic
-        className={classnames("sources-pane", enableLargeText ? "text-base" : "text-xs")}
-        expanded={!sourcesCollapsed}
-        onToggle={() => setSourcesCollapsed(!sourcesCollapsed)}
-        initialHeight={400}
-        button={<QuickOpenButton />}
-      >
-        <SourcesTree />
-      </AccordionPane>
+      {...sourcePanes as any}
       <AccordionPane
         header="Outline"
         className="outlines-pane"

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/FrameTimeline.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/FrameTimeline.tsx
@@ -32,9 +32,11 @@ import {
   PauseAndFrameId,
   PauseFrame,
   getExecutionPoint,
+  getTime,
   getSelectedFrameId,
 } from "../../reducers/pause";
 import { getSelectedFrameSuspense } from "../../selectors/pause";
+import { compareTimeStampedPoints } from "protocol/utils";
 
 function getBoundingClientRect(element?: HTMLElement) {
   if (!element) {
@@ -51,6 +53,7 @@ interface FrameTimelineState {
 
 interface FrameTimelineProps {
   executionPoint: string | null;
+  time: number;
   selectedLocation: PartialLocation | null;
   selectedFrame: PauseFrame | null;
   frameSteps: PointDescription[] | undefined;
@@ -176,7 +179,7 @@ class FrameTimelineRenderer extends Component<FrameTimelineProps, FrameTimelineS
 
   getVisibleProgress() {
     const { scrubbing, scrubbingProgress, lastDisplayIndex } = this.state;
-    const { frameSteps, selectedLocation, executionPoint } = this.props;
+    const { frameSteps, selectedLocation, executionPoint, time } = this.props;
 
     if (!frameSteps) {
       return 0;
@@ -193,7 +196,7 @@ class FrameTimelineRenderer extends Component<FrameTimelineProps, FrameTimelineS
     }
 
     const filteredSteps = frameSteps.filter(
-      position => BigInt(position.point) <= BigInt(executionPoint)
+      position => compareTimeStampedPoints(position, { point: executionPoint, time }) <= 0
     );
 
     // Check if the current executionPoint's corresponding index is similar to the
@@ -236,6 +239,7 @@ function FrameTimeline({ selectedFrameId }: { selectedFrameId: PauseAndFrameId |
   const replayClient = useContext(ReplayClientContext);
   const sourcesState = useAppSelector(state => state.sources);
   const executionPoint = useAppSelector(getExecutionPoint);
+  const time = useAppSelector(getTime);
   const selectedLocation = useAppSelector(getSelectedLocation);
   const selectedFrame = useAppSelector(state =>
     getSelectedFrameSuspense(replayClient, state, selectedFrameId)
@@ -256,6 +260,7 @@ function FrameTimeline({ selectedFrameId }: { selectedFrameId: PauseAndFrameId |
   return (
     <FrameTimelineRenderer
       executionPoint={executionPoint}
+      time={time}
       selectedLocation={selectedLocation}
       selectedFrame={selectedFrame}
       frameSteps={frameSteps}

--- a/src/devtools/client/debugger/src/components/shared/ManagedTree.tsx
+++ b/src/devtools/client/debugger/src/components/shared/ManagedTree.tsx
@@ -108,7 +108,7 @@ class ManagedTree<T extends { name: string }> extends Component<
   expandListItems(listItems: T[]) {
     const { expanded } = this.state;
     listItems.forEach(item => expanded.add(this.props.getPath(item)));
-    this.props.onFocus(listItems[0]);
+    //this.props.onFocus(listItems[0]);
     this.setState({ expanded });
   }
 

--- a/src/devtools/client/debugger/src/components/shared/tree.tsx
+++ b/src/devtools/client/debugger/src/components/shared/tree.tsx
@@ -936,10 +936,17 @@ export class Tree<T> extends React.Component<TreeProps<T>, TreeState> {
     const traversal = this._dfsFromRoots();
     const { active, focused } = this.props;
 
-    const nodes = traversal.map((v, i) => {
+    const seenKeys = new Set<string>();
+
+    const nodes: JSX.Element[] = [];
+    traversal.forEach((v, i) => {
       const { item, depth } = v;
       const key = this.props.getKey(item);
-      return (
+      if (seenKeys.has(key)) {
+        return;
+      }
+      seenKeys.add(key);
+      nodes.push(
         <TreeNode<any>
           // We make a key unique depending on whether the tree node is in active
           // or inactive state to make sure that it is actually replaced and the

--- a/src/devtools/client/debugger/src/utils/sources-tree/updateTree.ts
+++ b/src/devtools/client/debugger/src/utils/sources-tree/updateTree.ts
@@ -62,7 +62,9 @@ export function updateTree({ newSources, prevSources, uncollapsedTree }: UpdateT
   // produce a fully immutable update.
   const newUncollapsedTree = createNextState(uncollapsedTree, draft => {
     for (const source of sourcesToAdd) {
-      addToTree(draft, source, debuggeeHost!);
+      if (!ignoreSource(source)) {
+        addToTree(draft, source, debuggeeHost!);
+      }
     }
   });
 
@@ -73,4 +75,11 @@ export function updateTree({ newSources, prevSources, uncollapsedTree }: UpdateT
     sourceTree: newSourceTree,
     parentMap: createParentMap(newSourceTree),
   };
+}
+
+function ignoreSource(source: SourceDetails) {
+  if (source.url?.startsWith("browser-external:")) {
+    return true;
+  }
+  return false;
 }

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -123,6 +123,32 @@ function getSupplementalRecordings(recordingId: string): SupplementalRecording[]
               time: 54294.69953306548,
             },
           },
+          // Second /public network call is made.
+          {
+            clientFirst: true,
+            clientRecordingId: "d5513383-5986-4de5-ab9d-2a7e1f367e90",
+            clientPoint: {
+              point: "56141709792928477884264450686451782",
+              time: 25301.991150442478,
+            },
+            serverPoint: {
+              point: "20444669041365036140696939482054693",
+              time: 66999.47944537815,
+            },
+          },
+          // Second /public network call returns.
+          {
+            clientFirst: false,
+            clientRecordingId: "d5513383-5986-4de5-ab9d-2a7e1f367e90",
+            clientPoint: {
+              point: "56790746901441151898702525872734210",
+              time: 25524.865255979654,
+            },
+            serverPoint: {
+              point: "20444669041638352324265057053573869",
+              time: 68611.1162184874,
+            },
+          },
         ],
       }];
   }

--- a/src/ui/components/NetworkMonitor/utils.ts
+++ b/src/ui/components/NetworkMonitor/utils.ts
@@ -11,7 +11,7 @@ import {
 } from "@replayio/protocol";
 import keyBy from "lodash/keyBy";
 
-import { assert, compareExecutionPoints } from "protocol/utils";
+import { assert, compareNumericStrings } from "protocol/utils";
 import { NetworkRequestsCacheData } from "replay-next/src/suspense/NetworkRequestsCache";
 
 export enum CanonicalRequestType {
@@ -174,7 +174,7 @@ export const partialRequestsToCompleteSummaries = (
     })
     .filter(row => types.size === 0 || types.has(row.type));
 
-  summaries.sort((a, b) => compareExecutionPoints(a.point.point, b.point.point));
+  summaries.sort((a, b) => compareNumericStrings(a.point.point, b.point.point));
 
   return summaries;
 };

--- a/src/ui/components/NetworkMonitor/utils.ts
+++ b/src/ui/components/NetworkMonitor/utils.ts
@@ -11,7 +11,7 @@ import {
 } from "@replayio/protocol";
 import keyBy from "lodash/keyBy";
 
-import { assert, compareNumericStrings } from "protocol/utils";
+import { assert, compareExecutionPoints } from "protocol/utils";
 import { NetworkRequestsCacheData } from "replay-next/src/suspense/NetworkRequestsCache";
 
 export enum CanonicalRequestType {
@@ -174,7 +174,7 @@ export const partialRequestsToCompleteSummaries = (
     })
     .filter(row => types.size === 0 || types.has(row.type));
 
-  summaries.sort((a, b) => compareNumericStrings(a.point.point, b.point.point));
+  summaries.sort((a, b) => compareExecutionPoints(a.point.point, b.point.point));
 
   return summaries;
 };

--- a/src/ui/components/TestSuite/suspense/AnnotationsCache.ts
+++ b/src/ui/components/TestSuite/suspense/AnnotationsCache.ts
@@ -1,4 +1,4 @@
-import { compareNumericStrings } from "protocol/utils";
+import { compareExecutionPoints } from "protocol/utils";
 import { insert } from "replay-next/src/utils/array";
 import { createSingleEntryCacheWithTelemetry } from "replay-next/src/utils/suspense";
 import { ReplayClientInterface } from "shared/client/types";
@@ -20,7 +20,7 @@ export const AnnotationsCache = createSingleEntryCacheWithTelemetry<
       };
 
       insert(sortedAnnotations, processedAnnotation, (a, b) =>
-        compareNumericStrings(a.point, b.point)
+        compareExecutionPoints(a.point, b.point)
       );
     });
 
@@ -47,7 +47,7 @@ export const PlaywrightAnnotationsCache = createSingleEntryCacheWithTelemetry<
         };
 
         insert(sortedAnnotations, processedAnnotation, (a, b) =>
-          compareNumericStrings(a.point, b.point)
+          compareExecutionPoints(a.point, b.point)
         );
       }
     });

--- a/src/ui/components/TestSuite/suspense/AnnotationsCache.ts
+++ b/src/ui/components/TestSuite/suspense/AnnotationsCache.ts
@@ -1,4 +1,4 @@
-import { compareExecutionPoints } from "protocol/utils";
+import { compareNumericStrings } from "protocol/utils";
 import { insert } from "replay-next/src/utils/array";
 import { createSingleEntryCacheWithTelemetry } from "replay-next/src/utils/suspense";
 import { ReplayClientInterface } from "shared/client/types";
@@ -20,7 +20,7 @@ export const AnnotationsCache = createSingleEntryCacheWithTelemetry<
       };
 
       insert(sortedAnnotations, processedAnnotation, (a, b) =>
-        compareExecutionPoints(a.point, b.point)
+        compareNumericStrings(a.point, b.point)
       );
     });
 
@@ -47,7 +47,7 @@ export const PlaywrightAnnotationsCache = createSingleEntryCacheWithTelemetry<
         };
 
         insert(sortedAnnotations, processedAnnotation, (a, b) =>
-          compareExecutionPoints(a.point, b.point)
+          compareNumericStrings(a.point, b.point)
         );
       }
     });

--- a/src/ui/suspense/annotationsCaches.ts
+++ b/src/ui/suspense/annotationsCaches.ts
@@ -1,7 +1,7 @@
 import { Annotation, TimeStampedPoint } from "@replayio/protocol";
 import { Cache, createCache, createSingleEntryCache } from "suspense";
 
-import { compareNumericStrings } from "protocol/utils";
+import { compareExecutionPoints } from "protocol/utils";
 import { ReplayClientInterface } from "shared/client/types";
 import { InteractionEventKind } from "ui/actions/eventListeners/constants";
 import { EventListenerWithFunctionInfo } from "ui/actions/eventListeners/eventListenerUtils";
@@ -58,7 +58,7 @@ export const reactDevToolsAnnotationsCache = createSingleEntryCache<
       receivedAnnotations.push(annotation);
     });
 
-    receivedAnnotations.sort((a1, a2) => compareNumericStrings(a1.point, a2.point));
+    receivedAnnotations.sort((a1, a2) => compareExecutionPoints(a1.point, a2.point));
 
     const parsedAnnotations: ParsedReactDevToolsAnnotation[] = receivedAnnotations.map(
       ({ point, time, contents }) => ({
@@ -84,7 +84,7 @@ export const reduxDevToolsAnnotationsCache = createSingleEntryCache<
       receivedAnnotations.push(annotation);
     });
 
-    receivedAnnotations.sort((a1, a2) => compareNumericStrings(a1.point, a2.point));
+    receivedAnnotations.sort((a1, a2) => compareExecutionPoints(a1.point, a2.point));
 
     const parsedAnnotations = processReduxAnnotations(receivedAnnotations);
 
@@ -104,7 +104,7 @@ export const eventListenersJumpLocationsCache = createSingleEntryCache<
       receivedAnnotations.push(annotation);
     });
 
-    receivedAnnotations.sort((a1, a2) => compareNumericStrings(a1.point, a2.point));
+    receivedAnnotations.sort((a1, a2) => compareExecutionPoints(a1.point, a2.point));
 
     const parsedAnnotations: ParsedJumpToCodeAnnotation[] = receivedAnnotations.map(
       ({ point, time, contents }) => ({

--- a/src/ui/suspense/annotationsCaches.ts
+++ b/src/ui/suspense/annotationsCaches.ts
@@ -1,7 +1,7 @@
 import { Annotation, TimeStampedPoint } from "@replayio/protocol";
 import { Cache, createCache, createSingleEntryCache } from "suspense";
 
-import { compareExecutionPoints } from "protocol/utils";
+import { compareNumericStrings } from "protocol/utils";
 import { ReplayClientInterface } from "shared/client/types";
 import { InteractionEventKind } from "ui/actions/eventListeners/constants";
 import { EventListenerWithFunctionInfo } from "ui/actions/eventListeners/eventListenerUtils";
@@ -58,7 +58,7 @@ export const reactDevToolsAnnotationsCache = createSingleEntryCache<
       receivedAnnotations.push(annotation);
     });
 
-    receivedAnnotations.sort((a1, a2) => compareExecutionPoints(a1.point, a2.point));
+    receivedAnnotations.sort((a1, a2) => compareNumericStrings(a1.point, a2.point));
 
     const parsedAnnotations: ParsedReactDevToolsAnnotation[] = receivedAnnotations.map(
       ({ point, time, contents }) => ({
@@ -84,7 +84,7 @@ export const reduxDevToolsAnnotationsCache = createSingleEntryCache<
       receivedAnnotations.push(annotation);
     });
 
-    receivedAnnotations.sort((a1, a2) => compareExecutionPoints(a1.point, a2.point));
+    receivedAnnotations.sort((a1, a2) => compareNumericStrings(a1.point, a2.point));
 
     const parsedAnnotations = processReduxAnnotations(receivedAnnotations);
 
@@ -104,7 +104,7 @@ export const eventListenersJumpLocationsCache = createSingleEntryCache<
       receivedAnnotations.push(annotation);
     });
 
-    receivedAnnotations.sort((a1, a2) => compareExecutionPoints(a1.point, a2.point));
+    receivedAnnotations.sort((a1, a2) => compareNumericStrings(a1.point, a2.point));
 
     const parsedAnnotations: ParsedJumpToCodeAnnotation[] = receivedAnnotations.map(
       ({ point, time, contents }) => ({


### PR DESCRIPTION
WIP for full stack debugging.  When viewing a frontend recording we can specify a backend recording(s) to include as well.  The supplemental recordings are hard coded for now, and so far showing all the sources for the recordings together works along with loading sources, breakpoints, and hit counts from the supplemental ones.