### PR TITLE
add guards to a couple more `window` accesses in socket.ts

### DIFF
--- a/packages/protocol/socket.ts
+++ b/packages/protocol/socket.ts
@@ -250,7 +250,9 @@ export async function sendMessage<M extends CommandMethods>(
 }
 
 const doSend = makeInfallible(message => {
-  window.performance?.mark(`${message.method}_start`);
+  if (typeof window !== "undefined") {
+    window.performance?.mark(`${message.method}_start`);
+  }
   const stringified = JSON.stringify(message);
   gSentBytes += stringified.length;
 
@@ -328,8 +330,10 @@ function socketDataHandler(data: string) {
     const { method, resolve } = gMessageWaiters.get(msg.id)!;
     gSessionCallbacks?.onResponse(msg);
 
-    window.performance?.mark(`${method}_end`);
-    window.performance?.measure(method, `${method}_start`, `${method}_end`);
+    if (typeof window !== "undefined") {
+      window.performance?.mark(`${method}_end`);
+      window.performance?.measure(method, `${method}_start`, `${method}_end`);
+    }
 
     gMessageWaiters.delete(msg.id);
     resolve(msg);


### PR DESCRIPTION
trying to use this package from outside a browser.  some window references are guarded, but these weren't.