### PR TITLE
Fixed `displayName` extraction in `getReactInfo`

### DIFF
--- a/packages/replay-next/components/elements/suspense/DOMReactCache.ts
+++ b/packages/replay-next/components/elements/suspense/DOMReactCache.ts
@@ -90,7 +90,7 @@ function getReactInfo(domNodeId: ObjectId): Data {
             ) {
               const id = __RECORD_REPLAY_ARGUMENTS__.getPersistentId(debugOwner);
               if (id) {
-                const displayName = debugOwner.type.name ?? debugOwner.type.displayName ?? null;
+                const displayName = debugOwner.type.displayName ?? debugOwner.type.name ?? null;
 
                 return [id, displayName];
               }


### PR DESCRIPTION
This matches the traditional "priorities" of those 2 possible name sources. The proposed fix matches what React itself is doing, for example [here](https://github.com/facebook/react/blob/1460d67c5b9a0d4498b4d22e1a5a6c0ccac85fdd/packages/shared/getComponentNameFromType.js#L35-L46)