### PR TITLE
Use updated `ReactOwnerRenders` mode

### DIFF
--- a/packages/shared/client/types.ts
+++ b/packages/shared/client/types.ts
@@ -293,9 +293,9 @@ export type DependencyChainStep = DependencyChainStepInfo & {
 };
 
 export enum DependencyGraphMode {
-  // Renders of a fiber depend on the last time the parent of that fiber was
+  // Renders of a fiber depend on the last time the owner of that fiber was
   // rendered, instead of whatever triggered the fiber's render.
-  ReactParentRenders = "ReactParentRenders",
+  ReactOwnerRenders = "ReactOwnerRenders",
 }
 
 export interface ReplayClientInterface {

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/index.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/index.tsx
@@ -87,7 +87,7 @@ export default function SecondaryPanes() {
           onToggle={() => setReactDependencyGraphVisible(!reactDependencyGraphVisible)}
         >
           <DependencyGraph
-            mode={DependencyGraphMode.ReactParentRenders}
+            mode={DependencyGraphMode.ReactOwnerRenders}
             point={timeStampedPoint?.point}
           />
         </AccordionPane>

--- a/src/ui/suspense/depGraphCache.ts
+++ b/src/ui/suspense/depGraphCache.ts
@@ -201,7 +201,7 @@ export const reactComponentStackCache: Cache<
     const reactDependencies = await depGraphCache.readAsync(
       replayClient,
       point.point,
-      DependencyGraphMode.ReactParentRenders
+      DependencyGraphMode.ReactOwnerRenders
     );
 
     if (!originalDependencies || !reactDependencies) {


### PR DESCRIPTION
The name of this mode changed in the backend so this brings it up to date here.